### PR TITLE
Implement allowUnconfirmed for SQLite-backed DOs

### DIFF
--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -83,7 +83,7 @@ SqlStorage::IngestResult SqlStorage::ingest(jsg::Lock& js, kj::String querySql) 
 
 void SqlStorage::setMaxPageCountForTest(jsg::Lock& js, int count) {
   auto& db = getDb(js);
-  db.run(SqliteDatabase::TRUSTED, kj::str("PRAGMA max_page_count = ", count));
+  db.run({.regulator = SqliteDatabase::TRUSTED}, kj::str("PRAGMA max_page_count = ", count));
 }
 
 jsg::Ref<SqlStorage::Statement> SqlStorage::prepare(jsg::Lock& js, jsg::JsString query) {
@@ -156,7 +156,7 @@ SqlStorage::Cursor::State::State(SqliteDatabase& db,
     kj::StringPtr sqlCode,
     kj::Array<BindingValue> bindingsParam)
     : bindings(kj::mv(bindingsParam)),
-      query(db.run(regulator, sqlCode, mapBindings(bindings).asPtr())) {}
+      query(db.run({.regulator = regulator}, sqlCode, mapBindings(bindings).asPtr())) {}
 
 SqlStorage::Cursor::State::State(
     kj::Rc<CachedStatement> cachedStatementParam, kj::Array<BindingValue> bindingsParam)

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -491,7 +491,7 @@ kj::Maybe<kj::Promise<void>> ActorSqlite::put(kj::Array<KeyValuePair> pairs, Wri
   // TODO(cleanup): Most of this code comes from DurableObjectStorage::transactionSync and could be re-used.
   if (util::Autogate::isEnabled(util::AutogateKey::SQL_KV_PUT_MULTIPLE_TRANSACTION)) {
     if (currentTxn.is<NoTxn>()) {
-      // If we are not in a transcation, let's use an ExplicitTxn, which should rollback automatically
+      // If we are not in a transaction, let's use an ExplicitTxn, which should rollback automatically
       // if some put fails.
 
       // TODO(someday) this should really start an ImplicitTxn, which has the advantage of

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -227,7 +227,7 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
   AlarmLaterErrorHandler alarmLaterErrorHandler;
   kj::TaskSet alarmLaterTasks;
 
-  void onWrite();
+  void onWrite(bool allowUnconfirmed);
 
   void onCriticalError(kj::StringPtr errorMessage, kj::Maybe<kj::Exception> maybeException);
 

--- a/src/workerd/util/sqlite-kv.c++
+++ b/src/workerd/util/sqlite-kv.c++
@@ -53,9 +53,11 @@ void SqliteKv::cancelCurrentCursor() {
   }
 }
 
-SqliteKv::Initialized& SqliteKv::ensureInitialized() {
+SqliteKv::Initialized& SqliteKv::ensureInitialized(bool allowUnconfirmed) {
   if (!tableCreated) {
-    db.run(R"(
+    db.run(SqliteDatabase::QueryOptions{.regulator = SqliteDatabase::TRUSTED,
+             .allowUnconfirmed = allowUnconfirmed},
+        R"(
       CREATE TABLE IF NOT EXISTS _cf_KV (
         key TEXT PRIMARY KEY,
         value BLOB
@@ -137,11 +139,21 @@ kj::Maybe<SqliteKv::ListCursor::KeyValuePair> SqliteKv::ListCursor::next() {
 }
 
 void SqliteKv::put(KeyPtr key, ValuePtr value) {
-  ensureInitialized().stmtPut.run(key, value);
+  return put(key, value, {});
+}
+
+void SqliteKv::put(KeyPtr key, ValuePtr value, WriteOptions options) {
+  ensureInitialized(options.allowUnconfirmed)
+      .stmtPut.run({.allowUnconfirmed = options.allowUnconfirmed}, key, value);
 }
 
 bool SqliteKv::delete_(KeyPtr key) {
-  auto query = ensureInitialized().stmtDelete.run(key);
+  return delete_(key, {});
+}
+
+bool SqliteKv::delete_(KeyPtr key, WriteOptions options) {
+  auto query = ensureInitialized(options.allowUnconfirmed)
+                   .stmtDelete.run({.allowUnconfirmed = options.allowUnconfirmed}, key);
   return query.changeCount() > 0;
 }
 
@@ -149,7 +161,7 @@ uint SqliteKv::deleteAll() {
   // TODO(perf): Consider introducing a compatibility flag that causes deleteAll() to always return
   //   1. Apps almost certainly don't care about the return value but historically we returned the
   //   count of keys deleted, so now we're stuck counting the table size for no good reason.
-  uint count = tableCreated ? ensureInitialized().stmtCountKeys.run().getInt(0) : 0;
+  uint count = tableCreated ? ensureInitialized(false).stmtCountKeys.run().getInt(0) : 0;
   db.reset();
   return count;
 }

--- a/src/workerd/util/sqlite-kv.h
+++ b/src/workerd/util/sqlite-kv.h
@@ -54,11 +54,17 @@ class SqliteKv: private SqliteDatabase::ResetListener {
   class ListCursor;
   kj::Own<ListCursor> list(KeyPtr begin, kj::Maybe<KeyPtr> end, kj::Maybe<uint> limit, Order order);
 
+  struct WriteOptions {
+    bool allowUnconfirmed = false;
+  };
+
   // Store a value into the table.
   void put(KeyPtr key, ValuePtr value);
+  void put(KeyPtr key, ValuePtr value, WriteOptions options);
 
   // Delete the key and return whether it was matched.
   bool delete_(KeyPtr key);
+  bool delete_(KeyPtr key, WriteOptions options);
 
   uint deleteAll();
 
@@ -148,7 +154,7 @@ class SqliteKv: private SqliteDatabase::ResetListener {
 
   void cancelCurrentCursor();
 
-  Initialized& ensureInitialized();
+  Initialized& ensureInitialized(bool allowUnconfirmed);
   // Make sure the KV table is created and prepared statements are ready. Not called until the
   // first write.
 

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -449,7 +449,7 @@ KJ_TEST("SQLite onWrite callback") {
   SqliteDatabase db(vfs, kj::Path({"foo"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
 
   bool sawWrite = false;
-  db.onWrite([&]() { sawWrite = true; });
+  db.onWrite([&](bool allowUnconfirmed) { sawWrite = true; });
 
   setupSql(db);
   KJ_EXPECT(sawWrite);

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -482,7 +482,7 @@ RowCounts countRowsTouched(SqliteDatabase& db,
   uint64_t rowsFound = 0;
 
   // Runs a query; retrieves and discards all the data.
-  auto query = db.run(regulator, sqlCode, bindParams...);
+  auto query = db.run({.regulator = regulator}, sqlCode, bindParams...);
   while (!query.isDone()) {
     rowsFound++;
     query.nextRow();
@@ -749,10 +749,10 @@ KJ_TEST("SQLite row counters with triggers") {
 
   // A deletion incurs two writes: one for the row and one for the log.
   {
-    db.run(regulator, "DELETE FROM things");
-    db.run(regulator, "INSERT INTO things (id) VALUES (1)");
-    db.run(regulator, "INSERT INTO things (id) VALUES (2)");
-    db.run(regulator, "INSERT INTO things (id) VALUES (3)");
+    db.run({.regulator = regulator}, "DELETE FROM things");
+    db.run({.regulator = regulator}, "INSERT INTO things (id) VALUES (1)");
+    db.run({.regulator = regulator}, "INSERT INTO things (id) VALUES (2)");
+    db.run({.regulator = regulator}, "INSERT INTO things (id) VALUES (3)");
 
     RowCounts stats = countRowsTouched(db, regulator, "DELETE FROM things");
     KJ_EXPECT(stats.written == 6);
@@ -859,9 +859,9 @@ KJ_TEST("SQLite observer addQueryStats") {
   int rowsWrittenBefore = sqliteObserver.rowsWritten;
   constexpr int dbRowCount = 3;
   {
-    db.run(regulator, "INSERT INTO things (id) VALUES (10)");
-    db.run(regulator, "INSERT INTO things (id) VALUES (11)");
-    db.run(regulator, "INSERT INTO things (id) VALUES (12)");
+    db.run({.regulator = regulator}, "INSERT INTO things (id) VALUES (10)");
+    db.run({.regulator = regulator}, "INSERT INTO things (id) VALUES (11)");
+    db.run({.regulator = regulator}, "INSERT INTO things (id) VALUES (12)");
   }
   KJ_EXPECT(sqliteObserver.rowsRead - rowsReadBefore == dbRowCount);
   KJ_EXPECT(sqliteObserver.rowsWritten - rowsWrittenBefore == dbRowCount);
@@ -906,7 +906,7 @@ KJ_TEST("SQLite observer addQueryStats") {
   rowsReadBefore = sqliteObserver.rowsRead;
   rowsWrittenBefore = sqliteObserver.rowsWritten;
   {
-    auto query = db.run(regulator, "INSERT INTO things (id) VALUES (100)");
+    auto query = db.run({.regulator = regulator}, "INSERT INTO things (id) VALUES (100)");
     db.reset();
   }
   KJ_EXPECT(sqliteObserver.rowsRead - rowsReadBefore == 1);
@@ -1552,7 +1552,7 @@ KJ_TEST("I/O exceptions pass through SQLite") {
   SqliteDatabase::Vfs vfs(*dir);
   SqliteDatabase db(vfs, kj::Path({"db"}), kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
 
-  db.run(SqliteDatabase::TRUSTED, kj::str(R"(
+  db.run({.regulator = SqliteDatabase::TRUSTED}, kj::str(R"(
     CREATE TABLE IF NOT EXISTS things (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       value INTEGER
@@ -1564,7 +1564,8 @@ KJ_TEST("I/O exceptions pass through SQLite") {
   KJ_ASSERT_NONNULL(dir->dbFile)->error = KJ_EXCEPTION(FAILED, "test-vfs-error");
 
   // It should pass through.
-  KJ_EXPECT_THROW_MESSAGE("test-vfs-error", db.run(SqliteDatabase::TRUSTED, kj::str(R"(
+  KJ_EXPECT_THROW_MESSAGE(
+      "test-vfs-error", db.run({.regulator = SqliteDatabase::TRUSTED}, kj::str(R"(
     INSERT INTO things(value) VALUES (456);
   )")));
 }
@@ -1613,9 +1614,9 @@ KJ_TEST("SQLite critical error handling for SQLITE_IOERR") {
   });
 
   // Use a small cache size to force flushing to disk on even a small write
-  db.run(SqliteDatabase::TRUSTED, "PRAGMA cache_size = 1");  // 1 page cache
+  db.run({.regulator = SqliteDatabase::TRUSTED}, "PRAGMA cache_size = 1");  // 1 page cache
 
-  db.run(SqliteDatabase::TRUSTED, kj::str(R"(
+  db.run({.regulator = SqliteDatabase::TRUSTED}, kj::str(R"(
     CREATE TABLE IF NOT EXISTS things (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       value INTEGER
@@ -1629,7 +1630,8 @@ KJ_TEST("SQLite critical error handling for SQLITE_IOERR") {
   KJ_ASSERT_NONNULL(dir->dbFile)->error = KJ_EXCEPTION(FAILED, "test-vfs-error");
 
   KJ_EXPECT(!db.observedCriticalError());
-  KJ_EXPECT_THROW_MESSAGE("test-vfs-error", db.run(SqliteDatabase::TRUSTED, kj::str(R"(
+  KJ_EXPECT_THROW_MESSAGE(
+      "test-vfs-error", db.run({.regulator = SqliteDatabase::TRUSTED}, kj::str(R"(
     INSERT INTO things(value) VALUES (456);
   )")));
 
@@ -1655,7 +1657,8 @@ KJ_TEST("SQLite critical error handling for SQLITE_FULL") {
     auto largeData = kj::heapArray<byte>(100000, 'X');  // 100KB
 
     // This should eventually trigger SQLITE_FULL
-    db.run(SqliteDatabase::TRUSTED, "INSERT INTO test_full VALUES (?, ?)", 1, largeData.asPtr());
+    db.run({.regulator = SqliteDatabase::TRUSTED}, "INSERT INTO test_full VALUES (?, ?)", 1,
+        largeData.asPtr());
   });
 }
 
@@ -1676,7 +1679,8 @@ KJ_TEST("SQLite critical error handling for SQLITE_NOMEM") {
     // Create data that will exceed the memory limit
     auto largeData = kj::heapArray<byte>(50000, 'X');  // 50KB
 
-    db.run(SqliteDatabase::TRUSTED, "INSERT INTO test_nomem VALUES (?, ?)", 2, largeData.asPtr());
+    db.run({.regulator = SqliteDatabase::TRUSTED}, "INSERT INTO test_nomem VALUES (?, ?)", 2,
+        largeData.asPtr());
   });
 }
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -847,7 +847,7 @@ SqliteDatabase::IngestResult SqliteDatabase::ingestSql(
     // Slice off the next valid statement SQL
     auto nextStatement = kj::str(sqlCode.first(statementLength));
     // Create a Query object, which will prepare & execute it
-    auto q = Query(*this, regulator, nextStatement);
+    auto q = Query(*this, QueryOptions{.regulator = regulator}, nextStatement);
 
     rowsRead += q.getRowsRead();
     rowsWritten += q.getRowsWritten();
@@ -1340,11 +1340,11 @@ void SqliteDatabase::Statement::beforeSqliteReset() {
 }
 
 SqliteDatabase::Query::Query(SqliteDatabase& db,
-    const Regulator& regulator,
+    QueryOptions options,
     Statement& statement,
     kj::ArrayPtr<const ValuePtr> bindings)
     : ResetListener(db),
-      regulator(regulator),
+      regulator(options.regulator),
       maybeStatement(statement.prepareForExecution()),
       queryEvent(this->db.sqliteObserver) {
   // If we throw from the constructor, the destructor won't run. Need to call destroy() explicitly.
@@ -1353,11 +1353,11 @@ SqliteDatabase::Query::Query(SqliteDatabase& db,
 }
 
 SqliteDatabase::Query::Query(SqliteDatabase& db,
-    const Regulator& regulator,
+    QueryOptions options,
     kj::StringPtr sqlCode,
     kj::ArrayPtr<const ValuePtr> bindings)
     : ResetListener(db),
-      regulator(regulator),
+      regulator(options.regulator),
       ownStatement(db.prepareSql(regulator, sqlCode, 0, MULTI)),
       maybeStatement(ownStatement),
       queryEvent(this->db.sqliteObserver) {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -557,9 +557,9 @@ bool SqliteDatabase::observedCriticalError() {
   return criticalErrorOccurred;
 }
 
-void SqliteDatabase::notifyWrite() {
+void SqliteDatabase::notifyWrite(bool allowUnconfirmed) {
   KJ_IF_SOME(cb, onWriteCallback) {
-    cb();
+    cb(allowUnconfirmed);
   }
 }
 
@@ -766,7 +766,7 @@ SqliteDatabase::StatementAndEffect SqliteDatabase::prepareSql(const Regulator& r
               KJ_DEFER(currentRegulator = regulator);
               currentParseContext = kj::none;
               KJ_DEFER(currentParseContext = parseContext);
-              cb();
+              cb(false);  // prepareSql doesn't have access to allowUnconfirmed, use safe default
             }
           }
 
@@ -1423,7 +1423,7 @@ void SqliteDatabase::Query::checkRequirements(size_t size) {
 
   KJ_IF_SOME(cb, db.onWriteCallback) {
     if (!sqlite3_stmt_readonly(statement)) {
-      cb();
+      cb(allowUnconfirmed);
     }
   }
 }

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -76,6 +76,7 @@ class SqliteDatabase {
 
   struct QueryOptions {
     const Regulator& regulator;
+    bool allowUnconfirmed = false;
   };
 
   struct IngestResult {
@@ -204,7 +205,7 @@ class SqliteDatabase {
   //
   // Note that the write callback is NOT called before (or at any point during) a reset(). Use the
   // `ResetListener` mechanism or `afterReset()` instead for that case.
-  void onWrite(kj::Function<void()> callback) {
+  void onWrite(kj::Function<void(bool allowUnconfirmed)> callback) {
     onWriteCallback = kj::mv(callback);
   }
 
@@ -229,7 +230,7 @@ class SqliteDatabase {
   // implement explicit transactions. For synchronous transactions, the explicit transaction needs
   // to be nested inside the automatic transaction, so we need to force an auto-transaction to
   // start before the SAVEPOINT.
-  void notifyWrite();
+  void notifyWrite(bool allowUnconfirmed = false);
 
   // Get the currently-executing SQL query for debug purposes. The query is normalized to hide
   // any literal values that might contain sensitive information. This is intended to be safe for
@@ -332,7 +333,7 @@ class SqliteDatabase {
   kj::Maybe<sqlite3_stmt&> currentStatement;
 
   bool criticalErrorOccurred = false;
-  kj::Maybe<kj::Function<void()>> onWriteCallback;
+  kj::Maybe<kj::Function<void(bool allowUnconfirmed)>> onWriteCallback;
   kj::Maybe<kj::Function<void(kj::StringPtr errorMessage, kj::Maybe<kj::Exception> maybeException)>>
       onCriticalErrorCallback;
   kj::Maybe<kj::Function<void(SqliteDatabase&)>> afterResetCallback;
@@ -445,6 +446,13 @@ class SqliteDatabase::Statement final: private ResetListener {
   // this method returns.
   template <typename... Params>
   Query run(Params&&... bindings);
+
+  struct StatementOptions {
+    bool allowUnconfirmed = false;
+  };
+
+  template <typename... Params>
+  Query run(StatementOptions options, Params&&... bindings);
 
  private:
   const Regulator& regulator;
@@ -632,6 +640,9 @@ class SqliteDatabase::Query final: private ResetListener {
   uint64_t rowsRead = 0;
   uint64_t rowsWritten = 0;
 
+  // Whether this query allows unconfirmed writes.
+  bool allowUnconfirmed = false;
+
   friend class SqliteDatabase;
 
   Query(SqliteDatabase& db,
@@ -647,7 +658,8 @@ class SqliteDatabase::Query final: private ResetListener {
       : ResetListener(db),
         regulator(options.regulator),
         maybeStatement(statement.prepareForExecution()),
-        queryEvent(this->db.sqliteObserver) {
+        queryEvent(this->db.sqliteObserver),
+        allowUnconfirmed(options.allowUnconfirmed) {
     // If we throw from the constructor, the destructor won't run. Need to call destroy()
     // explicitly.
     KJ_ON_SCOPE_FAILURE(destroy());
@@ -659,7 +671,8 @@ class SqliteDatabase::Query final: private ResetListener {
         regulator(options.regulator),
         ownStatement(db.prepareSql(regulator, sqlCode, 0, MULTI)),
         maybeStatement(ownStatement),
-        queryEvent(this->db.sqliteObserver) {
+        queryEvent(this->db.sqliteObserver),
+        allowUnconfirmed(options.allowUnconfirmed) {
     // If we throw from the constructor, the destructor won't run. Need to call destroy()
     // explicitly.
     KJ_ON_SCOPE_FAILURE(destroy());
@@ -964,6 +977,12 @@ SqliteDatabase::Query SqliteDatabase::run(
 template <typename... Params>
 SqliteDatabase::Query SqliteDatabase::Statement::run(Params&&... params) {
   return Query(db, QueryOptions{.regulator = regulator}, *this, kj::fwd<Params>(params)...);
+}
+
+template <typename... Params>
+SqliteDatabase::Query SqliteDatabase::Statement::run(StatementOptions options, Params&&... params) {
+  return Query(db, {.regulator = regulator, .allowUnconfirmed = options.allowUnconfirmed}, *this,
+      kj::fwd<Params>(params)...);
 }
 
 template <size_t size, typename... Params>


### PR DESCRIPTION
This PR implements `allowUnconfirmed` for KV puts and deletes in SQLite-backed DOs.  See the commits and comments for the detailed design.