### PR TITLE
Handful of new module registry edits

### DIFF
--- a/src/workerd/api/tests/new-module-registry-test.js
+++ b/src/workerd/api/tests/new-module-registry-test.js
@@ -260,6 +260,17 @@ export const wasmDynamicSourcePhaseFailureTest = {
   },
 };
 
+export const complexModuleTest = {
+  async test() {
+    const { abc } = await import('complex');
+    strictEqual(abc.foo, 1);
+    strictEqual(abc.def.bar, 2);
+
+    const { default: abc2 } = await import('abc');
+    strictEqual(abc2, 'file:///bundle/abc');
+  },
+};
+
 // TODO(now): Tests
 // * [x] Include tests for all known module types
 //   * [x] ESM

--- a/src/workerd/api/tests/new-module-registry-test.wd-test
+++ b/src/workerd/api/tests/new-module-registry-test.wd-test
@@ -41,7 +41,16 @@ const unitTests :Workerd.Config = (
           (name = "json", json = "{ \"foo\": 1 }"),
           (name = "invalid-json", json = "1n"),
 
-          (name = "wasm", wasm = embed "test.wasm")
+          (name = "wasm", wasm = embed "test.wasm"),
+
+          (name = "complex", esModule = "import * as abc from '././././././complex/complex2'; export { abc };"),
+          (name = "complex/complex2", esModule = "import * as def from '/bundle/complex/complex3'; export { def }; export const foo = 1;"),
+          (name = "complex/complex3", esModule = "export const bar = 2;"),
+
+          # When the user bundle name begins with a slash, it is stripped before
+          # processing, ensuring that the module is still processed relative to
+          # the bundle base URL. Query strings and fragments are ignored.
+          (name = "/%61bc?abc#123", esModule = "export default import.meta.url"),
         ],
         compatibilityDate = "2025-05-01",
         compatibilityFlags = [

--- a/src/workerd/io/worker-modules.h
+++ b/src/workerd/io/worker-modules.h
@@ -104,7 +104,8 @@ static kj::Arc<jsg::modules::ModuleRegistry> newWorkerModuleRegistry(
     const CompatibilityFlags::Reader& featureFlags,
     const jsg::Url& bundleBase,
     auto setupForApi,
-    jsg::modules::ModuleRegistry::Builder::Options options) {
+    jsg::modules::ModuleRegistry::Builder::Options options =
+        jsg::modules::ModuleRegistry::Builder::Options::NONE) {
   jsg::modules::ModuleRegistry::Builder builder(resolveObserver, bundleBase, options);
 
   // This callback is used when a module is being loaded to arrange evaluating the
@@ -206,13 +207,14 @@ static kj::Arc<jsg::modules::ModuleRegistry> newWorkerModuleRegistry(
           break;
         }
         KJ_CASE_ONEOF(content, Worker::Script::PythonModule) {
-          KJ_REQUIRE(featureFlags.getPythonWorkers(),
-              "The python_workers compatibility flag is required to use Python.");
-          firstEsm = false;
-          hasPythonModules = true;
-          kj::StringPtr entry = PYTHON_ENTRYPOINT;
-          bundleBuilder.addEsmModule(def.name, entry);
-          break;
+          KJ_FAIL_ASSERT("Python modules are not currently supported with the new module registry");
+          // KJ_REQUIRE(featureFlags.getPythonWorkers(),
+          //     "The python_workers compatibility flag is required to use Python.");
+          // firstEsm = false;
+          // hasPythonModules = true;
+          // kj::StringPtr entry = PYTHON_ENTRYPOINT;
+          // bundleBuilder.addEsmModule(def.name, entry);
+          // break;
         }
         KJ_CASE_ONEOF(content, Worker::Script::PythonRequirement) {
           // Handled separately

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4247,8 +4247,19 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
   // config. So for now this just uses the defaults.
   auto workerFs = newWorkerFileSystem(kj::heap<FsMap>(), getBundleDirectory(def.source));
 
+  // TODO(soon): Either make python workers support the new module registry before
+  // NMR is defaulted on, or disable NMR by default when python workers are enabled.
+  // While NMR is experimental, we'll just throw an error if both are enabled.
+  if (def.featureFlags.getPythonWorkers()) {
+    KJ_REQUIRE(!def.featureFlags.getNewModuleRegistry(),
+        "Python workers do not currently support the new ModuleRegistry implementation. "
+        "Please disable the new ModuleRegistry feature flag to use Python workers.");
+  }
+
+  bool usingNewModuleRegistry = def.featureFlags.getNewModuleRegistry();
   kj::Maybe<kj::Arc<jsg::modules::ModuleRegistry>> newModuleRegistry;
-  if (def.featureFlags.getNewModuleRegistry()) {
+  // TODO(soon): Python workers do not currently support the new module registry.
+  if (usingNewModuleRegistry) {
     KJ_REQUIRE(experimental,
         "The new ModuleRegistry implementation is an experimental feature. "
         "You must run workerd with `--experimental` to use this feature.");
@@ -4289,8 +4300,8 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
     inspectorPolicy = Worker::Isolate::InspectorPolicy::ALLOW_FULLY_TRUSTED;
   }
   Worker::LoggingOptions isolateLoggingOptions = loggingOptions;
-  isolateLoggingOptions.consoleMode = def.source.variant.is<WorkerSource::ScriptSource>() &&
-          !def.featureFlags.getNewModuleRegistry()
+  isolateLoggingOptions.consoleMode =
+      def.source.variant.is<WorkerSource::ScriptSource>() && !usingNewModuleRegistry
       ? Worker::ConsoleMode::INSPECTOR_ONLY
       : loggingOptions.consoleMode;
   auto isolate = kj::atomicRefcounted<Worker::Isolate>(kj::mv(api), kj::mv(observer), name,
@@ -4302,7 +4313,7 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
     isolateRegistrar->registerIsolate(name, isolate.get());
   }
 
-  if (!def.featureFlags.getNewModuleRegistry()) {
+  if (!usingNewModuleRegistry) {
     KJ_IF_SOME(moduleFallback, def.moduleFallback) {
       KJ_REQUIRE(experimental,
           "The module fallback service is an experimental feature. "


### PR DESCRIPTION
* Disable new module registry for python workers
* Improve normalization of module names from the user bundle, with tests