### PR TITLE
Create enable_ctx_exports compat flag for ctx.exports.

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -656,7 +656,7 @@ class DurableObjectState: public jsg::Object {
 
   JSG_RESOURCE_TYPE(DurableObjectState, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
-    if (flags.getWorkerdExperimental()) {
+    if (flags.getEnableCtxExports()) {
       JSG_LAZY_INSTANCE_PROPERTY(exports, getExports);
     }
     JSG_LAZY_INSTANCE_PROPERTY(props, getProps);
@@ -686,7 +686,7 @@ class DurableObjectState: public jsg::Object {
     // * Make `storage` non-optional
     // * Make `id` strictly `DurableObjectId` (it's only a string for colo-local actors which are
     //   not available publicly).
-    if (flags.getWorkerdExperimental()) {
+    if (flags.getEnableCtxExports()) {
       JSG_TS_OVERRIDE(<Props = unknown> {
         readonly props: Props;
         readonly exports: Cloudflare.Exports;

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -239,7 +239,7 @@ class ExecutionContext: public jsg::Object {
   JSG_RESOURCE_TYPE(ExecutionContext, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     JSG_METHOD(passThroughOnException);
-    if (flags.getWorkerdExperimental()) {
+    if (flags.getEnableCtxExports()) {
       JSG_LAZY_INSTANCE_PROPERTY(exports, getExports);
     }
     JSG_LAZY_INSTANCE_PROPERTY(props, getProps);
@@ -258,7 +258,7 @@ class ExecutionContext: public jsg::Object {
       JSG_METHOD(abort);
     }
 
-    if (flags.getWorkerdExperimental()) {
+    if (flags.getEnableCtxExports()) {
       JSG_TS_OVERRIDE(<Props = unknown> {
         readonly props: Props;
         readonly exports: Cloudflare.Exports;

--- a/src/workerd/api/sync-kv-test.wd-test
+++ b/src/workerd/api/sync-kv-test.wd-test
@@ -10,7 +10,7 @@ const config :Workerd.Config = (
 const mainWorker :Workerd.Worker = (
   compatibilityDate = "2025-08-01",
 
-  compatibilityFlags = ["experimental", "nodejs_compat"],
+  compatibilityFlags = ["enable_ctx_exports", "nodejs_compat"],
 
   modules = [
     (name = "worker", esModule = embed "sync-kv-test.js"),

--- a/src/workerd/api/tests/global-scope-test.wd-test
+++ b/src/workerd/api/tests/global-scope-test.wd-test
@@ -7,9 +7,9 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "global-scope-test.js")
         ],
-        compatibilityDate = "2023-01-15",
+        compatibilityDate = "2025-01-15",
         # "experimental" is for ctx.exports
-        compatibilityFlags = ["nodejs_compat", "set_tostring_tag", "experimental"]
+        compatibilityFlags = ["nodejs_compat", "enable_ctx_exports"]
       )
     ),
   ],

--- a/src/workerd/api/worker-loader-test.js
+++ b/src/workerd/api/worker-loader-test.js
@@ -685,7 +685,7 @@ export let ctxExports = {
     let worker = env.loader.get('ctxExports', () => {
       return {
         compatibilityDate: '2025-01-01',
-        compatibilityFlags: ['experimental'],
+        compatibilityFlags: ['enable_ctx_exports'],
         mainModule: 'foo.js',
         allowExperimental: true,
         modules: {

--- a/src/workerd/api/worker-loader-test.wd-test
+++ b/src/workerd/api/worker-loader-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "worker-loader-test.js")
         ],
         compatibilityDate = "2025-01-01",
-        compatibilityFlags = ["nodejs_compat","experimental"],
+        compatibilityFlags = ["nodejs_compat","experimental","enable_ctx_exports"],
         bindings = [
           (name = "loader", workerLoader = ()),
           (name = "sharedLoader1", workerLoader = (id = "shared")),

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1184,4 +1184,8 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
     $experimental;
   # Enables the Node.js non-functional stub sqlite module. It is required to use this
   # flag with nodejs_compat (or nodejs_compat_v2).
+
+  enableCtxExports @139 :Bool
+    $compatEnableFlag("enable_ctx_exports");
+  # Enable the ctx.exports API.
 }

--- a/src/workerd/io/io-context-test.wd-test
+++ b/src/workerd/io/io-context-test.wd-test
@@ -10,7 +10,8 @@ const unitTests :Workerd.Config = (
         compatibilityDate = "2025-05-01",
         compatibilityFlags = [
           "nodejs_compat",  # for assert
-          "experimental",   # for ctx.exports
+          "experimental",   # for ctx.abort
+          "enable_ctx_exports",
         ],
       )
     ),

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4361,8 +4361,8 @@ KJ_TEST("Server: ctx.exports self-referential bindings") {
     services = [
       ( name = "hello",
         worker = (
-          compatibilityDate = "2024-02-23",
-          compatibilityFlags = ["experimental"],
+          compatibilityDate = "2025-02-23",
+          compatibilityFlags = ["enable_ctx_exports"],
           modules = [
             ( name = "main.js",
               esModule =
@@ -4704,7 +4704,7 @@ KJ_TEST("Server: Durable Object facets") {
       ( name = "hello",
         worker = (
           compatibilityDate = "2025-04-01",
-          compatibilityFlags = ["experimental"],
+          compatibilityFlags = ["experimental","enable_ctx_exports"],
           modules = [
             ( name = "main.js",
               esModule =
@@ -4975,7 +4975,7 @@ KJ_TEST("Server: Pass service stubs in ctx.props.") {
       ( name = "hello",
         worker = (
           compatibilityDate = "2025-08-01",
-          compatibilityFlags = ["experimental"],
+          compatibilityFlags = ["enable_ctx_exports"],
           modules = [
             ( name = "main.js",
               esModule =


### PR DESCRIPTION
Due to some weird edge cases, we can just enable ctx.exports for everyone in prod. But that means we need a compat flag for people to enable it. So this introduces that.

Since ctx.exports doesn't work in prod at all yet, we can safely *stop* enabling it for "experimental". This is the safe thing to do because we don't want people who are setting the "experimental" flag alone to accidentally rely on ctx.exports, when it won't work in prod unless they also set "enable_ctx_exports".