### PR TITLE
Ignore non-file URLs when building bundle-fs

### DIFF
--- a/src/workerd/api/node/tests/fs-dir-test.wd-test
+++ b/src/workerd/api/node/tests/fs-dir-test.wd-test
@@ -5,7 +5,9 @@ const unitTests :Workerd.Config = (
     ( name = "fs-dir-test",
       worker = (
         modules = [
-          (name = "worker", esModule = embed "fs-dir-test.js")
+          (name = "worker", esModule = embed "fs-dir-test.js"),
+          # Should be ignored due to non-file: URL
+          (name = "abc:foo", text = "abc-foo"),
         ],
         compatibilityDate = "2025-05-01",
         compatibilityFlags = ["nodejs_compat", "experimental", "enable_nodejs_fs_module"]

--- a/src/workerd/io/bundle-fs.c++
+++ b/src/workerd/io/bundle-fs.c++
@@ -85,6 +85,10 @@ kj::Rc<Directory> getBundleDirectory(const WorkerSource& conf) {
     kj::Path kRoot{};
     for (auto& entry: entries) {
       auto url = KJ_ASSERT_NONNULL(jsg::Url::tryParse(entry.name, "file:///"_kj));
+      // If the name is not a valid file URL path, ignore it.
+      if (url.getProtocol() != "file:"_kj) {
+        continue;
+      }
       auto pathStr = kj::str(url.getPathname().slice(1));
       auto path = kRoot.eval(pathStr);
       builder.addPath(path, File::newReadable(entry.data));


### PR DESCRIPTION
Technically this would be a breaking change but it's still early enough in the life of the vfs system that it's exceedingly unlikely anyone is relying on this buggy behavior. If the module name ends up being a non-file: URL we don't want to include it in the file system bundle at all.