### PR TITLE
[R2 Instrumentation] Emit hash checksums as hex strings instead of stringified arrays

### DIFF
--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -329,23 +329,26 @@ void addHeadResultSpanTags(
       kj::str(toISOString(js, headResult.getUploaded()).asPtr()));
   auto checksums = headResult.getChecksums();
   KJ_IF_SOME(md5, checksums.get()->md5) {
-    traceContext.userSpan.setTag("cloudflare.r2.response.checksum.value"_kjc, kj::str(md5));
+    traceContext.userSpan.setTag("cloudflare.r2.response.checksum.value"_kjc, kj::encodeHex(md5));
     traceContext.userSpan.setTag("cloudflare.r2.response.checksum.type"_kjc, kj::str("md5"));
   }
   KJ_IF_SOME(sha1, checksums.get()->sha1) {
-    traceContext.userSpan.setTag("cloudflare.r2.response.checksum.value"_kjc, kj::str(sha1));
+    traceContext.userSpan.setTag("cloudflare.r2.response.checksum.value"_kjc, kj::encodeHex(sha1));
     traceContext.userSpan.setTag("cloudflare.r2.response.checksum.type"_kjc, kj::str("sha1"));
   }
   KJ_IF_SOME(sha256, checksums.get()->sha256) {
-    traceContext.userSpan.setTag("cloudflare.r2.response.checksum.value"_kjc, kj::str(sha256));
+    traceContext.userSpan.setTag(
+        "cloudflare.r2.response.checksum.value"_kjc, kj::encodeHex(sha256));
     traceContext.userSpan.setTag("cloudflare.r2.response.checksum.type"_kjc, kj::str("sha256"));
   }
   KJ_IF_SOME(sha384, checksums.get()->sha384) {
-    traceContext.userSpan.setTag("cloudflare.r2.response.checksum.value"_kjc, kj::str(sha384));
+    traceContext.userSpan.setTag(
+        "cloudflare.r2.response.checksum.value"_kjc, kj::encodeHex(sha384));
     traceContext.userSpan.setTag("cloudflare.r2.response.checksum.type"_kjc, kj::str("sha384"));
   }
   KJ_IF_SOME(sha512, checksums.get()->sha512) {
-    traceContext.userSpan.setTag("cloudflare.r2.response.checksum.value"_kjc, kj::str(sha512));
+    traceContext.userSpan.setTag(
+        "cloudflare.r2.response.checksum.value"_kjc, kj::encodeHex(sha512));
     traceContext.userSpan.setTag("cloudflare.r2.response.checksum.type"_kjc, kj::str("sha512"));
   }
 
@@ -697,7 +700,7 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
             putBuilder.setMd5(bin.asArrayPtr());
             traceContext.userSpan.setTag("cloudflare.r2.request.checksum.type"_kjc, kj::str("md5"));
             traceContext.userSpan.setTag(
-                "cloudflare.r2.request.checksum.value"_kjc, kj::str(bin.asArrayPtr()));
+                "cloudflare.r2.request.checksum.value"_kjc, kj::encodeHex(bin.asArrayPtr()));
           }
           KJ_CASE_ONEOF(hex, jsg::NonCoercible<kj::String>) {
             JSG_REQUIRE(hex.value.size() == 32, TypeError, "MD5 is 32 hex characters, not ",
@@ -720,7 +723,7 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
             traceContext.userSpan.setTag(
                 "cloudflare.r2.request.checksum.type"_kjc, kj::str("sha1"));
             traceContext.userSpan.setTag(
-                "cloudflare.r2.request.checksum.value"_kjc, kj::str(bin.asArrayPtr()));
+                "cloudflare.r2.request.checksum.value"_kjc, kj::encodeHex(bin.asArrayPtr()));
           }
           KJ_CASE_ONEOF(hex, jsg::NonCoercible<kj::String>) {
             JSG_REQUIRE(hex.value.size() == 40, TypeError, "SHA-1 is 40 hex characters, not ",
@@ -744,7 +747,7 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
             traceContext.userSpan.setTag(
                 "cloudflare.r2.request.checksum.type"_kjc, kj::str("sha256"));
             traceContext.userSpan.setTag(
-                "cloudflare.r2.request.checksum.value"_kjc, kj::str(bin.asArrayPtr()));
+                "cloudflare.r2.request.checksum.value"_kjc, kj::encodeHex(bin.asArrayPtr()));
           }
           KJ_CASE_ONEOF(hex, jsg::NonCoercible<kj::String>) {
             JSG_REQUIRE(hex.value.size() == 64, TypeError, "SHA-256 is 64 hex characters, not ",
@@ -769,7 +772,7 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
             traceContext.userSpan.setTag(
                 "cloudflare.r2.request.checksum.type"_kjc, kj::str("sha384"));
             traceContext.userSpan.setTag(
-                "cloudflare.r2.request.checksum.value"_kjc, kj::str(bin.asArrayPtr()));
+                "cloudflare.r2.request.checksum.value"_kjc, kj::encodeHex(bin.asArrayPtr()));
           }
           KJ_CASE_ONEOF(hex, jsg::NonCoercible<kj::String>) {
             JSG_REQUIRE(hex.value.size() == 96, TypeError, "SHA-384 is 96 hex characters, not ",
@@ -794,7 +797,7 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
             traceContext.userSpan.setTag(
                 "cloudflare.r2.request.checksum.type"_kjc, kj::str("sha512"));
             traceContext.userSpan.setTag(
-                "cloudflare.r2.request.checksum.value"_kjc, kj::str(bin.asArrayPtr()));
+                "cloudflare.r2.request.checksum.value"_kjc, kj::encodeHex(bin.asArrayPtr()));
           }
           KJ_CASE_ONEOF(hex, jsg::NonCoercible<kj::String>) {
             JSG_REQUIRE(hex.value.size() == 128, TypeError, "SHA-512 is 128 hex characters, not ",

--- a/src/workerd/api/r2-instrumentation-test.js
+++ b/src/workerd/api/r2-instrumentation-test.js
@@ -1112,6 +1112,25 @@ export const test = {
         'cloudflare.r2.response.custom_metadata': true,
         closed: true,
       },
+      {
+        name: 'r2_put',
+        'cloudflare.binding.type': 'r2',
+        'cloudflare.binding.name': 'BUCKET',
+        'cloudflare.r2.operation': 'PutObject',
+        'cloudflare.r2.bucket': 'r2-test',
+        'cloudflare.r2.request.key': 'md5checksum',
+        'cloudflare.r2.request.checksum.type': 'md5',
+        'cloudflare.r2.request.checksum.value':
+          '9a0364b9e99bb480dd25e1f0284c8555',
+        'cloudflare.r2.request.size': 7n,
+        'cloudflare.r2.response.success': true,
+        'cloudflare.r2.response.etag': 'objectEtag',
+        'cloudflare.r2.response.size': 123,
+        'cloudflare.r2.response.uploaded': '2024-08-27T14:00:57.918Z',
+        'cloudflare.r2.response.storage_class': 'Standard',
+        'cloudflare.r2.response.custom_metadata': true,
+        closed: true,
+      },
     ];
 
     assert.deepStrictEqual(received, expected);

--- a/src/workerd/api/r2-test.js
+++ b/src/workerd/api/r2-test.js
@@ -40,6 +40,12 @@ const hexKey =
 const keyMd5 = 'WGR5pEm07DroP3hYRAh8Yw==';
 const conditionalDate = '946684800000';
 
+// Test checksums - known values for testing
+const md5Buffer = new Uint8Array([
+  0x9a, 0x03, 0x64, 0xb9, 0xe9, 0x9b, 0xb4, 0x80, 0xdd, 0x25, 0xe1, 0xf0, 0x28,
+  0x4c, 0x85, 0x55,
+]);
+const md5Hex = '9a0364b9e99bb480dd25e1f0284c8555';
 const objResponse = {
   name: key,
   version: 'objectVersion',
@@ -353,6 +359,12 @@ export default {
                 },
               });
             }
+          }
+          case 'md5checksum': {
+            return Response.json({
+              ...objResponse,
+              md5: md5Buffer,
+            });
           }
         }
         return Response.json(objResponse);
@@ -879,6 +891,13 @@ export default {
           );
         }
       }
+    }
+    // Checksums
+    {
+      // This exists purely to test the instrumentation
+      let resp = await env.BUCKET.put('md5checksum', body, {
+        md5: md5Buffer,
+      });
     }
   },
 };


### PR DESCRIPTION
Currently we're emitting `cloudflare.r2.response.checksum.value` in the format `111, 183, 179, 152, 196, 45, 225, 223, 171, 92, 151, 123, 22, 18, 235, 208` which isn't what a user would expect since they usually see this hex-encoded. This updates all of the tag values to be hex-encoded instead of arrays.