### PR TITLE
[KV Instrumentation] More KV attribute tweaks

### DIFF
--- a/src/workerd/api/kv-instrumentation-test.js
+++ b/src/workerd/api/kv-instrumentation-test.js
@@ -353,6 +353,7 @@ export const test = {
         'cloudflare.binding.type': 'KV',
         'cloudflare.kv.query.prefix': 'te',
         'cloudflare.kv.response.cache_status': 'HIT',
+        'cloudflare.kv.response.size': 291n,
         'cloudflare.kv.response.list_complete': false,
         'cloudflare.kv.response.cursor': '6Ck1la0VxJ0djhidm1MdX2FyD',
         'cloudflare.kv.response.expiration': 1234n,
@@ -369,6 +370,7 @@ export const test = {
         'cloudflare.kv.query.prefix': 'te',
         'cloudflare.kv.query.cursor': '123',
         'cloudflare.kv.response.cache_status': 'HIT',
+        'cloudflare.kv.response.size': 6939n,
         'cloudflare.kv.response.list_complete': true,
         'cloudflare.kv.response.expiration': 1234n,
         'cloudflare.kv.response.returned_rows': 100n,
@@ -382,6 +384,7 @@ export const test = {
         'cloudflare.binding.type': 'KV',
         'cloudflare.kv.query.prefix': 'not-found',
         'cloudflare.kv.response.cache_status': 'HIT',
+        'cloudflare.kv.response.size': 32n,
         'cloudflare.kv.response.list_complete': true,
         'cloudflare.kv.response.returned_rows': 0n,
         closed: true,
@@ -423,6 +426,8 @@ export const test = {
         closed: true,
       },
     ];
+
+    console.log(received);
 
     assert.equal(
       received.length,

--- a/src/workerd/api/kv-instrumentation-test.js
+++ b/src/workerd/api/kv-instrumentation-test.js
@@ -395,7 +395,8 @@ export const test = {
         'db.operation.name': 'put',
         'cloudflare.binding.name': 'KV',
         'cloudflare.binding.type': 'KV',
-        'cloudflare.kv.query.key': 'foo_with_exp',
+        'cloudflare.kv.query.keys': 'foo_with_exp',
+        'cloudflare.kv.query.keys.count': 1n,
         'cloudflare.kv.query.expiration': 10n,
         'cloudflare.kv.query.value_type': 'text',
         'cloudflare.kv.query.payload.size': 4n,
@@ -407,7 +408,8 @@ export const test = {
         'db.operation.name': 'put',
         'cloudflare.binding.name': 'KV',
         'cloudflare.binding.type': 'KV',
-        'cloudflare.kv.query.key': 'foo_with_expTtl',
+        'cloudflare.kv.query.keys': 'foo_with_expTtl',
+        'cloudflare.kv.query.keys.count': 1n,
         'cloudflare.kv.query.expiration_ttl': 15n,
         'cloudflare.kv.query.value_type': 'text',
         'cloudflare.kv.query.payload.size': 23n,
@@ -419,15 +421,14 @@ export const test = {
         'db.operation.name': 'put',
         'cloudflare.binding.name': 'KV',
         'cloudflare.binding.type': 'KV',
-        'cloudflare.kv.query.key': 'foo_with_expTtl',
+        'cloudflare.kv.query.keys': 'foo_with_expTtl',
+        'cloudflare.kv.query.keys.count': 1n,
         'cloudflare.kv.query.expiration_ttl': 15n,
         'cloudflare.kv.query.value_type': 'ArrayBuffer',
         'cloudflare.kv.query.payload.size': 256n,
         closed: true,
       },
     ];
-
-    console.log(received);
 
     assert.equal(
       received.length,

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -553,7 +553,8 @@ jsg::Promise<void> KvNamespace::put(jsg::Lock& js,
     traceContext.userSpan.setTag("db.operation.name"_kjc, kj::str("put"_kjc));
     traceContext.userSpan.setTag("cloudflare.binding.name"_kjc, kj::str(bindingName));
     traceContext.userSpan.setTag("cloudflare.binding.type"_kjc, kj::str("KV"_kjc));
-    traceContext.userSpan.setTag("cloudflare.kv.query.key"_kjc, kj::str(name));
+    traceContext.userSpan.setTag("cloudflare.kv.query.keys"_kjc, kj::str(name));
+    traceContext.userSpan.setTag("cloudflare.kv.query.keys.count"_kjc, static_cast<int64_t>(1));
 
     kj::Url url;
     url.scheme = kj::str("https");

--- a/src/workerd/api/kv.c++
+++ b/src/workerd/api/kv.c++
@@ -516,6 +516,10 @@ jsg::Promise<jsg::JsRef<jsg::JsValue>> KvNamespace::list(
           getContentEncoding(
               context, *response.headers, Response::BodyEncoding::AUTO, FeatureFlags::get(js)));
 
+      KJ_IF_SOME(size, stream->tryGetLength(StreamEncoding::IDENTITY)) {
+        traceContext.userSpan.setTag("cloudflare.kv.response.size"_kjc, static_cast<int64_t>(size));
+      }
+
       return context.awaitIo(js,
           stream->readAllText(context.getLimitEnforcer().getBufferingLimit())
               .attach(kj::mv(stream)),


### PR DESCRIPTION
Follow up to https://github.com/cloudflare/workerd/pull/5120

While documenting these attributes I found two more small issues:

- `kv_list` didn't set `cloudflare.kv.response.size`
- all methods except `kv_put` use `cloudflare.kv.query.keys`. For consistency I've also switched to it there even though we don't currently allow you to pass multiple keys in.