### PR TITLE
UniversalGatewayOptions Exclude ==> Omit

### DIFF
--- a/src/cloudflare/internal/aig-api.ts
+++ b/src/cloudflare/internal/aig-api.ts
@@ -24,7 +24,7 @@ export type GatewayOptions = {
   retries?: GatewayRetries;
 };
 
-export type UniversalGatewayOptions = Exclude<GatewayOptions, 'id'> & {
+export type UniversalGatewayOptions = Omit<GatewayOptions, 'id'> & {
   /**
    ** @deprecated
    */


### PR DESCRIPTION
Exclude here is a no-op and as a result `UniversalGatewayOptions` is equivalent to `GatewayOptions`. The intent here was to use Omit.