### PR TITLE
Fixes Python cron triggers when default entrypoint is used.

### DIFF
--- a/src/pyodide/internal/workers-api/src/workers/_workers.py
+++ b/src/pyodide/internal/workers-api/src/workers/_workers.py
@@ -841,9 +841,13 @@ def _python_from_rpc_default_converter(value, convert, cache):
     elif value.constructor.name == "Number":
         return value.valueOf()
 
-    raise TypeError(
-        f"Couldn't convert object to Python type, got {value.constructor.name}"
-    )
+    # We used to throw an error here, but since these conversions are now automatic when the default
+    # entrypoint is being used, it makes sense to be less loud about it and just pass through the
+    # JS value un-modified.
+    #
+    # This does mean that in the future we need to be careful when adding type wrappers for new
+    # types here, so if you're doing this make sure to do so behind a compat flag.
+    return value
 
 
 def python_from_rpc(obj: "JsProxy"):

--- a/src/workerd/server/tests/python/sdk/sdk.wd-test
+++ b/src/workerd/server/tests/python/sdk/sdk.wd-test
@@ -7,16 +7,16 @@ const python :Workerd.Worker = (
   bindings = [
     ( name = "SELF", service = "python-sdk" ),
   ],
-  compatibilityDate = "2024-10-01",
-  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_no_global_handlers"],
+  compatibilityDate = "2025-09-01",
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "service_binding_extra_handlers"],
 );
 
 const server :Workerd.Worker = (
   modules = [
     (name = "server.py", pythonModule = embed "server.py")
   ],
-  compatibilityDate = "2024-10-01",
-  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_no_global_handlers"],
+  compatibilityDate = "2025-09-01",
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
 );
 
 # We need this proxy so that internal requests made to fetch packages for Python Workers are sent
@@ -29,7 +29,7 @@ const jsChooserProxy :Workerd.Worker = (
     ( name = "PYTHON", service = "python-server" ),
     ( name = "INTERNET", service = "external" ),
   ],
-  compatibilityDate = "2024-10-01",
+  compatibilityDate = "2025-09-01",
 );
 
 const unitTests :Workerd.Config = (

--- a/src/workerd/server/tests/python/sdk/server.py
+++ b/src/workerd/server/tests/python/sdk/server.py
@@ -24,6 +24,10 @@ class Default(WorkerEntrypoint):
                 filename="metadata.json",
             )
             return Response(data)
+        elif request.url.endswith("/ignore"):
+            # Just a test path that we ignore, used for requests that we don't care about
+            # the result of.
+            return Response("ignored")
         else:
             raise ValueError("Unexpected path " + request.url)
 


### PR DESCRIPTION
This should resolve errors like "TypeError: Couldn't convert object to Python type, got ScheduledController ". It also adds a test to ensure cron triggers continue to work.