### PR TITLE
Don't require the experimental flag for eval

### DIFF
--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -305,8 +305,7 @@ struct WorkerdApi::Impl final {
       // Allows us to begin experimenting with eval/new fuction enabled in
       // preparation for *possibly* enabling it by default in the future
       // once v8 sandbox is fully enabled and rolled out.
-      if (featuresParam.getExperimentalAllowEvalAlways() &&
-          featuresParam.getWorkerdExperimental()) {
+      if (featuresParam.getExperimentalAllowEvalAlways()) {
         jsgIsolate.setAllowsAllowEval();
       }
     });


### PR DESCRIPTION
The `getExperimentalAllowEvalAlways` flag itself is marked as experimental so it doesn't need the `workerdExperimental` flag also.