### PR TITLE
fix: process toString support

### DIFF
--- a/src/node/internal/public_process.ts
+++ b/src/node/internal/public_process.ts
@@ -731,6 +731,11 @@ const process: Process = Object.setPrototypeOf(
 ) as Process;
 EventEmitter.call(process);
 
+Object.defineProperty(process, Symbol.toStringTag, {
+  value: 'process',
+  configurable: true,
+});
+
 // We lazily attach unhandled rejection and rejection handled listeners
 // to ensure performance optimizations remain in the no listener case
 let addedUnhandledRejection = false,

--- a/src/workerd/api/node/tests/process-nodejs-test.js
+++ b/src/workerd/api/node/tests/process-nodejs-test.js
@@ -1124,3 +1124,12 @@ export const processAssert = {
     assert.strictEqual(typeof process.assert, 'function');
   },
 };
+
+export const processToStringTag = {
+  test() {
+    assert.strictEqual(
+      Object.prototype.toString.call(process),
+      '[object process]'
+    );
+  },
+};


### PR DESCRIPTION
Ensures `Object.process.toString.call(process)` gives `[object process]`.