### PR TITLE
Fix the deprecation warnings on recent V8 releases.

### DIFF
--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -43,8 +43,12 @@ enum class ContextPointerSlot : int {
 
 inline void setAlignedPointerInEmbedderData(
     v8::Local<v8::Context> context, ContextPointerSlot slot, void* ptr) {
+  // The type tag is a small integer that should be different for every pointer
+  // type to avoid type confusion attacks.  We just use the slot index for now,
+  // since we have a different pointer type for each slot.
   KJ_DASSERT(slot != ContextPointerSlot::RESERVED, "Attempt to use reserved embedder data slot.");
-  context->SetAlignedPointerInEmbedderData(static_cast<int>(slot), ptr);
+  context->SetAlignedPointerInEmbedderData(
+      static_cast<int>(slot), ptr, static_cast<v8::EmbedderDataTypeTag>(slot));
 }
 
 template <typename T>


### PR DESCRIPTION
SetAlignedPointerInInternalFields has been deprecated so we do two calls to SetAlignedPointerInInternalField instead.

SetAlignedPointerInEmbedderData has gained an argument, a small integer used as a type tag.