### PR TITLE
improve js.obj() usages across the repository

### DIFF
--- a/src/workerd/api/node/process.c++
+++ b/src/workerd/api/node/process.c++
@@ -110,11 +110,11 @@ namespace {
 }  // namespace
 
 jsg::JsObject ProcessModule::getVersions(jsg::Lock& js) const {
-  auto versions = js.obj();
   // Node.js version - represents the most current Node.js version supported
   // by the platform, as defined in node-version.h
-  versions.set(js, "node"_kj, js.str(nodeVersion));
-  return versions;
+  static kj::StringPtr keys[] = {"node"_kj};
+  jsg::JsValue values[] = {js.str(nodeVersion)};
+  return js.obj(kj::arrayPtr(keys), kj::arrayPtr(values));
 }
 
 kj::StringPtr ProcessModule::getPlatform(jsg::Lock& js) const {

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -174,10 +174,9 @@ jsg::JsValue ToJs(
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::FetchResponseInfo& info, StringCache& cache) {
-  auto obj = js.obj();
-  obj.set(js, TYPE_STR, cache.get(js, FETCH_STR));
-  obj.set(js, STATUSCODE_STR, js.num(info.statusCode));
-  return obj;
+  static kj::StringPtr keys[] = {TYPE_STR, STATUSCODE_STR};
+  jsg::JsValue values[] = {cache.get(js, FETCH_STR), js.num(info.statusCode)};
+  return js.obj(kj::ArrayPtr<kj::StringPtr>(keys), kj::ArrayPtr<jsg::JsValue>(values));
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::FetchEventInfo& info, StringCache& cache) {
@@ -204,9 +203,9 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::FetchEventInfo& info, StringCach
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::JsRpcEventInfo& info, StringCache& cache) {
-  auto obj = js.obj();
-  obj.set(js, TYPE_STR, cache.get(js, JSRPC_STR));
-  return obj;
+  static kj::StringPtr keys[] = {TYPE_STR};
+  jsg::JsValue values[] = {cache.get(js, JSRPC_STR)};
+  return js.obj(kj::ArrayPtr<kj::StringPtr>(keys), kj::ArrayPtr<jsg::JsValue>(values));
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::ScheduledEventInfo& info, StringCache& cache) {
@@ -233,20 +232,17 @@ jsg::JsValue ToJs(jsg::Lock& js, const tracing::AlarmEventInfo& info, StringCach
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::QueueEventInfo& info, StringCache& cache) {
-  auto obj = js.obj();
-  obj.set(js, TYPE_STR, cache.get(js, QUEUE_STR));
-  obj.set(js, QUEUENAME_STR, js.str(info.queueName));
-  obj.set(js, BATCHSIZE_STR, js.num(info.batchSize));
-  return obj;
+  static kj::StringPtr keys[] = {TYPE_STR, QUEUENAME_STR, BATCHSIZE_STR};
+  jsg::JsValue values[] = {
+    cache.get(js, QUEUE_STR), js.str(info.queueName), js.num(info.batchSize)};
+  return js.obj(kj::ArrayPtr<kj::StringPtr>(keys), kj::ArrayPtr<jsg::JsValue>(values));
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::EmailEventInfo& info, StringCache& cache) {
-  auto obj = js.obj();
-  obj.set(js, TYPE_STR, cache.get(js, EMAIL_STR));
-  obj.set(js, MAILFROM_STR, js.str(info.mailFrom));
-  obj.set(js, RCPTTO_STR, js.str(info.rcptTo));
-  obj.set(js, RAWSIZE_STR, js.num(info.rawSize));
-  return obj;
+  static kj::StringPtr keys[] = {TYPE_STR, MAILFROM_STR, RCPTTO_STR, RAWSIZE_STR};
+  jsg::JsValue values[] = {
+    cache.get(js, EMAIL_STR), js.str(info.mailFrom), js.str(info.rcptTo), js.num(info.rawSize)};
+  return js.obj(kj::ArrayPtr<kj::StringPtr>(keys), kj::ArrayPtr<jsg::JsValue>(values));
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const tracing::TraceEventInfo& info, StringCache& cache) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2714,6 +2714,8 @@ class Lock {
   JsObject obj(
       kj::ArrayPtr<kj::StringPtr> keys, kj::ArrayPtr<jsg::JsValue> values) KJ_WARN_UNUSED_RESULT;
   JsObject objNoProto() KJ_WARN_UNUSED_RESULT;
+  JsObject objNoProto(
+      kj::ArrayPtr<kj::StringPtr> keys, kj::ArrayPtr<jsg::JsValue> values) KJ_WARN_UNUSED_RESULT;
   JsMap map() KJ_WARN_UNUSED_RESULT;
   JsValue external(void*) KJ_WARN_UNUSED_RESULT;
   JsValue error(kj::StringPtr message) KJ_WARN_UNUSED_RESULT;

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -536,16 +536,23 @@ JsObject Lock::obj() {
 
 JsObject Lock::obj(kj::ArrayPtr<kj::StringPtr> keys, kj::ArrayPtr<JsValue> values) {
   KJ_DASSERT(keys.size() == values.size());
-  v8::LocalVector<v8::Name> keys_(v8Isolate);
-  v8::LocalVector<v8::Value> values_(v8Isolate);
-  keys_.reserve(keys.size());
-  values_.reserve(keys.size());
-  for (auto& k: keys) {
-    v8::Local<v8::String> key = str(k);
-    keys_.push_back(key);
+  v8::LocalVector<v8::Name> keys_(v8Isolate, keys.size());
+  v8::LocalVector<v8::Value> values_(v8Isolate, keys.size());
+  for (size_t i = 0; i < keys.size(); i++) {
+    keys_[i] = strIntern(keys[i]).inner;
+    values_[i] = values[i];
   }
-  for (auto& v: values) {
-    values_.push_back(v);
+  return JsObject(v8::Object::New(
+      v8Isolate, v8::Object::New(v8Isolate), keys_.data(), values_.data(), keys.size()));
+}
+
+JsObject Lock::objNoProto(kj::ArrayPtr<kj::StringPtr> keys, kj::ArrayPtr<JsValue> values) {
+  KJ_DASSERT(keys.size() == values.size());
+  v8::LocalVector<v8::Name> keys_(v8Isolate, keys.size());
+  v8::LocalVector<v8::Value> values_(v8Isolate, keys.size());
+  for (size_t i = 0; i < keys.size(); i++) {
+    keys_[i] = strIntern(keys[i]).inner;
+    values_[i] = values[i];
   }
   return JsObject(
       v8::Object::New(v8Isolate, v8::Null(v8Isolate), keys_.data(), values_.data(), keys.size()));


### PR DESCRIPTION
Using js.obj(arrayPtr, arrayPtr) overload in favor of js.obj() due to performance. also uses strIntern for repetitive objects