### PR TITLE
refactor(bzlmod): remove bind of @icu

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,11 +23,6 @@ load("@//build/deps:v8.bzl", "deps_v8")
 
 deps_v8()
 
-bind(
-    name = "icu",
-    actual = "@com_googlesource_chromium_icu//:icu",
-)
-
 # Tell workerd code where to find v8.
 #
 # We indirect through `@workerd-v8` to allow dependents to override how and where `v8` is built.

--- a/build/deps/v8.bzl
+++ b/build/deps/v8.bzl
@@ -35,6 +35,7 @@ PATCHES = [
     "0027-Implement-additional-Exception-construction-methods.patch",
     "0028-Export-icudata-file-to-facilitate-embedding-it.patch",
     "0029-IsGraphAsync-module-cast-check.patch",
+    "0030-bind-icu-to-googlesource.patch",
 ]
 
 # V8 and its dependencies

--- a/patches/v8/0030-bind-icu-to-googlesource.patch
+++ b/patches/v8/0030-bind-icu-to-googlesource.patch
@@ -1,5 +1,5 @@
---- a/BUILD
-+++ b/BUILD
+--- a/BUILD.build
++++ b/BUILD.build
 @@ -4517,7 +4517,7 @@
      copts = ["-Wno-implicit-fallthrough"],
      icu_deps = [

--- a/patches/v8/0030-bind-icu-to-googlesource.patch
+++ b/patches/v8/0030-bind-icu-to-googlesource.patch
@@ -17,3 +17,4 @@
 +        "@com_googlesource_chromium_icu//:icu",
      ],
  )
+

--- a/patches/v8/0030-bind-icu-to-googlesource.patch
+++ b/patches/v8/0030-bind-icu-to-googlesource.patch
@@ -1,5 +1,5 @@
---- a/BUILD.build
-+++ b/BUILD.build
+--- a/BUILD.bazel
++++ b/BUILD.bazel
 @@ -4517,7 +4517,7 @@
      copts = ["-Wno-implicit-fallthrough"],
      icu_deps = [

--- a/patches/v8/0030-bind-icu-to-googlesource.patch
+++ b/patches/v8/0030-bind-icu-to-googlesource.patch
@@ -1,0 +1,19 @@
+--- a/BUILD
++++ b/BUILD
+@@ -4517,7 +4517,7 @@
+     copts = ["-Wno-implicit-fallthrough"],
+     icu_deps = [
+         ":icu/generated_torque_definitions_headers",
+-        "//external:icu",
++        "@com_googlesource_chromium_icu//:icu",
+     ],
+     icu_srcs = [
+         ":generated_regexp_special_case",
+@@ -4640,7 +4640,7 @@
+     ],
+     deps = [
+         ":v8_libbase",
+-        "//external:icu",
++        "@com_googlesource_chromium_icu//:icu",
+     ],
+ )


### PR DESCRIPTION
Per documentation: https://bazel.build/external/migration#bind-targets