### PR TITLE
Simplify streaming tail worker log serialization by treating messages as strings rather than parsing as JSON.

### DIFF
--- a/src/workerd/api/tests/tail-worker-test.js
+++ b/src/workerd/api/tests/tail-worker-test.js
@@ -130,7 +130,7 @@ export const test = {
       '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"MyActor","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"log","level":"log","message":["baz"]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"functionProperty"}]}{"type":"return"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       // Test for transient objects - getCounter returns an object with methods
       // All transient calls happen in a single trace event, with only the entrypoint method reported
-      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["getCounter called"]}{"type":"log","level":"log","message":["increment called on transient"]}{"type":"log","level":"log","message":["getValue called on transient"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":"[\\"bar\\"]"}{"type":"log","level":"log","message":"[\\"getCounter called\\"]"}{"type":"log","level":"log","message":"[\\"increment called on transient\\"]"}{"type":"log","level":"log","message":"[\\"getValue called on transient\\"]"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);

--- a/src/workerd/api/tests/tail-worker-test.js
+++ b/src/workerd/api/tests/tail-worker-test.js
@@ -130,7 +130,7 @@ export const test = {
       '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"MyActor","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"log","level":"log","message":["baz"]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"functionProperty"}]}{"type":"return"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       // Test for transient objects - getCounter returns an object with methods
       // All transient calls happen in a single trace event, with only the entrypoint method reported
-      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":"[\\"bar\\"]"}{"type":"log","level":"log","message":"[\\"getCounter called\\"]"}{"type":"log","level":"log","message":"[\\"increment called on transient\\"]"}{"type":"log","level":"log","message":"[\\"getValue called on transient\\"]"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["getCounter called"]}{"type":"log","level":"log","message":["increment called on transient"]}{"type":"log","level":"log","message":["getValue called on transient"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -475,8 +475,7 @@ jsg::JsValue ToJs(jsg::Lock& js, const Log& log, StringCache& cache) {
   auto obj = js.obj();
   obj.set(js, TYPE_STR, cache.get(js, LOG_STR));
   obj.set(js, LEVEL_STR, ToJs(js, log.logLevel, cache));
-  // TODO(o11y): Check that we are always returning an object here
-  obj.set(js, MESSAGE_STR, jsg::JsValue(js.parseJson(log.message).getHandle(js)));
+  obj.set(js, MESSAGE_STR, js.str(log.message));
   return obj;
 }
 

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -172,15 +172,11 @@ void WorkerTracer::addLog(const tracing::InvocationSpanContext& context,
   // available. If the given worker stage is only tailed by a streaming tail worker, adding the log
   // to the buffered trace object is not needed; this will be addressed in a future refactor.
   KJ_IF_SOME(writer, maybeTailStreamWriter) {
-    // If message is too big on its own, send error message instead of truncating
-    if (message.size() > MAX_TRACE_BYTES) {
-      writer->report(context,
-          {(tracing::Log(timestamp, logLevel,
-              kj::str("[\"Log message too large: ", message.size(), " bytes\"]")))},
-          timestamp);
-    } else {
-      writer->report(context, {(tracing::Log(timestamp, logLevel, kj::str(message)))}, timestamp);
-    }
+    // If message is too big on its own, truncate it.
+    writer->report(context,
+        {(tracing::Log(timestamp, logLevel,
+            kj::str(message.first(kj::min(message.size(), MAX_TRACE_BYTES)))))},
+        timestamp);
   }
 
   if (trace->exceededLogLimit) {

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -172,11 +172,7 @@ void WorkerTracer::addLog(const tracing::InvocationSpanContext& context,
   // available. If the given worker stage is only tailed by a streaming tail worker, adding the log
   // to the buffered trace object is not needed; this will be addressed in a future refactor.
   KJ_IF_SOME(writer, maybeTailStreamWriter) {
-    // If message is too big on its own, truncate it.
-    writer->report(context,
-        {(tracing::Log(timestamp, logLevel,
-            kj::str(message.first(kj::min(message.size(), MAX_TRACE_BYTES)))))},
-        timestamp);
+    writer->report(context, {(tracing::Log(timestamp, logLevel, kj::str(message)))}, timestamp);
   }
 
   if (trace->exceededLogLimit) {


### PR DESCRIPTION
Fixes JSON parsing error caused by truncated log messages.