### PR TITLE
feat: ability to run formatters using rules_lint

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
@@ -24,6 +25,14 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# For convenience, less typing than the full label:
+# (assuming working directory is the root of the repository)
+#   bazel run format
+alias(
+    name = "format",
+    actual = "//build/deps/formatters:format",
+)
+
 npm_link_all_packages(name = "node_modules")
 
 npm_link_package(
@@ -42,6 +51,12 @@ capnp_es_bins.capnpc_js_binary(
 capnp_es_bins.capnpc_ts_binary(
     name = "capnpc_ts_plugin",
     visibility = ["//visibility:public"],
+)
+
+js_library(
+    name = "prettierrc",
+    srcs = [":.prettierrc.json"],
+    visibility = ["//build/deps/formatters:__pkg__"],
 )
 
 # Platform definition for using clang-cl on Windows

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,7 @@
 module(name = "workerd")
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
+bazel_dep(name = "aspect_rules_lint", version = "1.10.2")
 bazel_dep(name = "bazel_features", version = "1.37.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "rules_shell", version = "0.6.1")

--- a/build/deps/formatters/BUILD
+++ b/build/deps/formatters/BUILD
@@ -1,4 +1,6 @@
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("@npm//:prettier/package_json.bzl", prettier = "bin")
 
 config_setting(
     name = "linux_amd64",
@@ -40,7 +42,7 @@ config_setting(
     ],
 )
 
-copy_file(
+native_binary(
     name = "clang-format@rule",
     src = select({
         ":linux_amd64": "@clang-format-linux-amd64//file:file",
@@ -52,7 +54,7 @@ copy_file(
     visibility = ["//visibility:public"],
 )
 
-copy_file(
+native_binary(
     name = "ruff@rule",
     src = select({
         ":linux_amd64": "@ruff-linux-amd64//:file",
@@ -64,7 +66,7 @@ copy_file(
     visibility = ["//visibility:public"],
 )
 
-copy_file(
+native_binary(
     name = "buildifier@rule",
     src = select({
         ":linux_amd64": "@buildifier-linux-amd64//file:file",
@@ -76,4 +78,28 @@ copy_file(
     }),
     out = "buildifier",
     visibility = ["//visibility:public"],
+)
+
+prettier.prettier_binary(
+    name = "prettier@rule",
+    # Include this js_library and its dependencies in the runfiles (runtime dependencies)
+    data = ["//:prettierrc"],
+    # Allow the binary to be run outside bazel
+    env = {"BAZEL_BINDIR": "."},
+    fixed_args = [
+        # `require` statements in the config file will be resolved relative to its location
+        # Therefore to make it hermetic, prettier must be pointed at the copy of the config file
+        # in the runfiles folder rather than the one in the source folder.
+        "--config=\"$$JS_BINARY__RUNFILES\"/$(rlocationpath //:prettierrc)",
+        "--log-level=warn",
+    ],
+)
+
+format_multirun(
+    name = "format",
+    cc = ":clang-format@rule",
+    javascript = ":prettier@rule",
+    python = ":ruff@rule",
+    starlark = ":buildifier@rule",
+    visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
This provides a shorter and more standard way to invoke formatters for all languages. rules_lint is widely adopted and has many companies contributing.

Subset of #5227 to rollout in smaller steps

This PR just introduces a new target that can be `bazel run` on specific files. Next steps will be:
- switch the pre-commit hook to the new approach.
- remove dep_clang_format stuff for fetching binaries per-platform
- switch vscode and zed configs to use the binary that came from rules_lint
- change how formatting is enforced, probably drop this from `tools/cross/format.py` which leaks a "you have to install python3" and is not hermetic.
