### PR TITLE
stream-utils improvements

### DIFF
--- a/src/workerd/util/stream-utils.c++
+++ b/src/workerd/util/stream-utils.c++
@@ -8,19 +8,80 @@
 namespace workerd {
 
 namespace {
+
+// An AsyncInputStream implementation that reads from an in-memory buffer.
+// This is optimized for the case where the entire contents are available
+// up-front, so it doesn't do any dynamic memory allocation or copying.
+// It also supports optimized teeing when the backing storage is provided.
 class MemoryInputStream final: public kj::AsyncInputStream {
+ private:
+  struct OwnedBacking: public kj::Refcounted {
+    kj::Own<void> backing;
+    OwnedBacking(kj::Own<void>&& backing): backing(kj::mv(backing)) {}
+  };
+
  public:
-  MemoryInputStream(kj::ArrayPtr<const kj::byte> data): data(data) {}
+  MemoryInputStream(
+      kj::ArrayPtr<const kj::byte> data, kj::Maybe<kj::Own<void>> maybeBacking = kj::none)
+      : data(data),
+        // Note that we don't actually check that maybeBacking actually owns the
+        // memory that `data` points to. It is the caller's responsibility to ensure
+        // this is the case if they want teeing to be safely supported.
+        ownedBacking(maybeBacking.map(
+            [](kj::Own<void>& backing) mutable { return kj::rc<OwnedBacking>(kj::mv(backing)); })) {
+  }
+  MemoryInputStream(kj::ArrayPtr<const kj::byte> data, kj::Rc<OwnedBacking> ownedBacking)
+      : data(data),
+        ownedBacking(kj::mv(ownedBacking)) {}
 
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    size_t toRead = kj::min(data.size(), maxBytes);
-    memcpy(buffer, data.begin(), toRead);
-    data = data.slice(toRead, data.size());
+    auto ptr = kj::arrayPtr<kj::byte>(static_cast<kj::byte*>(buffer), maxBytes);
+    size_t toRead = kj::min(data.size(), ptr.size());
+    KJ_DEFER(advance(toRead));
+    if (toRead == 0) return toRead;
+    ptr.first(toRead).copyFrom(data.first(toRead));
     return toRead;
+  }
+
+  kj::Maybe<uint64_t> tryGetLength() override {
+    return data.size();
+  }
+
+  kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override {
+    // An optimized pumpTo... we know we have all the data right here. We can
+    // just write it all at once up to `amount`.
+    uint64_t toRead = kj::min(data.size(), amount);
+    KJ_DEFER(advance(toRead));
+    co_await output.write(data.first(toRead));
+    co_return toRead;
+  }
+
+  kj::Maybe<kj::Own<AsyncInputStream>> tryTee(uint64_t limit = kj::maxValue) override {
+    // If a MemoryInputStream is holding onto backing storage, then we can safely
+    // tee it here, allowing us to avoid the default tee implementation which needs
+    // additional buffering. Tee'ing just becomes a matter of sharing the backing
+    // storage and the data slice directly. This allows us to avoid any additional
+    // buffering in unread stream branches since all of the data is already in memory
+    // anyway. If we're not holding onto the backing storage, then we cannot safely
+    // assume that the a tee branch will safely be able to read the data, so we'll
+    // fall back to the default kj::newTee implementation.
+    KJ_IF_SOME(owned, ownedBacking) {
+      return kj::heap<MemoryInputStream>(data, owned.addRef());
+    }
+    return kj::none;
   }
 
  private:
   kj::ArrayPtr<const kj::byte> data;
+  kj::Maybe<kj::Rc<OwnedBacking>> ownedBacking;
+
+  void advance(size_t amount) {
+    data = data.slice(amount);
+    // If we've consumed all the data, drop our reference to the backing storage eagerly.
+    if (data.size() == 0) {
+      ownedBacking = kj::none;
+    }
+  }
 };
 
 class NeuterableInputStreamImpl final: public NeuterableInputStream {
@@ -171,12 +232,14 @@ kj::Own<kj::AsyncOutputStream> newNullOutputStream() {
   return kj::Own<kj::AsyncOutputStream>(&nullStream, kj::NullDisposer::instance);
 }
 
-kj::Own<kj::AsyncInputStream> newMemoryInputStream(kj::ArrayPtr<const kj::byte> data) {
-  return kj::heap<MemoryInputStream>(data);
+kj::Own<kj::AsyncInputStream> newMemoryInputStream(
+    kj::ArrayPtr<const kj::byte> data, kj::Maybe<kj::Own<void>> maybeBacking) {
+  return kj::heap<MemoryInputStream>(data, kj::mv(maybeBacking));
 }
 
-kj::Own<kj::AsyncInputStream> newMemoryInputStream(kj::StringPtr data) {
-  return kj::heap<MemoryInputStream>(data.asBytes());
+kj::Own<kj::AsyncInputStream> newMemoryInputStream(
+    kj::StringPtr data, kj::Maybe<kj::Own<void>> maybeBacking) {
+  return kj::heap<MemoryInputStream>(data.asBytes(), kj::mv(maybeBacking));
 }
 
 kj::Own<NeuterableInputStream> newNeuterableInputStream(kj::AsyncInputStream& inner) {

--- a/src/workerd/util/stream-utils.h
+++ b/src/workerd/util/stream-utils.h
@@ -11,8 +11,16 @@ kj::Own<kj::AsyncOutputStream> newNullOutputStream();
 // Get a shared global null output stream (singleton, thread-safe)
 kj::AsyncOutputStream& getGlobalNullOutputStream();
 
-kj::Own<kj::AsyncInputStream> newMemoryInputStream(kj::ArrayPtr<const kj::byte>);
-kj::Own<kj::AsyncInputStream> newMemoryInputStream(kj::StringPtr);
+// When maybeBacking is provided, it is held onto by the MemoryInputStream
+// using a kj::Rc<...> so that teeing the stream can share ownership of
+// the backing storage without the need for any additional buffering. If
+// the backing storage is not provided, then optimized teeing of the stream
+// will not be supported and the implementation will return a kj::none from
+// tryTee().
+kj::Own<kj::AsyncInputStream> newMemoryInputStream(
+    kj::ArrayPtr<const kj::byte>, kj::Maybe<kj::Own<void>> maybeBacking = kj::none);
+kj::Own<kj::AsyncInputStream> newMemoryInputStream(
+    kj::StringPtr, kj::Maybe<kj::Own<void>> maybeBacking = kj::none);
 
 // An InputStream that can be disconnected.
 class NeuterableInputStream: public kj::AsyncInputStream, public kj::Refcounted {


### PR DESCRIPTION
* Eliminate duplicative null io stream... there's a kj::NullStream we can use.
* Improve MemoryInputStream in preparation for using it to replace multiple duplicative stream impls (in blob, http, email, etc).