### PR TITLE
containers: Fix expected status code when sending a signal to the container.

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -342,7 +342,7 @@ kj::Promise<void> ContainerClient::killContainer(uint32_t signal) {
       network, kj::str(dockerPath), kj::HttpMethod::POST, kj::mv(endpoint));
   // statusCode 409 refers to "container is not running"
   // We should not throw an error when the container is already not running.
-  JSG_REQUIRE(response.statusCode == 200 || response.statusCode == 409, Error,
+  JSG_REQUIRE(response.statusCode == 204 || response.statusCode == 409, Error,
       "Stopping container failed with: ", response.body);
 }
 


### PR DESCRIPTION
https://docs.docker.com/reference/api/engine/version/v1.49/#tag/Container/operation/ContainerKill - a successful response should be a 204 not 200. 
Currently we are seeing `Stopping container failed with: <empty body because its actually successful>` when we shut down a container in local dev.
