### PR TITLE
Implement multi-put in ActorSqlite using an ImplicitTxn

### DIFF
--- a/src/workerd/io/actor-sqlite-test.c++
+++ b/src/workerd/io/actor-sqlite-test.c++
@@ -319,6 +319,12 @@ KJ_TEST("check put multiple wraps operations in a transaction and rollback on er
     KJ_ASSERT(expectSync(test.get(kj::str("foo3"))) == nullptr);
   }
 
+  // Reset the transaction state by going async, which will cause the ImplicitTxn to commit.
+  {
+    auto commitFulfiller = kj::mv(test.pollAndExpectCalls({"commit"})[0]);
+    commitFulfiller->fulfill();
+  }
+
   // ExplicitTxn test
   {
     KJ_ASSERT(!test.actor.isCommitScheduled());

--- a/src/workerd/io/actor-sqlite-test.c++
+++ b/src/workerd/io/actor-sqlite-test.c++
@@ -1597,12 +1597,6 @@ KJ_TEST("allowUnconfirmed putMultiple does not block output gate") {
   // Gate should be unblocked at start
   KJ_ASSERT(test.gate.wait().poll(test.ws));
 
-  // Start an implicit transaction by doing a single put first
-  test.put("initial", "value", {.allowUnconfirmed = true});
-
-  // By now, we should check there's a commit scheduled in an ImplicitTxn.
-  KJ_ASSERT(test.actor.isCommitScheduled());
-
   // Create multiple key-value pairs for the test
   kj::Vector<ActorCache::KeyValuePair> putKVs;
   putKVs.add(ActorCache::KeyValuePair{kj::str("foo"), kj::heapArray(kj::str("bar").asBytes())});
@@ -1622,7 +1616,6 @@ KJ_TEST("allowUnconfirmed putMultiple does not block output gate") {
   KJ_ASSERT(test.gate.wait().poll(test.ws));
 
   // Verify all data was written correctly
-  KJ_ASSERT(KJ_ASSERT_NONNULL(expectSync(test.get("initial"))) == kj::str("value").asBytes());
   KJ_ASSERT(KJ_ASSERT_NONNULL(expectSync(test.get("foo"))) == kj::str("bar").asBytes());
   KJ_ASSERT(KJ_ASSERT_NONNULL(expectSync(test.get("baz"))) == kj::str("qux").asBytes());
   KJ_ASSERT(KJ_ASSERT_NONNULL(expectSync(test.get("key3"))) == kj::str("value3").asBytes());

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -237,6 +237,8 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
   AlarmLaterErrorHandler alarmLaterErrorHandler;
   kj::TaskSet alarmLaterTasks;
 
+  void startImplicitTxn();
+
   void onWrite(bool allowUnconfirmed);
 
   void onCriticalError(kj::StringPtr errorMessage, kj::Maybe<kj::Exception> maybeException);


### PR DESCRIPTION
As the main commit says: Normally, when you do a write with ActorSqlite and you’re not otherwise in a transaction, you’ll make an ImplicitTxn that will commit the next time the code goes async.  The multi-put code used an ExplicitTxn, which would commit immediately.  It’s a subtle difference, but we might as well get rid of it.
