### PR TITLE
Implement allowUnconfirmed for setAlarm

### DIFF
--- a/src/workerd/util/sqlite-metadata-test.c++
+++ b/src/workerd/util/sqlite-metadata-test.c++
@@ -21,37 +21,37 @@ KJ_TEST("SQLite-METADATA") {
   // Can set alarm to an explicit time
   constexpr kj::Date anAlarmTime1 =
       kj::UNIX_EPOCH + 1734099316 * kj::SECONDS + 987654321 * kj::NANOSECONDS;
-  metadata.setAlarm(anAlarmTime1);
+  metadata.setAlarm(anAlarmTime1, /*allowUnconfirmed=*/false);
 
   // Can get the set alarm time
   KJ_EXPECT(metadata.getAlarm() == anAlarmTime1);
 
   // Can overwrite the alarm time
   constexpr kj::Date anAlarmTime2 = anAlarmTime1 + 1 * kj::NANOSECONDS;
-  metadata.setAlarm(anAlarmTime2);
+  metadata.setAlarm(anAlarmTime2, /*allowUnconfirmed=*/false);
   KJ_EXPECT(metadata.getAlarm() != anAlarmTime1);
   KJ_EXPECT(metadata.getAlarm() == anAlarmTime2);
 
   // Can clear alarm
-  metadata.setAlarm(kj::none);
+  metadata.setAlarm(kj::none, /*allowUnconfirmed=*/false);
   KJ_EXPECT(metadata.getAlarm() == kj::none);
 
   // Zero alarm is distinct from unset (probably not important, but just checking)
-  metadata.setAlarm(kj::UNIX_EPOCH);
+  metadata.setAlarm(kj::UNIX_EPOCH, /*allowUnconfirmed=*/false);
   KJ_EXPECT(metadata.getAlarm() == kj::UNIX_EPOCH);
 
   // Can recreate table after resetting database
-  metadata.setAlarm(anAlarmTime1);
+  metadata.setAlarm(anAlarmTime1, /*allowUnconfirmed=*/false);
   KJ_EXPECT(metadata.getAlarm() == anAlarmTime1);
   db.reset();
   KJ_EXPECT(metadata.getAlarm() == kj::none);
-  metadata.setAlarm(anAlarmTime2);
+  metadata.setAlarm(anAlarmTime2, /*allowUnconfirmed=*/false);
   KJ_EXPECT(KJ_ASSERT_NONNULL(metadata.getAlarm()) == anAlarmTime2);
 
   // Can invalidate cache after rolling back.
-  metadata.setAlarm(anAlarmTime2);
+  metadata.setAlarm(anAlarmTime2, /*allowUnconfirmed=*/false);
   db.run("BEGIN TRANSACTION");
-  metadata.setAlarm(anAlarmTime1);
+  metadata.setAlarm(anAlarmTime1, /*allowUnconfirmed=*/false);
   KJ_EXPECT(metadata.getAlarm() == anAlarmTime1);
   db.run("ROLLBACK TRANSACTION");
   KJ_EXPECT(metadata.getAlarm() == anAlarmTime2);

--- a/src/workerd/util/sqlite-metadata.h
+++ b/src/workerd/util/sqlite-metadata.h
@@ -26,7 +26,7 @@ class SqliteMetadata final: private SqliteDatabase::ResetListener {
   kj::Maybe<kj::Date> getAlarm();
 
   // Sets current alarm time, or none.
-  void setAlarm(kj::Maybe<kj::Date> currentTime);
+  void setAlarm(kj::Maybe<kj::Date> currentTime, bool allowUnconfirmed);
 
   // Return the current local development bookmark, or none if no bookmark has been set.
   kj::Maybe<uint64_t> getLocalDevelopmentBookmark();
@@ -67,9 +67,9 @@ class SqliteMetadata final: private SqliteDatabase::ResetListener {
   kj::Maybe<Cache> cacheState;
 
   kj::Maybe<kj::Date> getAlarmUncached();
-  void setAlarmUncached(kj::Maybe<kj::Date> currentTime);
+  void setAlarmUncached(kj::Maybe<kj::Date> currentTime, bool allowUnconfirmed);
 
-  Initialized& ensureInitialized();
+  Initialized& ensureInitialized(bool allowUnconfirmed);
   // Make sure the metadata table is created and prepared statements are ready. Not called until the
   // first write.
 


### PR DESCRIPTION
We recorded something like 185 million occurrences of the “allowUnconfirmed disabled; reason = setAlarm is not supported” log message.  Apparently, people do use `setAlarm` with `allowUnconfirmed`.

Most of this is just plumbing to get the allowedUnconfirmed value from the WriteOptions struct all the way down to
`SqliteMetadata::ensureInitialized` and the actual `stmtSetAlarm` SQL statements.

Claude wrote the additional tests in actor-sqlite-test.c++.