### PR TITLE
Improve backpressure handling in Node writable adapter

### DIFF
--- a/src/node/internal/streams_writable.js
+++ b/src/node/internal/streams_writable.js
@@ -1035,12 +1035,13 @@ export function newStreamWritableFromWritableStream(
         }
       }
 
-      writer.ready.then(() => {
-        return Promise.all(chunks.map((data) => writer.write(data))).then(
-          done,
-          done
-        );
-      }, done);
+      const writes = async () => {
+        for (let n = 0; n < chunks.length; n++) {
+          if (writer.desiredSize <= 0) await writer.ready;
+          writer.write(chunks[n].chunk);
+        }
+      };
+      writes().then(done, done);
     },
 
     write(chunk, encoding, callback) {


### PR DESCRIPTION
In a vector write, in certain cases we could outpace the backpressure if the vector is large enough. Ensure appropriate backpressure pacing.