### PR TITLE
EW-9332 Update deprecated V8 function usage

### DIFF
--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -297,8 +297,15 @@ v8::Maybe<bool> Serializer::WriteHostObject(v8::Isolate* isolate, v8::Local<v8::
       throwDataCloneErrorForObject(js, object);
     }
 
+    // TODO(cleanup): Remove this #if when workerd's V8 version is updated to 14.2.
+#if V8_MAJOR_VERSION < 14 || V8_MINOR_VERSION < 2
     Wrappable* wrappable = reinterpret_cast<Wrappable*>(
         object->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX));
+#else
+    Wrappable* wrappable = reinterpret_cast<Wrappable*>(
+        object->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
+            static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX)));
+#endif
 
     // HACK: Although we don't technically know yet that `wrappable` is an `Object`, we know that
     //   only subclasses of `Object` register serializers. So *if* a serializer is found, then this

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -801,8 +801,15 @@ class Isolate: public IsolateBase {
       if (instance.IsEmpty()) {
         return kj::none;
       } else {
+        // TODO(cleanup): Remove this #if when workerd's V8 version is updated to 14.2.
+#if V8_MAJOR_VERSION < 14 || V8_MINOR_VERSION < 2
         return *reinterpret_cast<Object*>(
             instance->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX));
+#else
+        return *reinterpret_cast<Object*>(
+            instance->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
+                static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX)));
+#endif
       }
     }
 

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -416,8 +416,15 @@ kj::Maybe<Wrappable&> Wrappable::tryUnwrapOpaque(
         v8::Local<v8::Object>::Cast(handle)->FindInstanceInPrototypeChain(
             IsolateBase::getOpaqueTemplate(isolate));
     if (!instance.IsEmpty()) {
+      // TODO(cleanup): Remove this #if when workerd's V8 version is updated to 14.2.
+#if V8_MAJOR_VERSION < 14 || V8_MINOR_VERSION < 2
       return *reinterpret_cast<Wrappable*>(
           instance->GetAlignedPointerFromInternalField(WRAPPED_OBJECT_FIELD_INDEX));
+#else
+      return *reinterpret_cast<Wrappable*>(
+          instance->GetAlignedPointerFromInternalField(WRAPPED_OBJECT_FIELD_INDEX,
+              static_cast<v8::EmbedderDataTypeTag>(WRAPPED_OBJECT_FIELD_INDEX)));
+#endif
     }
   }
 


### PR DESCRIPTION
DCHECKs started failing in V8 14.2 until I heeded these warnings.

It appears that some of these functions were previously already updated. I followed existing convention of using a static_cast of the index argument as its own embedder tag.