### PR TITLE
feat: Add hard timeout support to container startup

### DIFF
--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -28,10 +28,27 @@ class Container: public jsg::Object {
     jsg::Optional<kj::Array<kj::String>> entrypoint;
     bool enableInternet = false;
     jsg::Optional<jsg::Dict<kj::String>> env;
+    jsg::Optional<int64_t> hardTimeout;
 
     // TODO(containers): Allow intercepting stdin/stdout/stderr by specifying streams here.
 
-    JSG_STRUCT(entrypoint, enableInternet, env);
+    JSG_STRUCT(entrypoint, enableInternet, env, hardTimeout);
+    JSG_STRUCT_TS_OVERRIDE_DYNAMIC(CompatibilityFlags::Reader flags) {
+      if (flags.getWorkerdExperimental()) {
+        JSG_TS_OVERRIDE(ContainerStartupOptions {
+          entrypoint?: string[];
+          enableInternet: boolean;
+          env?: Record<string, string>;
+          hardTimeout?: number | bigint;
+        });
+      } else {
+        JSG_TS_OVERRIDE(ContainerStartupOptions {
+          entrypoint?: string[];
+          enableInternet: boolean;
+          env?: Record<string, string>;
+        });
+      }
+    }
   };
 
   bool getRunning() {

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -34,6 +34,12 @@ interface Container @0x9aaceefc06523bca {
     # If null, the container will start with the environment variables defined in its image.
     # The format is defined as a list of `NAME=VALUE`.
     # The container runtime should validate the environment variables input.
+
+    hardTimeoutMs @3 :Int64;
+    # Configures an absolute timeout that starts when the container starts and never resets.
+    # The container will be forcefully terminated when this timeout expires, regardless of activity.
+    # Unlike inactivity timeout, this is a hard deadline from container startup.
+    # If 0 (default), no hard timeout is applied.
   }
 
   monitor @2 () -> (exitCode: Int32);

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3840,6 +3840,7 @@ interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
   env?: Record<string, string>;
+  hardTimeout?: number | bigint;
 }
 /**
  * The **`FileSystemHandle`** interface of the File System API is an object which represents a file or directory entry.

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3851,6 +3851,7 @@ export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
   env?: Record<string, string>;
+  hardTimeout?: number | bigint;
 }
 /**
  * The **`FileSystemHandle`** interface of the File System API is an object which represents a file or directory entry.

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -3736,6 +3736,7 @@ interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
   env?: Record<string, string>;
+  hardTimeout?: number | bigint;
 }
 /**
  * The **`MessagePort`** interface of the Channel Messaging API represents one of the two ports of a MessageChannel, allowing messages to be sent from one port and listening out for them arriving at the other.

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -3747,6 +3747,7 @@ export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
   env?: Record<string, string>;
+  hardTimeout?: number | bigint;
 }
 /**
  * The **`MessagePort`** interface of the Channel Messaging API represents one of the two ports of a MessageChannel, allowing messages to be sent from one port and listening out for them arriving at the other.


### PR DESCRIPTION
- Add hardTimeoutMs to StartupOptions struct
- Implement hard timeout RPC call during container.start()
- Add setHardTimeout @8 method to container.capnp schema
- Hard timeout is absolute from startup, unlike inactivity timeout