### PR TITLE
EW-9366 Provide return event timestamp if span is reported without valid incomingRequest

### DIFF
--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -1469,7 +1469,7 @@ SpanBuilder::SpanBuilder(kj::Maybe<kj::Own<SpanObserver>> observer,
   KJ_IF_SOME(obs, observer) {
     // TODO(o11y): Once we report the user tracing spanOpen event as soon as a span is created, we
     // should be able to fold this virtual call and just get the timestamp directly.
-    span.emplace(kj::mv(operationName), startTime.orDefault(obs->getTime()));
+    span.emplace(kj::mv(operationName), startTime.orDefault([&obs]() { return obs->getTime(); }));
     this->observer = kj::mv(obs);
   }
 }


### PR DESCRIPTION
Edge testing showed that the given error only happens after the return event timestamp has already been provided, which happens in one edge case when a DO request is aborted and spans are only reported as the IncomingRequest is being destructed. At that time, we can't look up the time anymore, but the return event timestamp will still be helpful.
As indicated in the TODO comment for the case where the IoContext itself is no longer available, we'll want to change span lifetimes at a later time so that they don't outlive the IncomingRequest/IoContext, but for now we'll provide the reasonable timestamp available to us.

Also perform some cleanup while we're at it (promote warnings to errors since we've always had the return event available in this case so if they still appear that's an actual issue, avoid superfluous timer lookups).