### PR TITLE
Revert "Improve backpressure handling in Node writable adapter"

### DIFF
--- a/src/node/internal/streams_writable.js
+++ b/src/node/internal/streams_writable.js
@@ -1035,13 +1035,12 @@ export function newStreamWritableFromWritableStream(
         }
       }
 
-      const writes = async () => {
-        for (let n = 0; n < chunks.length; n++) {
-          if (writer.desiredSize <= 0) await writer.ready;
-          writer.write(chunks[n].chunk);
-        }
-      };
-      writes().then(done, done);
+      writer.ready.then(() => {
+        return Promise.all(chunks.map((data) => writer.write(data))).then(
+          done,
+          done
+        );
+      }, done);
     },
 
     write(chunk, encoding, callback) {


### PR DESCRIPTION
The back pressure change causes some issues in some cases that need to be investigated further.

This reverts commit bb90ccf18c253fbd7c0170bee39e530a3a5cd69a.