### PR TITLE
Use a ring buffer over kj::Array rather than std::list for queue entries

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -121,6 +121,7 @@ wd_cc_library(
         "//src/workerd/util:checked-queue",
         "//src/workerd/util:completion-membrane",
         "//src/workerd/util:exception",
+        "//src/workerd/util:ring-buffer",
         "//src/workerd/util:sqlite",
         "//src/workerd/util:strong-bool",
         "//src/workerd/util:thread-scopes",

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -76,6 +76,13 @@ wd_cc_library(
 )
 
 wd_cc_library(
+    name = "ring-buffer",
+    hdrs = ["ring-buffer.h"],
+    visibility = ["//visibility:public"],
+    deps = ["@capnp-cpp//src/kj"],
+)
+
+wd_cc_library(
     name = "mimetype",
     srcs = ["mimetype.c++"],
     hdrs = ["mimetype.h"],
@@ -332,4 +339,9 @@ kj_test(
 kj_test(
     src = "checked-queue-test.c++",
     deps = [":checked-queue"],
+)
+
+kj_test(
+    src = "ring-buffer-test.c++",
+    deps = [":ring-buffer"],
 )

--- a/src/workerd/util/ring-buffer-test.c++
+++ b/src/workerd/util/ring-buffer-test.c++
@@ -1,0 +1,518 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "ring-buffer.h"
+
+#include <kj/test.h>
+
+namespace workerd {
+namespace {
+
+using kj::uint;
+
+KJ_TEST("RingBuffer basic operations") {
+  RingBuffer<int> buffer;
+
+  KJ_EXPECT(buffer.empty());
+  KJ_EXPECT(buffer.size() == 0);
+
+  buffer.push_back(1);
+  KJ_EXPECT(!buffer.empty());
+  KJ_EXPECT(buffer.size() == 1);
+  KJ_EXPECT(buffer.front() == 1);
+  KJ_EXPECT(buffer.back() == 1);
+
+  buffer.push_back(2);
+  KJ_EXPECT(buffer.size() == 2);
+  KJ_EXPECT(buffer.front() == 1);
+  KJ_EXPECT(buffer.back() == 2);
+
+  buffer.push_back(3);
+  KJ_EXPECT(buffer.size() == 3);
+  KJ_EXPECT(buffer.front() == 1);
+  KJ_EXPECT(buffer.back() == 3);
+
+  buffer.pop_front();
+  KJ_EXPECT(buffer.size() == 2);
+  KJ_EXPECT(buffer.front() == 2);
+  KJ_EXPECT(buffer.back() == 3);
+
+  buffer.pop_front();
+  KJ_EXPECT(buffer.size() == 1);
+  KJ_EXPECT(buffer.front() == 3);
+  KJ_EXPECT(buffer.back() == 3);
+
+  buffer.pop_front();
+  KJ_EXPECT(buffer.empty());
+  KJ_EXPECT(buffer.size() == 0);
+}
+
+KJ_TEST("RingBuffer push_back with move semantics") {
+  RingBuffer<kj::String> buffer;
+
+  auto str1 = kj::heapString("hello");
+  auto str2 = kj::heapString("world");
+
+  buffer.push_back(kj::mv(str1));
+  buffer.push_back(kj::mv(str2));
+
+  KJ_EXPECT(buffer.size() == 2);
+  KJ_EXPECT(buffer.front() == "hello");
+  KJ_EXPECT(buffer.back() == "world");
+}
+
+KJ_TEST("RingBuffer push_back with copy") {
+  RingBuffer<int> buffer;
+
+  int value = 42;
+  buffer.push_back(value);
+  KJ_EXPECT(buffer.size() == 1);
+  KJ_EXPECT(buffer.front() == 42);
+  KJ_EXPECT(value == 42);  // Original value unchanged
+}
+
+KJ_TEST("RingBuffer emplace_back") {
+  struct TestStruct {
+    int a = 0;
+    TestStruct() = default;
+    TestStruct(int a): a(a) {}
+    TestStruct(const TestStruct&) = default;
+    TestStruct& operator=(const TestStruct&) = default;
+  };
+
+  RingBuffer<TestStruct> buffer;
+
+  auto& ref = buffer.emplace_back(10);
+  KJ_EXPECT(buffer.size() == 1);
+  KJ_EXPECT(ref.a == 10);
+  KJ_EXPECT(buffer.front().a == 10);
+}
+
+KJ_TEST("RingBuffer clear") {
+  RingBuffer<int> buffer;
+
+  for (int i = 0; i < 10; i++) {
+    buffer.push_back(i);
+  }
+  KJ_EXPECT(buffer.size() == 10);
+
+  buffer.clear();
+  KJ_EXPECT(buffer.empty());
+  KJ_EXPECT(buffer.size() == 0);
+
+  // Should be able to use after clear
+  buffer.push_back(1);
+  KJ_EXPECT(buffer.size() == 1);
+  KJ_EXPECT(buffer.front() == 1);
+}
+
+KJ_TEST("RingBuffer iterator basic") {
+  RingBuffer<int> buffer;
+
+  for (int i = 0; i < 5; i++) {
+    buffer.push_back(i);
+  }
+
+  int expected = 0;
+  for (auto it = buffer.begin(); it != buffer.end(); ++it) {
+    KJ_EXPECT(*it == expected++);
+  }
+  KJ_EXPECT(expected == 5);
+}
+
+KJ_TEST("RingBuffer iterator range-based for loop") {
+  RingBuffer<int> buffer;
+
+  for (int i = 1; i <= 5; i++) {
+    buffer.push_back(i * 10);
+  }
+
+  int expected = 10;
+  for (auto& value: buffer) {
+    KJ_EXPECT(value == expected);
+    expected += 10;
+  }
+  KJ_EXPECT(expected == 60);
+}
+
+KJ_TEST("RingBuffer iterator modification") {
+  RingBuffer<int> buffer;
+
+  for (int i = 0; i < 5; i++) {
+    buffer.push_back(i);
+  }
+
+  // Modify through iterator
+  for (auto& value: buffer) {
+    value *= 2;
+  }
+
+  int expected = 0;
+  for (const auto& value: buffer) {
+    KJ_EXPECT(value == expected * 2);
+    expected++;
+  }
+}
+
+KJ_TEST("RingBuffer const_iterator") {
+  RingBuffer<int> buffer;
+
+  for (int i = 0; i < 5; i++) {
+    buffer.push_back(i);
+  }
+
+  const auto& constBuffer = buffer;
+
+  int expected = 0;
+  for (auto it = constBuffer.begin(); it != constBuffer.end(); ++it) {
+    KJ_EXPECT(*it == expected++);
+  }
+}
+
+KJ_TEST("RingBuffer iterator decrement") {
+  RingBuffer<int> buffer;
+
+  for (int i = 0; i < 5; i++) {
+    buffer.push_back(i);
+  }
+
+  auto it = buffer.end();
+  --it;
+  KJ_EXPECT(*it == 4);
+  --it;
+  KJ_EXPECT(*it == 3);
+
+  it--;
+  KJ_EXPECT(*it == 2);
+}
+
+KJ_TEST("RingBuffer iterator equality") {
+  RingBuffer<int> buffer;
+  buffer.push_back(1);
+  buffer.push_back(2);
+
+  auto it1 = buffer.begin();
+  auto it2 = buffer.begin();
+  KJ_EXPECT(it1 == it2);
+
+  ++it2;
+  KJ_EXPECT(it1 != it2);
+
+  auto end1 = buffer.end();
+  auto end2 = buffer.end();
+  KJ_EXPECT(end1 == end2);
+}
+
+KJ_TEST("RingBuffer iterator arrow operator") {
+  struct Point {
+    int x;
+    int y;
+  };
+
+  RingBuffer<Point> buffer;
+  buffer.push_back(Point{1, 2});
+  buffer.push_back(Point{3, 4});
+
+  auto it = buffer.begin();
+  KJ_EXPECT(it->x == 1);
+  KJ_EXPECT(it->y == 2);
+
+  ++it;
+  KJ_EXPECT(it->x == 3);
+  KJ_EXPECT(it->y == 4);
+}
+
+KJ_TEST("RingBuffer growth when capacity exceeded") {
+  RingBuffer<int, 4> buffer;  // Small initial capacity
+
+  // Fill beyond initial capacity
+  for (int i = 0; i < 10; i++) {
+    buffer.push_back(i);
+  }
+
+  KJ_EXPECT(buffer.size() == 10);
+
+  // Verify all elements are intact
+  int expected = 0;
+  for (const auto& value: buffer) {
+    KJ_EXPECT(value == expected++);
+  }
+  KJ_EXPECT(expected == 10);
+}
+
+KJ_TEST("RingBuffer growth maintains order across wrap-around") {
+  RingBuffer<int, 4> buffer;
+
+  // Create wrap-around scenario: fill, then pop, then fill again
+  buffer.push_back(1);
+  buffer.push_back(2);
+  buffer.push_back(3);
+  buffer.push_back(4);
+
+  buffer.pop_front();  // Remove 1
+  buffer.pop_front();  // Remove 2
+
+  // Now head is at index 2, tail wraps around
+  buffer.push_back(5);
+  buffer.push_back(6);
+  buffer.push_back(7);  // This should trigger growth
+
+  KJ_EXPECT(buffer.size() == 5);
+
+  // Verify order is maintained: 3, 4, 5, 6, 7
+  int expected = 3;
+  for (const auto& value: buffer) {
+    KJ_EXPECT(value == expected++);
+  }
+  KJ_EXPECT(expected == 8);
+}
+
+KJ_TEST("RingBuffer with non-trivial types") {
+  struct ComplexType {
+    kj::String str;
+    kj::Vector<int> vec;
+
+    ComplexType(kj::String s): str(kj::mv(s)) {
+      vec.add(1);
+      vec.add(2);
+    }
+
+    ComplexType(ComplexType&& other) = default;
+    ComplexType& operator=(ComplexType&& other) = default;
+
+    KJ_DISALLOW_COPY(ComplexType);
+  };
+
+  RingBuffer<kj::Own<ComplexType>> buffer;
+
+  buffer.push_back(kj::heap<ComplexType>(kj::str("first")));
+  buffer.push_back(kj::heap<ComplexType>(kj::str("second")));
+  buffer.push_back(kj::heap<ComplexType>(kj::str("third")));
+
+  KJ_EXPECT(buffer.size() == 3);
+  KJ_EXPECT(buffer.front()->str == "first");
+  KJ_EXPECT(buffer.back()->str == "third");
+
+  buffer.pop_front();
+  KJ_EXPECT(buffer.front()->str == "second");
+}
+
+KJ_TEST("RingBuffer destructor calls element destructors") {
+  struct DestructionDetector {
+    DestructionDetector(uint& count): count(count) {}
+    ~DestructionDetector() noexcept(false) {
+      ++count;
+    }
+    KJ_DISALLOW_COPY_AND_MOVE(DestructionDetector);
+    uint& count;
+  };
+
+  uint destructionCount = 0;
+
+  {
+    RingBuffer<kj::Own<DestructionDetector>> buffer;
+    buffer.push_back(kj::heap<DestructionDetector>(destructionCount));
+    buffer.push_back(kj::heap<DestructionDetector>(destructionCount));
+    buffer.push_back(kj::heap<DestructionDetector>(destructionCount));
+
+    KJ_EXPECT(destructionCount == 0);
+  }  // Buffer goes out of scope
+
+  KJ_EXPECT(destructionCount == 3);
+}
+
+KJ_TEST("RingBuffer pop_front calls element destructor") {
+  struct DestructionDetector {
+    DestructionDetector(uint& count): count(count) {}
+    ~DestructionDetector() noexcept(false) {
+      ++count;
+    }
+    KJ_DISALLOW_COPY_AND_MOVE(DestructionDetector);
+    uint& count;
+  };
+
+  uint destructionCount = 0;
+
+  RingBuffer<kj::Own<DestructionDetector>> buffer;
+  buffer.push_back(kj::heap<DestructionDetector>(destructionCount));
+  buffer.push_back(kj::heap<DestructionDetector>(destructionCount));
+
+  KJ_EXPECT(destructionCount == 0);
+
+  buffer.pop_front();
+  KJ_EXPECT(destructionCount == 1);
+
+  buffer.pop_front();
+  KJ_EXPECT(destructionCount == 2);
+}
+
+KJ_TEST("RingBuffer clear calls all element destructors") {
+  struct DestructionDetector {
+    DestructionDetector(uint& count): count(count) {}
+    ~DestructionDetector() noexcept(false) {
+      ++count;
+    }
+    KJ_DISALLOW_COPY_AND_MOVE(DestructionDetector);
+    uint& count;
+  };
+
+  uint destructionCount = 0;
+
+  RingBuffer<kj::Own<DestructionDetector>> buffer;
+  for (int i = 0; i < 5; i++) {
+    buffer.push_back(kj::heap<DestructionDetector>(destructionCount));
+  }
+
+  KJ_EXPECT(destructionCount == 0);
+
+  buffer.clear();
+  KJ_EXPECT(destructionCount == 5);
+  KJ_EXPECT(buffer.empty());
+}
+
+KJ_TEST("RingBuffer stress test - many operations") {
+  RingBuffer<int, 4> buffer;
+
+  // Perform many mixed operations
+  for (int i = 0; i < 100; i++) {
+    buffer.push_back(i);
+  }
+
+  for (int i = 0; i < 50; i++) {
+    buffer.pop_front();
+  }
+
+  for (int i = 100; i < 150; i++) {
+    buffer.push_back(i);
+  }
+
+  KJ_EXPECT(buffer.size() == 100);
+
+  // Verify contents
+  int expected = 50;
+  for (const auto& value: buffer) {
+    KJ_EXPECT(value == expected++);
+  }
+}
+
+KJ_TEST("RingBuffer empty buffer iterators") {
+  RingBuffer<int> buffer;
+
+  KJ_EXPECT(buffer.begin() == buffer.end());
+  KJ_EXPECT(buffer.cbegin() == buffer.cend());
+
+  // Range-based for should not execute
+  for ([[maybe_unused]] auto& value: buffer) {
+    KJ_FAIL_EXPECT("Should not iterate over empty buffer");
+  }
+}
+
+KJ_TEST("RingBuffer single element") {
+  RingBuffer<int> buffer;
+  buffer.push_back(42);
+
+  KJ_EXPECT(buffer.front() == 42);
+  KJ_EXPECT(buffer.back() == 42);
+  KJ_EXPECT(buffer.size() == 1);
+
+  int count = 0;
+  for (const auto& value: buffer) {
+    KJ_EXPECT(value == 42);
+    count++;
+  }
+  KJ_EXPECT(count == 1);
+}
+
+KJ_TEST("RingBuffer alternating push/pop maintains correctness") {
+  RingBuffer<int, 4> buffer;
+
+  for (int round = 0; round < 10; round++) {
+    buffer.push_back(round * 2);
+    buffer.push_back(round * 2 + 1);
+
+    KJ_EXPECT(buffer.front() == round * 2);
+    buffer.pop_front();
+
+    KJ_EXPECT(buffer.front() == round * 2 + 1);
+    buffer.pop_front();
+
+    KJ_EXPECT(buffer.empty());
+  }
+}
+
+KJ_TEST("RingBuffer with custom initial capacity") {
+  RingBuffer<int, 128> largeBuffer;
+  RingBuffer<int, 2> tinyBuffer;
+
+  // Both should work correctly regardless of initial capacity
+  for (int i = 0; i < 10; i++) {
+    largeBuffer.push_back(i);
+    tinyBuffer.push_back(i);
+  }
+
+  KJ_EXPECT(largeBuffer.size() == 10);
+  KJ_EXPECT(tinyBuffer.size() == 10);
+
+  int expected = 0;
+  for (const auto& value: largeBuffer) {
+    KJ_EXPECT(value == expected++);
+  }
+
+  expected = 0;
+  for (const auto& value: tinyBuffer) {
+    KJ_EXPECT(value == expected++);
+  }
+}
+
+KJ_TEST("RingBuffer front and back with wrap-around") {
+  RingBuffer<int, 4> buffer;
+
+  buffer.push_back(1);
+  buffer.push_back(2);
+  buffer.push_back(3);
+  buffer.push_back(4);
+
+  // Create wrap-around
+  buffer.pop_front();
+  buffer.pop_front();
+  buffer.push_back(5);
+  buffer.push_back(6);
+
+  KJ_EXPECT(buffer.size() == 4);
+  KJ_EXPECT(buffer.front() == 3);
+  KJ_EXPECT(buffer.back() == 6);
+}
+
+KJ_TEST("RingBuffer emplace_back returns reference") {
+  RingBuffer<int> buffer;
+
+  auto& ref1 = buffer.emplace_back(10);
+  ref1 = 20;
+
+  KJ_EXPECT(buffer.front() == 20);
+
+  buffer.emplace_back(30);
+  buffer.emplace_back(40);
+
+  auto& ref2 = buffer.emplace_back(50);
+  ref2 = 60;
+
+  KJ_EXPECT(buffer.back() == 60);
+}
+
+KJ_TEST("RingBuffer iterator conversion from mutable to const") {
+  RingBuffer<int> buffer;
+  buffer.push_back(1);
+  buffer.push_back(2);
+
+  auto it = buffer.begin();
+  RingBuffer<int>::const_iterator cit = it;  // Conversion
+
+  KJ_EXPECT(*cit == 1);
+  ++cit;
+  KJ_EXPECT(*cit == 2);
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/util/ring-buffer.h
+++ b/src/workerd/util/ring-buffer.h
@@ -1,0 +1,277 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <kj/debug.h>
+#include <kj/vector.h>
+
+#include <iterator>
+
+namespace workerd {
+
+// A simple ring buffer with amortized O(1) push/pop at both ends and O(1) random access
+// built on top of kj::Vector but with the same interface as std::list. The initial capacity
+// can be specified as a template parameter (default 16). The buffer will grow as needed.
+// The type T must be Moveable and/or Copyable.
+//
+// The purpose of this class is to provide a more memory-efficient alternative to std::list
+// for use in places where we need a double-ended queue with stable iterators and references
+// but avoids the memory overhead of std::list's per-node allocations and has better cache
+// locality than std::list. The trade-off is that iterators and references may be
+// invalidated when the buffer grows, which is not the case with std::list. However,
+// in our use cases, we do not rely on iterator/reference stability across growth
+// operations, so this fine.
+template <typename T, size_t InitialCapacity = 16>
+class RingBuffer final {
+ public:
+  RingBuffer() {
+    storage.resize(InitialCapacity);
+  }
+
+  bool empty() const {
+    return count == 0;
+  }
+  size_t size() const {
+    return count;
+  }
+
+  class iterator;
+  class const_iterator;
+
+  class iterator {
+   public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using reference = T&;
+
+    iterator(): buffer(nullptr), index(0) {}
+
+    reference operator*() const {
+      KJ_DREQUIRE(buffer != nullptr);
+      size_t physicalIndex = (buffer->head + index) % buffer->storage.size();
+      return buffer->storage[physicalIndex];
+    }
+
+    pointer operator->() const {
+      KJ_DREQUIRE(buffer != nullptr);
+      size_t physicalIndex = (buffer->head + index) % buffer->storage.size();
+      return &buffer->storage[physicalIndex];
+    }
+
+    iterator& operator++() {
+      KJ_DREQUIRE(buffer != nullptr);
+      ++index;
+      return *this;
+    }
+
+    iterator operator++(int) {
+      iterator tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+
+    iterator& operator--() {
+      KJ_DREQUIRE(buffer != nullptr);
+      --index;
+      return *this;
+    }
+
+    iterator operator--(int) {
+      iterator tmp = *this;
+      --(*this);
+      return tmp;
+    }
+
+    bool operator==(const iterator& other) const {
+      return buffer == other.buffer && index == other.index;
+    }
+
+    bool operator!=(const iterator& other) const {
+      return !(*this == other);
+    }
+
+   private:
+    friend class RingBuffer;
+    friend class const_iterator;
+
+    iterator(RingBuffer* buf, size_t idx): buffer(buf), index(idx) {}
+
+    RingBuffer* buffer;
+    size_t index;  // Logical index (0 to count-1)
+  };
+
+  class const_iterator {
+   public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const T*;
+    using reference = const T&;
+
+    const_iterator(): buffer(nullptr), index(0) {}
+
+    const_iterator(const iterator& it): buffer(it.buffer), index(it.index) {}
+
+    reference operator*() const {
+      KJ_DREQUIRE(buffer != nullptr);
+      size_t physicalIndex = (buffer->head + index) % buffer->storage.size();
+      return buffer->storage[physicalIndex];
+    }
+
+    pointer operator->() const {
+      KJ_DREQUIRE(buffer != nullptr);
+      size_t physicalIndex = (buffer->head + index) % buffer->storage.size();
+      return &buffer->storage[physicalIndex];
+    }
+
+    const_iterator& operator++() {
+      KJ_DREQUIRE(buffer != nullptr);
+      ++index;
+      return *this;
+    }
+
+    const_iterator operator++(int) {
+      const_iterator tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+
+    const_iterator& operator--() {
+      KJ_DREQUIRE(buffer != nullptr);
+      --index;
+      return *this;
+    }
+
+    const_iterator operator--(int) {
+      const_iterator tmp = *this;
+      --(*this);
+      return tmp;
+    }
+
+    bool operator==(const const_iterator& other) const {
+      return buffer == other.buffer && index == other.index;
+    }
+
+    bool operator!=(const const_iterator& other) const {
+      return !(*this == other);
+    }
+
+   private:
+    friend class RingBuffer;
+
+    const_iterator(const RingBuffer* buf, size_t idx): buffer(buf), index(idx) {}
+
+    const RingBuffer* buffer;
+    size_t index;
+  };
+
+  iterator begin() {
+    return iterator(this, 0);
+  }
+
+  iterator end() {
+    return iterator(this, count);
+  }
+
+  const_iterator begin() const {
+    return const_iterator(this, 0);
+  }
+
+  const_iterator end() const {
+    return const_iterator(this, count);
+  }
+
+  const_iterator cbegin() const {
+    return const_iterator(this, 0);
+  }
+
+  const_iterator cend() const {
+    return const_iterator(this, count);
+  }
+
+  void push_back(T&& item) {
+    if (count == storage.size()) {
+      grow();
+    }
+    storage[tail] = kj::mv(item);
+    tail = (tail + 1) % storage.size();
+    count++;
+  }
+
+  void push_back(const T& item) {
+    if (count == storage.size()) {
+      grow();
+    }
+    storage[tail] = item;
+    tail = (tail + 1) % storage.size();
+    count++;
+  }
+
+  template <typename... Args>
+  T& emplace_back(Args&&... args) {
+    if (count == storage.size()) {
+      grow();
+    }
+    // Construct in place at the tail position
+    storage[tail] = T(kj::fwd<Args>(args)...);
+    size_t insertedIndex = tail;
+    tail = (tail + 1) % storage.size();
+    count++;
+    return storage[insertedIndex];
+  }
+
+  void pop_front() {
+    KJ_DREQUIRE(count > 0);
+    storage[head].~T();
+    head = (head + 1) % storage.size();
+    count--;
+  }
+
+  T& front() {
+    KJ_DREQUIRE(count > 0);
+    return storage[head];
+  }
+
+  T& back() {
+    KJ_DREQUIRE(count > 0);
+    size_t backIdx = (tail == 0) ? storage.size() - 1 : tail - 1;
+    return storage[backIdx];
+  }
+
+  void clear() {
+    while (count > 0) {
+      storage[head].~T();
+      head = (head + 1) % storage.size();
+      count--;
+    }
+    // Reset to initial state
+    head = 0;
+    tail = 0;
+  }
+
+ private:
+  kj::Vector<T> storage;
+  size_t head = 0;
+  size_t tail = 0;
+  size_t count = 0;
+
+  void grow() {
+    size_t newCapacity = storage.size() * 2;
+    kj::Vector<T> newStorage;
+    newStorage.resize(newCapacity);
+
+    for (size_t i = 0; i < count; i++) {
+      newStorage[i] = kj::mv(storage[(head + i) % storage.size()]);
+    }
+
+    storage = kj::mv(newStorage);
+    head = 0;
+    tail = count;
+  }
+};
+
+}  // namespace workerd


### PR DESCRIPTION
Adds a RingBuffer<T> impl based on kj::Array<T> to replace std::list in the streams queue. This should reduce the number of allocations necessary for large queues by eliminating the per-node allocation. It should also improve cache locality by a significant margin. It implements the same API as std::list so it ends up being a drop in replacement.

Builds on https://github.com/cloudflare/workerd/pull/5287 which must land first.