### PR TITLE
Python: Disable vendor tests on windows

### DIFF
--- a/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
@@ -1,11 +1,5 @@
 load(":vendor_test.bzl", "vendored_py_wd_test")
 
-vendored_py_wd_test(
-    "fastapi",
-    skip_python_flags = ["0.28.2"],
-)
+vendored_py_wd_test("fastapi")
 
-vendored_py_wd_test(
-    "beautifulsoup4",
-    skip_python_flags = ["0.28.2"],
-)
+vendored_py_wd_test("beautifulsoup4")

--- a/src/workerd/server/tests/python/vendor_pkg_tests/vendor_test.bzl
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/vendor_test.bzl
@@ -65,6 +65,12 @@ with open('$@', 'w') as f:
             main_py_file,
             vendored_srcs_target,
         ],
+        # Disable on windows because of flakiness
+        # TODO fix this
+        target_compatible_with = select({
+            "@platforms//os:windows": ["@platforms//:incompatible"],
+            "//conditions:default": [],
+        }),
         **kwds
     )
 


### PR DESCRIPTION
And enable on 0.28.2