### PR TITLE
Add reranking controls to AutoRAG binding search methods

### DIFF
--- a/src/cloudflare/internal/autorag-api.ts
+++ b/src/cloudflare/internal/autorag-api.ts
@@ -71,6 +71,10 @@ export type AutoRagSearchRequest = {
     ranker?: string;
     score_threshold?: number;
   };
+  reranking?: {
+    enabled?: boolean;
+    model?: string;
+  };
   rewrite_query?: boolean;
 };
 

--- a/types/defines/autorag.d.ts
+++ b/types/defines/autorag.d.ts
@@ -20,6 +20,10 @@ export type AutoRagSearchRequest = {
     ranker?: string;
     score_threshold?: number;
   };
+  reranking?: {
+    enabled?: boolean;
+    model?: string;
+  };
   rewrite_query?: boolean;
 };
 export type AutoRagAiSearchRequest = AutoRagSearchRequest & {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -8241,6 +8241,10 @@ type AutoRagSearchRequest = {
     ranker?: string;
     score_threshold?: number;
   };
+  reranking?: {
+    enabled?: boolean;
+    model?: string;
+  };
   rewrite_query?: boolean;
 };
 type AutoRagAiSearchRequest = AutoRagSearchRequest & {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -8262,6 +8262,10 @@ export type AutoRagSearchRequest = {
     ranker?: string;
     score_threshold?: number;
   };
+  reranking?: {
+    enabled?: boolean;
+    model?: string;
+  };
   rewrite_query?: boolean;
 };
 export type AutoRagAiSearchRequest = AutoRagSearchRequest & {

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -7634,6 +7634,10 @@ type AutoRagSearchRequest = {
     ranker?: string;
     score_threshold?: number;
   };
+  reranking?: {
+    enabled?: boolean;
+    model?: string;
+  };
   rewrite_query?: boolean;
 };
 type AutoRagAiSearchRequest = AutoRagSearchRequest & {

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -7653,6 +7653,10 @@ export type AutoRagSearchRequest = {
     ranker?: string;
     score_threshold?: number;
   };
+  reranking?: {
+    enabled?: boolean;
+    model?: string;
+  };
   rewrite_query?: boolean;
 };
 export type AutoRagAiSearchRequest = AutoRagSearchRequest & {


### PR DESCRIPTION
Extends the `search` and `aiSearch` methods of the AI Search binding (`autorag`) to include the newly added re-ranking controls.