### PR TITLE
Fix `Cluster.setupMaster()` method to call `setupMaster()` function

### DIFF
--- a/src/node/cluster.ts
+++ b/src/node/cluster.ts
@@ -95,7 +95,7 @@ export class Cluster extends EventEmitter implements _Cluster {
     setupPrimary(settings);
   }
   setupMaster(settings?: ClusterSettings): void {
-    setupPrimary(settings);
+    setupMaster(settings);
   }
   disconnect(): void {
     disconnect();


### PR DESCRIPTION
It was incorrectly calling `setupPrimary()`, which doesn't really matter, right now, since both functions are "not implemented" and just throw.