### PR TITLE
Update Node version used for release to 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
   id-token: write
   contents: read
   actions: write
-  
+
 jobs:
   version:
     outputs:
@@ -185,7 +185,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Modify package.json version
         run: node npm/scripts/bump-version.mjs npm/workerd-${{ matrix.arch }}/package.json
         env:
@@ -247,7 +247,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Cache
         id: cache


### PR DESCRIPTION
This is a follow-up to https://github.com/cloudflare/workerd/pull/5302 to ensure that the version of the npm CLI used is compatible with [trusted publishing](https://docs.npmjs.com/trusted-publishers).

I think we can also delete the following lines but I can do another PR for that once we've confirmed the release has succeeded as is.

https://github.com/cloudflare/workerd/blob/aeaff544c56955a9dd5c9856750d88e25bd9e999/.github/workflows/release.yml#L198-L199