### PR TITLE
remove esm/cjs warning on esbuild on pyodide

### DIFF
--- a/src/pyodide/internal/pool/esbuild.config.mjs
+++ b/src/pyodide/internal/pool/esbuild.config.mjs
@@ -37,4 +37,11 @@ let resolvePlugin = {
 
 export default {
   plugins: [resolvePlugin],
+  logOverride: {
+    // Suppress warning about CommonJS 'module' variable in pyodide.asm.js (ES module context)
+    // The pyodide.asm.js file contains embedded libraries (like MiniLZ4) that use CommonJS
+    // style module.exports checks for compatibility. These are safe to ignore as they won't
+    // execute in our ES module context.
+    'commonjs-variable-in-esm': 'silent',
+  },
 };


### PR DESCRIPTION
This has been on my radar for a really long time.