### PR TITLE
[o11y] EW-9682 Fix missing Onset event under JSRpc with logLevel none

### DIFF
--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -512,9 +512,8 @@ void BaseTracer::adjustSpanTime(CompleteSpan& span) {
 
 void WorkerTracer::setReturn(
     kj::Maybe<kj::Date> timestamp, kj::Maybe<tracing::FetchResponseInfo> fetchResponseInfo) {
-  // Match the behavior of setEventInfo(). Any resolution of the TODO comments
-  // in setEventInfo() that are related to this check while probably also affect
-  // this function.
+  // Match the behavior of setEventInfo(). Any resolution of the TODO comments in setEventInfo()
+  // that are related to this check will probably also affect this function.
   if (pipelineLogLevel == PipelineLogLevel::NONE) {
     return;
   }
@@ -553,6 +552,10 @@ SpanParent BaseTracer::getUserRequestSpan() {
 void WorkerTracer::setJsRpcInfo(const tracing::InvocationSpanContext& context,
     kj::Date timestamp,
     const kj::ConstString& methodName) {
+  if (pipelineLogLevel == PipelineLogLevel::NONE) {
+    return;
+  }
+
   // Update the method name in the already-set JsRpcEventInfo for LTW compatibility
   KJ_IF_SOME(info, trace->eventInfo) {
     KJ_SWITCH_ONEOF(info) {


### PR DESCRIPTION
This appears to be the only place where the logLevel check is strictly needed and we were missing it.

Also see the regression test added downstream (same branch).