### PR TITLE
use native base64/hex methods added to Uint8Array

### DIFF
--- a/src/cloudflare/internal/to-markdown-api.ts
+++ b/src/cloudflare/internal/to-markdown-api.ts
@@ -1,6 +1,36 @@
 import { AiInternalError } from 'cloudflare-internal:ai-api';
 import type { GatewayOptions } from 'cloudflare-internal:aig-api';
-import base64 from 'cloudflare-internal:base64';
+
+// TODO(soon): Remove this once TypeScript recognizes base64/hex methods
+// Type declarations for V8 14.1+ ArrayBuffer base64/hex methods
+// https://tc39.es/proposal-arraybuffer-base64/
+declare global {
+  interface Uint8Array {
+    toHex(): string;
+    toBase64(options?: {
+      alphabet?: 'base64' | 'base64url';
+      omitPadding?: boolean;
+    }): string;
+    setFromHex(hexString: string): { read: number; written: number };
+    setFromBase64(
+      base64String: string,
+      options?: {
+        alphabet?: 'base64' | 'base64url';
+        lastChunkHandling?: 'loose' | 'strict' | 'stop-before-partial';
+      }
+    ): { read: number; written: number };
+  }
+  interface Uint8ArrayConstructor {
+    fromHex(hexString: string): Uint8Array;
+    fromBase64(
+      base64String: string,
+      options?: {
+        alphabet?: 'base64' | 'base64url';
+        lastChunkHandling?: 'loose' | 'strict' | 'stop-before-partial';
+      }
+    ): Uint8Array;
+  }
+}
 
 interface Fetcher {
   fetch: typeof fetch;
@@ -27,7 +57,8 @@ export type SupportedFileFormat = {
 };
 
 async function blobToBase64(blob: Blob): Promise<string> {
-  return base64.encodeArrayToString(await blob.arrayBuffer());
+  const arrayBuffer = await blob.arrayBuffer();
+  return new Uint8Array(arrayBuffer).toBase64();
 }
 
 export class ToMarkdownService {

--- a/src/node/internal/crypto_random.ts
+++ b/src/node/internal/crypto_random.ts
@@ -399,7 +399,8 @@ function unsignedBigIntToBuffer(bigint: bigint, name: string): Buffer {
 
   const hex = bigint.toString(16);
   const padded = hex.padStart(hex.length + (hex.length % 2), '0');
-  return Buffer.from(padded, 'hex');
+  const u8 = Uint8Array.fromHex(padded);
+  return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
 }
 
 function validateCandidate(candidate: PrimeNum): Buffer {

--- a/src/node/internal/internal_http_client.ts
+++ b/src/node/internal/internal_http_client.ts
@@ -71,6 +71,7 @@ export class ClientRequest extends OutgoingMessage implements _ClientRequest {
     search?: string | undefined;
     hash?: string | undefined;
   };
+  #encoder: TextEncoder | undefined;
 
   _ended: boolean = false;
 
@@ -276,9 +277,10 @@ export class ClientRequest extends OutgoingMessage implements _ClientRequest {
       }
 
       if (options.auth && !this.getHeader('Authorization')) {
+        this.#encoder ??= new TextEncoder();
         this.setHeader(
           'Authorization',
-          'Basic ' + Buffer.from(options.auth).toString('base64')
+          'Basic ' + this.#encoder.encode(options.auth).toBase64()
         );
       }
     } else {

--- a/src/pyodide/internal/pool/sentinel.ts
+++ b/src/pyodide/internal/pool/sentinel.ts
@@ -2,44 +2,24 @@
 // It goes into `pyodide.js` not `pyodide.asm.js`. We don't use `pyodide.js` so we have to reproduce
 // it here.
 
-// Per https://github.com/tc39/proposal-arraybuffer-base64/issues/51#issuecomment-3010378969, we
-// should be able to replace `decodeBase64()` with `Uint8Array.fromBase64()` once we update to a v8
-// released after September 2nd.
-const base64Lookup = new Uint8Array(128);
-for (let t = 0; t < 64; t++) {
-  let idx;
-  if (t < 26) {
-    idx = t + 65;
-  } else if (t < 52) {
-    idx = t + 71;
-  } else if (t < 62) {
-    idx = t - 4;
-  } else {
-    idx = t * 4 - 205;
+// TODO(soon): Remove this once TypeScript recognizes base64/hex methods
+// Type declarations for V8 14.1+ ArrayBuffer base64/hex methods
+// https://tc39.es/proposal-arraybuffer-base64/
+declare global {
+  interface Uint8ArrayConstructor {
+    fromBase64(
+      base64String: string,
+      options?: {
+        alphabet?: 'base64' | 'base64url';
+        lastChunkHandling?: 'loose' | 'strict' | 'stop-before-partial';
+      }
+    ): Uint8Array;
   }
-  base64Lookup[idx] = t;
-}
-
-function decodeBase64(input: string): Uint8Array {
-  const outputSize = ((input.length * 3) / 4) | 0;
-  const output = new Uint8Array(outputSize);
-  let inIdx = 0;
-  let outIdx = 0;
-  while (inIdx < input.length) {
-    const chunk1 = base64Lookup[input.charCodeAt(inIdx++)]!;
-    const chunk2 = base64Lookup[input.charCodeAt(inIdx++)]!;
-    const chunk3 = base64Lookup[input.charCodeAt(inIdx++)]!;
-    const chunk4 = base64Lookup[input.charCodeAt(inIdx++)]!;
-    output[outIdx++] = (chunk1 << 2) | (chunk2 >> 4);
-    output[outIdx++] = (chunk2 << 4) | (chunk3 >> 2);
-    output[outIdx++] = (chunk3 << 6) | chunk4;
-  }
-  return output;
 }
 
 // This string is https://github.com/pyodide/pyodide/blob/main/src/core/sentinel.wat assembled and
-// hex encoded.
-const sentinelWasm = decodeBase64(
+// base64 encoded.
+const sentinelWasm = Uint8Array.fromBase64(
   'AGFzbQEAAAABDANfAGAAAW9gAW8BfwMDAgECByECD2NyZWF0ZV9zZW50aW5lbAAAC2lzX3NlbnRpbmVsAAEKEwIHAPsBAPsbCwkAIAD7GvsUAAs'
 );
 


### PR DESCRIPTION
> We shouldn't merge this before we update TypeScript.

Some of the try/catches are causing performance issues and should probably be removed.

Some benchmarks from Node.js side -> https://github.com/nodejs/node/issues/60249#issuecomment-3405141088