### PR TITLE
SQC-646 Implement DatabaseServer service for Hyperdrive binding

### DIFF
--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -220,6 +220,9 @@ class Server final: private kj::TaskSet::ErrorHandler {
   kj::Own<Service> makeDiskDirectoryService(kj::StringPtr name,
       config::DiskDirectory::Reader conf,
       kj::HttpHeaderTable::Builder& headerTableBuilder);
+  kj::Own<Service> makeDatabaseService(kj::StringPtr name,
+      config::DatabaseServer::Reader conf,
+      kj::HttpHeaderTable::Builder& headerTableBuilder);
   kj::Promise<kj::Own<Service>> makeWorker(kj::StringPtr name,
       config::Worker::Reader conf,
       capnp::List<config::Extension>::Reader extensions);
@@ -252,6 +255,7 @@ class Server final: private kj::TaskSet::ErrorHandler {
   class ExternalTcpService;
   class NetworkService;
   class DiskDirectoryService;
+  class DatabaseService;
   class WorkerService;
   class WorkerEntrypointService;
   class HttpListener;


### PR DESCRIPTION
Implement DatabaseServer service to handle use case of upgrading client connection to TLS stream over TCP to databases that require SSL.

This is useful for local development with Hyperdrive binding where running wrangler dev can not automatically connect to an external database fails upgrading to TLS stream.
- Handles custom TLS start up packets for postgres/mysql
- Handles sslmodes 'prefer' anad 'require'
- Implement unit tests for DatabaseServer service with Hyperdrive binding
- Tested locally against local databases/external databases (i.e neondb/planetscale)