### PR TITLE
Ensure that ncipollo/release-action has correct permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         default: false
 permissions:
   id-token: write
-  contents: read
+  contents: write
   actions: write
 
 jobs:


### PR DESCRIPTION
The specified action requires write access to the contents of the repository in order to create "releases".

We recently added these explicit permissions in order to support trusted publishers for npm, but didn't realise that this action needed more than read-only access to the contents.

See https://github.com/ncipollo/release-action?tab=readme-ov-file#example