### PR TITLE
update codspeed to v1.3.0

### DIFF
--- a/build/google-benchmark/MODULE.bazel
+++ b/build/google-benchmark/MODULE.bazel
@@ -4,13 +4,12 @@ bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.8")
 
-http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-http_archive(
+git_repository(
     name = "codspeed",
-    url = "https://api.github.com/repos/CodSpeedHQ/codspeed-cpp/tarball/v1.2.0",
+    commit = "2b6afb971742dfc003aa350a6aae4efc33f933f4",
     patches = ["codspeed_pr_21.patch"],
-    strip_prefix = "CodSpeedHQ-codspeed-cpp-719c41f",
-    type = "tgz",
-    sha256 = "1ced2c2e813313a574f41de9a218f38b53a4114cf7e72ee286801eaba6d8b240",
+    recursive_init_submodules = True,
+    remote = "https://github.com/CodSpeedHQ/codspeed-cpp",
 )


### PR DESCRIPTION
Currently it's failing to build:

```
bazel build //...
INFO: Invocation ID: d946a77b-c0b1-40f5-8d04-a99328a7235f
ERROR: Traceback (most recent call last):
        File "/home/yagiz/.cache/bazel/_bazel_yagiz/70041cca1e237136b0381d56c240111f/external/workerd-google-benchmark++_repo_rules+codspeed/core/BUILD", line 15, column 16, in <toplevel>
                hdrs = glob(["instrument-hooks/includes/*.h"]),
Error in glob: glob pattern 'instrument-hooks/includes/*.h' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
ERROR: /home/yagiz/.cache/bazel/_bazel_yagiz/70041cca1e237136b0381d56c240111f/external/workerd-google-benchmark++_repo_rules+codspeed/core/BUILD: no such target '@@workerd-google-benchmark++_repo_rules+codspeed//core:codspeed': target 'codspeed' not declared in package 'core' defined by /home/yagiz/.cache/bazel/_bazel_yagiz/70041cca1e237136b0381d56c240111f/external/workerd-google-benchmark++_repo_rules+codspeed/core/BUILD
ERROR: /home/yagiz/.cache/bazel/_bazel_yagiz/70041cca1e237136b0381d56c240111f/external/workerd-google-benchmark++_repo_rules+codspeed/google_benchmark/BUILD.bazel:40:11: no such target '@@workerd-google-benchmark++_repo_rules+codspeed//core:codspeed': target 'codspeed' not declared in package 'core' defined by /home/yagiz/.cache/bazel/_bazel_yagiz/70041cca1e237136b0381d56c240111f/external/workerd-google-benchmark++_repo_rules+codspeed/core/BUILD and referenced by '@@workerd-google-benchmark++_repo_rules+codspeed//google_benchmark:benchmark'
```