### PR TITLE
fix node http client search attributes

### DIFF
--- a/src/workerd/api/node/tests/http-client-nodejs-test.js
+++ b/src/workerd/api/node/tests/http-client-nodejs-test.js
@@ -474,8 +474,7 @@ export const testHttpGetTestSearchParams = {
         hostname: env.SIDECAR_HOSTNAME,
         port: env.HELLO_WORLD_SERVER_PORT,
         method: 'POST',
-        path: '/search-path',
-        search: '?hello=world',
+        path: '/search-path?hello=world',
       },
       (res) => {
         strictEqual(res.statusCode, 200);


### PR DESCRIPTION
According to Node.js docs, http client can be called with `path` attribute which can contain search fields as well. Unfortunately, we didn't handle this properly (until now).

Fixes https://github.com/cloudflare/workerd/issues/5077