### PR TITLE
jsg: assert against adding to the destruction queue after v8 isolate is destroyed

### DIFF
--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -230,6 +230,7 @@ void IsolateBase::jsgGetMemoryInfo(MemoryTracker& tracker) const {
 }
 
 void IsolateBase::deferDestruction(Item item) {
+  KJ_REQUIRE_NONNULL(ptr, "tried to defer destruction after V8 isolate was destroyed");
   queue.lockExclusive()->push(kj::mv(item));
 }
 
@@ -457,6 +458,7 @@ IsolateBase::~IsolateBase() noexcept(false) {
     // Terminate the v8::platform's task queue associated with this isolate
     v8System.shutdownIsolate(ptr);
     ptr->Dispose();
+    ptr = nullptr;
     // TODO(cleanup): meaningless after V8 13.4 is released.
     cppHeap.reset();
   });


### PR DESCRIPTION
Presumably the assert shouldn't fire, but destruction order can be tricky to reason about, so it seems prudent to guard against the possibility of something inadvertently getting added to the destruction queue after its final clearing.

Also resets the isolate pointer to null after destruction, which might make memory bugs easier to detect.