### PR TITLE
Python snapshots: Fix path confusion when preloading dynamic libraries

### DIFF
--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -344,11 +344,14 @@ export function preloadDynamicLibs(Module: Module): void {
   const userBundleNames = MetadataReader.getNames();
   for (let path of LOADED_SNAPSHOT_META.loadOrder) {
     let root = sitePackagesRoot;
+    let base = '';
     if (path.startsWith(sitePackages)) {
       path = path.slice(sitePackages.length);
+      base = sitePackages;
     } else if (path.startsWith(dynlibPath)) {
       path = path.slice(dynlibPath.length);
       root = dynlibRoot;
+      base = dynlibPath;
     }
 
     const pathSplit = path.split('/');
@@ -361,7 +364,7 @@ export function preloadDynamicLibs(Module: Module): void {
     } else {
       // This is a file path relative to the site-packages directory, like pkg/lib.so. So we are
       // loading the built-in package's dynlibs here.
-      loadDynlibFromTarFs(Module, sitePackages, root, pathSplit);
+      loadDynlibFromTarFs(Module, base, root, pathSplit);
     }
   }
   Module.freeTableIndexes.push(PyEMCountArgsPtr);


### PR DESCRIPTION
There was a bug where we confused the site-packages directory with the /usr/lib directory for the sake of resolving dynamic library paths. This causes us to preload libcrypto.so under the incorrect path /session/lib/python3.13/site-packages/libcrypto.so instead of /usr/lib/libcrypto.so where it belongs. As a result of this, if we import any new packages (for example hashlib) that depend on libcrypto, the loader won't find it and will load it a second time. This works alright except that if we make a stacked memory snapshot, when we do the preloading we'll confuse both paths into /session/lib/python3.13/site-packages/libcrypto.so and the second load will be dropped. This causes an incorrect offset in the table base and so the loader will relocate all shared libraries loaded after haslib incorrectly.

The bug was introduced here:
https://github.com/cloudflare/workerd/pull/4612/files#diff-510242e139d24007d0356f32dbf4dfb6395b35498b5106813bb5bc6c9edd6030R295-R307 but only became noticeable when we started using dedicated snapshots.