### PR TITLE
add minimumReleaseAge to pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+- '@types/node'


### PR DESCRIPTION
This will reduce the probability of installing compromised packages.

ref: https://pnpm.io/settings#minimumreleaseage