### PR TITLE
Python: Refactor preloadDynamicLibs to improve readability

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -6,7 +6,6 @@ import {
 import {
   maybeCollectSnapshot,
   maybeRestoreSnapshot,
-  preloadDynamicLibs,
   finalizeBootstrap,
   isRestoringSnapshot,
 } from 'pyodide-internal:snapshot';
@@ -43,12 +42,6 @@ function prepareWasmLinearMemory(
   Module: Module,
   pyodide_entrypoint_helper: PyodideEntrypointHelper
 ): void {
-  enterJaegerSpan('preload_dynamic_libs', () => {
-    preloadDynamicLibs(Module);
-  });
-  enterJaegerSpan('remove_run_dependency', () => {
-    Module.removeRunDependency('dynlibs');
-  });
   maybeRestoreSnapshot(Module);
   // entropyAfterRuntimeInit adjusts JS state ==> always needs to be called.
   entropyAfterRuntimeInit(Module);

--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -2,6 +2,7 @@ import { parseTarInfo } from 'pyodide-internal:tar';
 import { createMetadataFS } from 'pyodide-internal:metadatafs';
 import { LOCKFILE } from 'pyodide-internal:metadata';
 import {
+  invalidateCaches,
   PythonRuntimeError,
   PythonUserError,
   simpleRunPython,
@@ -151,6 +152,7 @@ class VirtualizedDir {
     return this.dynlibTarFs;
   }
 
+  /** Only used for Pyodide 0.26.0a2 */
   getSoFilesToLoad(): FilePath[] {
     return this.soFiles;
   }
@@ -223,10 +225,7 @@ export function mountWorkerFiles(Module: Module): void {
   Module.FS.mkdirTree('/session/metadata');
   const mdFS = createMetadataFS(Module);
   Module.FS.mount(mdFS, {}, '/session/metadata');
-  simpleRunPython(
-    Module,
-    `from importlib import invalidate_caches; invalidate_caches(); del invalidate_caches`
-  );
+  invalidateCaches(Module);
 }
 
 /**

--- a/src/pyodide/internal/util.ts
+++ b/src/pyodide/internal/util.ts
@@ -69,3 +69,10 @@ export function simpleRunPython(
   }
   return cause;
 }
+
+export function invalidateCaches(Module: Module): void {
+  simpleRunPython(
+    Module,
+    `from importlib import invalidate_caches; invalidate_caches(); del invalidate_caches`
+  );
+}


### PR DESCRIPTION
We only call preloadDynamicLibs in one place directly before maybeRestoreSnapshot() we can roll it into maybeRestoreSnapshot.

I sequestered the 0.26.0a2 logic into separate functions `maybeRestoreSnapshot026()` and `preloadDynamicLibs026()` which should make it easier to avoid changing 0.26.0a2 when improving the newer versions. This increased the code duplication but I think it's a bit clearer.