### PR TITLE
Reset uncaught exception handling after startup execution

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1924,6 +1924,13 @@ Worker::Worker(kj::Own<const Script> scriptParam,
               impl->permanentException, currentSpan);
         }
       });
+
+      // Reset this back to its default after startup execution
+      // Leaving it on comes at the expense of collecting stack traces for all thrown exceptions
+      // Ref: https://github.com/cloudflare/workerd/issues/5332
+      if (script->isolate->impl->inspector == kj::none) {
+        lock.v8Isolate->SetCaptureStackTraceForUncaughtExceptions(false);
+      }
     });
   });
 }


### PR DESCRIPTION
Fixes #5332

I've confirmed this keeps the stack for any uncaught errors during startup:

```
service main: Uncaught Error: wtf
  at worker.js:14:11 in recurse2
  at worker.js:9:3 in recurse1
  at worker.js:16:3 in recurse2
  at worker.js:9:3 in recurse1
  at worker.js:16:3 in recurse2
  at worker.js:9:3 in recurse1
  at worker.js:16:3 in recurse2
  at worker.js:9:3 in recurse1
  at worker.js:16:3 in recurse2
  at worker.js:9:3 in recurse1
```

Turning this off any earlier (eg at the end of the Script constructor) is too early:

```
service main: Uncaught Error: wtf
  at worker.js:14:10
```

I've also confirmed this improves performance of running scripts with `throw` patterns as per #5332 