### PR TITLE
[build] Reduce CI remote cache fetch parallelism to debug CI freezes

### DIFF
--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -9,7 +9,9 @@ build:ci --verbose_failures
 # increasing this closer towards the suggested value of 200. Note the number of maximum build jobs
 # is controlled by the --local_resources=cpu flag and still limited to the number of cores by
 # default.
-build:ci --jobs=32
+# TODO (build perf): Temporarily setting this to 16, that might help with CI freezing on macOS
+# release jobs?
+build:ci --jobs=16
 # Do not check for changes in external repository files, should speed up bazel invocations after the first one
 build:ci --noexperimental_check_external_repository_files
 # Only build runfile trees when needed. Runfile trees are useful for directly invoking bazel-built


### PR DESCRIPTION
We use up to 32 concurrent Bazel jobs to fetch build outputs from cache – we have frequently seen transient cache fetch errors and more concerning CI freezes for macOS release jobs recently, reducing the parallelism may make fully cached builds slightly slower but may increase stability.