### PR TITLE
Normalise path before passing to loadDynlib in Python Workers.

### DIFF
--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -362,7 +362,7 @@ export function preloadDynamicLibs(Module: Module): void {
       base = dynlibPath;
     }
 
-    const pathSplit = path.split('/');
+    const pathSplit = Module.PATH.normalizeArray(path.split('/'), true);
     if (pathSplit[0] == '') {
       // This is a file path beginning with `/`, like /session/metadata/vendor/pkg/lib.so. So we
       // are loading the vendored package's dynlibs here.

--- a/src/pyodide/types/emscripten.d.ts
+++ b/src/pyodide/types/emscripten.d.ts
@@ -56,6 +56,11 @@ interface DSO {
   exports: WebAssembly.Exports;
 }
 
+// https://github.com/emscripten-core/emscripten/blob/main/src/lib/libpath.js
+interface PATH {
+  normalizeArray: (parts: string[], allowAboveRoot: boolean) => string[];
+}
+
 type PreRunHook = (mod: Module) => void;
 
 interface EmscriptenSettings {
@@ -84,6 +89,7 @@ interface Module {
   API: API;
   ENV: ENV;
   LDSO: LDSO;
+  PATH: PATH;
   newDSO: (path: string, opt: object | undefined, handle: string) => DSO;
   _Py_Version: number;
   _py_version_major?: () => number;


### PR DESCRIPTION
When the `shapely` package is deployed we get this error:

```
Could not find python_modules/shapely/../shapely.libs/libgeos.so in user bundle, which is required by the snapshot.
```

The user bundle contains the .so file at `python_modules/shapely.libs/libgeos.so` just fine, so to fix this we just need to normalise the path which this PR implements.