### PR TITLE
Python: In 0.28.2 tests, use stacked snapshot by default

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -86,6 +86,7 @@ def _make_bundle_version_info(versions):
         name = entry["name"]
         if name != "development":
             entry["id"] = _bundle_id(**entry)
+            entry["real_pyodide_version"] = entry["pyodide_version"]
         entry["feature_flags"] = [entry["flag"]]
         entry["feature_string_flags"] = [entry["enable_flag_name"]]
         if "packages" in entry:

--- a/src/cloudflare/internal/test/ai/BUILD.bazel
+++ b/src/cloudflare/internal/test/ai/BUILD.bazel
@@ -17,4 +17,5 @@ py_wd_test(
     ]),
     # Works but times out frequently
     make_snapshot = False,
+    use_snapshot = None,
 )

--- a/src/cloudflare/internal/test/aig/BUILD.bazel
+++ b/src/cloudflare/internal/test/aig/BUILD.bazel
@@ -17,4 +17,5 @@ py_wd_test(
     ]),
     # Works but times out
     make_snapshot = False,
+    use_snapshot = None,
 )

--- a/src/cloudflare/internal/test/autorag/BUILD.bazel
+++ b/src/cloudflare/internal/test/autorag/BUILD.bazel
@@ -17,4 +17,5 @@ py_wd_test(
     ]),
     # Works but times out
     make_snapshot = False,
+    use_snapshot = None,
 )

--- a/src/cloudflare/internal/test/br/BUILD.bazel
+++ b/src/cloudflare/internal/test/br/BUILD.bazel
@@ -17,4 +17,5 @@ py_wd_test(
     ]),
     # Works but times out
     make_snapshot = False,
+    use_snapshot = None,
 )

--- a/src/cloudflare/internal/test/d1/BUILD.bazel
+++ b/src/cloudflare/internal/test/d1/BUILD.bazel
@@ -25,4 +25,5 @@ py_wd_test(
         "*.js",
     ]),
     make_snapshot = False,
+    use_snapshot = None,
 )

--- a/src/cloudflare/internal/test/to-markdown/BUILD.bazel
+++ b/src/cloudflare/internal/test/to-markdown/BUILD.bazel
@@ -17,4 +17,5 @@ py_wd_test(
     ]),
     # Works but times out frequently
     make_snapshot = False,
+    use_snapshot = None,
 )

--- a/src/cloudflare/internal/test/vectorize/BUILD.bazel
+++ b/src/cloudflare/internal/test/vectorize/BUILD.bazel
@@ -15,4 +15,5 @@ py_wd_test(
     ]),
     # Works but times out
     make_snapshot = False,
+    use_snapshot = None,
 )

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -49,7 +49,11 @@ py_wd_test(
 
 py_wd_test("js-import")
 
-py_wd_test("importable-env")
+py_wd_test(
+    "importable-env",
+    # TODO: why doesn't dedicated snapshot work with this?
+    use_snapshot = None,
+)
 
 py_wd_test("python-rpc")
 
@@ -71,22 +75,4 @@ py_wd_test(
     "numpy",
     make_snapshot = False,
     use_snapshot = "numpy",
-)
-
-py_wd_test(
-    name = "numpy_stacked_snapshot",
-    directory = "numpy",
-    feature_flags = ["python_dedicated_snapshot"],
-    make_snapshot = True,
-    python_flags = ["0.28.2"],
-    use_snapshot = "baseline",
-)
-
-py_wd_test(
-    name = "fastapi_stacked_snapshot",
-    directory = "fastapi",
-    feature_flags = ["python_dedicated_snapshot"],
-    make_snapshot = True,
-    python_flags = ["0.28.2"],
-    use_snapshot = "baseline",
 )

--- a/src/workerd/server/tests/python/import_tests.bzl
+++ b/src/workerd/server/tests/python/import_tests.bzl
@@ -43,6 +43,7 @@ def _test(name, directory, wd_test, py_file, python_version, **kwds):
         directory = directory,
         src = wd_test,
         python_flags = [python_version],
+        use_snapshot = None,
         make_snapshot = False,
         args = ["--experimental", "--pyodide-package-disk-cache-dir", "../all_pyodide_wheels_%s" % pkg_tag],
         skip_default_data = True,

--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -23,10 +23,15 @@ def _py_wd_test_helper(
     name_flag = name + "_" + python_flag
     templated_src = name_flag.replace("/", "-") + "@template"
     templated_src = "/".join(src.split("/")[:-1] + [templated_src])
-    flags = _get_enable_flags(python_flag) + feature_flags
-    feature_flags_txt = ",".join(['"{}"'.format(flag) for flag in flags])
 
     load_snapshot = None
+    pyodide_version = BUNDLE_VERSION_INFO[python_flag]["real_pyodide_version"]
+    if use_snapshot == "stacked":
+        if pyodide_version == "0.26.0a2":
+            use_snapshot = None
+        else:
+            use_snapshot = "baseline"
+            feature_flags = feature_flags + ["python_dedicated_snapshot"]
     if use_snapshot:
         version_info = BUNDLE_VERSION_INFO[python_flag]
 
@@ -37,6 +42,8 @@ def _py_wd_test_helper(
     if load_snapshot and not make_snapshot:
         args += ["--python-load-snapshot", "load_snapshot.bin"]
 
+    flags = _get_enable_flags(python_flag) + feature_flags
+    feature_flags_txt = ",".join(['"{}"'.format(flag) for flag in flags])
     expand_template(
         name = name_flag + "@rule",
         out = templated_src,
@@ -118,7 +125,7 @@ def py_wd_test(
         size = "enormous",
         tags = [],
         make_snapshot = True,
-        use_snapshot = None,
+        use_snapshot = "stacked",
         skip_default_data = False,
         **kwargs):
     python_flags = compute_python_flags(python_flags, skip_python_flags)

--- a/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
@@ -1,4 +1,7 @@
+load("//src/workerd/server/tests/python:py_wd_test.bzl", "python_test_setup")
 load(":vendor_test.bzl", "vendored_py_wd_test")
+
+python_test_setup()
 
 vendored_py_wd_test("fastapi")
 


### PR DESCRIPTION
This will give us much better coverage of the stacked snapshots we are generally making in production