### PR TITLE
Rename PythonRuntimeError to PythonInternalError

### DIFF
--- a/src/pyodide/internal/loadPackage.ts
+++ b/src/pyodide/internal/loadPackage.ts
@@ -21,7 +21,10 @@ import {
 import { parseTarInfo } from 'pyodide-internal:tar';
 import { createTarFS } from 'pyodide-internal:tarfs';
 import { default as ArtifactBundler } from 'pyodide-internal:artifacts';
-import { PythonUserError, PythonRuntimeError } from 'pyodide-internal:util';
+import {
+  PythonUserError,
+  PythonWorkersInternalError,
+} from 'pyodide-internal:util';
 
 function getPackageMetadata(requirement: string): PackageDeclaration {
   const obj = LOCKFILE['packages'][requirement];
@@ -39,7 +42,7 @@ function loadBundleFromArtifactBundler(requirement: string): Reader {
   const fullPath = `python-package-bucket/${PACKAGES_VERSION}/${filename}`;
   const reader = ArtifactBundler.getPackage(fullPath);
   if (!reader) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       'Failed to get package ' + fullPath + ' from ArtifactBundler'
     );
   }

--- a/src/pyodide/internal/metadatafs.ts
+++ b/src/pyodide/internal/metadatafs.ts
@@ -1,6 +1,6 @@
 import { default as MetadataReader } from 'pyodide-internal:runtime-generated/metadata';
 import { createReadonlyFS } from 'pyodide-internal:readOnlyFS';
-import { PythonRuntimeError } from 'pyodide-internal:util';
+import { PythonWorkersInternalError } from 'pyodide-internal:util';
 
 function createTree(paths: string[]): MetadataDirInfo {
   const tree: MetadataFSInfo = new Map();
@@ -10,7 +10,9 @@ function createTree(paths: string[]): MetadataDirInfo {
     const name = parts.pop()!;
     for (const part of parts) {
       if (typeof subTree === 'number') {
-        throw new PythonRuntimeError('expected subtree to not be a number');
+        throw new PythonWorkersInternalError(
+          'expected subtree to not be a number'
+        );
       }
       let next: MetadataFSInfo | undefined = subTree.get(part);
       if (!next) {
@@ -20,7 +22,9 @@ function createTree(paths: string[]): MetadataDirInfo {
       subTree = next;
     }
     if (typeof subTree === 'number') {
-      throw new PythonRuntimeError('expected subtree to not be a number');
+      throw new PythonWorkersInternalError(
+        'expected subtree to not be a number'
+      );
     }
     subTree.set(name, idx);
   });
@@ -55,7 +59,7 @@ export function createMetadataFS(Module: Module): object {
     },
     readdir(node) {
       if (node.tree == undefined) {
-        throw new PythonRuntimeError(
+        throw new PythonWorkersInternalError(
           'cannot read directory, tree is undefined'
         );
       }
@@ -63,7 +67,7 @@ export function createMetadataFS(Module: Module): object {
     },
     lookup(parent, name) {
       if (parent.tree == undefined) {
-        throw new PythonRuntimeError(
+        throw new PythonWorkersInternalError(
           'cannot lookup directory, tree is undefined'
         );
       }

--- a/src/pyodide/internal/pool/builtin_wrappers.ts
+++ b/src/pyodide/internal/pool/builtin_wrappers.ts
@@ -1,6 +1,6 @@
 import type { getRandomValues as getRandomValuesType } from 'pyodide-internal:topLevelEntropy/lib';
 import type { default as UnsafeEvalType } from 'internal:unsafe-eval';
-import { PythonRuntimeError } from 'pyodide-internal:util';
+import { PythonWorkersInternalError } from 'pyodide-internal:util';
 
 if (typeof FinalizationRegistry === 'undefined') {
   // @ts-expect-error cannot assign to globalThis
@@ -196,7 +196,9 @@ function checkCallee(): void {
   }
   if (!isOkay) {
     console.warn('Invalid call to `WebAssembly.Module`', funcName);
-    throw new PythonRuntimeError('Invalid call to `WebAssembly.Module`');
+    throw new PythonWorkersInternalError(
+      'Invalid call to `WebAssembly.Module`'
+    );
   }
 }
 

--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -27,7 +27,7 @@ import type { PyodideEntrypointHelper } from 'pyodide:python-entrypoint-helper';
 import { default as SetupEmscripten } from 'internal:setup-emscripten';
 
 import { default as UnsafeEval } from 'internal:unsafe-eval';
-import { PythonRuntimeError, reportError } from 'pyodide-internal:util';
+import { PythonWorkersInternalError, reportError } from 'pyodide-internal:util';
 import { loadPackages } from 'pyodide-internal:loadPackage';
 import { default as MetadataReader } from 'pyodide-internal:runtime-generated/metadata';
 import { TRANSITIVE_REQUIREMENTS } from 'pyodide-internal:metadata';
@@ -109,7 +109,7 @@ function validatePyodideVersion(pyodide: Pyodide): void {
     return;
   }
   if (pyodide.version !== expectedPyodideVersion) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       `Pyodide version mismatch, expected '${expectedPyodideVersion}'`
     );
   }

--- a/src/pyodide/internal/setupPackages.ts
+++ b/src/pyodide/internal/setupPackages.ts
@@ -3,7 +3,7 @@ import { createMetadataFS } from 'pyodide-internal:metadatafs';
 import { LOCKFILE } from 'pyodide-internal:metadata';
 import {
   invalidateCaches,
-  PythonRuntimeError,
+  PythonWorkersInternalError,
   PythonUserError,
   simpleRunPython,
 } from 'pyodide-internal:util';
@@ -80,7 +80,7 @@ class VirtualizedDir {
     const dest = dir == 'dynlib' ? this.dynlibTarFs : this.rootInfo;
     overlayInfo.children!.forEach((val, key) => {
       if (dest.children!.has(key)) {
-        throw new PythonRuntimeError(
+        throw new PythonWorkersInternalError(
           `File/folder ${key} being written by multiple packages`
         );
       }
@@ -213,7 +213,7 @@ export function patchLoadPackage(pyodide: Pyodide): void {
 }
 
 function disabledLoadPackage(): never {
-  throw new PythonRuntimeError(
+  throw new PythonWorkersInternalError(
     'pyodide.loadPackage is disabled because packages are encoded in the binary'
   );
 }

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -18,7 +18,7 @@ import {
 } from 'pyodide-internal:metadata';
 import {
   invalidateCaches,
-  PythonRuntimeError,
+  PythonWorkersInternalError,
   PythonUserError,
   simpleRunPython,
 } from 'pyodide-internal:util';
@@ -237,7 +237,7 @@ function getMemoryPatched(
     if (expectedTableBase && tableBase !== expectedTableBase) {
       // If this happens, we will segfault if we ever try to use this dynamic library.
       // Save ourselves some debugging pain by crashing early.
-      throw new PythonRuntimeError(
+      throw new PythonWorkersInternalError(
         `Error loading ${libName}: Expected table base ${expectedTableBase} but got table base ${tableBase}`
       );
     }
@@ -302,7 +302,7 @@ function loadDynlibFromVendor(
   const path = soFile.slice(3).join('/');
   const index = userBundleNames.indexOf(path);
   if (index == -1) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       `Could not find ${path} in user bundle, which is required by the snapshot.`
     );
   }
@@ -618,14 +618,14 @@ function decodeSnapshot(
     return undefined;
   }
   if (reader.getMemorySnapshotSize() === 0) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       `SnapshotReader returned memory snapshot size of 0`
     );
   }
   const header = new Uint32Array(4);
   reader.readMemorySnapshot(0, header);
   if (header[0] !== SNAPSHOT_MAGIC) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       `Invalid magic number ${header[0]}, expected ${SNAPSHOT_MAGIC}`
     );
   }
@@ -686,7 +686,7 @@ function checkSnapshotType(snapshotType: string): void {
     snapshotType === 'dedicated' &&
     !IS_DEDICATED_SNAPSHOT_ENABLED
   ) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       'Received dedicated snapshot but compat flag for dedicated snapshots is not enabled'
     );
   }
@@ -696,7 +696,7 @@ function checkSnapshotType(snapshotType: string): void {
     snapshotType !== 'dedicated' &&
     IS_DEDICATED_SNAPSHOT_ENABLED
   ) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       'Received non-dedicated snapshot but compat flag for dedicated snapshots is enabled'
     );
   }
@@ -705,7 +705,7 @@ function checkSnapshotType(snapshotType: string): void {
   // should verify that the snapshot in the bundle is a dedicated snapshot. If it is not
   // we should fail with an error.
   if (snapshotType !== 'dedicated' && IS_SECOND_VALIDATION_PHASE) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       'The second validation phase should receive a dedicated snapshot, got ' +
         snapshotType
     );
@@ -766,7 +766,7 @@ function collectSnapshot(
     );
     DiskCache.put('snapshot.bin', snapshot);
   } else {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       "Attempted to collect snapshot outside of context where it's supported."
     );
   }
@@ -791,13 +791,13 @@ export function maybeCollectDedicatedSnapshot(
   if (Module.API.version == '0.26.0a2') {
     // 0.26.0a2 does not support serialisation of the hiwire state, so it cannot support dedicated
     // snapshots.
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       'Dedicated snapshot is not supported for Python runtime version 0.26.0a2'
     );
   }
 
   if (!pyodide_entrypoint_helper) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       'pyodide_entrypoint_helper is required for dedicated snapshot'
     );
   }
@@ -840,7 +840,7 @@ export function finalizeBootstrap(
     if ('pyodide_entrypoint_helper' in obj) {
       return pyodide_entrypoint_helper;
     }
-    throw new PythonRuntimeError(`Can't deserialize ${obj}`);
+    throw new PythonWorkersInternalError(`Can't deserialize ${obj}`);
   };
 
   Module.API.config._makeSnapshot =

--- a/src/pyodide/internal/tar.ts
+++ b/src/pyodide/internal/tar.ts
@@ -2,7 +2,7 @@
 // And some trial and error with real tar files.
 // https://en.wikipedia.org/wiki/Tar_(computing)#File_format
 
-import { PythonRuntimeError } from 'pyodide-internal:util';
+import { PythonWorkersInternalError } from 'pyodide-internal:util';
 
 const decoder = new TextDecoder();
 function decodeString(buf: Uint8Array): string {
@@ -134,7 +134,7 @@ export function parseTarInfo(reader: Reader): [TarFSInfo, string[]] {
       directory.children!.set(info.name, info);
     } else {
       // fail if we encounter other values of type (e.g., symlink, LongName, etc)
-      throw new PythonRuntimeError(
+      throw new PythonWorkersInternalError(
         `Python TarFS error: Unexpected type ${info.type}`
       );
     }

--- a/src/pyodide/internal/tarfs.ts
+++ b/src/pyodide/internal/tarfs.ts
@@ -1,5 +1,5 @@
 import { createReadonlyFS } from 'pyodide-internal:readOnlyFS';
-import { PythonRuntimeError } from 'pyodide-internal:util';
+import { PythonWorkersInternalError } from 'pyodide-internal:util';
 
 const FSOps: FSOps<TarFSInfo> = {
   getNodeMode(_parent, _name, info) {
@@ -19,22 +19,26 @@ const FSOps: FSOps<TarFSInfo> = {
   },
   readdir(node) {
     if (!node.info.children) {
-      throw new PythonRuntimeError('Trying to readdir from a non-dir node');
+      throw new PythonWorkersInternalError(
+        'Trying to readdir from a non-dir node'
+      );
     }
     return Array.from(node.info.children.keys());
   },
   lookup(parent, name) {
     if (!parent.info.children) {
-      throw new PythonRuntimeError('Trying to lookup from a non-dir node');
+      throw new PythonWorkersInternalError(
+        'Trying to lookup from a non-dir node'
+      );
     }
     return parent.info.children.get(name)!;
   },
   read(stream, position, buffer) {
     if (stream.node.contentsOffset == undefined) {
-      throw new PythonRuntimeError('contentsOffset is undefined');
+      throw new PythonWorkersInternalError('contentsOffset is undefined');
     }
     if (!stream.node.info.reader) {
-      throw new PythonRuntimeError('reader is undefined');
+      throw new PythonWorkersInternalError('reader is undefined');
     }
     return stream.node.info.reader.read(
       stream.node.contentsOffset + position,

--- a/src/pyodide/internal/util.ts
+++ b/src/pyodide/internal/util.ts
@@ -3,7 +3,7 @@
  * that is **not** a result of the user doing something wrong, i.e. it's an internal error that is
  * a result of a bug in our runtime.
  */
-export class PythonRuntimeError extends Error {
+export class PythonWorkersInternalError extends Error {
   override get name(): string {
     return this.constructor.name;
   }
@@ -65,7 +65,7 @@ export function simpleRunPython(
     // PyRun_SimpleString will have written a Python traceback to stderr.
     console.warn('Command failed:', code);
     console.warn(cause);
-    throw new PythonRuntimeError('Failed to run Python code');
+    throw new PythonWorkersInternalError('Failed to run Python code');
   }
   return cause;
 }

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -18,7 +18,7 @@ import {
 } from 'pyodide-internal:metadata';
 import { default as Limiter } from 'pyodide-internal:limiter';
 import {
-  PythonRuntimeError,
+  PythonWorkersInternalError,
   PythonUserError,
   reportError,
 } from 'pyodide-internal:util';
@@ -73,7 +73,7 @@ let _pyodide_entrypoint_helper: PyodideEntrypointHelper | null = null;
 
 function get_pyodide_entrypoint_helper(): PyodideEntrypointHelper {
   if (!_pyodide_entrypoint_helper) {
-    throw new PythonRuntimeError(
+    throw new PythonWorkersInternalError(
       'pyodide_entrypoint_helper is not initialized'
     );
   }


### PR DESCRIPTION
There is something called a RuntimeError in Python and if raised it will create a Python RuntimeError but this will be a user error. So the name is confusing. PythonInternalError is more accurate.