### PR TITLE
EW-9632 Increase max WebSocket message size limit to 32MiB

### DIFF
--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -25,6 +25,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "streaming-tail-worker"_kj;
     case AutogateKey::TAIL_STREAM_REFACTOR:
       return "tail-stream-refactor"_kj;
+    case AutogateKey::WEBSOCKET_MAX_MESSAGE_SIZE_32M:
+      return "websocket-max-message-size-32m"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -20,6 +20,8 @@ enum class AutogateKey {
   STREAMING_TAIL_WORKER,
   // Enable refactor used to consolidate the different tail worker stream implementations.
   TAIL_STREAM_REFACTOR,
+  // Increase max WebSocket message size to 32MiB.
+  WEBSOCKET_MAX_MESSAGE_SIZE_32M,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
See code comments for rationale.

This change will be deployed to the Cloudflare network via an autogate first. Then, once that stabilizes, we'll remove the autogate, making the new limit the default for both production and local development.