### PR TITLE
Implements shapely vendored test for Python Workers

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -186,6 +186,11 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
             #     "abi": "3.13",
             #     "sha256": "4f1b6fc179bd5c6d3de68abc4aa9fca2aaecd09c5c8d357c2ecfedce7d621f3d",
             # },
+            {
+                "name": "shapely",
+                "abi": "3.13",
+                "sha256": "2e5c462cb32ee8697b3647dfc9d5c88dcdfd0702da34a2d7dc6b07b8090dd321",
+            },
         ],
     },
     {

--- a/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
@@ -12,3 +12,11 @@ vendored_py_wd_test(
 )
 
 # vendored_py_wd_test("scipy")
+
+vendored_py_wd_test(
+    "shapely",
+    feature_flags = ["python_dedicated_snapshot"],
+    make_snapshot = True,
+    python_flags = ["0.28.2"],
+    use_snapshot = "baseline",
+)

--- a/src/workerd/server/tests/python/vendor_pkg_tests/shapely.py
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/shapely.py
@@ -1,0 +1,6 @@
+import shapely
+
+
+async def test():
+    assert shapely.__version__
+    print("shapely imported successfully!")

--- a/src/workerd/server/tests/python/vendor_pkg_tests/shapely_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/shapely_vendor.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "shapely-vendor-test",
+      worker = (
+        modules = [
+          (name = "main.py", pythonModule = embed "shapely.py"),
+          %PYTHON_VENDORED_MODULES%
+        ],
+        compatibilityDate = "2024-01-15",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python/vendor_pkg_tests:shapely_vendor_test_0.28.2@
```