### PR TITLE
use jsg::Lock methods more

### DIFF
--- a/src/workerd/api/capnp.c++
+++ b/src/workerd/api/capnp.c++
@@ -384,11 +384,11 @@ struct JsCapnpConverter {
     return js.withinHandleScope([&]() -> v8::Local<v8::Value> {
       switch (value.getType()) {
         case capnp::DynamicValue::UNKNOWN:
-          return js.v8Undefined();
+          return js.undefined();
         case capnp::DynamicValue::VOID:
-          return js.v8Null();
+          return js.null();
         case capnp::DynamicValue::BOOL:
-          return v8::Boolean::New(js.v8Isolate, value.as<bool>());
+          return js.boolean(value.as<bool>());
         case capnp::DynamicValue::INT: {
           if (type.which() == capnp::schema::Type::INT64 ||
               type.which() == capnp::schema::Type::UINT64) {
@@ -466,7 +466,7 @@ struct JsCapnpConverter {
             return wrapper.wrapCap(js, js.v8Context(), value.as<capnp::DynamicCapability>());
           }
         case capnp::DynamicValue::ANY_POINTER:
-          return js.v8Null();
+          return js.null();
       }
 
       KJ_FAIL_ASSERT("Unimplemented DynamicValue type.");

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -946,7 +946,7 @@ public:
   // the response. There are currently a proposal to add a "full" option which is the model
   // we support. Once "full" is added, we need to update this to accept either undefined or
   // "full", and possibly decide if we want to support the "half" option.
-  // jsg::JsValue getDuplex(jsg::Lock& js) { return js.v8Undefined(); }
+  // jsg::JsValue getDuplex(jsg::Lock& js) { return js.undefined(); }
   // TODO(conform): Might implement?
 
   // These relate to CORS support, which we do not implement. WinterTC has determined that

--- a/src/workerd/api/node/async-hooks.c++
+++ b/src/workerd/api/node/async-hooks.c++
@@ -71,7 +71,7 @@ v8::Local<v8::Value> AsyncLocalStorage::exit(jsg::Lock& js,
   // implementing the enterWith/disable methods. We can emulate the correct
   // behavior simply by calling run with the store value set to undefined, which
   // will propagate correctly.
-  return run(js, js.v8Undefined(), kj::mv(callback), kj::mv(args));
+  return run(js, js.undefined(), kj::mv(callback), kj::mv(args));
 }
 
 v8::Local<v8::Value> AsyncLocalStorage::getStore(jsg::Lock& js) {
@@ -83,7 +83,7 @@ v8::Local<v8::Value> AsyncLocalStorage::getStore(jsg::Lock& js) {
   KJ_IF_SOME(value, defaultValue) {
     return value.getHandle(js);
   }
-  return js.v8Undefined();
+  return js.undefined();
 }
 
 kj::StringPtr AsyncLocalStorage::getName() {

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -1925,7 +1925,7 @@ void ReadableStreamDefaultController::close(jsg::Lock& js) {
 
 void ReadableStreamDefaultController::enqueue(
     jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> chunk) {
-  auto value = chunk.orDefault(js.v8Undefined());
+  auto value = chunk.orDefault(js.undefined());
 
   JSG_REQUIRE(impl.canCloseOrEnqueue(), TypeError, "Unable to enqueue");
 
@@ -2138,7 +2138,7 @@ jsg::Promise<void> ReadableByteStreamController::cancel(
       byobRequest->invalidate(js);
     }
   }
-  return impl.cancel(js, JSG_THIS, maybeReason.orDefault(js.v8Undefined()));
+  return impl.cancel(js, JSG_THIS, maybeReason.orDefault(js.undefined()));
 }
 
 void ReadableByteStreamController::close(jsg::Lock& js) {
@@ -3193,7 +3193,7 @@ jsg::Promise<void> WritableStreamDefaultController::close(jsg::Lock& js) {
 
 void WritableStreamDefaultController::error(
     jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) {
-  impl.error(js, JSG_THIS, reason.orDefault(js.v8Undefined()));
+  impl.error(js, JSG_THIS, reason.orDefault(js.undefined()));
 }
 
 ssize_t WritableStreamDefaultController::getDesiredSize() {
@@ -3277,7 +3277,7 @@ jsg::Promise<void> WritableStreamJsController::abort(
       return KJ_ASSERT_NONNULL(maybeAbortPromise).whenResolved(js);
     }
     KJ_CASE_ONEOF(controller, Controller) {
-      maybeAbortPromise = controller->abort(js, reason.orDefault(js.v8Undefined()));
+      maybeAbortPromise = controller->abort(js, reason.orDefault(js.undefined()));
       return KJ_ASSERT_NONNULL(maybeAbortPromise).whenResolved(js);
     }
   }
@@ -3632,7 +3632,7 @@ jsg::Promise<void> WritableStreamJsController::write(
       return js.rejectedPromise<void>(errored.addRef(js));
     }
     KJ_CASE_ONEOF(controller, Controller) {
-      return controller->write(js, value.orDefault([&] { return js.v8Undefined(); }));
+      return controller->write(js, value.orDefault([&] { return js.undefined(); }));
     }
   }
   KJ_UNREACHABLE;

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2026,9 +2026,9 @@ void Worker::handleLog(jsg::Lock& js,
     auto formatLog = formatLogVal.As<v8::Function>();
 
     auto levelStr = logLevelToString(level);
-    args[length] = v8::Boolean::New(js.v8Isolate, colors);
-    args[length + 1] = v8::Boolean::New(js.v8Isolate, bool(loggingOptions.structuredLogging));
-    args[length + 2] = jsg::v8StrIntern(js.v8Isolate, levelStr);
+    args[length] = js.boolean(colors);
+    args[length + 1] = js.boolean(loggingOptions.structuredLogging.toBool());
+    args[length + 2] = js.strIntern(levelStr);
     auto formatted = js.toString(
         jsg::check(formatLog->Call(context, js.v8Undefined(), length + 3, args.data())));
     fprintf(fd, "%s\n", formatted.cStr());

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -556,7 +556,7 @@ class OptionalWrapper {
     KJ_IF_SOME(p, ptr) {
       return static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::fwd<U>(p));
     } else {
-      return v8::Undefined(js.v8Isolate);
+      return js.undefined();
     }
   }
 
@@ -593,7 +593,7 @@ class LenientOptionalWrapper {
     KJ_IF_SOME(p, ptr) {
       return static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::fwd<U>(p));
     } else {
-      return v8::Undefined(js.v8Isolate);
+      return js.undefined();
     }
   }
 
@@ -641,7 +641,7 @@ class MaybeWrapper {
     KJ_IF_SOME(p, ptr) {
       return static_cast<TypeWrapper*>(this)->wrap(js, context, creator, kj::fwd<U>(p));
     } else {
-      return v8::Null(js.v8Isolate);
+      return js.null();
     }
   }
 
@@ -718,7 +718,7 @@ class OneOfWrapper {
       kj::OneOf<U...> value) {
     v8::Local<v8::Value> result;
     if (!(wrapHelper<U>(js, context, creator, value, result) || ...)) {
-      result = v8::Undefined(js.v8Isolate);
+      result = js.undefined();
     }
     return result;
   }


### PR DESCRIPTION
Let's avoid using v8 methods when there are jsg::Lock alternatives.