### PR TITLE
Python: Temporarily disable scipy-vendor-test

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -180,11 +180,11 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
                 "abi": None,
                 "sha256": "fc4fb50f73973c257277155b3cb113aa2cf68e9da8ef424ecb049b41bc463183",
             },
-            {
-                "name": "scipy",
-                "abi": "3.13",
-                "sha256": "4f1b6fc179bd5c6d3de68abc4aa9fca2aaecd09c5c8d357c2ecfedce7d621f3d",
-            },
+            # {
+            #     "name": "scipy",
+            #     "abi": "3.13",
+            #     "sha256": "4f1b6fc179bd5c6d3de68abc4aa9fca2aaecd09c5c8d357c2ecfedce7d621f3d",
+            # },
         ],
     },
     {

--- a/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
@@ -8,4 +8,4 @@ vendored_py_wd_test(
     "python-workers-runtime-sdk",
 )
 
-vendored_py_wd_test("scipy")
+# vendored_py_wd_test("scipy")


### PR DESCRIPTION
I accidentally uploaded over the r2 resource this test uses. Disabling to unblock CI.