### PR TITLE
Use a shared Fetcher instance for ServiceWorkerGlobalScope requests

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -930,6 +930,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
   jsg::UnhandledRejectionHandler unhandledRejections;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> processValue;
   kj::Maybe<jsg::JsRef<jsg::JsValue>> bufferValue;
+  kj::Maybe<jsg::Ref<Fetcher>> defaultFetcher;
 
   // Global properties such as scheduler, crypto, caches, self, and origin should
   // be monkeypatchable / mutable at the global scope.


### PR DESCRIPTION
We were creating a new Fetcher instance for every request despite the fact that the Fetcher itself was stateless and not storing any request-specific data. This changes it so that all requests to a given ServiceWorkerGlobalScope instance share a single default Fetcher instance.

Very small performance win as it reduces per-request work.

The question, however, is whether we need to consider this potentially breaking. No one should reasonably be relying on the identity of the `request.fetcher` being unique across each request but I suppose it's at least possible.