### PR TITLE
Remove additional header checks

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -163,8 +163,6 @@ Headers::Headers(jsg::Lock& js, const Headers& other): guard(Guard::NONE) {
 }
 
 Headers::Headers(jsg::Lock& js, const kj::HttpHeaders& other, Guard guard): guard(Guard::NONE) {
-  // TODO(soon): Remove this. Throw if the any header values are invalid.
-  throwIfInvalidHeaderValue(other);
   other.forEach([this, &js](auto name, auto value) {
     append(js, jsg::ByteString(kj::str(name)), jsg::ByteString(kj::str(value)));
   });

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -248,7 +248,6 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
     const kj::HttpHeaders& headers,
     kj::AsyncInputStream& requestBody,
     Response& response) {
-  throwIfInvalidHeaderValue(headers);
   TRACE_EVENT("workerd", "WorkerEntrypoint::request()", "url", url.cStr(),
       PERFETTO_FLOW_FROM_POINTER(this));
   auto incomingRequest =

--- a/src/workerd/io/worker-interface.c++
+++ b/src/workerd/io/worker-interface.c++
@@ -27,12 +27,10 @@ class PromisedWorkerInterface final: public WorkerInterface {
       const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody,
       Response& response) override {
-    throwIfInvalidHeaderValue(headers);
     KJ_IF_SOME(w, worker) {
       co_await w->request(method, url, headers, requestBody, response);
     } else {
       co_await promise;
-      throwIfInvalidHeaderValue(headers);
       co_await KJ_ASSERT_NONNULL(worker)->request(method, url, headers, requestBody, response);
     }
   }
@@ -257,7 +255,6 @@ kj::Promise<void> RevocableWebSocketWorkerInterface::request(kj::HttpMethod meth
     kj::AsyncInputStream& requestBody,
     kj::HttpService::Response& response) {
   auto wrappedResponse = kj::heap<RevocableWebSocketHttpResponse>(response, revokeProm.addBranch());
-  throwIfInvalidHeaderValue(headers);
   return worker.request(method, url, headers, requestBody, *wrappedResponse)
       .attach(kj::mv(wrappedResponse));
 }
@@ -369,7 +366,6 @@ kj::Promise<void> RpcWorkerInterface::request(kj::HttpMethod method,
     const kj::HttpHeaders& headers,
     kj::AsyncInputStream& requestBody,
     Response& response) {
-  throwIfInvalidHeaderValue(headers);
   auto inner = httpOverCapnpFactory.capnpToKj(dispatcher.getHttpServiceRequest().send().getHttp());
   auto promise = inner->request(method, url, headers, requestBody, response);
   return promise.attach(kj::mv(inner));

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -186,13 +186,11 @@ class LazyWorkerInterface final: public WorkerInterface {
       const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody,
       Response& response) override {
-    throwIfInvalidHeaderValue(headers);
     ensureResolve();
     KJ_IF_SOME(w, worker) {
       co_await w->request(method, url, headers, requestBody, response);
     } else {
       co_await KJ_ASSERT_NONNULL(promise);
-      throwIfInvalidHeaderValue(headers);
       co_await KJ_ASSERT_NONNULL(worker)->request(method, url, headers, requestBody, response);
     }
   }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -4312,7 +4312,6 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(kj::HttpMethod meth
     const kj::HttpHeaders& headers,
     kj::AsyncInputStream& requestBody,
     kj::HttpService::Response& response) {
-  throwIfInvalidHeaderValue(headers);
   using InspectorLock = InspectorChannelImpl::InspectorLock;
 
   auto signalRequest = [this, method, urlCopy = kj::str(url),
@@ -4501,7 +4500,6 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(kj::HttpMethod meth
 
   // While we checked above that the headers are valid, let's check again
   // after the co_await...
-  throwIfInvalidHeaderValue(headers);
   KJ_IF_SOME(rid, maybeRequestId) {
     ResponseWrapper wrapper(response, kj::mv(rid), kj::mv(signalResponse));
     co_await inner->request(method, url, headers, requestBody, wrapper);

--- a/src/workerd/util/http-util.h
+++ b/src/workerd/util/http-util.h
@@ -67,11 +67,4 @@ class SimpleResponseObserver final: public kj::HttpService::Response {
   kj::uint* statusCode;
 };
 
-inline void throwIfInvalidHeaderValue(const kj::HttpHeaders& headers) {
-  headers.forEach([](kj::StringPtr name, kj::StringPtr value) {
-    KJ_REQUIRE(kj::HttpHeaders::isValidHeaderValue(value),
-        "Invalid header value received from request", name, value.asBytes());
-  });
-};
-
 }  // namespace workerd


### PR DESCRIPTION
The additional header checks were added previously while investigating another issue, but the issue has been since resolved. The additional checks were left in place to ensure the issue did not reoccur but we've had zero hits since. They can be safely removed now.