### PR TITLE
Remove querysync from .bazelproject

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -22,5 +22,3 @@ test_sources:
   src/workerd/api/*-test.js
   src/workerd/api/*-test.wd-test
   src/workerd/api/*-test.c++
-
-use_query_sync: true


### PR DESCRIPTION
querysync seems to be flawed. ref: https://x.com/you_johnny/status/1981980138171515019?s=46