### PR TITLE
[build] Expand clang-tidy, clang-format coverage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: >
   misc-unused-alias-decls,
   modernize-macro-to-enum,
   modernize-redundant-void-arg,
+  modernize-type-traits,
   modernize-unary-static-assert,
   modernize-use-bool-literals,
   performance-for-range-copy,
@@ -23,18 +24,23 @@ Checks: >
   readability-container-contains,
   readability-duplicate-include,
   readability-redundant-access-specifiers,
+  readability-redundant-casting,
+  readability-redundant-declaration,
   readability-static-accessed-through-instance
 
-# TODO: Fix and re-enable
+# TODO: Fix and enable
+# bugprone-parent-virtual-call
 # bugprone-return-const-ref-from-parameter
-# modernize-type-traits
+# cppcoreguidelines-missing-std-forward
 # modernize-use-override
-# readability-redundant-casting
+# readability-avoid-const-params-in-decls
 
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*/workerd/.*'
+HeaderFilterRegex: '.*src/workerd/.*'
 
 CheckOptions:
   # JSG has very entrenched include cycles
   - key: misc-header-include-cycle.IgnoredFilesList
     value: "jsg/jsg.h|jsg/dom-exception.h"
+  - key: cppcoreguidelines-missing-std-forward.ForwardFunction
+    value: "kj::fwd"

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -16,6 +16,8 @@
 -Iexternal/ncrypto/include
 -isystembazel-bin/external/sqlite3
 -Isrc
+-isystem/usr/lib/llvm-21/include/c++/v1
+-isystem/usr/lib/llvm-21/lib/clang/21/include
 -isystem/usr/lib/llvm-20/include/c++/v1
 -isystem/usr/lib/llvm-20/lib/clang/20/include
 -isystem/usr/lib/llvm-19/include/c++/v1
@@ -137,3 +139,13 @@
 -Wunused-variable
 -no-canonical-prefixes
 -fbracket-depth=512
+-D___COMMENT_0___="include paths needed while bzlmod and WORKSPACE are used together resulting in mangled path names, can drop after bzlmod transition is complete"
+-Iexternal/+_repo_rules2+simdutf/
+-Iexternal/+_repo_rules+nbytes/include/
+-Iexternal/+_repo_rules+ncrypto/include
+-Iexternal/workerd-google-benchmark++_repo_rules+codspeed/google_benchmark/include/
+-Iexternal/perfetto+/include/
+-Iexternal/perfetto+/include/perfetto/base/build_configs/bazel/
+-Ibazel-bin/external/perfetto+/
+-isystemexternal/+_repo_rules2+com_googlesource_chromium_icu/source/common
+-isystemexternal/+_repo_rules+v8/include

--- a/src/rust/cxx-integration-test/cxx-rust-integration-test.c++
+++ b/src/rust/cxx-integration-test/cxx-rust-integration-test.c++
@@ -1,12 +1,12 @@
 #include <workerd/rust/cxx-integration-test/lib.rs.h>
 #include <workerd/rust/cxx-integration/lib.rs.h>
 
+#include <kj-rs/kj-rs.h>
 #include <rust/cxx.h>
 #include <signal.h>
 
 #include <kj/async.h>
 #include <kj/test.h>
-#include <kj-rs/kj-rs.h>
 
 using namespace kj_rs;
 

--- a/src/rust/cxx-integration-test/cxx-rust-integration-test.h
+++ b/src/rust/cxx-integration-test/cxx-rust-integration-test.h
@@ -10,4 +10,4 @@ using TestCallback = kj::Function<size_t(size_t, size_t)>;
 
 using UsizeCallback = kj::Function<void(size_t)>;
 
-}  // namespace edgeworker::rust::test
+}  // namespace workerd::rust::test

--- a/src/rust/gen-compile-cache/cxx-bridge.h
+++ b/src/rust/gen-compile-cache/cxx-bridge.h
@@ -3,5 +3,5 @@
 #include <rust/cxx.h>
 
 namespace workerd::rust::gen_compile_cache {
-  ::rust::Vec<uint8_t> compile(::rust::Str path, ::rust::Str source);
+::rust::Vec<uint8_t> compile(::rust::Str path, ::rust::Str source);
 }

--- a/src/rust/kj/ffi.c++
+++ b/src/rust/kj/ffi.c++
@@ -9,7 +9,8 @@
 #include <kj/compat/http.h>
 
 static_assert(sizeof(kj::rust::HttpConnectSettings) == 16, "HttpConnectSettings size mismatch");
-static_assert(alignof(kj::rust::HttpConnectSettings) == alignof(uint64_t), "HttpConnectSettings alignment mismatch");
+static_assert(alignof(kj::rust::HttpConnectSettings) == alignof(uint64_t),
+    "HttpConnectSettings alignment mismatch");
 
 namespace kj::rust {
 kj::Promise<void> connect(HttpService& service,

--- a/src/rust/kj/tests/ffi-test.c++
+++ b/src/rust/kj/tests/ffi-test.c++
@@ -8,10 +8,10 @@
 #include <kj-rs/kj-rs.h>
 
 #include <kj/test.h>
+
 #include <cmath>
 
 using namespace kj_rs;
-
 
 static kj::StringPtr tlsHost;
 
@@ -28,8 +28,8 @@ class MockHttpService: public kj::HttpService {
       const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody,
       kj::HttpService::Response& response) override {
-        KJ_UNIMPLEMENTED("not exercised by test");
-      }
+    KJ_UNIMPLEMENTED("not exercised by test");
+  }
 
   kj::Promise<void> connect(kj::StringPtr host,
       const kj::HttpHeaders& headers,
@@ -55,8 +55,8 @@ class TestConnectResponse: public kj::HttpService::ConnectResponse {
       kj::StringPtr statusText,
       const kj::HttpHeaders& headers,
       kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
-        KJ_UNIMPLEMENTED("not exercised by test");
-      }
+    KJ_UNIMPLEMENTED("not exercised by test");
+  }
 };
 
 KJ_TEST("http connect settings") {
@@ -82,6 +82,6 @@ KJ_TEST("http connect settings") {
   settings.tls_starter = tlsStarter;
 
   auto promise = proxy->connect(host.asBytes().as<Rust>(), headers, connection, tunnel, settings);
-  KJ_ASSERT_NONNULL(*tlsStarter)(host).wait(waitScope);
+  KJ_ASSERT_NONNULL (*tlsStarter)(host).wait(waitScope);
   KJ_EXPECT(tlsHost == host);
 }

--- a/src/rust/python-parser/import_parsing.c++
+++ b/src/rust/python-parser/import_parsing.c++
@@ -3,7 +3,9 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 #include <workerd/rust/python-parser/lib.rs.h>
+
 #include <kj-rs/kj-rs.h>
+
 #include <kj/test.h>
 
 using namespace kj_rs;
@@ -93,12 +95,14 @@ KJ_TEST("supports commas") {
 }
 
 KJ_TEST("supports backslash") {
+  // clang-format off
   auto result = parseImports(kj::arr(
     "import a\\\n,b"_kj,
     "import\\\n q,w"_kj,
     "from \\\nx import y"_kj,
     "from \\\n   c import y"_kj
   ));
+  // clang-format on
   KJ_REQUIRE(result.size() == 6);
   KJ_REQUIRE(result[0] == "a");
   KJ_REQUIRE(result[1] == "b");
@@ -109,6 +113,7 @@ KJ_TEST("supports backslash") {
 }
 
 KJ_TEST("multiline-strings ignored") {
+  // clang-format off
   auto files = kj::arr(R"SCRIPT(
 FOO="""
 import x
@@ -128,6 +133,7 @@ import b \
 R"SCRIPT(import x
 from y import z
 """)SCRIPT"_kj);
+  // clang-format on
   auto result = parseImports(files);
   KJ_REQUIRE(result.size() == 0);
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2968,8 +2968,8 @@ inline V8Ref<T> V8Ref<T>::addRef(jsg::Lock& js) {
   return js.v8Ref(getHandle(js));
 }
 
-v8::Local<v8::Value> deepClone(v8::Local<v8::Context> context, v8::Local<v8::Value> value);
-// Defined in util.c++.
+// v8::Local<v8::Value> deepClone(v8::Local<v8::Context> context, v8::Local<v8::Value> value);
+// Already defined in util.c++.
 
 template <typename T>
 V8Ref<T> V8Ref<T>::deepClone(jsg::Lock& js) {

--- a/src/workerd/jsg/url.c++
+++ b/src/workerd/jsg/url.c++
@@ -314,13 +314,13 @@ void Url::setHash(kj::Maybe<kj::ArrayPtr<const char>> value) {
 }
 
 Url::SchemeType Url::getSchemeType() const {
-  uint8_t value = ada_get_scheme_type(const_cast<void*>(getInner<ada_url>(inner)));
+  uint8_t value = ada_get_scheme_type(getInner<ada_url>(inner));
   KJ_REQUIRE(value <= static_cast<uint8_t>(SchemeType::FILE));
   return static_cast<SchemeType>(value);
 }
 
 Url::HostType Url::getHostType() const {
-  uint8_t value = ada_get_host_type(const_cast<void*>(getInner<ada_url>(inner)));
+  uint8_t value = ada_get_host_type(getInner<ada_url>(inner));
   KJ_REQUIRE(value <= static_cast<uint8_t>(HostType::IPV6));
   return static_cast<HostType>(value);
 }

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -287,8 +287,4 @@ class Server final: private kj::TaskSet::ErrorHandler {
   friend struct FutureActorClassChannel;
 };
 
-// An ActorStorage implementation which will always respond to reads as if the state is empty,
-// and will fail any writes.
-kj::Own<rpc::ActorStorage::Stage::Server> newEmptyReadOnlyActorStorage();
-
 }  // namespace workerd::server

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -350,8 +350,8 @@ class WorkerdApi final: public Worker::Api {
 
 kj::Array<kj::String> getPythonRequirements(const Worker::Script::ModulesSource& source);
 
-// Helper method for defining actor storage server treating all reads as empty, defined here to be
-// used by test-fixture and server.
+// An ActorStorage implementation which will always respond to reads as if the state is empty,
+// and will fail any writes. Defined here to be used by test-fixture and server.
 kj::Own<rpc::ActorStorage::Stage::Server> newEmptyReadOnlyActorStorage();
 
 }  // namespace workerd::server

--- a/src/workerd/util/checked-queue.h
+++ b/src/workerd/util/checked-queue.h
@@ -32,7 +32,7 @@ class Queue final {
 
   template <typename... Args>
   T& emplace(Args&&... args) KJ_LIFETIMEBOUND {
-    return inner.emplace_back(std::forward<Args>(args)...);
+    return inner.emplace_back(kj::fwd<Args>(args)...);
   }
 
   // Pops the front element from the queue, moving it out.

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -493,8 +493,7 @@ RowCounts countRowsTouched(SqliteDatabase& db,
 
 template <typename... Params>
 RowCounts countRowsTouched(SqliteDatabase& db, kj::StringPtr sqlCode, Params... bindParams) {
-  return countRowsTouched(
-      db, SqliteDatabase::TRUSTED, sqlCode, std::forward<Params>(bindParams)...);
+  return countRowsTouched(db, SqliteDatabase::TRUSTED, sqlCode, kj::fwd<Params>(bindParams)...);
 }
 
 KJ_TEST("SQLite read row counters (basic)") {

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -474,8 +474,6 @@ static constexpr PragmaInfo ALLOWED_PRAGMAS[] = {{"data_version"_kj, PragmaSigna
 
 SqliteObserver SqliteObserver::DEFAULT = SqliteObserver{};
 
-constexpr SqliteDatabase::Regulator SqliteDatabase::TRUSTED;
-
 SqliteDatabase::SqliteDatabase(const Vfs& vfs,
     kj::Path path,
     kj::Maybe<kj::WriteMode> maybeMode,

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -715,7 +715,7 @@ class SqliteDatabase::Query final: private ResetListener {
   template <typename... T, size_t... i>
   void bindAll(std::index_sequence<i...>, T&&... value) {
     checkRequirements(sizeof...(T));
-    (bind(i, value), ...);
+    (bind(i, kj::fwd<T>(value)), ...);
     nextRow(/*first=*/true);
   }
 

--- a/tools/cross/format.json
+++ b/tools/cross/format.json
@@ -1,6 +1,6 @@
 [
   {
-    "directory": "src/workerd",
+    "directory": "src",
     "globs": ["*.c++", "*.h"],
     "formatter": "clang-format"
   },


### PR DESCRIPTION
- Apply clang-format on src/rust too
- Enable modernize-type-traits, readability-redundant-casting, readability-redundant-declaration tidy checks
- Fix compile_flags.txt based on bzlmod transition