### PR TITLE
[build] Fix macOS-cross build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,6 +32,7 @@ alias(
 alias(
     name = "format",
     actual = "//build/deps/formatters:format",
+    tags = ["manual"],
 )
 
 npm_link_all_packages(name = "node_modules")

--- a/build/deps/formatters/BUILD
+++ b/build/deps/formatters/BUILD
@@ -51,6 +51,7 @@ native_binary(
         "//conditions:default": "@clang-format-linux-amd64//file:file",
     }),
     out = "clang-format",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
@@ -63,6 +64,7 @@ native_binary(
         "//conditions:default": "@ruff-linux-amd64//:file",
     }),
     out = "ruff",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
@@ -77,6 +79,7 @@ native_binary(
         "//conditions:default": "@buildifier-linux-amd64//file:file",
     }),
     out = "buildifier",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -32,5 +32,6 @@ native_binary(
         },
     ),
     out = "clang_tidy",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This is needed since we don't have an x64 macOS clang-tidy binary, we should only fetch that when we actually use it. Also add "manual" tags for other binaries so we only fetch them when needed.

Regression introduced in https://github.com/cloudflare/workerd/pull/5415, this wasn't caught by CI since we only run macOS-cross as a release build on the main branch due to CI rate limiting.