### PR TITLE
Fix tail stream handler lifetime using reverse ownership pattern

### DIFF
--- a/src/workerd/io/io-own.h
+++ b/src/workerd/io/io-own.h
@@ -289,6 +289,16 @@ class ReverseIoOwn {
   ReverseIoOwn& operator=(ReverseIoOwn&& other);
   ReverseIoOwn& operator=(decltype(nullptr));
 
+  // Try to get the underlying object if safe to dereference.
+  // Returns kj::none if the IoContext has been destroyed or if this is null.
+  // This is a safe alternative to operator->() that won't throw or crash.
+  kj::Maybe<T&> tryGet() {
+    if (item != nullptr && weakRef->isValid()) {
+      return *item->ptr.get();
+    }
+    return kj::none;
+  }
+
  private:
   friend class IoContext;
   friend class DeleteQueue;

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -617,8 +617,15 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
       // We will only dispatch the remaining events if a handler is returned.
       auto result = ([&]() -> kj::Promise<void> {
         KJ_IF_SOME(handler, maybeHandler) {
-          auto h = handler->getHandle(lock);
-          return handleEvents(lock, h, ioContext, events.releaseAsArray(), kj::mv(sharedResults));
+          KJ_IF_SOME(h, handler.tryGet()) {
+            auto handle = h.getHandle(lock);
+            return handleEvents(
+                lock, handle, ioContext, events.releaseAsArray(), kj::mv(sharedResults));
+          } else {
+            KJ_LOG(ERROR, "tail stream handler was destroyed while processing events");
+            JSG_FAIL_REQUIRE(Error, "Tail stream handler became invalid during event processing");
+            KJ_UNREACHABLE;
+          }
         } else {
           return handleOnset(lock, ioContext, events.releaseAsArray(), kj::mv(sharedResults));
         }


### PR DESCRIPTION
Tail stream handlers (jsg::JsRef<jsg::JsValue>) could outlive their IoContext, causing V8 fatal crashes when the isolate is destroyed while TailStreamTarget still holds JavaScript references. Use reverse ownership pattern to ensure JavaScript references are destroyed when the IoContext is destroyed, not when the RPC server is destroyed.
