### PR TITLE
Remove Blob-specific ReadableStreamSource subclass with autogate

### DIFF
--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -33,6 +33,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "identity-transform-stream-use-state-machine"_kj;
     case AutogateKey::RPC_USE_EXTERNAL_PUSHER:
       return "rpc-use-external-pusher"_kj;
+    case AutogateKey::BLOB_USE_STREAMS_NEW_MEMORY_SOURCE:
+      return "blob-use-streams-new-memory-source"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -28,6 +28,8 @@ enum class AutogateKey {
   IDENTITY_TRANSFORM_STREAM_USE_STATE_MACHINE,
   // Use ExternalPusher instead of StreamSink to handle streams in RPC.
   RPC_USE_EXTERNAL_PUSHER,
+  // Switch Blob stream() to use streams::newMemorySource instead of Blob::BlobInputStream
+  BLOB_USE_STREAMS_NEW_MEMORY_SOURCE,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
Use the generic MemoryInputStream to provide the stream for blob data.

Part of getting ready to use the updated ReadableSource adapters