### PR TITLE
Prevent alarm update races with promise chain serialization

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2957,7 +2957,9 @@ class Server::WorkerService final: public Service,
           : alarmScheduler(alarmScheduler),
             actor(actor) {}
 
-      kj::Promise<void> scheduleRun(kj::Maybe<kj::Date> newAlarmTime) override {
+      // We ignore the priorTask in workerd because everything should run synchronously.
+      kj::Promise<void> scheduleRun(
+          kj::Maybe<kj::Date> newAlarmTime, kj::Promise<void> priorTask) override {
         KJ_IF_SOME(scheduledTime, newAlarmTime) {
           alarmScheduler.setAlarm(actor, scheduledTime);
         } else {


### PR DESCRIPTION
`alarmLaterTasks` is a background task queue for updating the alarm manager when alarms are moved to a later time (including deletion). Tasks in this queue retry up to 4 times on failure.

Prior to this commit, a race condition could occur:
1. Alarm handler completes, queuing a deferred delete in `alarmLaterTasks`
2. User calls setAlarm() with a new time, which precommits to alarm manager
3. The deferred delete from step 1 retries and overwrites the new alarm

This causes the alarm manager to have no alarm while SRS has the new alarm time, leading to alarms that never fire (or fire late if the alarm time was set to run later, not never).

To fix this race, we clear `alarmLaterTasks` whenever a new alarm is set. This is safe because:

- If we have a pending "move later" task, the alarm manager already has an earlier alarm time that will fire and reconcile via `armAlarmHandler`

- The new alarm being set supersedes any pending "move later" operations anyway

This ensures the alarm manager always converges to the correct state without racing background updates.