### PR TITLE
Workers AI Types support for OpenAI's Responses API

### DIFF
--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -263,6 +263,414 @@ export declare abstract class BaseAiTranslation {
   inputs: AiTranslationInput;
   postProcessedOutputs: AiTranslationOutput;
 }
+/**
+ * Workers AI support for OpenAI's Responses API
+ * Reference: https://github.com/openai/openai-node/blob/master/src/resources/responses/responses.ts
+ *
+ * It's a stripped down version from its source.
+ * It currently supports basic function calling, json mode and accepts images as input.
+ *
+ * It does not include types for WebSearch, CodeInterpreter, FileInputs, MCP, CustomTools.
+ * We plan to add those incrementally as model + platform capabilities evolve.
+ */
+export type ResponsesInput = {
+  background?: boolean | null;
+  conversation?: string | ResponseConversationParam | null;
+  include?: Array<ResponseIncludable> | null;
+  input?: string | ResponseInput;
+  instructions?: string | null;
+  max_output_tokens?: number | null;
+  parallel_tool_calls?: boolean | null;
+  previous_response_id?: string | null;
+  prompt_cache_key?: string;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  stream?: boolean | null;
+  stream_options?: StreamOptions | null;
+  temperature?: number | null;
+  text?: ResponseTextConfig;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  truncation?: "auto" | "disabled" | null;
+};
+export type ResponsesOutput = {
+  id?: string;
+  created_at?: number;
+  output_text?: string;
+  error?: ResponseError | null;
+  incomplete_details?: ResponseIncompleteDetails | null;
+  instructions?: string | Array<ResponseInputItem> | null;
+  object?: "response";
+  output?: Array<ResponseOutputItem>;
+  parallel_tool_calls?: boolean;
+  temperature?: number | null;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  max_output_tokens?: number | null;
+  previous_response_id?: string | null;
+  prompt?: ResponsePrompt | null;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  status?: ResponseStatus;
+  text?: ResponseTextConfig;
+  truncation?: "auto" | "disabled" | null;
+  usage?: ResponseUsage;
+};
+export type EasyInputMessage = {
+  content: string | ResponseInputMessageContentList;
+  role: "user" | "assistant" | "system" | "developer";
+  type?: "message";
+};
+export type ResponsesFunctionTool = {
+  name: string;
+  parameters: {
+    [key: string]: unknown;
+  } | null;
+  strict: boolean | null;
+  type: "function";
+  description?: string | null;
+};
+export type ResponseIncompleteDetails = {
+  reason?: "max_output_tokens" | "content_filter";
+};
+export type ResponsePrompt = {
+  id: string;
+  variables?: {
+    [key: string]: string | ResponseInputText | ResponseInputImage;
+  } | null;
+  version?: string | null;
+};
+export type Reasoning = {
+  effort?: ReasoningEffort | null;
+  generate_summary?: "auto" | "concise" | "detailed" | null;
+  summary?: "auto" | "concise" | "detailed" | null;
+};
+export type ResponseContent =
+  | ResponseInputText
+  | ResponseInputImage
+  | ResponseOutputText
+  | ResponseOutputRefusal
+  | ResponseContentReasoningText;
+export type ResponseContentReasoningText = {
+  text: string;
+  type: "reasoning_text";
+};
+export type ResponseConversationParam = {
+  id: string;
+};
+export type ResponseCreatedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.created";
+};
+export type ResponseCustomToolCallOutput = {
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "custom_tool_call_output";
+  id?: string;
+};
+export type ResponseError = {
+  code:
+    | "server_error"
+    | "rate_limit_exceeded"
+    | "invalid_prompt"
+    | "vector_store_timeout"
+    | "invalid_image"
+    | "invalid_image_format"
+    | "invalid_base64_image"
+    | "invalid_image_url"
+    | "image_too_large"
+    | "image_too_small"
+    | "image_parse_error"
+    | "image_content_policy_violation"
+    | "invalid_image_mode"
+    | "image_file_too_large"
+    | "unsupported_image_media_type"
+    | "empty_image_file"
+    | "failed_to_download_image"
+    | "image_file_not_found";
+  message: string;
+};
+export type ResponseErrorEvent = {
+  code: string | null;
+  message: string;
+  param: string | null;
+  sequence_number: number;
+  type: "error";
+};
+export type ResponseFailedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.failed";
+};
+export type ResponseFormatText = {
+  type: "text";
+};
+export type ResponseFormatJSONObject = {
+  type: "json_object";
+};
+export type ResponseFormatTextConfig =
+  | ResponseFormatText
+  | ResponseFormatTextJSONSchemaConfig
+  | ResponseFormatJSONObject;
+export type ResponseFormatTextJSONSchemaConfig = {
+  name: string;
+  schema: {
+    [key: string]: unknown;
+  };
+  type: "json_schema";
+  description?: string;
+  strict?: boolean | null;
+};
+export type ResponseFunctionCallArgumentsDeltaEvent = {
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.delta";
+};
+export type ResponseFunctionCallArgumentsDoneEvent = {
+  arguments: string;
+  item_id: string;
+  name: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.done";
+};
+export type ResponseFunctionCallOutputItem = ResponseInputTextContent | ResponseInputImageContent;
+export type ResponseFunctionCallOutputItemList = Array<ResponseFunctionCallOutputItem>;
+export type ResponseFunctionToolCall = {
+  arguments: string;
+  call_id: string;
+  name: string;
+  type: "function_call";
+  id?: string;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export interface ResponseFunctionToolCallItem extends ResponseFunctionToolCall {
+  id: string;
+}
+export type ResponseFunctionToolCallOutputItem = {
+  id: string;
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "function_call_output";
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export type ResponseIncludable = "message.input_image.image_url" | "message.output_text.logprobs";
+export type ResponseIncompleteEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.incomplete";
+};
+export type ResponseInput = Array<ResponseInputItem>;
+export type ResponseInputContent = ResponseInputText | ResponseInputImage;
+export type ResponseInputImage = {
+  detail: "low" | "high" | "auto";
+  type: "input_image";
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+export type ResponseInputImageContent = {
+  type: "input_image";
+  detail?: "low" | "high" | "auto" | null;
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+export type ResponseInputItem =
+  | EasyInputMessage
+  | ResponseInputItemMessage
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseInputItemFunctionCallOutput
+  | ResponseReasoningItem;
+export type ResponseInputItemFunctionCallOutput = {
+  call_id: string;
+  output: string | ResponseFunctionCallOutputItemList;
+  type: "function_call_output";
+  id?: string | null;
+  status?: "in_progress" | "completed" | "incomplete" | null;
+};
+export type ResponseInputItemMessage = {
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+export type ResponseInputMessageContentList = Array<ResponseInputContent>;
+export type ResponseInputMessageItem = {
+  id: string;
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+export type ResponseInputText = {
+  text: string;
+  type: "input_text";
+};
+export type ResponseInputTextContent = {
+  text: string;
+  type: "input_text";
+};
+export type ResponseItem =
+  | ResponseInputMessageItem
+  | ResponseOutputMessage
+  | ResponseFunctionToolCallItem
+  | ResponseFunctionToolCallOutputItem;
+export type ResponseOutputItem = ResponseOutputMessage | ResponseFunctionToolCall | ResponseReasoningItem;
+export type ResponseOutputItemAddedEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.added";
+};
+export type ResponseOutputItemDoneEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.done";
+};
+export type ResponseOutputMessage = {
+  id: string;
+  content: Array<ResponseOutputText | ResponseOutputRefusal>;
+  role: "assistant";
+  status: "in_progress" | "completed" | "incomplete";
+  type: "message";
+};
+export type ResponseOutputRefusal = {
+  refusal: string;
+  type: "refusal";
+};
+export type ResponseOutputText = {
+  text: string;
+  type: "output_text";
+  logprobs?: Array<Logprob>;
+};
+export type ResponseReasoningItem = {
+  id: string;
+  summary: Array<ResponseReasoningSummaryItem>;
+  type: "reasoning";
+  content?: Array<ResponseReasoningContentItem>;
+  encrypted_content?: string | null;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export type ResponseReasoningSummaryItem = {
+  text: string;
+  type: "summary_text";
+};
+export type ResponseReasoningContentItem = {
+  text: string;
+  type: "reasoning_text";
+};
+export type ResponseReasoningTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.reasoning_text.delta";
+};
+export type ResponseReasoningTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.reasoning_text.done";
+};
+export type ResponseRefusalDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.refusal.delta";
+};
+export type ResponseRefusalDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  refusal: string;
+  sequence_number: number;
+  type: "response.refusal.done";
+};
+export type ResponseStatus = "completed" | "failed" | "in_progress" | "cancelled" | "queued" | "incomplete";
+export type ResponseStreamEvent =
+  | ResponseCompletedEvent
+  | ResponseCreatedEvent
+  | ResponseErrorEvent
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseFailedEvent
+  | ResponseIncompleteEvent
+  | ResponseOutputItemAddedEvent
+  | ResponseOutputItemDoneEvent
+  | ResponseReasoningTextDeltaEvent
+  | ResponseReasoningTextDoneEvent
+  | ResponseRefusalDeltaEvent
+  | ResponseRefusalDoneEvent
+  | ResponseTextDeltaEvent
+  | ResponseTextDoneEvent;
+export type ResponseCompletedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.completed";
+};
+export type ResponseTextConfig = {
+  format?: ResponseFormatTextConfig;
+  verbosity?: "low" | "medium" | "high" | null;
+};
+export type ResponseTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_text.delta";
+};
+export type ResponseTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.output_text.done";
+};
+export type Logprob = {
+  token: string;
+  logprob: number;
+  top_logprobs?: Array<TopLogprob>;
+};
+export type TopLogprob = {
+  token?: string;
+  logprob?: number;
+};
+export type ResponseUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+};
+export type Tool = ResponsesFunctionTool;
+export type ToolChoiceFunction = {
+  name: string;
+  type: "function";
+};
+export type ToolChoiceOptions = "none";
+export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
+export type StreamOptions = {
+  include_obfuscation?: boolean;
+};
 export type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -295,8 +703,8 @@ export type Ai_Cf_Baai_Bge_Base_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
-export interface AsyncResponse {
+  | Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse {
   /**
    * The async request id that can be used to obtain the results.
    */
@@ -378,7 +786,13 @@ export type Ai_Cf_Meta_M2M100_1_2B_Output =
        */
       translated_text?: string;
     }
-  | AsyncResponse;
+  | Ai_Cf_Meta_M2M100_1_2B_AsyncResponse;
+export interface Ai_Cf_Meta_M2M100_1_2B_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Meta_M2M100_1_2B {
   inputs: Ai_Cf_Meta_M2M100_1_2B_Input;
   postProcessedOutputs: Ai_Cf_Meta_M2M100_1_2B_Output;
@@ -415,7 +829,13 @@ export type Ai_Cf_Baai_Bge_Small_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Baai_Bge_Small_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Output;
@@ -452,7 +872,13 @@ export type Ai_Cf_Baai_Bge_Large_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Baai_Bge_Large_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Output;
@@ -643,15 +1069,15 @@ export declare abstract class Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo {
   postProcessedOutputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output;
 }
 export type Ai_Cf_Baai_Bge_M3_Input =
-  | BGEM3InputQueryAndContexts
-  | BGEM3InputEmbedding
+  | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts
+  | Ai_Cf_Baai_Bge_M3_Input_Embedding
   | {
       /**
        * Batch of the embeddings requests to run using async-queue
        */
-      requests: (BGEM3InputQueryAndContexts1 | BGEM3InputEmbedding1)[];
+      requests: (Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1 | Ai_Cf_Baai_Bge_M3_Input_Embedding_1)[];
     };
-export interface BGEM3InputQueryAndContexts {
+export interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -670,14 +1096,14 @@ export interface BGEM3InputQueryAndContexts {
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputEmbedding {
+export interface Ai_Cf_Baai_Bge_M3_Input_Embedding {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputQueryAndContexts1 {
+export interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1 {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -696,7 +1122,7 @@ export interface BGEM3InputQueryAndContexts1 {
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputEmbedding1 {
+export interface Ai_Cf_Baai_Bge_M3_Input_Embedding_1 {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
@@ -704,11 +1130,11 @@ export interface BGEM3InputEmbedding1 {
   truncate_inputs?: boolean;
 }
 export type Ai_Cf_Baai_Bge_M3_Output =
-  | BGEM3OuputQuery
-  | BGEM3OutputEmbeddingForContexts
-  | BGEM3OuputEmbedding
-  | AsyncResponse;
-export interface BGEM3OuputQuery {
+  | Ai_Cf_Baai_Bge_M3_Ouput_Query
+  | Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts
+  | Ai_Cf_Baai_Bge_M3_Ouput_Embedding
+  | Ai_Cf_Baai_Bge_M3_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_M3_Ouput_Query {
   response?: {
     /**
      * Index of the context in the request
@@ -720,7 +1146,7 @@ export interface BGEM3OuputQuery {
     score?: number;
   }[];
 }
-export interface BGEM3OutputEmbeddingForContexts {
+export interface Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts {
   response?: number[][];
   shape?: number[];
   /**
@@ -728,7 +1154,7 @@ export interface BGEM3OutputEmbeddingForContexts {
    */
   pooling?: "mean" | "cls";
 }
-export interface BGEM3OuputEmbedding {
+export interface Ai_Cf_Baai_Bge_M3_Ouput_Embedding {
   shape?: number[];
   /**
    * Embeddings of the requested text values
@@ -738,6 +1164,12 @@ export interface BGEM3OuputEmbedding {
    * The pooling method used in the embedding process.
    */
   pooling?: "mean" | "cls";
+}
+export interface Ai_Cf_Baai_Bge_M3_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
 }
 export declare abstract class Base_Ai_Cf_Baai_Bge_M3 {
   inputs: Ai_Cf_Baai_Bge_M3_Input;
@@ -763,8 +1195,10 @@ export declare abstract class Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell {
   inputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Input;
   postProcessedOutputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Output;
 }
-export type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input = Prompt | Messages;
-export interface Prompt {
+export type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input =
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages;
+export interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -815,7 +1249,7 @@ export interface Prompt {
    */
   lora?: string;
 }
-export interface Messages {
+export interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -1013,10 +1447,10 @@ export declare abstract class Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct {
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Output;
 }
 export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input =
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
-  | AsyncBatch;
-export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch;
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -1025,7 +1459,7 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -1067,11 +1501,11 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    */
   presence_penalty?: number;
 }
-export interface JSONMode {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode {
   type?: "json_object" | "json_schema";
   json_schema?: unknown;
 }
-export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -1179,7 +1613,7 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -1221,7 +1655,11 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
    */
   presence_penalty?: number;
 }
-export interface AsyncBatch {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch {
   requests?: {
     /**
      * User-supplied reference. This field will be present in the response as well it can be used to reference the request and response. It's NOT validated to be unique.
@@ -1263,8 +1701,12 @@ export interface AsyncBatch {
      * Increases the likelihood of the model introducing new topics.
      */
     presence_penalty?: number;
-    response_format?: JSONMode;
+    response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2;
   }[];
+}
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
 }
 export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
   | {
@@ -1304,7 +1746,13 @@ export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
       }[];
     }
   | string
-  | AsyncResponse;
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse;
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast {
   inputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output;
@@ -1411,9 +1859,9 @@ export declare abstract class Base_Ai_Cf_Baai_Bge_Reranker_Base {
   postProcessedOutputs: Ai_Cf_Baai_Bge_Reranker_Base_Output;
 }
 export type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input =
-  | Qwen2_5_Coder_32B_Instruct_Prompt
-  | Qwen2_5_Coder_32B_Instruct_Messages;
-export interface Qwen2_5_Coder_32B_Instruct_Prompt {
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages;
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -1422,7 +1870,7 @@ export interface Qwen2_5_Coder_32B_Instruct_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -1464,7 +1912,11 @@ export interface Qwen2_5_Coder_32B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Qwen2_5_Coder_32B_Instruct_Messages {
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -1572,7 +2024,7 @@ export interface Qwen2_5_Coder_32B_Instruct_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -1614,6 +2066,10 @@ export interface Qwen2_5_Coder_32B_Instruct_Messages {
    */
   presence_penalty?: number;
 }
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
 export type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output = {
   /**
    * The generated text response from the model
@@ -1654,8 +2110,8 @@ export declare abstract class Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct {
   inputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output;
 }
-export type Ai_Cf_Qwen_Qwq_32B_Input = Qwen_Qwq_32B_Prompt | Qwen_Qwq_32B_Messages;
-export interface Qwen_Qwq_32B_Prompt {
+export type Ai_Cf_Qwen_Qwq_32B_Input = Ai_Cf_Qwen_Qwq_32B_Prompt | Ai_Cf_Qwen_Qwq_32B_Messages;
+export interface Ai_Cf_Qwen_Qwq_32B_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -1705,7 +2161,7 @@ export interface Qwen_Qwq_32B_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Qwen_Qwq_32B_Messages {
+export interface Ai_Cf_Qwen_Qwq_32B_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -1927,9 +2383,9 @@ export declare abstract class Base_Ai_Cf_Qwen_Qwq_32B {
   postProcessedOutputs: Ai_Cf_Qwen_Qwq_32B_Output;
 }
 export type Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input =
-  | Mistral_Small_3_1_24B_Instruct_Prompt
-  | Mistral_Small_3_1_24B_Instruct_Messages;
-export interface Mistral_Small_3_1_24B_Instruct_Prompt {
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages;
+export interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -1979,7 +2435,7 @@ export interface Mistral_Small_3_1_24B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Mistral_Small_3_1_24B_Instruct_Messages {
+export interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -2200,8 +2656,10 @@ export declare abstract class Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruc
   inputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output;
 }
-export type Ai_Cf_Google_Gemma_3_12B_It_Input = Google_Gemma_3_12B_It_Prompt | Google_Gemma_3_12B_It_Messages;
-export interface Google_Gemma_3_12B_It_Prompt {
+export type Ai_Cf_Google_Gemma_3_12B_It_Input =
+  | Ai_Cf_Google_Gemma_3_12B_It_Prompt
+  | Ai_Cf_Google_Gemma_3_12B_It_Messages;
+export interface Ai_Cf_Google_Gemma_3_12B_It_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -2251,7 +2709,7 @@ export interface Google_Gemma_3_12B_It_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Google_Gemma_3_12B_It_Messages {
+export interface Ai_Cf_Google_Gemma_3_12B_It_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -2274,20 +2732,7 @@ export interface Google_Gemma_3_12B_It_Messages {
              */
             url?: string;
           };
-        }[]
-      | {
-          /**
-           * Type of the content provided
-           */
-          type?: string;
-          text?: string;
-          image_url?: {
-            /**
-             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-             */
-            url?: string;
-          };
-        };
+        }[];
   }[];
   functions?: {
     name: string;
@@ -2469,10 +2914,10 @@ export declare abstract class Base_Ai_Cf_Google_Gemma_3_12B_It {
   postProcessedOutputs: Ai_Cf_Google_Gemma_3_12B_It_Output;
 }
 export type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input =
-  | Ai_Cf_Meta_Llama_4_Prompt
-  | Ai_Cf_Meta_Llama_4_Messages
-  | Ai_Cf_Meta_Llama_4_Async_Batch;
-export interface Ai_Cf_Meta_Llama_4_Prompt {
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch;
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -2481,7 +2926,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -2523,7 +2968,11 @@ export interface Ai_Cf_Meta_Llama_4_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Messages {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -2659,7 +3108,7 @@ export interface Ai_Cf_Meta_Llama_4_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -2705,10 +3154,13 @@ export interface Ai_Cf_Meta_Llama_4_Messages {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Async_Batch {
-  requests: (Ai_Cf_Meta_Llama_4_Prompt_Inner | Ai_Cf_Meta_Llama_4_Messages_Inner)[];
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch {
+  requests: (
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner
+  )[];
 }
-export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -2717,7 +3169,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -2759,7 +3211,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Messages_Inner {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -2895,7 +3347,7 @@ export interface Ai_Cf_Meta_Llama_4_Messages_Inner {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -2993,6 +3445,610 @@ export type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output = {
 export declare abstract class Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct {
   inputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output;
+}
+export type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch;
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch {
+  requests: (Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1 | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1)[];
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response
+  | string
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse;
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+export declare abstract class Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8 {
+  inputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output;
 }
 export interface Ai_Cf_Deepgram_Nova_3_Input {
   audio: {
@@ -3177,6 +4233,23 @@ export declare abstract class Base_Ai_Cf_Deepgram_Nova_3 {
   inputs: Ai_Cf_Deepgram_Nova_3_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Nova_3_Output;
 }
+export interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input {
+  queries?: string | string[];
+  /**
+   * Optional instruction for the task
+   */
+  instruction?: string;
+  documents?: string | string[];
+  text?: string | string[];
+}
+export interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output {
+  data?: number[][];
+  shape?: number[];
+}
+export declare abstract class Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B {
+  inputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output;
+}
 export type Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input =
   | {
       /**
@@ -3215,85 +4288,13 @@ export declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   inputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input;
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
-export type Ai_Cf_Openai_Gpt_Oss_120B_Input = GPT_OSS_120B_Responses | GPT_OSS_120B_Responses_Async;
-export interface GPT_OSS_120B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-export interface GPT_OSS_120B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-export type Ai_Cf_Openai_Gpt_Oss_120B_Output = {} | (string & NonNullable<unknown>);
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_120B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_120B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
-export type Ai_Cf_Openai_Gpt_Oss_20B_Input = GPT_OSS_20B_Responses | GPT_OSS_20B_Responses_Async;
-export interface GPT_OSS_20B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-export interface GPT_OSS_20B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-export type Ai_Cf_Openai_Gpt_Oss_20B_Output = {} | (string & NonNullable<unknown>);
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_20B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_20B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
 export interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**
@@ -3419,6 +4420,896 @@ export declare abstract class Base_Ai_Cf_Deepgram_Aura_1 {
   inputs: Ai_Cf_Deepgram_Aura_1_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Aura_1_Output;
 }
+export interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
+  /**
+   * Input text to translate. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+  /**
+   * Target langauge to translate to
+   */
+  target_language:
+    | "asm_Beng"
+    | "awa_Deva"
+    | "ben_Beng"
+    | "bho_Deva"
+    | "brx_Deva"
+    | "doi_Deva"
+    | "eng_Latn"
+    | "gom_Deva"
+    | "gon_Deva"
+    | "guj_Gujr"
+    | "hin_Deva"
+    | "hne_Deva"
+    | "kan_Knda"
+    | "kas_Arab"
+    | "kas_Deva"
+    | "kha_Latn"
+    | "lus_Latn"
+    | "mag_Deva"
+    | "mai_Deva"
+    | "mal_Mlym"
+    | "mar_Deva"
+    | "mni_Beng"
+    | "mni_Mtei"
+    | "npi_Deva"
+    | "ory_Orya"
+    | "pan_Guru"
+    | "san_Deva"
+    | "sat_Olck"
+    | "snd_Arab"
+    | "snd_Deva"
+    | "tam_Taml"
+    | "tel_Telu"
+    | "urd_Arab"
+    | "unr_Deva";
+}
+export interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output {
+  /**
+   * Translated texts
+   */
+  translations: string[];
+}
+export declare abstract class Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B {
+  inputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input;
+  postProcessedOutputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output;
+}
+export type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch;
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch {
+  requests: (
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1
+  )[];
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response
+  | string
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse;
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+export declare abstract class Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It {
+  inputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input;
+  postProcessedOutputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output;
+}
+export interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Input {
+  /**
+   * Input text to embed. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+}
+export interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Output {
+  /**
+   * Embedding vectors, where each vector is a list of floats.
+   */
+  data: number[][];
+  /**
+   * Shape of the embedding data as [number_of_embeddings, embedding_dimension].
+   *
+   * @minItems 2
+   * @maxItems 2
+   */
+  shape: [number, number];
+}
+export declare abstract class Base_Ai_Cf_Pfnet_Plamo_Embedding_1B {
+  inputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Input;
+  postProcessedOutputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Output;
+}
+export interface Ai_Cf_Deepgram_Flux_Input {
+  /**
+   * Encoding of the audio stream. Currently only supports raw signed little-endian 16-bit PCM.
+   */
+  encoding: "linear16";
+  /**
+   * Sample rate of the audio stream in Hz.
+   */
+  sample_rate: string;
+  /**
+   * End-of-turn confidence required to fire an eager end-of-turn event. When set, enables EagerEndOfTurn and TurnResumed events. Valid Values 0.3 - 0.9.
+   */
+  eager_eot_threshold?: string;
+  /**
+   * End-of-turn confidence required to finish a turn. Valid Values 0.5 - 0.9.
+   */
+  eot_threshold?: string;
+  /**
+   * A turn will be finished when this much time has passed after speech, regardless of EOT confidence.
+   */
+  eot_timeout_ms?: string;
+  /**
+   * Keyterm prompting can improve recognition of specialized terminology. Pass multiple keyterm query parameters to boost multiple keyterms.
+   */
+  keyterm?: string;
+  /**
+   * Opts out requests from the Deepgram Model Improvement Program. Refer to Deepgram Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
+   */
+  mip_opt_out?: "true" | "false";
+  /**
+   * Label your requests for the purpose of identification during usage reporting
+   */
+  tag?: string;
+}
+/**
+ * Output will be returned as websocket messages.
+ */
+export interface Ai_Cf_Deepgram_Flux_Output {
+  /**
+   * The unique identifier of the request (uuid)
+   */
+  request_id?: string;
+  /**
+   * Starts at 0 and increments for each message the server sends to the client.
+   */
+  sequence_id?: number;
+  /**
+   * The type of event being reported.
+   */
+  event?: "Update" | "StartOfTurn" | "EagerEndOfTurn" | "TurnResumed" | "EndOfTurn";
+  /**
+   * The index of the current turn
+   */
+  turn_index?: number;
+  /**
+   * Start time in seconds of the audio range that was transcribed
+   */
+  audio_window_start?: number;
+  /**
+   * End time in seconds of the audio range that was transcribed
+   */
+  audio_window_end?: number;
+  /**
+   * Text that was said over the course of the current turn
+   */
+  transcript?: string;
+  /**
+   * The words in the transcript
+   */
+  words?: {
+    /**
+     * The individual punctuated, properly-cased word from the transcript
+     */
+    word: string;
+    /**
+     * Confidence that this word was transcribed correctly
+     */
+    confidence: number;
+  }[];
+  /**
+   * Confidence that no more speech is coming in this turn
+   */
+  end_of_turn_confidence?: number;
+}
+export declare abstract class Base_Ai_Cf_Deepgram_Flux {
+  inputs: Ai_Cf_Deepgram_Flux_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Flux_Output;
+}
+export interface Ai_Cf_Deepgram_Aura_2_En_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "amalthea"
+    | "andromeda"
+    | "apollo"
+    | "arcas"
+    | "aries"
+    | "asteria"
+    | "athena"
+    | "atlas"
+    | "aurora"
+    | "callista"
+    | "cora"
+    | "cordelia"
+    | "delia"
+    | "draco"
+    | "electra"
+    | "harmonia"
+    | "helena"
+    | "hera"
+    | "hermes"
+    | "hyperion"
+    | "iris"
+    | "janus"
+    | "juno"
+    | "jupiter"
+    | "luna"
+    | "mars"
+    | "minerva"
+    | "neptune"
+    | "odysseus"
+    | "ophelia"
+    | "orion"
+    | "orpheus"
+    | "pandora"
+    | "phoebe"
+    | "pluto"
+    | "saturn"
+    | "thalia"
+    | "theia"
+    | "vesta"
+    | "zeus";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+export type Ai_Cf_Deepgram_Aura_2_En_Output = string;
+export declare abstract class Base_Ai_Cf_Deepgram_Aura_2_En {
+  inputs: Ai_Cf_Deepgram_Aura_2_En_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_En_Output;
+}
+export interface Ai_Cf_Deepgram_Aura_2_Es_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "sirio"
+    | "nestor"
+    | "carina"
+    | "celeste"
+    | "alvaro"
+    | "diana"
+    | "aquila"
+    | "selena"
+    | "estrella"
+    | "javier";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+export type Ai_Cf_Deepgram_Aura_2_Es_Output = string;
+export declare abstract class Base_Ai_Cf_Deepgram_Aura_2_Es {
+  inputs: Ai_Cf_Deepgram_Aura_2_Es_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_Es_Output;
+}
 export interface AiModels {
   "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
   "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
@@ -3462,12 +5353,12 @@ export interface AiModels {
   "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
   "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
-  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
   "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": BaseAiTextGeneration;
+  "@cf/ibm-granite/granite-4.0-h-micro": BaseAiTextGeneration;
   "@cf/facebook/bart-large-cnn": BaseAiSummarization;
   "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
   "@cf/baai/bge-base-en-v1.5": Base_Ai_Cf_Baai_Bge_Base_En_V1_5;
@@ -3489,13 +5380,21 @@ export interface AiModels {
   "@cf/mistralai/mistral-small-3.1-24b-instruct": Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct;
   "@cf/google/gemma-3-12b-it": Base_Ai_Cf_Google_Gemma_3_12B_It;
   "@cf/meta/llama-4-scout-17b-16e-instruct": Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct;
+  "@cf/qwen/qwen3-30b-a3b-fp8": Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8;
   "@cf/deepgram/nova-3": Base_Ai_Cf_Deepgram_Nova_3;
+  "@cf/qwen/qwen3-embedding-0.6b": Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B;
   "@cf/pipecat-ai/smart-turn-v2": Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
   "@cf/openai/gpt-oss-120b": Base_Ai_Cf_Openai_Gpt_Oss_120B;
   "@cf/openai/gpt-oss-20b": Base_Ai_Cf_Openai_Gpt_Oss_20B;
   "@cf/leonardo/phoenix-1.0": Base_Ai_Cf_Leonardo_Phoenix_1_0;
   "@cf/leonardo/lucid-origin": Base_Ai_Cf_Leonardo_Lucid_Origin;
   "@cf/deepgram/aura-1": Base_Ai_Cf_Deepgram_Aura_1;
+  "@cf/ai4bharat/indictrans2-en-indic-1B": Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B;
+  "@cf/aisingapore/gemma-sea-lion-v4-27b-it": Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It;
+  "@cf/pfnet/plamo-embedding-1b": Base_Ai_Cf_Pfnet_Plamo_Embedding_1B;
+  "@cf/deepgram/flux": Base_Ai_Cf_Deepgram_Flux;
+  "@cf/deepgram/aura-2-en": Base_Ai_Cf_Deepgram_Aura_2_En;
+  "@cf/deepgram/aura-2-es": Base_Ai_Cf_Deepgram_Aura_2_Es;
 }
 export type AiOptions = {
   /**
@@ -3507,6 +5406,16 @@ export type AiOptions = {
    * Establish websocket connections, only works for supported models
    */
   websocket?: boolean;
+  /**
+   * Tag your requests to group and view them in Cloudflare dashboard.
+   *
+   * Rules:
+   * Tags must only contain letters, numbers, and the symbols: : - . / @
+   * Each tag can have maximum 50 characters.
+   * Maximum 5 tags are allowed each request.
+   * Duplicate tags will removed.
+   */
+  tags: string[];
   gateway?: GatewayOptions;
   returnRawResponse?: boolean;
   prefix?: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4746,6 +4746,427 @@ declare abstract class BaseAiTranslation {
   inputs: AiTranslationInput;
   postProcessedOutputs: AiTranslationOutput;
 }
+/**
+ * Workers AI support for OpenAI's Responses API
+ * Reference: https://github.com/openai/openai-node/blob/master/src/resources/responses/responses.ts
+ *
+ * It's a stripped down version from its source.
+ * It currently supports basic function calling, json mode and accepts images as input.
+ *
+ * It does not include types for WebSearch, CodeInterpreter, FileInputs, MCP, CustomTools.
+ * We plan to add those incrementally as model + platform capabilities evolve.
+ */
+type ResponsesInput = {
+  background?: boolean | null;
+  conversation?: string | ResponseConversationParam | null;
+  include?: Array<ResponseIncludable> | null;
+  input?: string | ResponseInput;
+  instructions?: string | null;
+  max_output_tokens?: number | null;
+  parallel_tool_calls?: boolean | null;
+  previous_response_id?: string | null;
+  prompt_cache_key?: string;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  stream?: boolean | null;
+  stream_options?: StreamOptions | null;
+  temperature?: number | null;
+  text?: ResponseTextConfig;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  truncation?: "auto" | "disabled" | null;
+};
+type ResponsesOutput = {
+  id?: string;
+  created_at?: number;
+  output_text?: string;
+  error?: ResponseError | null;
+  incomplete_details?: ResponseIncompleteDetails | null;
+  instructions?: string | Array<ResponseInputItem> | null;
+  object?: "response";
+  output?: Array<ResponseOutputItem>;
+  parallel_tool_calls?: boolean;
+  temperature?: number | null;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  max_output_tokens?: number | null;
+  previous_response_id?: string | null;
+  prompt?: ResponsePrompt | null;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  status?: ResponseStatus;
+  text?: ResponseTextConfig;
+  truncation?: "auto" | "disabled" | null;
+  usage?: ResponseUsage;
+};
+type EasyInputMessage = {
+  content: string | ResponseInputMessageContentList;
+  role: "user" | "assistant" | "system" | "developer";
+  type?: "message";
+};
+type ResponsesFunctionTool = {
+  name: string;
+  parameters: {
+    [key: string]: unknown;
+  } | null;
+  strict: boolean | null;
+  type: "function";
+  description?: string | null;
+};
+type ResponseIncompleteDetails = {
+  reason?: "max_output_tokens" | "content_filter";
+};
+type ResponsePrompt = {
+  id: string;
+  variables?: {
+    [key: string]: string | ResponseInputText | ResponseInputImage;
+  } | null;
+  version?: string | null;
+};
+type Reasoning = {
+  effort?: ReasoningEffort | null;
+  generate_summary?: "auto" | "concise" | "detailed" | null;
+  summary?: "auto" | "concise" | "detailed" | null;
+};
+type ResponseContent =
+  | ResponseInputText
+  | ResponseInputImage
+  | ResponseOutputText
+  | ResponseOutputRefusal
+  | ResponseContentReasoningText;
+type ResponseContentReasoningText = {
+  text: string;
+  type: "reasoning_text";
+};
+type ResponseConversationParam = {
+  id: string;
+};
+type ResponseCreatedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.created";
+};
+type ResponseCustomToolCallOutput = {
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "custom_tool_call_output";
+  id?: string;
+};
+type ResponseError = {
+  code:
+    | "server_error"
+    | "rate_limit_exceeded"
+    | "invalid_prompt"
+    | "vector_store_timeout"
+    | "invalid_image"
+    | "invalid_image_format"
+    | "invalid_base64_image"
+    | "invalid_image_url"
+    | "image_too_large"
+    | "image_too_small"
+    | "image_parse_error"
+    | "image_content_policy_violation"
+    | "invalid_image_mode"
+    | "image_file_too_large"
+    | "unsupported_image_media_type"
+    | "empty_image_file"
+    | "failed_to_download_image"
+    | "image_file_not_found";
+  message: string;
+};
+type ResponseErrorEvent = {
+  code: string | null;
+  message: string;
+  param: string | null;
+  sequence_number: number;
+  type: "error";
+};
+type ResponseFailedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.failed";
+};
+type ResponseFormatText = {
+  type: "text";
+};
+type ResponseFormatJSONObject = {
+  type: "json_object";
+};
+type ResponseFormatTextConfig =
+  | ResponseFormatText
+  | ResponseFormatTextJSONSchemaConfig
+  | ResponseFormatJSONObject;
+type ResponseFormatTextJSONSchemaConfig = {
+  name: string;
+  schema: {
+    [key: string]: unknown;
+  };
+  type: "json_schema";
+  description?: string;
+  strict?: boolean | null;
+};
+type ResponseFunctionCallArgumentsDeltaEvent = {
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.delta";
+};
+type ResponseFunctionCallArgumentsDoneEvent = {
+  arguments: string;
+  item_id: string;
+  name: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.done";
+};
+type ResponseFunctionCallOutputItem =
+  | ResponseInputTextContent
+  | ResponseInputImageContent;
+type ResponseFunctionCallOutputItemList = Array<ResponseFunctionCallOutputItem>;
+type ResponseFunctionToolCall = {
+  arguments: string;
+  call_id: string;
+  name: string;
+  type: "function_call";
+  id?: string;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+interface ResponseFunctionToolCallItem extends ResponseFunctionToolCall {
+  id: string;
+}
+type ResponseFunctionToolCallOutputItem = {
+  id: string;
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "function_call_output";
+  status?: "in_progress" | "completed" | "incomplete";
+};
+type ResponseIncludable =
+  | "message.input_image.image_url"
+  | "message.output_text.logprobs";
+type ResponseIncompleteEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.incomplete";
+};
+type ResponseInput = Array<ResponseInputItem>;
+type ResponseInputContent = ResponseInputText | ResponseInputImage;
+type ResponseInputImage = {
+  detail: "low" | "high" | "auto";
+  type: "input_image";
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+type ResponseInputImageContent = {
+  type: "input_image";
+  detail?: "low" | "high" | "auto" | null;
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+type ResponseInputItem =
+  | EasyInputMessage
+  | ResponseInputItemMessage
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseInputItemFunctionCallOutput
+  | ResponseReasoningItem;
+type ResponseInputItemFunctionCallOutput = {
+  call_id: string;
+  output: string | ResponseFunctionCallOutputItemList;
+  type: "function_call_output";
+  id?: string | null;
+  status?: "in_progress" | "completed" | "incomplete" | null;
+};
+type ResponseInputItemMessage = {
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+type ResponseInputMessageContentList = Array<ResponseInputContent>;
+type ResponseInputMessageItem = {
+  id: string;
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+type ResponseInputText = {
+  text: string;
+  type: "input_text";
+};
+type ResponseInputTextContent = {
+  text: string;
+  type: "input_text";
+};
+type ResponseItem =
+  | ResponseInputMessageItem
+  | ResponseOutputMessage
+  | ResponseFunctionToolCallItem
+  | ResponseFunctionToolCallOutputItem;
+type ResponseOutputItem =
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseReasoningItem;
+type ResponseOutputItemAddedEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.added";
+};
+type ResponseOutputItemDoneEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.done";
+};
+type ResponseOutputMessage = {
+  id: string;
+  content: Array<ResponseOutputText | ResponseOutputRefusal>;
+  role: "assistant";
+  status: "in_progress" | "completed" | "incomplete";
+  type: "message";
+};
+type ResponseOutputRefusal = {
+  refusal: string;
+  type: "refusal";
+};
+type ResponseOutputText = {
+  text: string;
+  type: "output_text";
+  logprobs?: Array<Logprob>;
+};
+type ResponseReasoningItem = {
+  id: string;
+  summary: Array<ResponseReasoningSummaryItem>;
+  type: "reasoning";
+  content?: Array<ResponseReasoningContentItem>;
+  encrypted_content?: string | null;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+type ResponseReasoningSummaryItem = {
+  text: string;
+  type: "summary_text";
+};
+type ResponseReasoningContentItem = {
+  text: string;
+  type: "reasoning_text";
+};
+type ResponseReasoningTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.reasoning_text.delta";
+};
+type ResponseReasoningTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.reasoning_text.done";
+};
+type ResponseRefusalDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.refusal.delta";
+};
+type ResponseRefusalDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  refusal: string;
+  sequence_number: number;
+  type: "response.refusal.done";
+};
+type ResponseStatus =
+  | "completed"
+  | "failed"
+  | "in_progress"
+  | "cancelled"
+  | "queued"
+  | "incomplete";
+type ResponseStreamEvent =
+  | ResponseCompletedEvent
+  | ResponseCreatedEvent
+  | ResponseErrorEvent
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseFailedEvent
+  | ResponseIncompleteEvent
+  | ResponseOutputItemAddedEvent
+  | ResponseOutputItemDoneEvent
+  | ResponseReasoningTextDeltaEvent
+  | ResponseReasoningTextDoneEvent
+  | ResponseRefusalDeltaEvent
+  | ResponseRefusalDoneEvent
+  | ResponseTextDeltaEvent
+  | ResponseTextDoneEvent;
+type ResponseCompletedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.completed";
+};
+type ResponseTextConfig = {
+  format?: ResponseFormatTextConfig;
+  verbosity?: "low" | "medium" | "high" | null;
+};
+type ResponseTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_text.delta";
+};
+type ResponseTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.output_text.done";
+};
+type Logprob = {
+  token: string;
+  logprob: number;
+  top_logprobs?: Array<TopLogprob>;
+};
+type TopLogprob = {
+  token?: string;
+  logprob?: number;
+};
+type ResponseUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+};
+type Tool = ResponsesFunctionTool;
+type ToolChoiceFunction = {
+  name: string;
+  type: "function";
+};
+type ToolChoiceOptions = "none";
+type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
+type StreamOptions = {
+  include_obfuscation?: boolean;
+};
 type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -4778,8 +5199,8 @@ type Ai_Cf_Baai_Bge_Base_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
-interface AsyncResponse {
+  | Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse;
+interface Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse {
   /**
    * The async request id that can be used to obtain the results.
    */
@@ -4861,7 +5282,13 @@ type Ai_Cf_Meta_M2M100_1_2B_Output =
        */
       translated_text?: string;
     }
-  | AsyncResponse;
+  | Ai_Cf_Meta_M2M100_1_2B_AsyncResponse;
+interface Ai_Cf_Meta_M2M100_1_2B_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 declare abstract class Base_Ai_Cf_Meta_M2M100_1_2B {
   inputs: Ai_Cf_Meta_M2M100_1_2B_Input;
   postProcessedOutputs: Ai_Cf_Meta_M2M100_1_2B_Output;
@@ -4898,7 +5325,13 @@ type Ai_Cf_Baai_Bge_Small_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse;
+interface Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 declare abstract class Base_Ai_Cf_Baai_Bge_Small_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Output;
@@ -4935,7 +5368,13 @@ type Ai_Cf_Baai_Bge_Large_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse;
+interface Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 declare abstract class Base_Ai_Cf_Baai_Bge_Large_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Output;
@@ -5126,15 +5565,18 @@ declare abstract class Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo {
   postProcessedOutputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output;
 }
 type Ai_Cf_Baai_Bge_M3_Input =
-  | BGEM3InputQueryAndContexts
-  | BGEM3InputEmbedding
+  | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts
+  | Ai_Cf_Baai_Bge_M3_Input_Embedding
   | {
       /**
        * Batch of the embeddings requests to run using async-queue
        */
-      requests: (BGEM3InputQueryAndContexts1 | BGEM3InputEmbedding1)[];
+      requests: (
+        | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1
+        | Ai_Cf_Baai_Bge_M3_Input_Embedding_1
+      )[];
     };
-interface BGEM3InputQueryAndContexts {
+interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -5153,14 +5595,14 @@ interface BGEM3InputQueryAndContexts {
    */
   truncate_inputs?: boolean;
 }
-interface BGEM3InputEmbedding {
+interface Ai_Cf_Baai_Bge_M3_Input_Embedding {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
    */
   truncate_inputs?: boolean;
 }
-interface BGEM3InputQueryAndContexts1 {
+interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1 {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -5179,7 +5621,7 @@ interface BGEM3InputQueryAndContexts1 {
    */
   truncate_inputs?: boolean;
 }
-interface BGEM3InputEmbedding1 {
+interface Ai_Cf_Baai_Bge_M3_Input_Embedding_1 {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
@@ -5187,11 +5629,11 @@ interface BGEM3InputEmbedding1 {
   truncate_inputs?: boolean;
 }
 type Ai_Cf_Baai_Bge_M3_Output =
-  | BGEM3OuputQuery
-  | BGEM3OutputEmbeddingForContexts
-  | BGEM3OuputEmbedding
-  | AsyncResponse;
-interface BGEM3OuputQuery {
+  | Ai_Cf_Baai_Bge_M3_Ouput_Query
+  | Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts
+  | Ai_Cf_Baai_Bge_M3_Ouput_Embedding
+  | Ai_Cf_Baai_Bge_M3_AsyncResponse;
+interface Ai_Cf_Baai_Bge_M3_Ouput_Query {
   response?: {
     /**
      * Index of the context in the request
@@ -5203,7 +5645,7 @@ interface BGEM3OuputQuery {
     score?: number;
   }[];
 }
-interface BGEM3OutputEmbeddingForContexts {
+interface Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts {
   response?: number[][];
   shape?: number[];
   /**
@@ -5211,7 +5653,7 @@ interface BGEM3OutputEmbeddingForContexts {
    */
   pooling?: "mean" | "cls";
 }
-interface BGEM3OuputEmbedding {
+interface Ai_Cf_Baai_Bge_M3_Ouput_Embedding {
   shape?: number[];
   /**
    * Embeddings of the requested text values
@@ -5221,6 +5663,12 @@ interface BGEM3OuputEmbedding {
    * The pooling method used in the embedding process.
    */
   pooling?: "mean" | "cls";
+}
+interface Ai_Cf_Baai_Bge_M3_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
 }
 declare abstract class Base_Ai_Cf_Baai_Bge_M3 {
   inputs: Ai_Cf_Baai_Bge_M3_Input;
@@ -5246,8 +5694,10 @@ declare abstract class Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell {
   inputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Input;
   postProcessedOutputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Output;
 }
-type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input = Prompt | Messages;
-interface Prompt {
+type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input =
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages;
+interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5298,7 +5748,7 @@ interface Prompt {
    */
   lora?: string;
 }
-interface Messages {
+interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5496,10 +5946,10 @@ declare abstract class Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct {
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Output;
 }
 type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input =
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
-  | AsyncBatch;
-interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch;
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5508,7 +5958,7 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5550,11 +6000,11 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    */
   presence_penalty?: number;
 }
-interface JSONMode {
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode {
   type?: "json_object" | "json_schema";
   json_schema?: unknown;
 }
-interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5662,7 +6112,7 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5704,7 +6154,11 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
    */
   presence_penalty?: number;
 }
-interface AsyncBatch {
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch {
   requests?: {
     /**
      * User-supplied reference. This field will be present in the response as well it can be used to reference the request and response. It's NOT validated to be unique.
@@ -5746,8 +6200,12 @@ interface AsyncBatch {
      * Increases the likelihood of the model introducing new topics.
      */
     presence_penalty?: number;
-    response_format?: JSONMode;
+    response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2;
   }[];
+}
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
 }
 type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
   | {
@@ -5787,7 +6245,13 @@ type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
       }[];
     }
   | string
-  | AsyncResponse;
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse;
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 declare abstract class Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast {
   inputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output;
@@ -5894,9 +6358,9 @@ declare abstract class Base_Ai_Cf_Baai_Bge_Reranker_Base {
   postProcessedOutputs: Ai_Cf_Baai_Bge_Reranker_Base_Output;
 }
 type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input =
-  | Qwen2_5_Coder_32B_Instruct_Prompt
-  | Qwen2_5_Coder_32B_Instruct_Messages;
-interface Qwen2_5_Coder_32B_Instruct_Prompt {
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages;
+interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5905,7 +6369,7 @@ interface Qwen2_5_Coder_32B_Instruct_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5947,7 +6411,11 @@ interface Qwen2_5_Coder_32B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-interface Qwen2_5_Coder_32B_Instruct_Messages {
+interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6055,7 +6523,7 @@ interface Qwen2_5_Coder_32B_Instruct_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -6097,6 +6565,10 @@ interface Qwen2_5_Coder_32B_Instruct_Messages {
    */
   presence_penalty?: number;
 }
+interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
 type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output = {
   /**
    * The generated text response from the model
@@ -6137,8 +6609,10 @@ declare abstract class Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct {
   inputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output;
 }
-type Ai_Cf_Qwen_Qwq_32B_Input = Qwen_Qwq_32B_Prompt | Qwen_Qwq_32B_Messages;
-interface Qwen_Qwq_32B_Prompt {
+type Ai_Cf_Qwen_Qwq_32B_Input =
+  | Ai_Cf_Qwen_Qwq_32B_Prompt
+  | Ai_Cf_Qwen_Qwq_32B_Messages;
+interface Ai_Cf_Qwen_Qwq_32B_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6188,7 +6662,7 @@ interface Qwen_Qwq_32B_Prompt {
    */
   presence_penalty?: number;
 }
-interface Qwen_Qwq_32B_Messages {
+interface Ai_Cf_Qwen_Qwq_32B_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6410,9 +6884,9 @@ declare abstract class Base_Ai_Cf_Qwen_Qwq_32B {
   postProcessedOutputs: Ai_Cf_Qwen_Qwq_32B_Output;
 }
 type Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input =
-  | Mistral_Small_3_1_24B_Instruct_Prompt
-  | Mistral_Small_3_1_24B_Instruct_Messages;
-interface Mistral_Small_3_1_24B_Instruct_Prompt {
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages;
+interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6462,7 +6936,7 @@ interface Mistral_Small_3_1_24B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-interface Mistral_Small_3_1_24B_Instruct_Messages {
+interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6684,9 +7158,9 @@ declare abstract class Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct {
   postProcessedOutputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output;
 }
 type Ai_Cf_Google_Gemma_3_12B_It_Input =
-  | Google_Gemma_3_12B_It_Prompt
-  | Google_Gemma_3_12B_It_Messages;
-interface Google_Gemma_3_12B_It_Prompt {
+  | Ai_Cf_Google_Gemma_3_12B_It_Prompt
+  | Ai_Cf_Google_Gemma_3_12B_It_Messages;
+interface Ai_Cf_Google_Gemma_3_12B_It_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6736,7 +7210,7 @@ interface Google_Gemma_3_12B_It_Prompt {
    */
   presence_penalty?: number;
 }
-interface Google_Gemma_3_12B_It_Messages {
+interface Ai_Cf_Google_Gemma_3_12B_It_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6759,20 +7233,7 @@ interface Google_Gemma_3_12B_It_Messages {
              */
             url?: string;
           };
-        }[]
-      | {
-          /**
-           * Type of the content provided
-           */
-          type?: string;
-          text?: string;
-          image_url?: {
-            /**
-             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-             */
-            url?: string;
-          };
-        };
+        }[];
   }[];
   functions?: {
     name: string;
@@ -6954,10 +7415,10 @@ declare abstract class Base_Ai_Cf_Google_Gemma_3_12B_It {
   postProcessedOutputs: Ai_Cf_Google_Gemma_3_12B_It_Output;
 }
 type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input =
-  | Ai_Cf_Meta_Llama_4_Prompt
-  | Ai_Cf_Meta_Llama_4_Messages
-  | Ai_Cf_Meta_Llama_4_Async_Batch;
-interface Ai_Cf_Meta_Llama_4_Prompt {
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch;
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6966,7 +7427,7 @@ interface Ai_Cf_Meta_Llama_4_Prompt {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -7008,7 +7469,11 @@ interface Ai_Cf_Meta_Llama_4_Prompt {
    */
   presence_penalty?: number;
 }
-interface Ai_Cf_Meta_Llama_4_Messages {
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -7144,7 +7609,7 @@ interface Ai_Cf_Meta_Llama_4_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -7190,13 +7655,13 @@ interface Ai_Cf_Meta_Llama_4_Messages {
    */
   presence_penalty?: number;
 }
-interface Ai_Cf_Meta_Llama_4_Async_Batch {
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch {
   requests: (
-    | Ai_Cf_Meta_Llama_4_Prompt_Inner
-    | Ai_Cf_Meta_Llama_4_Messages_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner
   )[];
 }
-interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -7205,7 +7670,7 @@ interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -7247,7 +7712,7 @@ interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    */
   presence_penalty?: number;
 }
-interface Ai_Cf_Meta_Llama_4_Messages_Inner {
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -7383,7 +7848,7 @@ interface Ai_Cf_Meta_Llama_4_Messages_Inner {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -7481,6 +7946,613 @@ type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output = {
 declare abstract class Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct {
   inputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output;
+}
+type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch;
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch {
+  requests: (
+    | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1
+    | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1
+  )[];
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response
+  | string
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse;
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+declare abstract class Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8 {
+  inputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output;
 }
 interface Ai_Cf_Deepgram_Nova_3_Input {
   audio: {
@@ -7673,6 +8745,23 @@ declare abstract class Base_Ai_Cf_Deepgram_Nova_3 {
   inputs: Ai_Cf_Deepgram_Nova_3_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Nova_3_Output;
 }
+interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input {
+  queries?: string | string[];
+  /**
+   * Optional instruction for the task
+   */
+  instruction?: string;
+  documents?: string | string[];
+  text?: string | string[];
+}
+interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output {
+  data?: number[][];
+  shape?: number[];
+}
+declare abstract class Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B {
+  inputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output;
+}
 type Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input =
   | {
       /**
@@ -7711,89 +8800,13 @@ declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   inputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input;
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
-type Ai_Cf_Openai_Gpt_Oss_120B_Input =
-  | GPT_OSS_120B_Responses
-  | GPT_OSS_120B_Responses_Async;
-interface GPT_OSS_120B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-interface GPT_OSS_120B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-type Ai_Cf_Openai_Gpt_Oss_120B_Output = {} | (string & NonNullable<unknown>);
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_120B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_120B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
-type Ai_Cf_Openai_Gpt_Oss_20B_Input =
-  | GPT_OSS_20B_Responses
-  | GPT_OSS_20B_Responses_Async;
-interface GPT_OSS_20B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-interface GPT_OSS_20B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-type Ai_Cf_Openai_Gpt_Oss_20B_Output = {} | (string & NonNullable<unknown>);
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_20B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_20B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
 interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**
@@ -7919,6 +8932,901 @@ declare abstract class Base_Ai_Cf_Deepgram_Aura_1 {
   inputs: Ai_Cf_Deepgram_Aura_1_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Aura_1_Output;
 }
+interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
+  /**
+   * Input text to translate. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+  /**
+   * Target langauge to translate to
+   */
+  target_language:
+    | "asm_Beng"
+    | "awa_Deva"
+    | "ben_Beng"
+    | "bho_Deva"
+    | "brx_Deva"
+    | "doi_Deva"
+    | "eng_Latn"
+    | "gom_Deva"
+    | "gon_Deva"
+    | "guj_Gujr"
+    | "hin_Deva"
+    | "hne_Deva"
+    | "kan_Knda"
+    | "kas_Arab"
+    | "kas_Deva"
+    | "kha_Latn"
+    | "lus_Latn"
+    | "mag_Deva"
+    | "mai_Deva"
+    | "mal_Mlym"
+    | "mar_Deva"
+    | "mni_Beng"
+    | "mni_Mtei"
+    | "npi_Deva"
+    | "ory_Orya"
+    | "pan_Guru"
+    | "san_Deva"
+    | "sat_Olck"
+    | "snd_Arab"
+    | "snd_Deva"
+    | "tam_Taml"
+    | "tel_Telu"
+    | "urd_Arab"
+    | "unr_Deva";
+}
+interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output {
+  /**
+   * Translated texts
+   */
+  translations: string[];
+}
+declare abstract class Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B {
+  inputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input;
+  postProcessedOutputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output;
+}
+type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch;
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch {
+  requests: (
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1
+  )[];
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response
+  | string
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse;
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+declare abstract class Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It {
+  inputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input;
+  postProcessedOutputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output;
+}
+interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Input {
+  /**
+   * Input text to embed. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+}
+interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Output {
+  /**
+   * Embedding vectors, where each vector is a list of floats.
+   */
+  data: number[][];
+  /**
+   * Shape of the embedding data as [number_of_embeddings, embedding_dimension].
+   *
+   * @minItems 2
+   * @maxItems 2
+   */
+  shape: [number, number];
+}
+declare abstract class Base_Ai_Cf_Pfnet_Plamo_Embedding_1B {
+  inputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Input;
+  postProcessedOutputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Output;
+}
+interface Ai_Cf_Deepgram_Flux_Input {
+  /**
+   * Encoding of the audio stream. Currently only supports raw signed little-endian 16-bit PCM.
+   */
+  encoding: "linear16";
+  /**
+   * Sample rate of the audio stream in Hz.
+   */
+  sample_rate: string;
+  /**
+   * End-of-turn confidence required to fire an eager end-of-turn event. When set, enables EagerEndOfTurn and TurnResumed events. Valid Values 0.3 - 0.9.
+   */
+  eager_eot_threshold?: string;
+  /**
+   * End-of-turn confidence required to finish a turn. Valid Values 0.5 - 0.9.
+   */
+  eot_threshold?: string;
+  /**
+   * A turn will be finished when this much time has passed after speech, regardless of EOT confidence.
+   */
+  eot_timeout_ms?: string;
+  /**
+   * Keyterm prompting can improve recognition of specialized terminology. Pass multiple keyterm query parameters to boost multiple keyterms.
+   */
+  keyterm?: string;
+  /**
+   * Opts out requests from the Deepgram Model Improvement Program. Refer to Deepgram Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
+   */
+  mip_opt_out?: "true" | "false";
+  /**
+   * Label your requests for the purpose of identification during usage reporting
+   */
+  tag?: string;
+}
+/**
+ * Output will be returned as websocket messages.
+ */
+interface Ai_Cf_Deepgram_Flux_Output {
+  /**
+   * The unique identifier of the request (uuid)
+   */
+  request_id?: string;
+  /**
+   * Starts at 0 and increments for each message the server sends to the client.
+   */
+  sequence_id?: number;
+  /**
+   * The type of event being reported.
+   */
+  event?:
+    | "Update"
+    | "StartOfTurn"
+    | "EagerEndOfTurn"
+    | "TurnResumed"
+    | "EndOfTurn";
+  /**
+   * The index of the current turn
+   */
+  turn_index?: number;
+  /**
+   * Start time in seconds of the audio range that was transcribed
+   */
+  audio_window_start?: number;
+  /**
+   * End time in seconds of the audio range that was transcribed
+   */
+  audio_window_end?: number;
+  /**
+   * Text that was said over the course of the current turn
+   */
+  transcript?: string;
+  /**
+   * The words in the transcript
+   */
+  words?: {
+    /**
+     * The individual punctuated, properly-cased word from the transcript
+     */
+    word: string;
+    /**
+     * Confidence that this word was transcribed correctly
+     */
+    confidence: number;
+  }[];
+  /**
+   * Confidence that no more speech is coming in this turn
+   */
+  end_of_turn_confidence?: number;
+}
+declare abstract class Base_Ai_Cf_Deepgram_Flux {
+  inputs: Ai_Cf_Deepgram_Flux_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Flux_Output;
+}
+interface Ai_Cf_Deepgram_Aura_2_En_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "amalthea"
+    | "andromeda"
+    | "apollo"
+    | "arcas"
+    | "aries"
+    | "asteria"
+    | "athena"
+    | "atlas"
+    | "aurora"
+    | "callista"
+    | "cora"
+    | "cordelia"
+    | "delia"
+    | "draco"
+    | "electra"
+    | "harmonia"
+    | "helena"
+    | "hera"
+    | "hermes"
+    | "hyperion"
+    | "iris"
+    | "janus"
+    | "juno"
+    | "jupiter"
+    | "luna"
+    | "mars"
+    | "minerva"
+    | "neptune"
+    | "odysseus"
+    | "ophelia"
+    | "orion"
+    | "orpheus"
+    | "pandora"
+    | "phoebe"
+    | "pluto"
+    | "saturn"
+    | "thalia"
+    | "theia"
+    | "vesta"
+    | "zeus";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+type Ai_Cf_Deepgram_Aura_2_En_Output = string;
+declare abstract class Base_Ai_Cf_Deepgram_Aura_2_En {
+  inputs: Ai_Cf_Deepgram_Aura_2_En_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_En_Output;
+}
+interface Ai_Cf_Deepgram_Aura_2_Es_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "sirio"
+    | "nestor"
+    | "carina"
+    | "celeste"
+    | "alvaro"
+    | "diana"
+    | "aquila"
+    | "selena"
+    | "estrella"
+    | "javier";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+type Ai_Cf_Deepgram_Aura_2_Es_Output = string;
+declare abstract class Base_Ai_Cf_Deepgram_Aura_2_Es {
+  inputs: Ai_Cf_Deepgram_Aura_2_Es_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_Es_Output;
+}
 interface AiModels {
   "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
   "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
@@ -7962,12 +9870,12 @@ interface AiModels {
   "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
   "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
-  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
   "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": BaseAiTextGeneration;
+  "@cf/ibm-granite/granite-4.0-h-micro": BaseAiTextGeneration;
   "@cf/facebook/bart-large-cnn": BaseAiSummarization;
   "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
   "@cf/baai/bge-base-en-v1.5": Base_Ai_Cf_Baai_Bge_Base_En_V1_5;
@@ -7989,13 +9897,21 @@ interface AiModels {
   "@cf/mistralai/mistral-small-3.1-24b-instruct": Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct;
   "@cf/google/gemma-3-12b-it": Base_Ai_Cf_Google_Gemma_3_12B_It;
   "@cf/meta/llama-4-scout-17b-16e-instruct": Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct;
+  "@cf/qwen/qwen3-30b-a3b-fp8": Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8;
   "@cf/deepgram/nova-3": Base_Ai_Cf_Deepgram_Nova_3;
+  "@cf/qwen/qwen3-embedding-0.6b": Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B;
   "@cf/pipecat-ai/smart-turn-v2": Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
   "@cf/openai/gpt-oss-120b": Base_Ai_Cf_Openai_Gpt_Oss_120B;
   "@cf/openai/gpt-oss-20b": Base_Ai_Cf_Openai_Gpt_Oss_20B;
   "@cf/leonardo/phoenix-1.0": Base_Ai_Cf_Leonardo_Phoenix_1_0;
   "@cf/leonardo/lucid-origin": Base_Ai_Cf_Leonardo_Lucid_Origin;
   "@cf/deepgram/aura-1": Base_Ai_Cf_Deepgram_Aura_1;
+  "@cf/ai4bharat/indictrans2-en-indic-1B": Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B;
+  "@cf/aisingapore/gemma-sea-lion-v4-27b-it": Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It;
+  "@cf/pfnet/plamo-embedding-1b": Base_Ai_Cf_Pfnet_Plamo_Embedding_1B;
+  "@cf/deepgram/flux": Base_Ai_Cf_Deepgram_Flux;
+  "@cf/deepgram/aura-2-en": Base_Ai_Cf_Deepgram_Aura_2_En;
+  "@cf/deepgram/aura-2-es": Base_Ai_Cf_Deepgram_Aura_2_Es;
 }
 type AiOptions = {
   /**
@@ -8007,6 +9923,16 @@ type AiOptions = {
    * Establish websocket connections, only works for supported models
    */
   websocket?: boolean;
+  /**
+   * Tag your requests to group and view them in Cloudflare dashboard.
+   *
+   * Rules:
+   * Tags must only contain letters, numbers, and the symbols: : - . / @
+   * Each tag can have maximum 50 characters.
+   * Maximum 5 tags are allowed each request.
+   * Duplicate tags will removed.
+   */
+  tags: string[];
   gateway?: GatewayOptions;
   returnRawResponse?: boolean;
   prefix?: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4759,6 +4759,428 @@ export declare abstract class BaseAiTranslation {
   inputs: AiTranslationInput;
   postProcessedOutputs: AiTranslationOutput;
 }
+/**
+ * Workers AI support for OpenAI's Responses API
+ * Reference: https://github.com/openai/openai-node/blob/master/src/resources/responses/responses.ts
+ *
+ * It's a stripped down version from its source.
+ * It currently supports basic function calling, json mode and accepts images as input.
+ *
+ * It does not include types for WebSearch, CodeInterpreter, FileInputs, MCP, CustomTools.
+ * We plan to add those incrementally as model + platform capabilities evolve.
+ */
+export type ResponsesInput = {
+  background?: boolean | null;
+  conversation?: string | ResponseConversationParam | null;
+  include?: Array<ResponseIncludable> | null;
+  input?: string | ResponseInput;
+  instructions?: string | null;
+  max_output_tokens?: number | null;
+  parallel_tool_calls?: boolean | null;
+  previous_response_id?: string | null;
+  prompt_cache_key?: string;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  stream?: boolean | null;
+  stream_options?: StreamOptions | null;
+  temperature?: number | null;
+  text?: ResponseTextConfig;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  truncation?: "auto" | "disabled" | null;
+};
+export type ResponsesOutput = {
+  id?: string;
+  created_at?: number;
+  output_text?: string;
+  error?: ResponseError | null;
+  incomplete_details?: ResponseIncompleteDetails | null;
+  instructions?: string | Array<ResponseInputItem> | null;
+  object?: "response";
+  output?: Array<ResponseOutputItem>;
+  parallel_tool_calls?: boolean;
+  temperature?: number | null;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  max_output_tokens?: number | null;
+  previous_response_id?: string | null;
+  prompt?: ResponsePrompt | null;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  status?: ResponseStatus;
+  text?: ResponseTextConfig;
+  truncation?: "auto" | "disabled" | null;
+  usage?: ResponseUsage;
+};
+export type EasyInputMessage = {
+  content: string | ResponseInputMessageContentList;
+  role: "user" | "assistant" | "system" | "developer";
+  type?: "message";
+};
+export type ResponsesFunctionTool = {
+  name: string;
+  parameters: {
+    [key: string]: unknown;
+  } | null;
+  strict: boolean | null;
+  type: "function";
+  description?: string | null;
+};
+export type ResponseIncompleteDetails = {
+  reason?: "max_output_tokens" | "content_filter";
+};
+export type ResponsePrompt = {
+  id: string;
+  variables?: {
+    [key: string]: string | ResponseInputText | ResponseInputImage;
+  } | null;
+  version?: string | null;
+};
+export type Reasoning = {
+  effort?: ReasoningEffort | null;
+  generate_summary?: "auto" | "concise" | "detailed" | null;
+  summary?: "auto" | "concise" | "detailed" | null;
+};
+export type ResponseContent =
+  | ResponseInputText
+  | ResponseInputImage
+  | ResponseOutputText
+  | ResponseOutputRefusal
+  | ResponseContentReasoningText;
+export type ResponseContentReasoningText = {
+  text: string;
+  type: "reasoning_text";
+};
+export type ResponseConversationParam = {
+  id: string;
+};
+export type ResponseCreatedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.created";
+};
+export type ResponseCustomToolCallOutput = {
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "custom_tool_call_output";
+  id?: string;
+};
+export type ResponseError = {
+  code:
+    | "server_error"
+    | "rate_limit_exceeded"
+    | "invalid_prompt"
+    | "vector_store_timeout"
+    | "invalid_image"
+    | "invalid_image_format"
+    | "invalid_base64_image"
+    | "invalid_image_url"
+    | "image_too_large"
+    | "image_too_small"
+    | "image_parse_error"
+    | "image_content_policy_violation"
+    | "invalid_image_mode"
+    | "image_file_too_large"
+    | "unsupported_image_media_type"
+    | "empty_image_file"
+    | "failed_to_download_image"
+    | "image_file_not_found";
+  message: string;
+};
+export type ResponseErrorEvent = {
+  code: string | null;
+  message: string;
+  param: string | null;
+  sequence_number: number;
+  type: "error";
+};
+export type ResponseFailedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.failed";
+};
+export type ResponseFormatText = {
+  type: "text";
+};
+export type ResponseFormatJSONObject = {
+  type: "json_object";
+};
+export type ResponseFormatTextConfig =
+  | ResponseFormatText
+  | ResponseFormatTextJSONSchemaConfig
+  | ResponseFormatJSONObject;
+export type ResponseFormatTextJSONSchemaConfig = {
+  name: string;
+  schema: {
+    [key: string]: unknown;
+  };
+  type: "json_schema";
+  description?: string;
+  strict?: boolean | null;
+};
+export type ResponseFunctionCallArgumentsDeltaEvent = {
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.delta";
+};
+export type ResponseFunctionCallArgumentsDoneEvent = {
+  arguments: string;
+  item_id: string;
+  name: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.done";
+};
+export type ResponseFunctionCallOutputItem =
+  | ResponseInputTextContent
+  | ResponseInputImageContent;
+export type ResponseFunctionCallOutputItemList =
+  Array<ResponseFunctionCallOutputItem>;
+export type ResponseFunctionToolCall = {
+  arguments: string;
+  call_id: string;
+  name: string;
+  type: "function_call";
+  id?: string;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export interface ResponseFunctionToolCallItem extends ResponseFunctionToolCall {
+  id: string;
+}
+export type ResponseFunctionToolCallOutputItem = {
+  id: string;
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "function_call_output";
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export type ResponseIncludable =
+  | "message.input_image.image_url"
+  | "message.output_text.logprobs";
+export type ResponseIncompleteEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.incomplete";
+};
+export type ResponseInput = Array<ResponseInputItem>;
+export type ResponseInputContent = ResponseInputText | ResponseInputImage;
+export type ResponseInputImage = {
+  detail: "low" | "high" | "auto";
+  type: "input_image";
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+export type ResponseInputImageContent = {
+  type: "input_image";
+  detail?: "low" | "high" | "auto" | null;
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+export type ResponseInputItem =
+  | EasyInputMessage
+  | ResponseInputItemMessage
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseInputItemFunctionCallOutput
+  | ResponseReasoningItem;
+export type ResponseInputItemFunctionCallOutput = {
+  call_id: string;
+  output: string | ResponseFunctionCallOutputItemList;
+  type: "function_call_output";
+  id?: string | null;
+  status?: "in_progress" | "completed" | "incomplete" | null;
+};
+export type ResponseInputItemMessage = {
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+export type ResponseInputMessageContentList = Array<ResponseInputContent>;
+export type ResponseInputMessageItem = {
+  id: string;
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+export type ResponseInputText = {
+  text: string;
+  type: "input_text";
+};
+export type ResponseInputTextContent = {
+  text: string;
+  type: "input_text";
+};
+export type ResponseItem =
+  | ResponseInputMessageItem
+  | ResponseOutputMessage
+  | ResponseFunctionToolCallItem
+  | ResponseFunctionToolCallOutputItem;
+export type ResponseOutputItem =
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseReasoningItem;
+export type ResponseOutputItemAddedEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.added";
+};
+export type ResponseOutputItemDoneEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.done";
+};
+export type ResponseOutputMessage = {
+  id: string;
+  content: Array<ResponseOutputText | ResponseOutputRefusal>;
+  role: "assistant";
+  status: "in_progress" | "completed" | "incomplete";
+  type: "message";
+};
+export type ResponseOutputRefusal = {
+  refusal: string;
+  type: "refusal";
+};
+export type ResponseOutputText = {
+  text: string;
+  type: "output_text";
+  logprobs?: Array<Logprob>;
+};
+export type ResponseReasoningItem = {
+  id: string;
+  summary: Array<ResponseReasoningSummaryItem>;
+  type: "reasoning";
+  content?: Array<ResponseReasoningContentItem>;
+  encrypted_content?: string | null;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export type ResponseReasoningSummaryItem = {
+  text: string;
+  type: "summary_text";
+};
+export type ResponseReasoningContentItem = {
+  text: string;
+  type: "reasoning_text";
+};
+export type ResponseReasoningTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.reasoning_text.delta";
+};
+export type ResponseReasoningTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.reasoning_text.done";
+};
+export type ResponseRefusalDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.refusal.delta";
+};
+export type ResponseRefusalDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  refusal: string;
+  sequence_number: number;
+  type: "response.refusal.done";
+};
+export type ResponseStatus =
+  | "completed"
+  | "failed"
+  | "in_progress"
+  | "cancelled"
+  | "queued"
+  | "incomplete";
+export type ResponseStreamEvent =
+  | ResponseCompletedEvent
+  | ResponseCreatedEvent
+  | ResponseErrorEvent
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseFailedEvent
+  | ResponseIncompleteEvent
+  | ResponseOutputItemAddedEvent
+  | ResponseOutputItemDoneEvent
+  | ResponseReasoningTextDeltaEvent
+  | ResponseReasoningTextDoneEvent
+  | ResponseRefusalDeltaEvent
+  | ResponseRefusalDoneEvent
+  | ResponseTextDeltaEvent
+  | ResponseTextDoneEvent;
+export type ResponseCompletedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.completed";
+};
+export type ResponseTextConfig = {
+  format?: ResponseFormatTextConfig;
+  verbosity?: "low" | "medium" | "high" | null;
+};
+export type ResponseTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_text.delta";
+};
+export type ResponseTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.output_text.done";
+};
+export type Logprob = {
+  token: string;
+  logprob: number;
+  top_logprobs?: Array<TopLogprob>;
+};
+export type TopLogprob = {
+  token?: string;
+  logprob?: number;
+};
+export type ResponseUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+};
+export type Tool = ResponsesFunctionTool;
+export type ToolChoiceFunction = {
+  name: string;
+  type: "function";
+};
+export type ToolChoiceOptions = "none";
+export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
+export type StreamOptions = {
+  include_obfuscation?: boolean;
+};
 export type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -4791,8 +5213,8 @@ export type Ai_Cf_Baai_Bge_Base_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
-export interface AsyncResponse {
+  | Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse {
   /**
    * The async request id that can be used to obtain the results.
    */
@@ -4874,7 +5296,13 @@ export type Ai_Cf_Meta_M2M100_1_2B_Output =
        */
       translated_text?: string;
     }
-  | AsyncResponse;
+  | Ai_Cf_Meta_M2M100_1_2B_AsyncResponse;
+export interface Ai_Cf_Meta_M2M100_1_2B_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Meta_M2M100_1_2B {
   inputs: Ai_Cf_Meta_M2M100_1_2B_Input;
   postProcessedOutputs: Ai_Cf_Meta_M2M100_1_2B_Output;
@@ -4911,7 +5339,13 @@ export type Ai_Cf_Baai_Bge_Small_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Baai_Bge_Small_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Output;
@@ -4948,7 +5382,13 @@ export type Ai_Cf_Baai_Bge_Large_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Baai_Bge_Large_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Output;
@@ -5139,15 +5579,18 @@ export declare abstract class Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo {
   postProcessedOutputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output;
 }
 export type Ai_Cf_Baai_Bge_M3_Input =
-  | BGEM3InputQueryAndContexts
-  | BGEM3InputEmbedding
+  | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts
+  | Ai_Cf_Baai_Bge_M3_Input_Embedding
   | {
       /**
        * Batch of the embeddings requests to run using async-queue
        */
-      requests: (BGEM3InputQueryAndContexts1 | BGEM3InputEmbedding1)[];
+      requests: (
+        | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1
+        | Ai_Cf_Baai_Bge_M3_Input_Embedding_1
+      )[];
     };
-export interface BGEM3InputQueryAndContexts {
+export interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -5166,14 +5609,14 @@ export interface BGEM3InputQueryAndContexts {
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputEmbedding {
+export interface Ai_Cf_Baai_Bge_M3_Input_Embedding {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputQueryAndContexts1 {
+export interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1 {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -5192,7 +5635,7 @@ export interface BGEM3InputQueryAndContexts1 {
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputEmbedding1 {
+export interface Ai_Cf_Baai_Bge_M3_Input_Embedding_1 {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
@@ -5200,11 +5643,11 @@ export interface BGEM3InputEmbedding1 {
   truncate_inputs?: boolean;
 }
 export type Ai_Cf_Baai_Bge_M3_Output =
-  | BGEM3OuputQuery
-  | BGEM3OutputEmbeddingForContexts
-  | BGEM3OuputEmbedding
-  | AsyncResponse;
-export interface BGEM3OuputQuery {
+  | Ai_Cf_Baai_Bge_M3_Ouput_Query
+  | Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts
+  | Ai_Cf_Baai_Bge_M3_Ouput_Embedding
+  | Ai_Cf_Baai_Bge_M3_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_M3_Ouput_Query {
   response?: {
     /**
      * Index of the context in the request
@@ -5216,7 +5659,7 @@ export interface BGEM3OuputQuery {
     score?: number;
   }[];
 }
-export interface BGEM3OutputEmbeddingForContexts {
+export interface Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts {
   response?: number[][];
   shape?: number[];
   /**
@@ -5224,7 +5667,7 @@ export interface BGEM3OutputEmbeddingForContexts {
    */
   pooling?: "mean" | "cls";
 }
-export interface BGEM3OuputEmbedding {
+export interface Ai_Cf_Baai_Bge_M3_Ouput_Embedding {
   shape?: number[];
   /**
    * Embeddings of the requested text values
@@ -5234,6 +5677,12 @@ export interface BGEM3OuputEmbedding {
    * The pooling method used in the embedding process.
    */
   pooling?: "mean" | "cls";
+}
+export interface Ai_Cf_Baai_Bge_M3_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
 }
 export declare abstract class Base_Ai_Cf_Baai_Bge_M3 {
   inputs: Ai_Cf_Baai_Bge_M3_Input;
@@ -5259,8 +5708,10 @@ export declare abstract class Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell {
   inputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Input;
   postProcessedOutputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Output;
 }
-export type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input = Prompt | Messages;
-export interface Prompt {
+export type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input =
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages;
+export interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5311,7 +5762,7 @@ export interface Prompt {
    */
   lora?: string;
 }
-export interface Messages {
+export interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5509,10 +5960,10 @@ export declare abstract class Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct {
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Output;
 }
 export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input =
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
-  | AsyncBatch;
-export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch;
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5521,7 +5972,7 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5563,11 +6014,11 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    */
   presence_penalty?: number;
 }
-export interface JSONMode {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode {
   type?: "json_object" | "json_schema";
   json_schema?: unknown;
 }
-export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5675,7 +6126,7 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5717,7 +6168,11 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
    */
   presence_penalty?: number;
 }
-export interface AsyncBatch {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch {
   requests?: {
     /**
      * User-supplied reference. This field will be present in the response as well it can be used to reference the request and response. It's NOT validated to be unique.
@@ -5759,8 +6214,12 @@ export interface AsyncBatch {
      * Increases the likelihood of the model introducing new topics.
      */
     presence_penalty?: number;
-    response_format?: JSONMode;
+    response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2;
   }[];
+}
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
 }
 export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
   | {
@@ -5800,7 +6259,13 @@ export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
       }[];
     }
   | string
-  | AsyncResponse;
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse;
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast {
   inputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output;
@@ -5907,9 +6372,9 @@ export declare abstract class Base_Ai_Cf_Baai_Bge_Reranker_Base {
   postProcessedOutputs: Ai_Cf_Baai_Bge_Reranker_Base_Output;
 }
 export type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input =
-  | Qwen2_5_Coder_32B_Instruct_Prompt
-  | Qwen2_5_Coder_32B_Instruct_Messages;
-export interface Qwen2_5_Coder_32B_Instruct_Prompt {
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages;
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5918,7 +6383,7 @@ export interface Qwen2_5_Coder_32B_Instruct_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5960,7 +6425,11 @@ export interface Qwen2_5_Coder_32B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Qwen2_5_Coder_32B_Instruct_Messages {
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6068,7 +6537,7 @@ export interface Qwen2_5_Coder_32B_Instruct_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -6109,6 +6578,10 @@ export interface Qwen2_5_Coder_32B_Instruct_Messages {
    * Increases the likelihood of the model introducing new topics.
    */
   presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
 }
 export type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output = {
   /**
@@ -6151,9 +6624,9 @@ export declare abstract class Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct {
   postProcessedOutputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output;
 }
 export type Ai_Cf_Qwen_Qwq_32B_Input =
-  | Qwen_Qwq_32B_Prompt
-  | Qwen_Qwq_32B_Messages;
-export interface Qwen_Qwq_32B_Prompt {
+  | Ai_Cf_Qwen_Qwq_32B_Prompt
+  | Ai_Cf_Qwen_Qwq_32B_Messages;
+export interface Ai_Cf_Qwen_Qwq_32B_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6203,7 +6676,7 @@ export interface Qwen_Qwq_32B_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Qwen_Qwq_32B_Messages {
+export interface Ai_Cf_Qwen_Qwq_32B_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6425,9 +6898,9 @@ export declare abstract class Base_Ai_Cf_Qwen_Qwq_32B {
   postProcessedOutputs: Ai_Cf_Qwen_Qwq_32B_Output;
 }
 export type Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input =
-  | Mistral_Small_3_1_24B_Instruct_Prompt
-  | Mistral_Small_3_1_24B_Instruct_Messages;
-export interface Mistral_Small_3_1_24B_Instruct_Prompt {
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages;
+export interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6477,7 +6950,7 @@ export interface Mistral_Small_3_1_24B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Mistral_Small_3_1_24B_Instruct_Messages {
+export interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6699,9 +7172,9 @@ export declare abstract class Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruc
   postProcessedOutputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output;
 }
 export type Ai_Cf_Google_Gemma_3_12B_It_Input =
-  | Google_Gemma_3_12B_It_Prompt
-  | Google_Gemma_3_12B_It_Messages;
-export interface Google_Gemma_3_12B_It_Prompt {
+  | Ai_Cf_Google_Gemma_3_12B_It_Prompt
+  | Ai_Cf_Google_Gemma_3_12B_It_Messages;
+export interface Ai_Cf_Google_Gemma_3_12B_It_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6751,7 +7224,7 @@ export interface Google_Gemma_3_12B_It_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Google_Gemma_3_12B_It_Messages {
+export interface Ai_Cf_Google_Gemma_3_12B_It_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6774,20 +7247,7 @@ export interface Google_Gemma_3_12B_It_Messages {
              */
             url?: string;
           };
-        }[]
-      | {
-          /**
-           * Type of the content provided
-           */
-          type?: string;
-          text?: string;
-          image_url?: {
-            /**
-             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-             */
-            url?: string;
-          };
-        };
+        }[];
   }[];
   functions?: {
     name: string;
@@ -6969,10 +7429,10 @@ export declare abstract class Base_Ai_Cf_Google_Gemma_3_12B_It {
   postProcessedOutputs: Ai_Cf_Google_Gemma_3_12B_It_Output;
 }
 export type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input =
-  | Ai_Cf_Meta_Llama_4_Prompt
-  | Ai_Cf_Meta_Llama_4_Messages
-  | Ai_Cf_Meta_Llama_4_Async_Batch;
-export interface Ai_Cf_Meta_Llama_4_Prompt {
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch;
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6981,7 +7441,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -7023,7 +7483,11 @@ export interface Ai_Cf_Meta_Llama_4_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Messages {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -7159,7 +7623,7 @@ export interface Ai_Cf_Meta_Llama_4_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -7205,13 +7669,13 @@ export interface Ai_Cf_Meta_Llama_4_Messages {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Async_Batch {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch {
   requests: (
-    | Ai_Cf_Meta_Llama_4_Prompt_Inner
-    | Ai_Cf_Meta_Llama_4_Messages_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner
   )[];
 }
-export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -7220,7 +7684,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -7262,7 +7726,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Messages_Inner {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -7398,7 +7862,7 @@ export interface Ai_Cf_Meta_Llama_4_Messages_Inner {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -7496,6 +7960,613 @@ export type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output = {
 export declare abstract class Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct {
   inputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output;
+}
+export type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch;
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch {
+  requests: (
+    | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1
+    | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1
+  )[];
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response
+  | string
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse;
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+export declare abstract class Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8 {
+  inputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output;
 }
 export interface Ai_Cf_Deepgram_Nova_3_Input {
   audio: {
@@ -7688,6 +8759,23 @@ export declare abstract class Base_Ai_Cf_Deepgram_Nova_3 {
   inputs: Ai_Cf_Deepgram_Nova_3_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Nova_3_Output;
 }
+export interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input {
+  queries?: string | string[];
+  /**
+   * Optional instruction for the task
+   */
+  instruction?: string;
+  documents?: string | string[];
+  text?: string | string[];
+}
+export interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output {
+  data?: number[][];
+  shape?: number[];
+}
+export declare abstract class Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B {
+  inputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output;
+}
 export type Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input =
   | {
       /**
@@ -7726,93 +8814,13 @@ export declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   inputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input;
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
-export type Ai_Cf_Openai_Gpt_Oss_120B_Input =
-  | GPT_OSS_120B_Responses
-  | GPT_OSS_120B_Responses_Async;
-export interface GPT_OSS_120B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-export interface GPT_OSS_120B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-export type Ai_Cf_Openai_Gpt_Oss_120B_Output =
-  | {}
-  | (string & NonNullable<unknown>);
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_120B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_120B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
-export type Ai_Cf_Openai_Gpt_Oss_20B_Input =
-  | GPT_OSS_20B_Responses
-  | GPT_OSS_20B_Responses_Async;
-export interface GPT_OSS_20B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-export interface GPT_OSS_20B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-export type Ai_Cf_Openai_Gpt_Oss_20B_Output =
-  | {}
-  | (string & NonNullable<unknown>);
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_20B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_20B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
 export interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**
@@ -7938,6 +8946,901 @@ export declare abstract class Base_Ai_Cf_Deepgram_Aura_1 {
   inputs: Ai_Cf_Deepgram_Aura_1_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Aura_1_Output;
 }
+export interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
+  /**
+   * Input text to translate. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+  /**
+   * Target langauge to translate to
+   */
+  target_language:
+    | "asm_Beng"
+    | "awa_Deva"
+    | "ben_Beng"
+    | "bho_Deva"
+    | "brx_Deva"
+    | "doi_Deva"
+    | "eng_Latn"
+    | "gom_Deva"
+    | "gon_Deva"
+    | "guj_Gujr"
+    | "hin_Deva"
+    | "hne_Deva"
+    | "kan_Knda"
+    | "kas_Arab"
+    | "kas_Deva"
+    | "kha_Latn"
+    | "lus_Latn"
+    | "mag_Deva"
+    | "mai_Deva"
+    | "mal_Mlym"
+    | "mar_Deva"
+    | "mni_Beng"
+    | "mni_Mtei"
+    | "npi_Deva"
+    | "ory_Orya"
+    | "pan_Guru"
+    | "san_Deva"
+    | "sat_Olck"
+    | "snd_Arab"
+    | "snd_Deva"
+    | "tam_Taml"
+    | "tel_Telu"
+    | "urd_Arab"
+    | "unr_Deva";
+}
+export interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output {
+  /**
+   * Translated texts
+   */
+  translations: string[];
+}
+export declare abstract class Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B {
+  inputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input;
+  postProcessedOutputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output;
+}
+export type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch;
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch {
+  requests: (
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1
+  )[];
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response
+  | string
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse;
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+export declare abstract class Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It {
+  inputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input;
+  postProcessedOutputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output;
+}
+export interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Input {
+  /**
+   * Input text to embed. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+}
+export interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Output {
+  /**
+   * Embedding vectors, where each vector is a list of floats.
+   */
+  data: number[][];
+  /**
+   * Shape of the embedding data as [number_of_embeddings, embedding_dimension].
+   *
+   * @minItems 2
+   * @maxItems 2
+   */
+  shape: [number, number];
+}
+export declare abstract class Base_Ai_Cf_Pfnet_Plamo_Embedding_1B {
+  inputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Input;
+  postProcessedOutputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Output;
+}
+export interface Ai_Cf_Deepgram_Flux_Input {
+  /**
+   * Encoding of the audio stream. Currently only supports raw signed little-endian 16-bit PCM.
+   */
+  encoding: "linear16";
+  /**
+   * Sample rate of the audio stream in Hz.
+   */
+  sample_rate: string;
+  /**
+   * End-of-turn confidence required to fire an eager end-of-turn event. When set, enables EagerEndOfTurn and TurnResumed events. Valid Values 0.3 - 0.9.
+   */
+  eager_eot_threshold?: string;
+  /**
+   * End-of-turn confidence required to finish a turn. Valid Values 0.5 - 0.9.
+   */
+  eot_threshold?: string;
+  /**
+   * A turn will be finished when this much time has passed after speech, regardless of EOT confidence.
+   */
+  eot_timeout_ms?: string;
+  /**
+   * Keyterm prompting can improve recognition of specialized terminology. Pass multiple keyterm query parameters to boost multiple keyterms.
+   */
+  keyterm?: string;
+  /**
+   * Opts out requests from the Deepgram Model Improvement Program. Refer to Deepgram Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
+   */
+  mip_opt_out?: "true" | "false";
+  /**
+   * Label your requests for the purpose of identification during usage reporting
+   */
+  tag?: string;
+}
+/**
+ * Output will be returned as websocket messages.
+ */
+export interface Ai_Cf_Deepgram_Flux_Output {
+  /**
+   * The unique identifier of the request (uuid)
+   */
+  request_id?: string;
+  /**
+   * Starts at 0 and increments for each message the server sends to the client.
+   */
+  sequence_id?: number;
+  /**
+   * The type of event being reported.
+   */
+  event?:
+    | "Update"
+    | "StartOfTurn"
+    | "EagerEndOfTurn"
+    | "TurnResumed"
+    | "EndOfTurn";
+  /**
+   * The index of the current turn
+   */
+  turn_index?: number;
+  /**
+   * Start time in seconds of the audio range that was transcribed
+   */
+  audio_window_start?: number;
+  /**
+   * End time in seconds of the audio range that was transcribed
+   */
+  audio_window_end?: number;
+  /**
+   * Text that was said over the course of the current turn
+   */
+  transcript?: string;
+  /**
+   * The words in the transcript
+   */
+  words?: {
+    /**
+     * The individual punctuated, properly-cased word from the transcript
+     */
+    word: string;
+    /**
+     * Confidence that this word was transcribed correctly
+     */
+    confidence: number;
+  }[];
+  /**
+   * Confidence that no more speech is coming in this turn
+   */
+  end_of_turn_confidence?: number;
+}
+export declare abstract class Base_Ai_Cf_Deepgram_Flux {
+  inputs: Ai_Cf_Deepgram_Flux_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Flux_Output;
+}
+export interface Ai_Cf_Deepgram_Aura_2_En_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "amalthea"
+    | "andromeda"
+    | "apollo"
+    | "arcas"
+    | "aries"
+    | "asteria"
+    | "athena"
+    | "atlas"
+    | "aurora"
+    | "callista"
+    | "cora"
+    | "cordelia"
+    | "delia"
+    | "draco"
+    | "electra"
+    | "harmonia"
+    | "helena"
+    | "hera"
+    | "hermes"
+    | "hyperion"
+    | "iris"
+    | "janus"
+    | "juno"
+    | "jupiter"
+    | "luna"
+    | "mars"
+    | "minerva"
+    | "neptune"
+    | "odysseus"
+    | "ophelia"
+    | "orion"
+    | "orpheus"
+    | "pandora"
+    | "phoebe"
+    | "pluto"
+    | "saturn"
+    | "thalia"
+    | "theia"
+    | "vesta"
+    | "zeus";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+export type Ai_Cf_Deepgram_Aura_2_En_Output = string;
+export declare abstract class Base_Ai_Cf_Deepgram_Aura_2_En {
+  inputs: Ai_Cf_Deepgram_Aura_2_En_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_En_Output;
+}
+export interface Ai_Cf_Deepgram_Aura_2_Es_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "sirio"
+    | "nestor"
+    | "carina"
+    | "celeste"
+    | "alvaro"
+    | "diana"
+    | "aquila"
+    | "selena"
+    | "estrella"
+    | "javier";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+export type Ai_Cf_Deepgram_Aura_2_Es_Output = string;
+export declare abstract class Base_Ai_Cf_Deepgram_Aura_2_Es {
+  inputs: Ai_Cf_Deepgram_Aura_2_Es_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_Es_Output;
+}
 export interface AiModels {
   "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
   "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
@@ -7981,12 +9884,12 @@ export interface AiModels {
   "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
   "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
-  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
   "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": BaseAiTextGeneration;
+  "@cf/ibm-granite/granite-4.0-h-micro": BaseAiTextGeneration;
   "@cf/facebook/bart-large-cnn": BaseAiSummarization;
   "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
   "@cf/baai/bge-base-en-v1.5": Base_Ai_Cf_Baai_Bge_Base_En_V1_5;
@@ -8008,13 +9911,21 @@ export interface AiModels {
   "@cf/mistralai/mistral-small-3.1-24b-instruct": Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct;
   "@cf/google/gemma-3-12b-it": Base_Ai_Cf_Google_Gemma_3_12B_It;
   "@cf/meta/llama-4-scout-17b-16e-instruct": Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct;
+  "@cf/qwen/qwen3-30b-a3b-fp8": Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8;
   "@cf/deepgram/nova-3": Base_Ai_Cf_Deepgram_Nova_3;
+  "@cf/qwen/qwen3-embedding-0.6b": Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B;
   "@cf/pipecat-ai/smart-turn-v2": Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
   "@cf/openai/gpt-oss-120b": Base_Ai_Cf_Openai_Gpt_Oss_120B;
   "@cf/openai/gpt-oss-20b": Base_Ai_Cf_Openai_Gpt_Oss_20B;
   "@cf/leonardo/phoenix-1.0": Base_Ai_Cf_Leonardo_Phoenix_1_0;
   "@cf/leonardo/lucid-origin": Base_Ai_Cf_Leonardo_Lucid_Origin;
   "@cf/deepgram/aura-1": Base_Ai_Cf_Deepgram_Aura_1;
+  "@cf/ai4bharat/indictrans2-en-indic-1B": Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B;
+  "@cf/aisingapore/gemma-sea-lion-v4-27b-it": Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It;
+  "@cf/pfnet/plamo-embedding-1b": Base_Ai_Cf_Pfnet_Plamo_Embedding_1B;
+  "@cf/deepgram/flux": Base_Ai_Cf_Deepgram_Flux;
+  "@cf/deepgram/aura-2-en": Base_Ai_Cf_Deepgram_Aura_2_En;
+  "@cf/deepgram/aura-2-es": Base_Ai_Cf_Deepgram_Aura_2_Es;
 }
 export type AiOptions = {
   /**
@@ -8026,6 +9937,16 @@ export type AiOptions = {
    * Establish websocket connections, only works for supported models
    */
   websocket?: boolean;
+  /**
+   * Tag your requests to group and view them in Cloudflare dashboard.
+   *
+   * Rules:
+   * Tags must only contain letters, numbers, and the symbols: : - . / @
+   * Each tag can have maximum 50 characters.
+   * Maximum 5 tags are allowed each request.
+   * Duplicate tags will removed.
+   */
+  tags: string[];
   gateway?: GatewayOptions;
   returnRawResponse?: boolean;
   prefix?: string;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -4142,6 +4142,427 @@ declare abstract class BaseAiTranslation {
   inputs: AiTranslationInput;
   postProcessedOutputs: AiTranslationOutput;
 }
+/**
+ * Workers AI support for OpenAI's Responses API
+ * Reference: https://github.com/openai/openai-node/blob/master/src/resources/responses/responses.ts
+ *
+ * It's a stripped down version from its source.
+ * It currently supports basic function calling, json mode and accepts images as input.
+ *
+ * It does not include types for WebSearch, CodeInterpreter, FileInputs, MCP, CustomTools.
+ * We plan to add those incrementally as model + platform capabilities evolve.
+ */
+type ResponsesInput = {
+  background?: boolean | null;
+  conversation?: string | ResponseConversationParam | null;
+  include?: Array<ResponseIncludable> | null;
+  input?: string | ResponseInput;
+  instructions?: string | null;
+  max_output_tokens?: number | null;
+  parallel_tool_calls?: boolean | null;
+  previous_response_id?: string | null;
+  prompt_cache_key?: string;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  stream?: boolean | null;
+  stream_options?: StreamOptions | null;
+  temperature?: number | null;
+  text?: ResponseTextConfig;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  truncation?: "auto" | "disabled" | null;
+};
+type ResponsesOutput = {
+  id?: string;
+  created_at?: number;
+  output_text?: string;
+  error?: ResponseError | null;
+  incomplete_details?: ResponseIncompleteDetails | null;
+  instructions?: string | Array<ResponseInputItem> | null;
+  object?: "response";
+  output?: Array<ResponseOutputItem>;
+  parallel_tool_calls?: boolean;
+  temperature?: number | null;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  max_output_tokens?: number | null;
+  previous_response_id?: string | null;
+  prompt?: ResponsePrompt | null;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  status?: ResponseStatus;
+  text?: ResponseTextConfig;
+  truncation?: "auto" | "disabled" | null;
+  usage?: ResponseUsage;
+};
+type EasyInputMessage = {
+  content: string | ResponseInputMessageContentList;
+  role: "user" | "assistant" | "system" | "developer";
+  type?: "message";
+};
+type ResponsesFunctionTool = {
+  name: string;
+  parameters: {
+    [key: string]: unknown;
+  } | null;
+  strict: boolean | null;
+  type: "function";
+  description?: string | null;
+};
+type ResponseIncompleteDetails = {
+  reason?: "max_output_tokens" | "content_filter";
+};
+type ResponsePrompt = {
+  id: string;
+  variables?: {
+    [key: string]: string | ResponseInputText | ResponseInputImage;
+  } | null;
+  version?: string | null;
+};
+type Reasoning = {
+  effort?: ReasoningEffort | null;
+  generate_summary?: "auto" | "concise" | "detailed" | null;
+  summary?: "auto" | "concise" | "detailed" | null;
+};
+type ResponseContent =
+  | ResponseInputText
+  | ResponseInputImage
+  | ResponseOutputText
+  | ResponseOutputRefusal
+  | ResponseContentReasoningText;
+type ResponseContentReasoningText = {
+  text: string;
+  type: "reasoning_text";
+};
+type ResponseConversationParam = {
+  id: string;
+};
+type ResponseCreatedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.created";
+};
+type ResponseCustomToolCallOutput = {
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "custom_tool_call_output";
+  id?: string;
+};
+type ResponseError = {
+  code:
+    | "server_error"
+    | "rate_limit_exceeded"
+    | "invalid_prompt"
+    | "vector_store_timeout"
+    | "invalid_image"
+    | "invalid_image_format"
+    | "invalid_base64_image"
+    | "invalid_image_url"
+    | "image_too_large"
+    | "image_too_small"
+    | "image_parse_error"
+    | "image_content_policy_violation"
+    | "invalid_image_mode"
+    | "image_file_too_large"
+    | "unsupported_image_media_type"
+    | "empty_image_file"
+    | "failed_to_download_image"
+    | "image_file_not_found";
+  message: string;
+};
+type ResponseErrorEvent = {
+  code: string | null;
+  message: string;
+  param: string | null;
+  sequence_number: number;
+  type: "error";
+};
+type ResponseFailedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.failed";
+};
+type ResponseFormatText = {
+  type: "text";
+};
+type ResponseFormatJSONObject = {
+  type: "json_object";
+};
+type ResponseFormatTextConfig =
+  | ResponseFormatText
+  | ResponseFormatTextJSONSchemaConfig
+  | ResponseFormatJSONObject;
+type ResponseFormatTextJSONSchemaConfig = {
+  name: string;
+  schema: {
+    [key: string]: unknown;
+  };
+  type: "json_schema";
+  description?: string;
+  strict?: boolean | null;
+};
+type ResponseFunctionCallArgumentsDeltaEvent = {
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.delta";
+};
+type ResponseFunctionCallArgumentsDoneEvent = {
+  arguments: string;
+  item_id: string;
+  name: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.done";
+};
+type ResponseFunctionCallOutputItem =
+  | ResponseInputTextContent
+  | ResponseInputImageContent;
+type ResponseFunctionCallOutputItemList = Array<ResponseFunctionCallOutputItem>;
+type ResponseFunctionToolCall = {
+  arguments: string;
+  call_id: string;
+  name: string;
+  type: "function_call";
+  id?: string;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+interface ResponseFunctionToolCallItem extends ResponseFunctionToolCall {
+  id: string;
+}
+type ResponseFunctionToolCallOutputItem = {
+  id: string;
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "function_call_output";
+  status?: "in_progress" | "completed" | "incomplete";
+};
+type ResponseIncludable =
+  | "message.input_image.image_url"
+  | "message.output_text.logprobs";
+type ResponseIncompleteEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.incomplete";
+};
+type ResponseInput = Array<ResponseInputItem>;
+type ResponseInputContent = ResponseInputText | ResponseInputImage;
+type ResponseInputImage = {
+  detail: "low" | "high" | "auto";
+  type: "input_image";
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+type ResponseInputImageContent = {
+  type: "input_image";
+  detail?: "low" | "high" | "auto" | null;
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+type ResponseInputItem =
+  | EasyInputMessage
+  | ResponseInputItemMessage
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseInputItemFunctionCallOutput
+  | ResponseReasoningItem;
+type ResponseInputItemFunctionCallOutput = {
+  call_id: string;
+  output: string | ResponseFunctionCallOutputItemList;
+  type: "function_call_output";
+  id?: string | null;
+  status?: "in_progress" | "completed" | "incomplete" | null;
+};
+type ResponseInputItemMessage = {
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+type ResponseInputMessageContentList = Array<ResponseInputContent>;
+type ResponseInputMessageItem = {
+  id: string;
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+type ResponseInputText = {
+  text: string;
+  type: "input_text";
+};
+type ResponseInputTextContent = {
+  text: string;
+  type: "input_text";
+};
+type ResponseItem =
+  | ResponseInputMessageItem
+  | ResponseOutputMessage
+  | ResponseFunctionToolCallItem
+  | ResponseFunctionToolCallOutputItem;
+type ResponseOutputItem =
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseReasoningItem;
+type ResponseOutputItemAddedEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.added";
+};
+type ResponseOutputItemDoneEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.done";
+};
+type ResponseOutputMessage = {
+  id: string;
+  content: Array<ResponseOutputText | ResponseOutputRefusal>;
+  role: "assistant";
+  status: "in_progress" | "completed" | "incomplete";
+  type: "message";
+};
+type ResponseOutputRefusal = {
+  refusal: string;
+  type: "refusal";
+};
+type ResponseOutputText = {
+  text: string;
+  type: "output_text";
+  logprobs?: Array<Logprob>;
+};
+type ResponseReasoningItem = {
+  id: string;
+  summary: Array<ResponseReasoningSummaryItem>;
+  type: "reasoning";
+  content?: Array<ResponseReasoningContentItem>;
+  encrypted_content?: string | null;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+type ResponseReasoningSummaryItem = {
+  text: string;
+  type: "summary_text";
+};
+type ResponseReasoningContentItem = {
+  text: string;
+  type: "reasoning_text";
+};
+type ResponseReasoningTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.reasoning_text.delta";
+};
+type ResponseReasoningTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.reasoning_text.done";
+};
+type ResponseRefusalDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.refusal.delta";
+};
+type ResponseRefusalDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  refusal: string;
+  sequence_number: number;
+  type: "response.refusal.done";
+};
+type ResponseStatus =
+  | "completed"
+  | "failed"
+  | "in_progress"
+  | "cancelled"
+  | "queued"
+  | "incomplete";
+type ResponseStreamEvent =
+  | ResponseCompletedEvent
+  | ResponseCreatedEvent
+  | ResponseErrorEvent
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseFailedEvent
+  | ResponseIncompleteEvent
+  | ResponseOutputItemAddedEvent
+  | ResponseOutputItemDoneEvent
+  | ResponseReasoningTextDeltaEvent
+  | ResponseReasoningTextDoneEvent
+  | ResponseRefusalDeltaEvent
+  | ResponseRefusalDoneEvent
+  | ResponseTextDeltaEvent
+  | ResponseTextDoneEvent;
+type ResponseCompletedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.completed";
+};
+type ResponseTextConfig = {
+  format?: ResponseFormatTextConfig;
+  verbosity?: "low" | "medium" | "high" | null;
+};
+type ResponseTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_text.delta";
+};
+type ResponseTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.output_text.done";
+};
+type Logprob = {
+  token: string;
+  logprob: number;
+  top_logprobs?: Array<TopLogprob>;
+};
+type TopLogprob = {
+  token?: string;
+  logprob?: number;
+};
+type ResponseUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+};
+type Tool = ResponsesFunctionTool;
+type ToolChoiceFunction = {
+  name: string;
+  type: "function";
+};
+type ToolChoiceOptions = "none";
+type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
+type StreamOptions = {
+  include_obfuscation?: boolean;
+};
 type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -4174,8 +4595,8 @@ type Ai_Cf_Baai_Bge_Base_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
-interface AsyncResponse {
+  | Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse;
+interface Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse {
   /**
    * The async request id that can be used to obtain the results.
    */
@@ -4257,7 +4678,13 @@ type Ai_Cf_Meta_M2M100_1_2B_Output =
        */
       translated_text?: string;
     }
-  | AsyncResponse;
+  | Ai_Cf_Meta_M2M100_1_2B_AsyncResponse;
+interface Ai_Cf_Meta_M2M100_1_2B_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 declare abstract class Base_Ai_Cf_Meta_M2M100_1_2B {
   inputs: Ai_Cf_Meta_M2M100_1_2B_Input;
   postProcessedOutputs: Ai_Cf_Meta_M2M100_1_2B_Output;
@@ -4294,7 +4721,13 @@ type Ai_Cf_Baai_Bge_Small_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse;
+interface Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 declare abstract class Base_Ai_Cf_Baai_Bge_Small_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Output;
@@ -4331,7 +4764,13 @@ type Ai_Cf_Baai_Bge_Large_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse;
+interface Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 declare abstract class Base_Ai_Cf_Baai_Bge_Large_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Output;
@@ -4522,15 +4961,18 @@ declare abstract class Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo {
   postProcessedOutputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output;
 }
 type Ai_Cf_Baai_Bge_M3_Input =
-  | BGEM3InputQueryAndContexts
-  | BGEM3InputEmbedding
+  | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts
+  | Ai_Cf_Baai_Bge_M3_Input_Embedding
   | {
       /**
        * Batch of the embeddings requests to run using async-queue
        */
-      requests: (BGEM3InputQueryAndContexts1 | BGEM3InputEmbedding1)[];
+      requests: (
+        | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1
+        | Ai_Cf_Baai_Bge_M3_Input_Embedding_1
+      )[];
     };
-interface BGEM3InputQueryAndContexts {
+interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -4549,14 +4991,14 @@ interface BGEM3InputQueryAndContexts {
    */
   truncate_inputs?: boolean;
 }
-interface BGEM3InputEmbedding {
+interface Ai_Cf_Baai_Bge_M3_Input_Embedding {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
    */
   truncate_inputs?: boolean;
 }
-interface BGEM3InputQueryAndContexts1 {
+interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1 {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -4575,7 +5017,7 @@ interface BGEM3InputQueryAndContexts1 {
    */
   truncate_inputs?: boolean;
 }
-interface BGEM3InputEmbedding1 {
+interface Ai_Cf_Baai_Bge_M3_Input_Embedding_1 {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
@@ -4583,11 +5025,11 @@ interface BGEM3InputEmbedding1 {
   truncate_inputs?: boolean;
 }
 type Ai_Cf_Baai_Bge_M3_Output =
-  | BGEM3OuputQuery
-  | BGEM3OutputEmbeddingForContexts
-  | BGEM3OuputEmbedding
-  | AsyncResponse;
-interface BGEM3OuputQuery {
+  | Ai_Cf_Baai_Bge_M3_Ouput_Query
+  | Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts
+  | Ai_Cf_Baai_Bge_M3_Ouput_Embedding
+  | Ai_Cf_Baai_Bge_M3_AsyncResponse;
+interface Ai_Cf_Baai_Bge_M3_Ouput_Query {
   response?: {
     /**
      * Index of the context in the request
@@ -4599,7 +5041,7 @@ interface BGEM3OuputQuery {
     score?: number;
   }[];
 }
-interface BGEM3OutputEmbeddingForContexts {
+interface Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts {
   response?: number[][];
   shape?: number[];
   /**
@@ -4607,7 +5049,7 @@ interface BGEM3OutputEmbeddingForContexts {
    */
   pooling?: "mean" | "cls";
 }
-interface BGEM3OuputEmbedding {
+interface Ai_Cf_Baai_Bge_M3_Ouput_Embedding {
   shape?: number[];
   /**
    * Embeddings of the requested text values
@@ -4617,6 +5059,12 @@ interface BGEM3OuputEmbedding {
    * The pooling method used in the embedding process.
    */
   pooling?: "mean" | "cls";
+}
+interface Ai_Cf_Baai_Bge_M3_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
 }
 declare abstract class Base_Ai_Cf_Baai_Bge_M3 {
   inputs: Ai_Cf_Baai_Bge_M3_Input;
@@ -4642,8 +5090,10 @@ declare abstract class Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell {
   inputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Input;
   postProcessedOutputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Output;
 }
-type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input = Prompt | Messages;
-interface Prompt {
+type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input =
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages;
+interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -4694,7 +5144,7 @@ interface Prompt {
    */
   lora?: string;
 }
-interface Messages {
+interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -4892,10 +5342,10 @@ declare abstract class Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct {
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Output;
 }
 type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input =
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
-  | AsyncBatch;
-interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch;
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -4904,7 +5354,7 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -4946,11 +5396,11 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    */
   presence_penalty?: number;
 }
-interface JSONMode {
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode {
   type?: "json_object" | "json_schema";
   json_schema?: unknown;
 }
-interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5058,7 +5508,7 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5100,7 +5550,11 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
    */
   presence_penalty?: number;
 }
-interface AsyncBatch {
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch {
   requests?: {
     /**
      * User-supplied reference. This field will be present in the response as well it can be used to reference the request and response. It's NOT validated to be unique.
@@ -5142,8 +5596,12 @@ interface AsyncBatch {
      * Increases the likelihood of the model introducing new topics.
      */
     presence_penalty?: number;
-    response_format?: JSONMode;
+    response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2;
   }[];
+}
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
 }
 type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
   | {
@@ -5183,7 +5641,13 @@ type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
       }[];
     }
   | string
-  | AsyncResponse;
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse;
+interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 declare abstract class Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast {
   inputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output;
@@ -5290,9 +5754,9 @@ declare abstract class Base_Ai_Cf_Baai_Bge_Reranker_Base {
   postProcessedOutputs: Ai_Cf_Baai_Bge_Reranker_Base_Output;
 }
 type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input =
-  | Qwen2_5_Coder_32B_Instruct_Prompt
-  | Qwen2_5_Coder_32B_Instruct_Messages;
-interface Qwen2_5_Coder_32B_Instruct_Prompt {
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages;
+interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5301,7 +5765,7 @@ interface Qwen2_5_Coder_32B_Instruct_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5343,7 +5807,11 @@ interface Qwen2_5_Coder_32B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-interface Qwen2_5_Coder_32B_Instruct_Messages {
+interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5451,7 +5919,7 @@ interface Qwen2_5_Coder_32B_Instruct_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5493,6 +5961,10 @@ interface Qwen2_5_Coder_32B_Instruct_Messages {
    */
   presence_penalty?: number;
 }
+interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
 type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output = {
   /**
    * The generated text response from the model
@@ -5533,8 +6005,10 @@ declare abstract class Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct {
   inputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output;
 }
-type Ai_Cf_Qwen_Qwq_32B_Input = Qwen_Qwq_32B_Prompt | Qwen_Qwq_32B_Messages;
-interface Qwen_Qwq_32B_Prompt {
+type Ai_Cf_Qwen_Qwq_32B_Input =
+  | Ai_Cf_Qwen_Qwq_32B_Prompt
+  | Ai_Cf_Qwen_Qwq_32B_Messages;
+interface Ai_Cf_Qwen_Qwq_32B_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5584,7 +6058,7 @@ interface Qwen_Qwq_32B_Prompt {
    */
   presence_penalty?: number;
 }
-interface Qwen_Qwq_32B_Messages {
+interface Ai_Cf_Qwen_Qwq_32B_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5806,9 +6280,9 @@ declare abstract class Base_Ai_Cf_Qwen_Qwq_32B {
   postProcessedOutputs: Ai_Cf_Qwen_Qwq_32B_Output;
 }
 type Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input =
-  | Mistral_Small_3_1_24B_Instruct_Prompt
-  | Mistral_Small_3_1_24B_Instruct_Messages;
-interface Mistral_Small_3_1_24B_Instruct_Prompt {
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages;
+interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5858,7 +6332,7 @@ interface Mistral_Small_3_1_24B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-interface Mistral_Small_3_1_24B_Instruct_Messages {
+interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6080,9 +6554,9 @@ declare abstract class Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct {
   postProcessedOutputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output;
 }
 type Ai_Cf_Google_Gemma_3_12B_It_Input =
-  | Google_Gemma_3_12B_It_Prompt
-  | Google_Gemma_3_12B_It_Messages;
-interface Google_Gemma_3_12B_It_Prompt {
+  | Ai_Cf_Google_Gemma_3_12B_It_Prompt
+  | Ai_Cf_Google_Gemma_3_12B_It_Messages;
+interface Ai_Cf_Google_Gemma_3_12B_It_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6132,7 +6606,7 @@ interface Google_Gemma_3_12B_It_Prompt {
    */
   presence_penalty?: number;
 }
-interface Google_Gemma_3_12B_It_Messages {
+interface Ai_Cf_Google_Gemma_3_12B_It_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6155,20 +6629,7 @@ interface Google_Gemma_3_12B_It_Messages {
              */
             url?: string;
           };
-        }[]
-      | {
-          /**
-           * Type of the content provided
-           */
-          type?: string;
-          text?: string;
-          image_url?: {
-            /**
-             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-             */
-            url?: string;
-          };
-        };
+        }[];
   }[];
   functions?: {
     name: string;
@@ -6350,10 +6811,10 @@ declare abstract class Base_Ai_Cf_Google_Gemma_3_12B_It {
   postProcessedOutputs: Ai_Cf_Google_Gemma_3_12B_It_Output;
 }
 type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input =
-  | Ai_Cf_Meta_Llama_4_Prompt
-  | Ai_Cf_Meta_Llama_4_Messages
-  | Ai_Cf_Meta_Llama_4_Async_Batch;
-interface Ai_Cf_Meta_Llama_4_Prompt {
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch;
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6362,7 +6823,7 @@ interface Ai_Cf_Meta_Llama_4_Prompt {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -6404,7 +6865,11 @@ interface Ai_Cf_Meta_Llama_4_Prompt {
    */
   presence_penalty?: number;
 }
-interface Ai_Cf_Meta_Llama_4_Messages {
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6540,7 +7005,7 @@ interface Ai_Cf_Meta_Llama_4_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -6586,13 +7051,13 @@ interface Ai_Cf_Meta_Llama_4_Messages {
    */
   presence_penalty?: number;
 }
-interface Ai_Cf_Meta_Llama_4_Async_Batch {
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch {
   requests: (
-    | Ai_Cf_Meta_Llama_4_Prompt_Inner
-    | Ai_Cf_Meta_Llama_4_Messages_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner
   )[];
 }
-interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6601,7 +7066,7 @@ interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -6643,7 +7108,7 @@ interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    */
   presence_penalty?: number;
 }
-interface Ai_Cf_Meta_Llama_4_Messages_Inner {
+interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6779,7 +7244,7 @@ interface Ai_Cf_Meta_Llama_4_Messages_Inner {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -6877,6 +7342,613 @@ type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output = {
 declare abstract class Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct {
   inputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output;
+}
+type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch;
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch {
+  requests: (
+    | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1
+    | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1
+  )[];
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response
+  | string
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse;
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+declare abstract class Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8 {
+  inputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output;
 }
 interface Ai_Cf_Deepgram_Nova_3_Input {
   audio: {
@@ -7069,6 +8141,23 @@ declare abstract class Base_Ai_Cf_Deepgram_Nova_3 {
   inputs: Ai_Cf_Deepgram_Nova_3_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Nova_3_Output;
 }
+interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input {
+  queries?: string | string[];
+  /**
+   * Optional instruction for the task
+   */
+  instruction?: string;
+  documents?: string | string[];
+  text?: string | string[];
+}
+interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output {
+  data?: number[][];
+  shape?: number[];
+}
+declare abstract class Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B {
+  inputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output;
+}
 type Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input =
   | {
       /**
@@ -7107,89 +8196,13 @@ declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   inputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input;
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
-type Ai_Cf_Openai_Gpt_Oss_120B_Input =
-  | GPT_OSS_120B_Responses
-  | GPT_OSS_120B_Responses_Async;
-interface GPT_OSS_120B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-interface GPT_OSS_120B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-type Ai_Cf_Openai_Gpt_Oss_120B_Output = {} | (string & NonNullable<unknown>);
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_120B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_120B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
-type Ai_Cf_Openai_Gpt_Oss_20B_Input =
-  | GPT_OSS_20B_Responses
-  | GPT_OSS_20B_Responses_Async;
-interface GPT_OSS_20B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-interface GPT_OSS_20B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-type Ai_Cf_Openai_Gpt_Oss_20B_Output = {} | (string & NonNullable<unknown>);
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_20B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_20B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
 interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**
@@ -7315,6 +8328,901 @@ declare abstract class Base_Ai_Cf_Deepgram_Aura_1 {
   inputs: Ai_Cf_Deepgram_Aura_1_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Aura_1_Output;
 }
+interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
+  /**
+   * Input text to translate. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+  /**
+   * Target langauge to translate to
+   */
+  target_language:
+    | "asm_Beng"
+    | "awa_Deva"
+    | "ben_Beng"
+    | "bho_Deva"
+    | "brx_Deva"
+    | "doi_Deva"
+    | "eng_Latn"
+    | "gom_Deva"
+    | "gon_Deva"
+    | "guj_Gujr"
+    | "hin_Deva"
+    | "hne_Deva"
+    | "kan_Knda"
+    | "kas_Arab"
+    | "kas_Deva"
+    | "kha_Latn"
+    | "lus_Latn"
+    | "mag_Deva"
+    | "mai_Deva"
+    | "mal_Mlym"
+    | "mar_Deva"
+    | "mni_Beng"
+    | "mni_Mtei"
+    | "npi_Deva"
+    | "ory_Orya"
+    | "pan_Guru"
+    | "san_Deva"
+    | "sat_Olck"
+    | "snd_Arab"
+    | "snd_Deva"
+    | "tam_Taml"
+    | "tel_Telu"
+    | "urd_Arab"
+    | "unr_Deva";
+}
+interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output {
+  /**
+   * Translated texts
+   */
+  translations: string[];
+}
+declare abstract class Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B {
+  inputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input;
+  postProcessedOutputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output;
+}
+type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch;
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch {
+  requests: (
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1
+  )[];
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response
+  | string
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse;
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+declare abstract class Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It {
+  inputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input;
+  postProcessedOutputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output;
+}
+interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Input {
+  /**
+   * Input text to embed. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+}
+interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Output {
+  /**
+   * Embedding vectors, where each vector is a list of floats.
+   */
+  data: number[][];
+  /**
+   * Shape of the embedding data as [number_of_embeddings, embedding_dimension].
+   *
+   * @minItems 2
+   * @maxItems 2
+   */
+  shape: [number, number];
+}
+declare abstract class Base_Ai_Cf_Pfnet_Plamo_Embedding_1B {
+  inputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Input;
+  postProcessedOutputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Output;
+}
+interface Ai_Cf_Deepgram_Flux_Input {
+  /**
+   * Encoding of the audio stream. Currently only supports raw signed little-endian 16-bit PCM.
+   */
+  encoding: "linear16";
+  /**
+   * Sample rate of the audio stream in Hz.
+   */
+  sample_rate: string;
+  /**
+   * End-of-turn confidence required to fire an eager end-of-turn event. When set, enables EagerEndOfTurn and TurnResumed events. Valid Values 0.3 - 0.9.
+   */
+  eager_eot_threshold?: string;
+  /**
+   * End-of-turn confidence required to finish a turn. Valid Values 0.5 - 0.9.
+   */
+  eot_threshold?: string;
+  /**
+   * A turn will be finished when this much time has passed after speech, regardless of EOT confidence.
+   */
+  eot_timeout_ms?: string;
+  /**
+   * Keyterm prompting can improve recognition of specialized terminology. Pass multiple keyterm query parameters to boost multiple keyterms.
+   */
+  keyterm?: string;
+  /**
+   * Opts out requests from the Deepgram Model Improvement Program. Refer to Deepgram Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
+   */
+  mip_opt_out?: "true" | "false";
+  /**
+   * Label your requests for the purpose of identification during usage reporting
+   */
+  tag?: string;
+}
+/**
+ * Output will be returned as websocket messages.
+ */
+interface Ai_Cf_Deepgram_Flux_Output {
+  /**
+   * The unique identifier of the request (uuid)
+   */
+  request_id?: string;
+  /**
+   * Starts at 0 and increments for each message the server sends to the client.
+   */
+  sequence_id?: number;
+  /**
+   * The type of event being reported.
+   */
+  event?:
+    | "Update"
+    | "StartOfTurn"
+    | "EagerEndOfTurn"
+    | "TurnResumed"
+    | "EndOfTurn";
+  /**
+   * The index of the current turn
+   */
+  turn_index?: number;
+  /**
+   * Start time in seconds of the audio range that was transcribed
+   */
+  audio_window_start?: number;
+  /**
+   * End time in seconds of the audio range that was transcribed
+   */
+  audio_window_end?: number;
+  /**
+   * Text that was said over the course of the current turn
+   */
+  transcript?: string;
+  /**
+   * The words in the transcript
+   */
+  words?: {
+    /**
+     * The individual punctuated, properly-cased word from the transcript
+     */
+    word: string;
+    /**
+     * Confidence that this word was transcribed correctly
+     */
+    confidence: number;
+  }[];
+  /**
+   * Confidence that no more speech is coming in this turn
+   */
+  end_of_turn_confidence?: number;
+}
+declare abstract class Base_Ai_Cf_Deepgram_Flux {
+  inputs: Ai_Cf_Deepgram_Flux_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Flux_Output;
+}
+interface Ai_Cf_Deepgram_Aura_2_En_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "amalthea"
+    | "andromeda"
+    | "apollo"
+    | "arcas"
+    | "aries"
+    | "asteria"
+    | "athena"
+    | "atlas"
+    | "aurora"
+    | "callista"
+    | "cora"
+    | "cordelia"
+    | "delia"
+    | "draco"
+    | "electra"
+    | "harmonia"
+    | "helena"
+    | "hera"
+    | "hermes"
+    | "hyperion"
+    | "iris"
+    | "janus"
+    | "juno"
+    | "jupiter"
+    | "luna"
+    | "mars"
+    | "minerva"
+    | "neptune"
+    | "odysseus"
+    | "ophelia"
+    | "orion"
+    | "orpheus"
+    | "pandora"
+    | "phoebe"
+    | "pluto"
+    | "saturn"
+    | "thalia"
+    | "theia"
+    | "vesta"
+    | "zeus";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+type Ai_Cf_Deepgram_Aura_2_En_Output = string;
+declare abstract class Base_Ai_Cf_Deepgram_Aura_2_En {
+  inputs: Ai_Cf_Deepgram_Aura_2_En_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_En_Output;
+}
+interface Ai_Cf_Deepgram_Aura_2_Es_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "sirio"
+    | "nestor"
+    | "carina"
+    | "celeste"
+    | "alvaro"
+    | "diana"
+    | "aquila"
+    | "selena"
+    | "estrella"
+    | "javier";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+type Ai_Cf_Deepgram_Aura_2_Es_Output = string;
+declare abstract class Base_Ai_Cf_Deepgram_Aura_2_Es {
+  inputs: Ai_Cf_Deepgram_Aura_2_Es_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_Es_Output;
+}
 interface AiModels {
   "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
   "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
@@ -7358,12 +9266,12 @@ interface AiModels {
   "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
   "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
-  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
   "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": BaseAiTextGeneration;
+  "@cf/ibm-granite/granite-4.0-h-micro": BaseAiTextGeneration;
   "@cf/facebook/bart-large-cnn": BaseAiSummarization;
   "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
   "@cf/baai/bge-base-en-v1.5": Base_Ai_Cf_Baai_Bge_Base_En_V1_5;
@@ -7385,13 +9293,21 @@ interface AiModels {
   "@cf/mistralai/mistral-small-3.1-24b-instruct": Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct;
   "@cf/google/gemma-3-12b-it": Base_Ai_Cf_Google_Gemma_3_12B_It;
   "@cf/meta/llama-4-scout-17b-16e-instruct": Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct;
+  "@cf/qwen/qwen3-30b-a3b-fp8": Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8;
   "@cf/deepgram/nova-3": Base_Ai_Cf_Deepgram_Nova_3;
+  "@cf/qwen/qwen3-embedding-0.6b": Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B;
   "@cf/pipecat-ai/smart-turn-v2": Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
   "@cf/openai/gpt-oss-120b": Base_Ai_Cf_Openai_Gpt_Oss_120B;
   "@cf/openai/gpt-oss-20b": Base_Ai_Cf_Openai_Gpt_Oss_20B;
   "@cf/leonardo/phoenix-1.0": Base_Ai_Cf_Leonardo_Phoenix_1_0;
   "@cf/leonardo/lucid-origin": Base_Ai_Cf_Leonardo_Lucid_Origin;
   "@cf/deepgram/aura-1": Base_Ai_Cf_Deepgram_Aura_1;
+  "@cf/ai4bharat/indictrans2-en-indic-1B": Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B;
+  "@cf/aisingapore/gemma-sea-lion-v4-27b-it": Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It;
+  "@cf/pfnet/plamo-embedding-1b": Base_Ai_Cf_Pfnet_Plamo_Embedding_1B;
+  "@cf/deepgram/flux": Base_Ai_Cf_Deepgram_Flux;
+  "@cf/deepgram/aura-2-en": Base_Ai_Cf_Deepgram_Aura_2_En;
+  "@cf/deepgram/aura-2-es": Base_Ai_Cf_Deepgram_Aura_2_Es;
 }
 type AiOptions = {
   /**
@@ -7403,6 +9319,16 @@ type AiOptions = {
    * Establish websocket connections, only works for supported models
    */
   websocket?: boolean;
+  /**
+   * Tag your requests to group and view them in Cloudflare dashboard.
+   *
+   * Rules:
+   * Tags must only contain letters, numbers, and the symbols: : - . / @
+   * Each tag can have maximum 50 characters.
+   * Maximum 5 tags are allowed each request.
+   * Duplicate tags will removed.
+   */
+  tags: string[];
   gateway?: GatewayOptions;
   returnRawResponse?: boolean;
   prefix?: string;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -4153,6 +4153,428 @@ export declare abstract class BaseAiTranslation {
   inputs: AiTranslationInput;
   postProcessedOutputs: AiTranslationOutput;
 }
+/**
+ * Workers AI support for OpenAI's Responses API
+ * Reference: https://github.com/openai/openai-node/blob/master/src/resources/responses/responses.ts
+ *
+ * It's a stripped down version from its source.
+ * It currently supports basic function calling, json mode and accepts images as input.
+ *
+ * It does not include types for WebSearch, CodeInterpreter, FileInputs, MCP, CustomTools.
+ * We plan to add those incrementally as model + platform capabilities evolve.
+ */
+export type ResponsesInput = {
+  background?: boolean | null;
+  conversation?: string | ResponseConversationParam | null;
+  include?: Array<ResponseIncludable> | null;
+  input?: string | ResponseInput;
+  instructions?: string | null;
+  max_output_tokens?: number | null;
+  parallel_tool_calls?: boolean | null;
+  previous_response_id?: string | null;
+  prompt_cache_key?: string;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  stream?: boolean | null;
+  stream_options?: StreamOptions | null;
+  temperature?: number | null;
+  text?: ResponseTextConfig;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  truncation?: "auto" | "disabled" | null;
+};
+export type ResponsesOutput = {
+  id?: string;
+  created_at?: number;
+  output_text?: string;
+  error?: ResponseError | null;
+  incomplete_details?: ResponseIncompleteDetails | null;
+  instructions?: string | Array<ResponseInputItem> | null;
+  object?: "response";
+  output?: Array<ResponseOutputItem>;
+  parallel_tool_calls?: boolean;
+  temperature?: number | null;
+  tool_choice?: ToolChoiceOptions | ToolChoiceFunction;
+  tools?: Array<Tool>;
+  top_p?: number | null;
+  max_output_tokens?: number | null;
+  previous_response_id?: string | null;
+  prompt?: ResponsePrompt | null;
+  reasoning?: Reasoning | null;
+  safety_identifier?: string;
+  service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+  status?: ResponseStatus;
+  text?: ResponseTextConfig;
+  truncation?: "auto" | "disabled" | null;
+  usage?: ResponseUsage;
+};
+export type EasyInputMessage = {
+  content: string | ResponseInputMessageContentList;
+  role: "user" | "assistant" | "system" | "developer";
+  type?: "message";
+};
+export type ResponsesFunctionTool = {
+  name: string;
+  parameters: {
+    [key: string]: unknown;
+  } | null;
+  strict: boolean | null;
+  type: "function";
+  description?: string | null;
+};
+export type ResponseIncompleteDetails = {
+  reason?: "max_output_tokens" | "content_filter";
+};
+export type ResponsePrompt = {
+  id: string;
+  variables?: {
+    [key: string]: string | ResponseInputText | ResponseInputImage;
+  } | null;
+  version?: string | null;
+};
+export type Reasoning = {
+  effort?: ReasoningEffort | null;
+  generate_summary?: "auto" | "concise" | "detailed" | null;
+  summary?: "auto" | "concise" | "detailed" | null;
+};
+export type ResponseContent =
+  | ResponseInputText
+  | ResponseInputImage
+  | ResponseOutputText
+  | ResponseOutputRefusal
+  | ResponseContentReasoningText;
+export type ResponseContentReasoningText = {
+  text: string;
+  type: "reasoning_text";
+};
+export type ResponseConversationParam = {
+  id: string;
+};
+export type ResponseCreatedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.created";
+};
+export type ResponseCustomToolCallOutput = {
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "custom_tool_call_output";
+  id?: string;
+};
+export type ResponseError = {
+  code:
+    | "server_error"
+    | "rate_limit_exceeded"
+    | "invalid_prompt"
+    | "vector_store_timeout"
+    | "invalid_image"
+    | "invalid_image_format"
+    | "invalid_base64_image"
+    | "invalid_image_url"
+    | "image_too_large"
+    | "image_too_small"
+    | "image_parse_error"
+    | "image_content_policy_violation"
+    | "invalid_image_mode"
+    | "image_file_too_large"
+    | "unsupported_image_media_type"
+    | "empty_image_file"
+    | "failed_to_download_image"
+    | "image_file_not_found";
+  message: string;
+};
+export type ResponseErrorEvent = {
+  code: string | null;
+  message: string;
+  param: string | null;
+  sequence_number: number;
+  type: "error";
+};
+export type ResponseFailedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.failed";
+};
+export type ResponseFormatText = {
+  type: "text";
+};
+export type ResponseFormatJSONObject = {
+  type: "json_object";
+};
+export type ResponseFormatTextConfig =
+  | ResponseFormatText
+  | ResponseFormatTextJSONSchemaConfig
+  | ResponseFormatJSONObject;
+export type ResponseFormatTextJSONSchemaConfig = {
+  name: string;
+  schema: {
+    [key: string]: unknown;
+  };
+  type: "json_schema";
+  description?: string;
+  strict?: boolean | null;
+};
+export type ResponseFunctionCallArgumentsDeltaEvent = {
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.delta";
+};
+export type ResponseFunctionCallArgumentsDoneEvent = {
+  arguments: string;
+  item_id: string;
+  name: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.function_call_arguments.done";
+};
+export type ResponseFunctionCallOutputItem =
+  | ResponseInputTextContent
+  | ResponseInputImageContent;
+export type ResponseFunctionCallOutputItemList =
+  Array<ResponseFunctionCallOutputItem>;
+export type ResponseFunctionToolCall = {
+  arguments: string;
+  call_id: string;
+  name: string;
+  type: "function_call";
+  id?: string;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export interface ResponseFunctionToolCallItem extends ResponseFunctionToolCall {
+  id: string;
+}
+export type ResponseFunctionToolCallOutputItem = {
+  id: string;
+  call_id: string;
+  output: string | Array<ResponseInputText | ResponseInputImage>;
+  type: "function_call_output";
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export type ResponseIncludable =
+  | "message.input_image.image_url"
+  | "message.output_text.logprobs";
+export type ResponseIncompleteEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.incomplete";
+};
+export type ResponseInput = Array<ResponseInputItem>;
+export type ResponseInputContent = ResponseInputText | ResponseInputImage;
+export type ResponseInputImage = {
+  detail: "low" | "high" | "auto";
+  type: "input_image";
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+export type ResponseInputImageContent = {
+  type: "input_image";
+  detail?: "low" | "high" | "auto" | null;
+  /**
+   * Base64 encoded image
+   */
+  image_url?: string | null;
+};
+export type ResponseInputItem =
+  | EasyInputMessage
+  | ResponseInputItemMessage
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseInputItemFunctionCallOutput
+  | ResponseReasoningItem;
+export type ResponseInputItemFunctionCallOutput = {
+  call_id: string;
+  output: string | ResponseFunctionCallOutputItemList;
+  type: "function_call_output";
+  id?: string | null;
+  status?: "in_progress" | "completed" | "incomplete" | null;
+};
+export type ResponseInputItemMessage = {
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+export type ResponseInputMessageContentList = Array<ResponseInputContent>;
+export type ResponseInputMessageItem = {
+  id: string;
+  content: ResponseInputMessageContentList;
+  role: "user" | "system" | "developer";
+  status?: "in_progress" | "completed" | "incomplete";
+  type?: "message";
+};
+export type ResponseInputText = {
+  text: string;
+  type: "input_text";
+};
+export type ResponseInputTextContent = {
+  text: string;
+  type: "input_text";
+};
+export type ResponseItem =
+  | ResponseInputMessageItem
+  | ResponseOutputMessage
+  | ResponseFunctionToolCallItem
+  | ResponseFunctionToolCallOutputItem;
+export type ResponseOutputItem =
+  | ResponseOutputMessage
+  | ResponseFunctionToolCall
+  | ResponseReasoningItem;
+export type ResponseOutputItemAddedEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.added";
+};
+export type ResponseOutputItemDoneEvent = {
+  item: ResponseOutputItem;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_item.done";
+};
+export type ResponseOutputMessage = {
+  id: string;
+  content: Array<ResponseOutputText | ResponseOutputRefusal>;
+  role: "assistant";
+  status: "in_progress" | "completed" | "incomplete";
+  type: "message";
+};
+export type ResponseOutputRefusal = {
+  refusal: string;
+  type: "refusal";
+};
+export type ResponseOutputText = {
+  text: string;
+  type: "output_text";
+  logprobs?: Array<Logprob>;
+};
+export type ResponseReasoningItem = {
+  id: string;
+  summary: Array<ResponseReasoningSummaryItem>;
+  type: "reasoning";
+  content?: Array<ResponseReasoningContentItem>;
+  encrypted_content?: string | null;
+  status?: "in_progress" | "completed" | "incomplete";
+};
+export type ResponseReasoningSummaryItem = {
+  text: string;
+  type: "summary_text";
+};
+export type ResponseReasoningContentItem = {
+  text: string;
+  type: "reasoning_text";
+};
+export type ResponseReasoningTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.reasoning_text.delta";
+};
+export type ResponseReasoningTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.reasoning_text.done";
+};
+export type ResponseRefusalDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  output_index: number;
+  sequence_number: number;
+  type: "response.refusal.delta";
+};
+export type ResponseRefusalDoneEvent = {
+  content_index: number;
+  item_id: string;
+  output_index: number;
+  refusal: string;
+  sequence_number: number;
+  type: "response.refusal.done";
+};
+export type ResponseStatus =
+  | "completed"
+  | "failed"
+  | "in_progress"
+  | "cancelled"
+  | "queued"
+  | "incomplete";
+export type ResponseStreamEvent =
+  | ResponseCompletedEvent
+  | ResponseCreatedEvent
+  | ResponseErrorEvent
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseFailedEvent
+  | ResponseIncompleteEvent
+  | ResponseOutputItemAddedEvent
+  | ResponseOutputItemDoneEvent
+  | ResponseReasoningTextDeltaEvent
+  | ResponseReasoningTextDoneEvent
+  | ResponseRefusalDeltaEvent
+  | ResponseRefusalDoneEvent
+  | ResponseTextDeltaEvent
+  | ResponseTextDoneEvent;
+export type ResponseCompletedEvent = {
+  response: Response;
+  sequence_number: number;
+  type: "response.completed";
+};
+export type ResponseTextConfig = {
+  format?: ResponseFormatTextConfig;
+  verbosity?: "low" | "medium" | "high" | null;
+};
+export type ResponseTextDeltaEvent = {
+  content_index: number;
+  delta: string;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  type: "response.output_text.delta";
+};
+export type ResponseTextDoneEvent = {
+  content_index: number;
+  item_id: string;
+  logprobs: Array<Logprob>;
+  output_index: number;
+  sequence_number: number;
+  text: string;
+  type: "response.output_text.done";
+};
+export type Logprob = {
+  token: string;
+  logprob: number;
+  top_logprobs?: Array<TopLogprob>;
+};
+export type TopLogprob = {
+  token?: string;
+  logprob?: number;
+};
+export type ResponseUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+};
+export type Tool = ResponsesFunctionTool;
+export type ToolChoiceFunction = {
+  name: string;
+  type: "function";
+};
+export type ToolChoiceOptions = "none";
+export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
+export type StreamOptions = {
+  include_obfuscation?: boolean;
+};
 export type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -4185,8 +4607,8 @@ export type Ai_Cf_Baai_Bge_Base_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
-export interface AsyncResponse {
+  | Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse {
   /**
    * The async request id that can be used to obtain the results.
    */
@@ -4268,7 +4690,13 @@ export type Ai_Cf_Meta_M2M100_1_2B_Output =
        */
       translated_text?: string;
     }
-  | AsyncResponse;
+  | Ai_Cf_Meta_M2M100_1_2B_AsyncResponse;
+export interface Ai_Cf_Meta_M2M100_1_2B_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Meta_M2M100_1_2B {
   inputs: Ai_Cf_Meta_M2M100_1_2B_Input;
   postProcessedOutputs: Ai_Cf_Meta_M2M100_1_2B_Output;
@@ -4305,7 +4733,13 @@ export type Ai_Cf_Baai_Bge_Small_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Baai_Bge_Small_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Output;
@@ -4342,7 +4776,13 @@ export type Ai_Cf_Baai_Bge_Large_En_V1_5_Output =
        */
       pooling?: "mean" | "cls";
     }
-  | AsyncResponse;
+  | Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Baai_Bge_Large_En_V1_5 {
   inputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Input;
   postProcessedOutputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Output;
@@ -4533,15 +4973,18 @@ export declare abstract class Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo {
   postProcessedOutputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output;
 }
 export type Ai_Cf_Baai_Bge_M3_Input =
-  | BGEM3InputQueryAndContexts
-  | BGEM3InputEmbedding
+  | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts
+  | Ai_Cf_Baai_Bge_M3_Input_Embedding
   | {
       /**
        * Batch of the embeddings requests to run using async-queue
        */
-      requests: (BGEM3InputQueryAndContexts1 | BGEM3InputEmbedding1)[];
+      requests: (
+        | Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1
+        | Ai_Cf_Baai_Bge_M3_Input_Embedding_1
+      )[];
     };
-export interface BGEM3InputQueryAndContexts {
+export interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -4560,14 +5003,14 @@ export interface BGEM3InputQueryAndContexts {
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputEmbedding {
+export interface Ai_Cf_Baai_Bge_M3_Input_Embedding {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputQueryAndContexts1 {
+export interface Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts_1 {
   /**
    * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
    */
@@ -4586,7 +5029,7 @@ export interface BGEM3InputQueryAndContexts1 {
    */
   truncate_inputs?: boolean;
 }
-export interface BGEM3InputEmbedding1 {
+export interface Ai_Cf_Baai_Bge_M3_Input_Embedding_1 {
   text: string | string[];
   /**
    * When provided with too long context should the model error out or truncate the context to fit?
@@ -4594,11 +5037,11 @@ export interface BGEM3InputEmbedding1 {
   truncate_inputs?: boolean;
 }
 export type Ai_Cf_Baai_Bge_M3_Output =
-  | BGEM3OuputQuery
-  | BGEM3OutputEmbeddingForContexts
-  | BGEM3OuputEmbedding
-  | AsyncResponse;
-export interface BGEM3OuputQuery {
+  | Ai_Cf_Baai_Bge_M3_Ouput_Query
+  | Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts
+  | Ai_Cf_Baai_Bge_M3_Ouput_Embedding
+  | Ai_Cf_Baai_Bge_M3_AsyncResponse;
+export interface Ai_Cf_Baai_Bge_M3_Ouput_Query {
   response?: {
     /**
      * Index of the context in the request
@@ -4610,7 +5053,7 @@ export interface BGEM3OuputQuery {
     score?: number;
   }[];
 }
-export interface BGEM3OutputEmbeddingForContexts {
+export interface Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts {
   response?: number[][];
   shape?: number[];
   /**
@@ -4618,7 +5061,7 @@ export interface BGEM3OutputEmbeddingForContexts {
    */
   pooling?: "mean" | "cls";
 }
-export interface BGEM3OuputEmbedding {
+export interface Ai_Cf_Baai_Bge_M3_Ouput_Embedding {
   shape?: number[];
   /**
    * Embeddings of the requested text values
@@ -4628,6 +5071,12 @@ export interface BGEM3OuputEmbedding {
    * The pooling method used in the embedding process.
    */
   pooling?: "mean" | "cls";
+}
+export interface Ai_Cf_Baai_Bge_M3_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
 }
 export declare abstract class Base_Ai_Cf_Baai_Bge_M3 {
   inputs: Ai_Cf_Baai_Bge_M3_Input;
@@ -4653,8 +5102,10 @@ export declare abstract class Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell {
   inputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Input;
   postProcessedOutputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Output;
 }
-export type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input = Prompt | Messages;
-export interface Prompt {
+export type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input =
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages;
+export interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -4705,7 +5156,7 @@ export interface Prompt {
    */
   lora?: string;
 }
-export interface Messages {
+export interface Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -4903,10 +5354,10 @@ export declare abstract class Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct {
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Output;
 }
 export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input =
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
-  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
-  | AsyncBatch;
-export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch;
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -4915,7 +5366,7 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -4957,11 +5408,11 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
    */
   presence_penalty?: number;
 }
-export interface JSONMode {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode {
   type?: "json_object" | "json_schema";
   json_schema?: unknown;
 }
-export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5069,7 +5520,7 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5111,7 +5562,11 @@ export interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
    */
   presence_penalty?: number;
 }
-export interface AsyncBatch {
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch {
   requests?: {
     /**
      * User-supplied reference. This field will be present in the response as well it can be used to reference the request and response. It's NOT validated to be unique.
@@ -5153,8 +5608,12 @@ export interface AsyncBatch {
      * Increases the likelihood of the model introducing new topics.
      */
     presence_penalty?: number;
-    response_format?: JSONMode;
+    response_format?: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2;
   }[];
+}
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
 }
 export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
   | {
@@ -5194,7 +5653,13 @@ export type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
       }[];
     }
   | string
-  | AsyncResponse;
+  | Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse;
+export interface Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
 export declare abstract class Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast {
   inputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output;
@@ -5301,9 +5766,9 @@ export declare abstract class Base_Ai_Cf_Baai_Bge_Reranker_Base {
   postProcessedOutputs: Ai_Cf_Baai_Bge_Reranker_Base_Output;
 }
 export type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input =
-  | Qwen2_5_Coder_32B_Instruct_Prompt
-  | Qwen2_5_Coder_32B_Instruct_Messages;
-export interface Qwen2_5_Coder_32B_Instruct_Prompt {
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt
+  | Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages;
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5312,7 +5777,7 @@ export interface Qwen2_5_Coder_32B_Instruct_Prompt {
    * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
    */
   lora?: string;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5354,7 +5819,11 @@ export interface Qwen2_5_Coder_32B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Qwen2_5_Coder_32B_Instruct_Messages {
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5462,7 +5931,7 @@ export interface Qwen2_5_Coder_32B_Instruct_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -5503,6 +5972,10 @@ export interface Qwen2_5_Coder_32B_Instruct_Messages {
    * Increases the likelihood of the model introducing new topics.
    */
   presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
 }
 export type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output = {
   /**
@@ -5545,9 +6018,9 @@ export declare abstract class Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct {
   postProcessedOutputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output;
 }
 export type Ai_Cf_Qwen_Qwq_32B_Input =
-  | Qwen_Qwq_32B_Prompt
-  | Qwen_Qwq_32B_Messages;
-export interface Qwen_Qwq_32B_Prompt {
+  | Ai_Cf_Qwen_Qwq_32B_Prompt
+  | Ai_Cf_Qwen_Qwq_32B_Messages;
+export interface Ai_Cf_Qwen_Qwq_32B_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5597,7 +6070,7 @@ export interface Qwen_Qwq_32B_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Qwen_Qwq_32B_Messages {
+export interface Ai_Cf_Qwen_Qwq_32B_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -5819,9 +6292,9 @@ export declare abstract class Base_Ai_Cf_Qwen_Qwq_32B {
   postProcessedOutputs: Ai_Cf_Qwen_Qwq_32B_Output;
 }
 export type Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input =
-  | Mistral_Small_3_1_24B_Instruct_Prompt
-  | Mistral_Small_3_1_24B_Instruct_Messages;
-export interface Mistral_Small_3_1_24B_Instruct_Prompt {
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt
+  | Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages;
+export interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -5871,7 +6344,7 @@ export interface Mistral_Small_3_1_24B_Instruct_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Mistral_Small_3_1_24B_Instruct_Messages {
+export interface Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6093,9 +6566,9 @@ export declare abstract class Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruc
   postProcessedOutputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output;
 }
 export type Ai_Cf_Google_Gemma_3_12B_It_Input =
-  | Google_Gemma_3_12B_It_Prompt
-  | Google_Gemma_3_12B_It_Messages;
-export interface Google_Gemma_3_12B_It_Prompt {
+  | Ai_Cf_Google_Gemma_3_12B_It_Prompt
+  | Ai_Cf_Google_Gemma_3_12B_It_Messages;
+export interface Ai_Cf_Google_Gemma_3_12B_It_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6145,7 +6618,7 @@ export interface Google_Gemma_3_12B_It_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Google_Gemma_3_12B_It_Messages {
+export interface Ai_Cf_Google_Gemma_3_12B_It_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6168,20 +6641,7 @@ export interface Google_Gemma_3_12B_It_Messages {
              */
             url?: string;
           };
-        }[]
-      | {
-          /**
-           * Type of the content provided
-           */
-          type?: string;
-          text?: string;
-          image_url?: {
-            /**
-             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-             */
-            url?: string;
-          };
-        };
+        }[];
   }[];
   functions?: {
     name: string;
@@ -6363,10 +6823,10 @@ export declare abstract class Base_Ai_Cf_Google_Gemma_3_12B_It {
   postProcessedOutputs: Ai_Cf_Google_Gemma_3_12B_It_Output;
 }
 export type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input =
-  | Ai_Cf_Meta_Llama_4_Prompt
-  | Ai_Cf_Meta_Llama_4_Messages
-  | Ai_Cf_Meta_Llama_4_Async_Batch;
-export interface Ai_Cf_Meta_Llama_4_Prompt {
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages
+  | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch;
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6375,7 +6835,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -6417,7 +6877,11 @@ export interface Ai_Cf_Meta_Llama_4_Prompt {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Messages {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6553,7 +7017,7 @@ export interface Ai_Cf_Meta_Llama_4_Messages {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -6599,13 +7063,13 @@ export interface Ai_Cf_Meta_Llama_4_Messages {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Async_Batch {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch {
   requests: (
-    | Ai_Cf_Meta_Llama_4_Prompt_Inner
-    | Ai_Cf_Meta_Llama_4_Messages_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner
+    | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner
   )[];
 }
-export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner {
   /**
    * The input text prompt for the model to generate a response.
    */
@@ -6614,7 +7078,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    * JSON schema that should be fulfilled for the response.
    */
   guided_json?: object;
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
    */
@@ -6656,7 +7120,7 @@ export interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
    */
   presence_penalty?: number;
 }
-export interface Ai_Cf_Meta_Llama_4_Messages_Inner {
+export interface Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner {
   /**
    * An array of message objects representing the conversation history.
    */
@@ -6792,7 +7256,7 @@ export interface Ai_Cf_Meta_Llama_4_Messages_Inner {
         };
       }
   )[];
-  response_format?: JSONMode;
+  response_format?: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode;
   /**
    * JSON schema that should be fufilled for the response.
    */
@@ -6890,6 +7354,613 @@ export type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output = {
 export declare abstract class Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct {
   inputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input;
   postProcessedOutputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output;
+}
+export type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch;
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch {
+  requests: (
+    | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1
+    | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1
+  )[];
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output =
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response
+  | string
+  | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse;
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+export interface Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+export declare abstract class Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8 {
+  inputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output;
 }
 export interface Ai_Cf_Deepgram_Nova_3_Input {
   audio: {
@@ -7082,6 +8153,23 @@ export declare abstract class Base_Ai_Cf_Deepgram_Nova_3 {
   inputs: Ai_Cf_Deepgram_Nova_3_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Nova_3_Output;
 }
+export interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input {
+  queries?: string | string[];
+  /**
+   * Optional instruction for the task
+   */
+  instruction?: string;
+  documents?: string | string[];
+  text?: string | string[];
+}
+export interface Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output {
+  data?: number[][];
+  shape?: number[];
+}
+export declare abstract class Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B {
+  inputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Output;
+}
 export type Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input =
   | {
       /**
@@ -7120,93 +8208,13 @@ export declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   inputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input;
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
-export type Ai_Cf_Openai_Gpt_Oss_120B_Input =
-  | GPT_OSS_120B_Responses
-  | GPT_OSS_120B_Responses_Async;
-export interface GPT_OSS_120B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-export interface GPT_OSS_120B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-export type Ai_Cf_Openai_Gpt_Oss_120B_Output =
-  | {}
-  | (string & NonNullable<unknown>);
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_120B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_120B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
-export type Ai_Cf_Openai_Gpt_Oss_20B_Input =
-  | GPT_OSS_20B_Responses
-  | GPT_OSS_20B_Responses_Async;
-export interface GPT_OSS_20B_Responses {
-  /**
-   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-   */
-  input: string | unknown[];
-  reasoning?: {
-    /**
-     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-     */
-    effort?: "low" | "medium" | "high";
-    /**
-     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-     */
-    summary?: "auto" | "concise" | "detailed";
-  };
-}
-export interface GPT_OSS_20B_Responses_Async {
-  requests: {
-    /**
-     * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-     */
-    input: string | unknown[];
-    reasoning?: {
-      /**
-       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-       */
-      effort?: "low" | "medium" | "high";
-      /**
-       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-       */
-      summary?: "auto" | "concise" | "detailed";
-    };
-  }[];
-}
-export type Ai_Cf_Openai_Gpt_Oss_20B_Output =
-  | {}
-  | (string & NonNullable<unknown>);
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: Ai_Cf_Openai_Gpt_Oss_20B_Input;
-  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_20B_Output;
+  inputs: ResponsesInput;
+  postProcessedOutputs: ResponsesOutput;
 }
 export interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**
@@ -7332,6 +8340,901 @@ export declare abstract class Base_Ai_Cf_Deepgram_Aura_1 {
   inputs: Ai_Cf_Deepgram_Aura_1_Input;
   postProcessedOutputs: Ai_Cf_Deepgram_Aura_1_Output;
 }
+export interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
+  /**
+   * Input text to translate. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+  /**
+   * Target langauge to translate to
+   */
+  target_language:
+    | "asm_Beng"
+    | "awa_Deva"
+    | "ben_Beng"
+    | "bho_Deva"
+    | "brx_Deva"
+    | "doi_Deva"
+    | "eng_Latn"
+    | "gom_Deva"
+    | "gon_Deva"
+    | "guj_Gujr"
+    | "hin_Deva"
+    | "hne_Deva"
+    | "kan_Knda"
+    | "kas_Arab"
+    | "kas_Deva"
+    | "kha_Latn"
+    | "lus_Latn"
+    | "mag_Deva"
+    | "mai_Deva"
+    | "mal_Mlym"
+    | "mar_Deva"
+    | "mni_Beng"
+    | "mni_Mtei"
+    | "npi_Deva"
+    | "ory_Orya"
+    | "pan_Guru"
+    | "san_Deva"
+    | "sat_Olck"
+    | "snd_Arab"
+    | "snd_Deva"
+    | "tam_Taml"
+    | "tel_Telu"
+    | "urd_Arab"
+    | "unr_Deva";
+}
+export interface Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output {
+  /**
+   * Translated texts
+   */
+  translations: string[];
+}
+export declare abstract class Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B {
+  inputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input;
+  postProcessedOutputs: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Output;
+}
+export type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch;
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch {
+  requests: (
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1
+    | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1
+  )[];
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1 {
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1 {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
+    /**
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
+     */
+    role: string;
+    /**
+     * The content of the message as a string.
+     */
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
+        /**
+         * The name of the tool. More descriptive the better.
+         */
+        name: string;
+        /**
+         * A brief description of what the tool does.
+         */
+        description: string;
+        /**
+         * Schema defining the parameters accepted by the tool.
+         */
+        parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
+            /**
+             * The type of the parameters object (usually 'object').
+             */
+            type: string;
+            /**
+             * List of required parameter names.
+             */
+            required?: string[];
+            /**
+             * Definitions of each parameter.
+             */
+            properties: {
+              [k: string]: {
+                /**
+                 * The data type of the parameter.
+                 */
+                type: string;
+                /**
+                 * A description of the expected parameter.
+                 */
+                description: string;
+              };
+            };
+          };
+        };
+      }
+  )[];
+  response_format?: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3 {
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
+}
+export type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output =
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response
+  | string
+  | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse;
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "chat.completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index?: number;
+    /**
+     * The message generated by the model
+     */
+    message?: {
+      /**
+       * Role of the message author
+       */
+      role: string;
+      /**
+       * The content of the message
+       */
+      content: string;
+      /**
+       * Internal reasoning content (if available)
+       */
+      reasoning_content?: string;
+      /**
+       * Tool calls made by the assistant
+       */
+      tool_calls?: {
+        /**
+         * Unique identifier for the tool call
+         */
+        id: string;
+        /**
+         * Type of tool call
+         */
+        type: "function";
+        function: {
+          /**
+           * Name of the function to call
+           */
+          name: string;
+          /**
+           * JSON string of arguments for the function
+           */
+          arguments: string;
+        };
+      }[];
+    };
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason?: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * Log probabilities for the prompt (if requested)
+   */
+  prompt_logprobs?: {} | null;
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response {
+  /**
+   * Unique identifier for the completion
+   */
+  id?: string;
+  /**
+   * Object type identifier
+   */
+  object?: "text_completion";
+  /**
+   * Unix timestamp of when the completion was created
+   */
+  created?: number;
+  /**
+   * Model used for the completion
+   */
+  model?: string;
+  /**
+   * List of completion choices
+   */
+  choices?: {
+    /**
+     * Index of the choice in the list
+     */
+    index: number;
+    /**
+     * The generated text completion
+     */
+    text: string;
+    /**
+     * Reason why the model stopped generating
+     */
+    finish_reason: string;
+    /**
+     * Stop reason (may be null)
+     */
+    stop_reason?: string | null;
+    /**
+     * Log probabilities (if requested)
+     */
+    logprobs?: {} | null;
+    /**
+     * Log probabilities for the prompt (if requested)
+     */
+    prompt_logprobs?: {} | null;
+  }[];
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
+    /**
+     * Total number of tokens in input
+     */
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+}
+export interface Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse {
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
+}
+export declare abstract class Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It {
+  inputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Input;
+  postProcessedOutputs: Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Output;
+}
+export interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Input {
+  /**
+   * Input text to embed. Can be a single string or a list of strings.
+   */
+  text: string | string[];
+}
+export interface Ai_Cf_Pfnet_Plamo_Embedding_1B_Output {
+  /**
+   * Embedding vectors, where each vector is a list of floats.
+   */
+  data: number[][];
+  /**
+   * Shape of the embedding data as [number_of_embeddings, embedding_dimension].
+   *
+   * @minItems 2
+   * @maxItems 2
+   */
+  shape: [number, number];
+}
+export declare abstract class Base_Ai_Cf_Pfnet_Plamo_Embedding_1B {
+  inputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Input;
+  postProcessedOutputs: Ai_Cf_Pfnet_Plamo_Embedding_1B_Output;
+}
+export interface Ai_Cf_Deepgram_Flux_Input {
+  /**
+   * Encoding of the audio stream. Currently only supports raw signed little-endian 16-bit PCM.
+   */
+  encoding: "linear16";
+  /**
+   * Sample rate of the audio stream in Hz.
+   */
+  sample_rate: string;
+  /**
+   * End-of-turn confidence required to fire an eager end-of-turn event. When set, enables EagerEndOfTurn and TurnResumed events. Valid Values 0.3 - 0.9.
+   */
+  eager_eot_threshold?: string;
+  /**
+   * End-of-turn confidence required to finish a turn. Valid Values 0.5 - 0.9.
+   */
+  eot_threshold?: string;
+  /**
+   * A turn will be finished when this much time has passed after speech, regardless of EOT confidence.
+   */
+  eot_timeout_ms?: string;
+  /**
+   * Keyterm prompting can improve recognition of specialized terminology. Pass multiple keyterm query parameters to boost multiple keyterms.
+   */
+  keyterm?: string;
+  /**
+   * Opts out requests from the Deepgram Model Improvement Program. Refer to Deepgram Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
+   */
+  mip_opt_out?: "true" | "false";
+  /**
+   * Label your requests for the purpose of identification during usage reporting
+   */
+  tag?: string;
+}
+/**
+ * Output will be returned as websocket messages.
+ */
+export interface Ai_Cf_Deepgram_Flux_Output {
+  /**
+   * The unique identifier of the request (uuid)
+   */
+  request_id?: string;
+  /**
+   * Starts at 0 and increments for each message the server sends to the client.
+   */
+  sequence_id?: number;
+  /**
+   * The type of event being reported.
+   */
+  event?:
+    | "Update"
+    | "StartOfTurn"
+    | "EagerEndOfTurn"
+    | "TurnResumed"
+    | "EndOfTurn";
+  /**
+   * The index of the current turn
+   */
+  turn_index?: number;
+  /**
+   * Start time in seconds of the audio range that was transcribed
+   */
+  audio_window_start?: number;
+  /**
+   * End time in seconds of the audio range that was transcribed
+   */
+  audio_window_end?: number;
+  /**
+   * Text that was said over the course of the current turn
+   */
+  transcript?: string;
+  /**
+   * The words in the transcript
+   */
+  words?: {
+    /**
+     * The individual punctuated, properly-cased word from the transcript
+     */
+    word: string;
+    /**
+     * Confidence that this word was transcribed correctly
+     */
+    confidence: number;
+  }[];
+  /**
+   * Confidence that no more speech is coming in this turn
+   */
+  end_of_turn_confidence?: number;
+}
+export declare abstract class Base_Ai_Cf_Deepgram_Flux {
+  inputs: Ai_Cf_Deepgram_Flux_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Flux_Output;
+}
+export interface Ai_Cf_Deepgram_Aura_2_En_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "amalthea"
+    | "andromeda"
+    | "apollo"
+    | "arcas"
+    | "aries"
+    | "asteria"
+    | "athena"
+    | "atlas"
+    | "aurora"
+    | "callista"
+    | "cora"
+    | "cordelia"
+    | "delia"
+    | "draco"
+    | "electra"
+    | "harmonia"
+    | "helena"
+    | "hera"
+    | "hermes"
+    | "hyperion"
+    | "iris"
+    | "janus"
+    | "juno"
+    | "jupiter"
+    | "luna"
+    | "mars"
+    | "minerva"
+    | "neptune"
+    | "odysseus"
+    | "ophelia"
+    | "orion"
+    | "orpheus"
+    | "pandora"
+    | "phoebe"
+    | "pluto"
+    | "saturn"
+    | "thalia"
+    | "theia"
+    | "vesta"
+    | "zeus";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+export type Ai_Cf_Deepgram_Aura_2_En_Output = string;
+export declare abstract class Base_Ai_Cf_Deepgram_Aura_2_En {
+  inputs: Ai_Cf_Deepgram_Aura_2_En_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_En_Output;
+}
+export interface Ai_Cf_Deepgram_Aura_2_Es_Input {
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "sirio"
+    | "nestor"
+    | "carina"
+    | "celeste"
+    | "alvaro"
+    | "diana"
+    | "aquila"
+    | "selena"
+    | "estrella"
+    | "javier";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
+}
+/**
+ * The generated audio in MP3 format
+ */
+export type Ai_Cf_Deepgram_Aura_2_Es_Output = string;
+export declare abstract class Base_Ai_Cf_Deepgram_Aura_2_Es {
+  inputs: Ai_Cf_Deepgram_Aura_2_Es_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_2_Es_Output;
+}
 export interface AiModels {
   "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
   "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
@@ -7375,12 +9278,12 @@ export interface AiModels {
   "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
   "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
-  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
   "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
   "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
   "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": BaseAiTextGeneration;
+  "@cf/ibm-granite/granite-4.0-h-micro": BaseAiTextGeneration;
   "@cf/facebook/bart-large-cnn": BaseAiSummarization;
   "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
   "@cf/baai/bge-base-en-v1.5": Base_Ai_Cf_Baai_Bge_Base_En_V1_5;
@@ -7402,13 +9305,21 @@ export interface AiModels {
   "@cf/mistralai/mistral-small-3.1-24b-instruct": Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct;
   "@cf/google/gemma-3-12b-it": Base_Ai_Cf_Google_Gemma_3_12B_It;
   "@cf/meta/llama-4-scout-17b-16e-instruct": Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct;
+  "@cf/qwen/qwen3-30b-a3b-fp8": Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8;
   "@cf/deepgram/nova-3": Base_Ai_Cf_Deepgram_Nova_3;
+  "@cf/qwen/qwen3-embedding-0.6b": Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B;
   "@cf/pipecat-ai/smart-turn-v2": Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
   "@cf/openai/gpt-oss-120b": Base_Ai_Cf_Openai_Gpt_Oss_120B;
   "@cf/openai/gpt-oss-20b": Base_Ai_Cf_Openai_Gpt_Oss_20B;
   "@cf/leonardo/phoenix-1.0": Base_Ai_Cf_Leonardo_Phoenix_1_0;
   "@cf/leonardo/lucid-origin": Base_Ai_Cf_Leonardo_Lucid_Origin;
   "@cf/deepgram/aura-1": Base_Ai_Cf_Deepgram_Aura_1;
+  "@cf/ai4bharat/indictrans2-en-indic-1B": Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B;
+  "@cf/aisingapore/gemma-sea-lion-v4-27b-it": Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It;
+  "@cf/pfnet/plamo-embedding-1b": Base_Ai_Cf_Pfnet_Plamo_Embedding_1B;
+  "@cf/deepgram/flux": Base_Ai_Cf_Deepgram_Flux;
+  "@cf/deepgram/aura-2-en": Base_Ai_Cf_Deepgram_Aura_2_En;
+  "@cf/deepgram/aura-2-es": Base_Ai_Cf_Deepgram_Aura_2_Es;
 }
 export type AiOptions = {
   /**
@@ -7420,6 +9331,16 @@ export type AiOptions = {
    * Establish websocket connections, only works for supported models
    */
   websocket?: boolean;
+  /**
+   * Tag your requests to group and view them in Cloudflare dashboard.
+   *
+   * Rules:
+   * Tags must only contain letters, numbers, and the symbols: : - . / @
+   * Each tag can have maximum 50 characters.
+   * Maximum 5 tags are allowed each request.
+   * Duplicate tags will removed.
+   */
+  tags: string[];
   gateway?: GatewayOptions;
   returnRawResponse?: boolean;
   prefix?: string;


### PR DESCRIPTION
Updates types for gpt-oss models to support Responses format

Adds types for following new models -
- @cf/ibm-granite/granite-4.0-h-micro
- @cf/ai4bharat/indictrans2-en-indic-1B
- @cf/aisingapore/gemma-sea-lion-v4-27b-it
- @cf/pfnet/plamo-embedding-1b
- @cf/deepgram/flux
- @cf/deepgram/aura-2-en
- @cf/deepgram/aura-2-es