### PR TITLE
Minor improvements to MimeType

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -659,21 +659,15 @@ Body::ExtractedBody Body::extractBody(jsg::Lock& js, Initializer init) {
     }
     KJ_CASE_ONEOF(formData, jsg::Ref<FormData>) {
       auto boundary = makeRandomBoundaryCharacters();
-      auto type = MimeType::FORM_DATA.clone();
-      type.addParam("boundary"_kj, boundary);
-      contentType = type.toString();
+      contentType = MimeType::formDataWithBoundary(boundary);
       buffer = formData->serialize(boundary);
     }
     KJ_CASE_ONEOF(searchParams, jsg::Ref<URLSearchParams>) {
-      auto type = MimeType::FORM_URLENCODED.clone();
-      type.addParam("charset"_kj, "UTF-8"_kj);
-      contentType = type.toString();
+      contentType = MimeType::formUrlEncodedWithCharset("UTF-8"_kj);
       buffer = searchParams->toString();
     }
     KJ_CASE_ONEOF(searchParams, jsg::Ref<url::URLSearchParams>) {
-      auto type = MimeType::FORM_URLENCODED.clone();
-      type.addParam("charset"_kj, "UTF-8"_kj);
-      contentType = type.toString();
+      contentType = MimeType::formUrlEncodedWithCharset("UTF-8"_kj);
       buffer = searchParams->toString();
     }
   }

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -100,6 +100,7 @@ wd_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":strings",
         "//src/workerd/jsg:memory-tracker",
         "@capnp-cpp//src/kj",
         "@capnp-cpp//src/kj:kj-async",

--- a/src/workerd/util/mimetype.c++
+++ b/src/workerd/util/mimetype.c++
@@ -136,13 +136,12 @@ kj::Maybe<MimeType> MimeType::tryParseImpl(kj::ArrayPtr<const char> input, Parse
     if (typeCandidate.size() == 0 || hasInvalidCodepoints(typeCandidate, isTokenChar)) {
       return kj::none;
     }
-    maybeType = kj::str(typeCandidate);
+    maybeType = toLower(typeCandidate);
     input = input.slice(n + 1);
   } else {
     // If the solidus is not found, then it's not a valid mime type
     return kj::none;
   }
-  auto& type = KJ_ASSERT_NONNULL(maybeType);
 
   // If there's nothing else to parse at this point, it's not a valid mime type.
   if (input.size() == 0) return kj::none;
@@ -155,19 +154,18 @@ kj::Maybe<MimeType> MimeType::tryParseImpl(kj::ArrayPtr<const char> input, Parse
     if (subtypeCandidate.size() == 0 || hasInvalidCodepoints(subtypeCandidate, isTokenChar)) {
       return kj::none;
     }
-    maybeSubtype = kj::str(subtypeCandidate);
+    maybeSubtype = toLower(subtypeCandidate);
     input = input.slice(n + 1);
   } else {
     auto subtypeCandidate = trimWhitespace(input);
     if (subtypeCandidate.size() == 0 || hasInvalidCodepoints(subtypeCandidate, isTokenChar)) {
       return kj::none;
     }
-    maybeSubtype = kj::str(subtypeCandidate);
+    maybeSubtype = toLower(subtypeCandidate);
     input = input.slice(input.size());
   }
-  auto& subtype = KJ_ASSERT_NONNULL(maybeSubtype);
 
-  MimeType result(type, subtype);
+  MimeType result(kj::mv(KJ_ASSERT_NONNULL(maybeType)), mv(KJ_ASSERT_NONNULL(maybeSubtype)));
 
   if (!(options & ParseOptions::IGNORE_PARAMS)) {
     // Parse the parameters...
@@ -247,8 +245,11 @@ kj::Maybe<MimeType> MimeType::tryParseImpl(kj::ArrayPtr<const char> input, Parse
 }
 
 MimeType::MimeType(kj::StringPtr type, kj::StringPtr subtype, kj::Maybe<MimeParams> params)
-    : type_(toLower(type)),
-      subtype_(toLower(subtype)) {
+    : MimeType(toLower(type), toLower(subtype), kj::mv(params)) {}
+
+MimeType::MimeType(kj::String type, kj::String subtype, kj::Maybe<MimeParams> params)
+    : type_(kj::mv(type)),
+      subtype_(kj::mv(subtype)) {
   KJ_IF_SOME(p, params) {
     params_ = kj::mv(p);
   }
@@ -352,7 +353,7 @@ MimeType MimeType::clone(ParseOptions options) const {
       copy.insert(kj::str(entry.key), kj::str(entry.value));
     }
   }
-  return MimeType(type_, subtype_, kj::mv(copy));
+  return MimeType(kj::str(type_), kj::str(subtype_), kj::mv(copy));
 }
 
 bool MimeType::operator==(const MimeType& other) const {
@@ -367,68 +368,12 @@ kj::String KJ_STRINGIFY(const MimeType& mimeType) {
   return mimeType.toString();
 }
 
-const kj::StringPtr MimeType::PLAINTEXT_STRING = "text/plain;charset=UTF-8"_kj;
-const kj::StringPtr MimeType::PLAINTEXT_ASCII_STRING = "text/plain;charset=US-ASCII"_kj;
+kj::String KJ_STRINGIFY(const ConstMimeType& state) {
+  return state.toString();
+}
+
 const MimeType MimeType::PLAINTEXT = MimeType::parse(PLAINTEXT_STRING);
 const MimeType MimeType::PLAINTEXT_ASCII = MimeType::parse(PLAINTEXT_ASCII_STRING);
-const MimeType MimeType::CSS = MimeType("text"_kj, "css"_kj);
-const MimeType MimeType::HTML = MimeType("text"_kj, "html"_kj);
-const MimeType MimeType::TEXT_JAVASCRIPT = MimeType("text"_kj, "javascript"_kj);
-const MimeType MimeType::JSON = MimeType("application"_kj, "json"_kj);
-const MimeType MimeType::FORM_URLENCODED = MimeType("application"_kj, "x-www-form-urlencoded"_kj);
-const MimeType MimeType::OCTET_STREAM = MimeType("application"_kj, "octet-stream"_kj);
-const MimeType MimeType::XHTML = MimeType("application"_kj, "xhtml+xml"_kj);
-const MimeType MimeType::JAVASCRIPT = MimeType("application"_kj, "javascript"_kj);
-const MimeType MimeType::XJAVASCRIPT = MimeType("application"_kj, "x-javascript"_kj);
-const MimeType MimeType::FORM_DATA = MimeType("multipart"_kj, "form-data"_kj);
-const MimeType MimeType::MANIFEST_JSON = MimeType("application"_kj, "manifest+json"_kj);
-const MimeType MimeType::VTT = MimeType("text"_kj, "vtt"_kj);
-const MimeType MimeType::EVENT_STREAM = MimeType("text"_kj, "event-stream"_kj);
-const MimeType MimeType::WILDCARD = MimeType("*"_kj, "*"_kj);
-
-bool MimeType::isText(const MimeType& mimeType) {
-  auto type = mimeType.type();
-  auto subtype = mimeType.subtype();
-  return type == "text" || isXml(mimeType) || isJson(mimeType) || isJavascript(mimeType) ||
-      (type == "application" && subtype == "dns-json");
-}
-
-bool MimeType::isXml(const MimeType& mimeType) {
-  auto type = mimeType.type();
-  auto subtype = mimeType.subtype();
-  return (type == "text" || type == "application") &&
-      (subtype == "xml" || subtype.endsWith("+xml"));
-}
-
-bool MimeType::isJson(const MimeType& mimeType) {
-  auto type = mimeType.type();
-  auto subtype = mimeType.subtype();
-  return (type == "text" || type == "application") &&
-      (subtype == "json" || subtype.endsWith("+json"));
-}
-
-bool MimeType::isFont(const MimeType& mimeType) {
-  auto type = mimeType.type();
-  auto subtype = mimeType.subtype();
-  return (type == "font" || type == "application") &&
-      (subtype.startsWith("font-") || subtype.startsWith("x-font-"));
-}
-
-bool MimeType::isJavascript(const MimeType& mimeType) {
-  return JAVASCRIPT == mimeType || XJAVASCRIPT == mimeType || TEXT_JAVASCRIPT == mimeType;
-}
-
-bool MimeType::isImage(const MimeType& mimeType) {
-  return mimeType.type() == "image";
-}
-
-bool MimeType::isVideo(const MimeType& mimeType) {
-  return mimeType.type() == "video";
-}
-
-bool MimeType::isAudio(const MimeType& mimeType) {
-  return mimeType.type() == "audio";
-}
 
 kj::Maybe<MimeType> MimeType::extract(kj::StringPtr input) {
   kj::Maybe<MimeType> mimeType;
@@ -487,6 +432,20 @@ kj::Maybe<MimeType> MimeType::extract(kj::StringPtr input) {
   }
 
   return kj::mv(mimeType);
+}
+
+kj::String MimeType::formDataWithBoundary(kj::StringPtr boundary) {
+  ToStringBuffer buffer(128);
+  // Note that the expectation is that the boundary is already properly formed
+  // and does not need any additional quoting or escaping.
+  buffer.append("multipart/form-data; boundary=", boundary);
+  return buffer.toString();
+}
+
+kj::String MimeType::formUrlEncodedWithCharset(kj::StringPtr charset) {
+  ToStringBuffer buffer(128);
+  buffer.append("application/x-www-form-urlencoded;charset=", charset);
+  return buffer.toString();
 }
 
 }  // namespace workerd

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <workerd/jsg/memory.h>
+#include <workerd/util/strings.h>
 
 #include <kj/common.h>
 #include <kj/map.h>
@@ -13,6 +14,53 @@ namespace workerd {
 
 template <size_t>
 class StringBuffer;
+class MimeType;
+class ConstMimeType final {
+ public:
+  constexpr ConstMimeType(kj::StringPtr type, kj::StringPtr subtype)
+      : type_(type),
+        subtype_(subtype) {}
+
+  constexpr kj::StringPtr type() const {
+    return type_;
+  }
+  constexpr kj::StringPtr subtype() const {
+    return subtype_;
+  }
+
+  constexpr bool operator==(const ConstMimeType& other) const {
+    return this == &other || (type_ == other.type_ && subtype_ == other.subtype_);
+  }
+
+  inline bool operator==(kj::StringPtr other) const {
+    KJ_IF_SOME(slashPos, other.findFirst('/')) {
+      return strcaseeq(type_, other.first(slashPos)) &&
+          strcaseeq(subtype_, other.slice(slashPos + 1));
+    }
+    return false;
+  }
+
+  bool operator==(const MimeType& other) const;
+  operator MimeType() const;
+  MimeType clone() const;
+
+  inline kj::String toString() const {
+    return kj::str(type_, "/", subtype_);
+  }
+
+  inline kj::String essence() const {
+    return toString();
+  }
+
+ private:
+  kj::StringPtr type_;
+  kj::StringPtr subtype_;
+};
+
+template <typename T>
+concept IsMimeType = kj::isSameType<T, MimeType>() || kj::isSameType<T, ConstMimeType>();
+static_assert(IsMimeType<MimeType>);
+static_assert(IsMimeType<ConstMimeType>);
 
 class MimeType final {
  public:
@@ -35,6 +83,7 @@ class MimeType final {
 
   explicit MimeType(
       kj::StringPtr type, kj::StringPtr subtype, kj::Maybe<MimeParams> params = kj::none);
+  explicit MimeType(kj::String type, kj::String subtype, kj::Maybe<MimeParams> params = kj::none);
 
   MimeType(MimeType&&) = default;
   MimeType& operator=(MimeType&&) = default;
@@ -68,35 +117,83 @@ class MimeType final {
 
   operator kj::String() const;
 
-  static bool isXml(const MimeType& mimeType);
-  static bool isJson(const MimeType& mimeType);
-  static bool isFont(const MimeType& mimeType);
-  static bool isJavascript(const MimeType& mimeType);
-  static bool isImage(const MimeType& mimeType);
-  static bool isVideo(const MimeType& mimeType);
-  static bool isAudio(const MimeType& mimeType);
-  static bool isText(const MimeType& mimeType);
+  template <IsMimeType T>
+  static constexpr bool isXml(const T& mimeType) {
+    auto type = mimeType.type();
+    auto subtype = mimeType.subtype();
+    return (type == "text" || type == "application") &&
+        (subtype == "xml" || subtype.endsWith("+xml"));
+  }
 
-  static const MimeType JSON;
+  template <IsMimeType T>
+  static constexpr bool isJson(const T& mimeType) {
+    auto type = mimeType.type();
+    auto subtype = mimeType.subtype();
+    return (type == "text" || type == "application") &&
+        (subtype == "json" || subtype.endsWith("+json"));
+  }
+
+  template <IsMimeType T>
+  static constexpr bool isFont(const T& mimeType) {
+    auto type = mimeType.type();
+    auto subtype = mimeType.subtype();
+    return (type == "font" || type == "application") &&
+        (subtype.startsWith("font-") || subtype.startsWith("x-font-"));
+  }
+
+  template <IsMimeType T>
+  static constexpr bool isJavascript(const T& mimeType) {
+    return JAVASCRIPT == mimeType || XJAVASCRIPT == mimeType || TEXT_JAVASCRIPT == mimeType;
+  }
+
+  template <IsMimeType T>
+  static constexpr bool isText(const T& mimeType) {
+    auto type = mimeType.type();
+    auto subtype = mimeType.subtype();
+    return type == "text" || isXml(mimeType) || isJson(mimeType) || isJavascript(mimeType) ||
+        (type == "application" && subtype == "dns-json");
+  }
+
+  template <IsMimeType T>
+  static constexpr bool isImage(const T& mimeType) {
+    return mimeType.type() == "image";
+  }
+
+  template <IsMimeType T>
+  static constexpr bool isVideo(const T& mimeType) {
+    return mimeType.type() == "video";
+  }
+
+  template <IsMimeType T>
+  static constexpr bool isAudio(const T& mimeType) {
+    return mimeType.type() == "audio";
+  }
+
   static const MimeType PLAINTEXT;
   static const MimeType PLAINTEXT_ASCII;
-  static const MimeType FORM_URLENCODED;
-  static const MimeType FORM_DATA;
-  static const MimeType OCTET_STREAM;
-  static const MimeType XHTML;
-  static const MimeType JAVASCRIPT;
-  static const MimeType XJAVASCRIPT;
-  static const MimeType HTML;
-  static const MimeType CSS;
-  static const MimeType TEXT_JAVASCRIPT;
-  static const MimeType MANIFEST_JSON;
-  static const MimeType VTT;
-  static const MimeType EVENT_STREAM;
-  static const MimeType WILDCARD;
+  static constexpr ConstMimeType JSON = ConstMimeType("application"_kj, "json"_kj);
+  static constexpr ConstMimeType FORM_URLENCODED =
+      ConstMimeType("application"_kj, "x-www-form-urlencoded"_kj);
+  static constexpr ConstMimeType FORM_DATA = ConstMimeType("multipart"_kj, "form-data"_kj);
+  static constexpr ConstMimeType OCTET_STREAM = ConstMimeType("application"_kj, "octet-stream"_kj);
+  static constexpr ConstMimeType XHTML = ConstMimeType("application"_kj, "xhtml+xml"_kj);
+  static constexpr ConstMimeType JAVASCRIPT = ConstMimeType("application"_kj, "javascript"_kj);
+  static constexpr ConstMimeType XJAVASCRIPT = ConstMimeType("application"_kj, "x-javascript"_kj);
+  static constexpr ConstMimeType TEXT_JAVASCRIPT = ConstMimeType("text"_kj, "javascript"_kj);
+  static constexpr ConstMimeType HTML = ConstMimeType("text"_kj, "html"_kj);
+  static constexpr ConstMimeType CSS = ConstMimeType("text"_kj, "css"_kj);
+  static constexpr ConstMimeType MANIFEST_JSON =
+      ConstMimeType("application"_kj, "manifest+json"_kj);
+  static constexpr ConstMimeType VTT = ConstMimeType("text"_kj, "vtt"_kj);
+  static constexpr ConstMimeType EVENT_STREAM = ConstMimeType("text"_kj, "event-stream"_kj);
+  static constexpr ConstMimeType WILDCARD = ConstMimeType("*"_kj, "*"_kj);
 
   // exposed directly for performance reasons
-  static const kj::StringPtr PLAINTEXT_STRING;
-  static const kj::StringPtr PLAINTEXT_ASCII_STRING;
+  static constexpr kj::StringPtr PLAINTEXT_STRING = "text/plain;charset=UTF-8"_kj;
+  static constexpr kj::StringPtr PLAINTEXT_ASCII_STRING = "text/plain;charset=US-ASCII"_kj;
+
+  static kj::String formDataWithBoundary(kj::StringPtr boundary);
+  static kj::String formUrlEncodedWithCharset(kj::StringPtr charset);
 
   // Extracts a mime type from a concatenated list of content-type values
   // per the algorithm defined in the fetch spec:
@@ -123,6 +220,19 @@ class MimeType final {
       kj::ArrayPtr<const char> input, ParseOptions options = ParseOptions::DEFAULT);
 };
 
+inline ConstMimeType::operator MimeType() const {
+  return MimeType(type_, subtype_);
+}
+
+inline MimeType ConstMimeType::clone() const {
+  return *this;
+}
+
+inline bool ConstMimeType::operator==(const MimeType& other) const {
+  return type_ == other.type() && subtype_ == other.subtype();
+}
+
 kj::String KJ_STRINGIFY(const MimeType& state);
+kj::String KJ_STRINGIFY(const ConstMimeType& state);
 
 }  // namespace workerd

--- a/src/workerd/util/strings.c++
+++ b/src/workerd/util/strings.c++
@@ -98,4 +98,18 @@ kj::Array<kj::byte> stripInnerWhitespace(kj::ArrayPtr<kj::byte> input) {
   return result.first(len).attach(kj::mv(result));
 };
 
+bool strcaseeq(kj::ArrayPtr<const char> a, kj::ArrayPtr<const char> b) {
+  // This could likely be optimized further but this is more than sufficient for now.
+  if (a.size() != b.size()) return false;
+  for (size_t i = 0; i < a.size(); ++i) {
+    char ca = a[i];
+    char cb = b[i];
+    // Convert to lowercase for comparison
+    if (isAlphaUpper(ca)) ca += 32;
+    if (isAlphaUpper(cb)) cb += 32;
+    if (ca != cb) return false;
+  }
+  return true;
+}
+
 }  // namespace workerd

--- a/src/workerd/util/strings.h
+++ b/src/workerd/util/strings.h
@@ -76,6 +76,10 @@ constexpr bool isAlphaLower(const kj::byte c) noexcept {
   return kCharLookupTable[c] & CharAttributeFlag::LOWER_CASE;
 }
 
+// TODO(later): If kj::ArrayPtr ever supports a constexpr [] operator,
+// make this function constexpr.
+bool strcaseeq(kj::ArrayPtr<const char> a, kj::ArrayPtr<const char> b);
+
 // Convert ASCII alpha characters in the given string to lowercase in place.
 kj::String toLower(kj::String&& str);
 


### PR DESCRIPTION
Make the constants constexpr, eliminate a couple of double allocations in parse, and add a couple of utility functions for common uses to eliminate extraneous allocations.