### PR TITLE
Minor perf improvements to UUID and address a todo

### DIFF
--- a/src/workerd/util/uuid-test.c++
+++ b/src/workerd/util/uuid-test.c++
@@ -22,31 +22,31 @@ namespace {
 
 KJ_TEST("Valid UUIDs") {
   ASSERT_VALID_AND_EQUAL(
-      72340172838076673ull, 1157442765409226768ull, "01010101-0101-0101-1010-101010101010");
+      72340172838076673ull, 1157442765409226768ull, "01010101-0101-0101-1010-101010101010"_kjc);
   ASSERT_VALID_AND_EQUAL(
-      81985529216486895ull, 81985529216486895ull, "01234567-89ab-cdef-0123-456789abcdef");
+      81985529216486895ull, 81985529216486895ull, "01234567-89ab-cdef-0123-456789abcdef"_kjc);
   ASSERT_VALID_AND_EQUAL(
-      16045690984833335023ull, 16045690984833335023ull, "deadbeef-dead-beef-dead-beefdeadbeef");
+      16045690984833335023ull, 16045690984833335023ull, "deadbeef-dead-beef-dead-beefdeadbeef"_kjc);
 }
 
 KJ_TEST("Null UUIDs") {
   KJ_EXPECT(UUID::fromUpperLower(0ull, 0ull) == kj::none);
-  KJ_EXPECT(UUID::fromString("00000000-0000-0000-0000-000000000000") == kj::none);
+  KJ_EXPECT(UUID::fromString("00000000-0000-0000-0000-000000000000"_kj) == kj::none);
 }
 
 KJ_TEST("Invalid UUIDs") {
-  KJ_EXPECT(UUID::fromString("") == kj::none);
-  KJ_EXPECT(UUID::fromString("foo") == kj::none);
-  KJ_EXPECT(UUID::fromString("+_{};'<>?,.`/'!@#$%^&*()") == kj::none);
-  KJ_EXPECT(UUID::fromString("101010101-0101-0101-1010-101010101010") == kj::none);
-  KJ_EXPECT(UUID::fromString("01010101-10101-0101-1010-101010101010") == kj::none);
-  KJ_EXPECT(UUID::fromString("01010101-0101-10101-1010-101010101010") == kj::none);
-  KJ_EXPECT(UUID::fromString("01010101-0101-0101-10101-101010101010") == kj::none);
-  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-1010101010101") == kj::none);
-  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-101010101010-") == kj::none);
-  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-10101010101-") == kj::none);
-  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-10101010101g") == kj::none);
-  KJ_EXPECT(UUID::fromString("0123456789abcdef0123456789abcdef") == kj::none);
+  KJ_EXPECT(UUID::fromString(""_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("foo"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("+_{};'<>?,.`/'!@#$%^&*()"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("101010101-0101-0101-1010-101010101010"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-10101-0101-1010-101010101010"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-10101-1010-101010101010"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-10101-101010101010"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-1010101010101"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-101010101010-"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-10101010101-"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("01010101-0101-0101-1010-10101010101g"_kjc) == kj::none);
+  KJ_EXPECT(UUID::fromString("0123456789abcdef0123456789abcdef"_kjc) == kj::none);
 }
 
 }  // namespace

--- a/src/workerd/util/uuid.c++
+++ b/src/workerd/util/uuid.c++
@@ -14,6 +14,31 @@
 namespace workerd {
 namespace {
 constexpr char HEX_DIGITS[] = "0123456789abcdef";
+
+static constexpr kj::FixedArray<int8_t, 256> HEX_VALUES = []() consteval {
+  kj::FixedArray<int8_t, 256> result{};
+  for (int i = 0; i < 256; i++) {
+    result[i] = -1;
+  }
+  for (uint8_t c = '0'; c <= '9'; c++) {
+    result[c] = c - '0';
+  }
+  for (uint8_t c = 'a'; c <= 'f'; c++) {
+    result[c] = c - 'a' + 10;
+  }
+  for (uint8_t c = 'A'; c <= 'F'; c++) {
+    result[c] = c - 'A' + 10;
+  }
+  return result;
+}();
+
+constexpr int hexValue(char c) {
+  return HEX_VALUES[static_cast<uint8_t>(c)];
+}
+static_assert(hexValue('B') == 11);
+static_assert(hexValue('a') == 10);
+static_assert(hexValue('0') == 0);
+static_assert(hexValue('G') == -1);
 }  // namespace
 
 kj::String randomUUID(kj::Maybe<kj::EntropySource&> optionalEntropySource) {
@@ -82,37 +107,71 @@ kj::Maybe<UUID> UUID::fromUpperLower(uint64_t upper, uint64_t lower) {
   return UUID(upper, lower);
 }
 
-kj::Maybe<UUID> UUID::fromString(kj::StringPtr str) {
-  if (str.size() != 36u) {
+kj::Maybe<UUID> UUID::fromString(kj::ArrayPtr<const char> str) {
+  if (str.size() != 36u || str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-') {
     return kj::none;
   }
-  uint64_t upper = 0;
-  uint64_t lower = 0;
-  auto begin = str.cStr();
-  char* p;
-  upper += (strtoull(begin, &p, 16) << 32u);
-  if (p - begin != 8 || *p != '-') {
+
+  int v0 = hexValue(str[0]);
+  int v1 = hexValue(str[1]);
+  int v2 = hexValue(str[2]);
+  int v3 = hexValue(str[3]);
+  int v4 = hexValue(str[4]);
+  int v5 = hexValue(str[5]);
+  int v6 = hexValue(str[6]);
+  int v7 = hexValue(str[7]);
+
+  int v9 = hexValue(str[9]);
+  int v10 = hexValue(str[10]);
+  int v11 = hexValue(str[11]);
+  int v12 = hexValue(str[12]);
+
+  int v14 = hexValue(str[14]);
+  int v15 = hexValue(str[15]);
+  int v16 = hexValue(str[16]);
+  int v17 = hexValue(str[17]);
+
+  int v19 = hexValue(str[19]);
+  int v20 = hexValue(str[20]);
+  int v21 = hexValue(str[21]);
+  int v22 = hexValue(str[22]);
+
+  int v24 = hexValue(str[24]);
+  int v25 = hexValue(str[25]);
+  int v26 = hexValue(str[26]);
+  int v27 = hexValue(str[27]);
+  int v28 = hexValue(str[28]);
+  int v29 = hexValue(str[29]);
+  int v30 = hexValue(str[30]);
+  int v31 = hexValue(str[31]);
+  int v32 = hexValue(str[32]);
+  int v33 = hexValue(str[33]);
+  int v34 = hexValue(str[34]);
+  int v35 = hexValue(str[35]);
+
+  if ((v0 | v1 | v2 | v3 | v4 | v5 | v6 | v7 | v9 | v10 | v11 | v12 | v14 | v15 | v16 | v17 | v19 |
+          v20 | v21 | v22 | v24 | v25 | v26 | v27 | v28 | v29 | v30 | v31 | v32 | v33 | v34 | v35) <
+      0) {
     return kj::none;
   }
-  upper += (strtoull(++p, &p, 16) << 16u);
-  if (p - begin != 13 || *p != '-') {
-    return kj::none;
-  }
-  upper += (strtoull(++p, &p, 16));
-  if (p - begin != 18 || *p != '-') {
-    return kj::none;
-  }
-  lower += (strtoull(++p, &p, 16) << 48u);
-  if (p - begin != 23 || *p != '-') {
-    return kj::none;
-  }
-  lower += (strtoull(++p, &p, 16));
-  if (p - begin != 36) {
-    return kj::none;
-  }
+
+  // Please forgive the c-style casts here. Way less verbose and more readable than static_casts.
+  uint64_t upper = ((uint64_t)v0 << 60) | ((uint64_t)v1 << 56) | ((uint64_t)v2 << 52) |
+      ((uint64_t)v3 << 48) | ((uint64_t)v4 << 44) | ((uint64_t)v5 << 40) | ((uint64_t)v6 << 36) |
+      ((uint64_t)v7 << 32) | ((uint64_t)v9 << 28) | ((uint64_t)v10 << 24) | ((uint64_t)v11 << 20) |
+      ((uint64_t)v12 << 16) | ((uint64_t)v14 << 12) | ((uint64_t)v15 << 8) | ((uint64_t)v16 << 4) |
+      ((uint64_t)v17);
+
+  uint64_t lower = ((uint64_t)v19 << 60) | ((uint64_t)v20 << 56) | ((uint64_t)v21 << 52) |
+      ((uint64_t)v22 << 48) | ((uint64_t)v24 << 44) | ((uint64_t)v25 << 40) |
+      ((uint64_t)v26 << 36) | ((uint64_t)v27 << 32) | ((uint64_t)v28 << 28) |
+      ((uint64_t)v29 << 24) | ((uint64_t)v30 << 20) | ((uint64_t)v31 << 16) |
+      ((uint64_t)v32 << 12) | ((uint64_t)v33 << 8) | ((uint64_t)v34 << 4) | ((uint64_t)v35);
+
   if (upper == 0 && lower == 0) {
     return kj::none;
   }
+
   return UUID(upper, lower);
 }
 

--- a/src/workerd/util/uuid.h
+++ b/src/workerd/util/uuid.h
@@ -39,7 +39,7 @@ class UUID {
 
   // Create a UUID from 8-4-4-4-12 hex format. If the provided string is not valid, or the UUID
   // would be null, return kj::none.
-  static kj::Maybe<UUID> fromString(kj::StringPtr str);
+  static kj::Maybe<UUID> fromString(kj::ArrayPtr<const char> str);
 
   uint64_t getUpper() const {
     return upper;


### PR DESCRIPTION
Not that it needed to be faster but hey, I was bored waiting for some other benchmarks to run so why not. Also addresses a TODO from the internal repo about avoiding a temporary string allocation when parsing. The `fromString` should be roughly about 3-5x faster.