### PR TITLE
EW-9632 Remove websocket-max-message-size-32m autogate

### DIFF
--- a/src/workerd/api/tests/websocket-client-error-sidecar.js
+++ b/src/workerd/api/tests/websocket-client-error-sidecar.js
@@ -93,5 +93,5 @@ server.listen(port, host, () => reportAddress(server));
 // Function to handle WebSocket connections
 function handleWebSocketConnection(socket) {
   // Send a welcome message
-  sendMessage(socket, new Uint8Array(2 * 1024 * 1024));
+  sendMessage(socket, new Uint8Array(33 * 1024 * 1024));
 }

--- a/src/workerd/api/tests/websocket-client-error-test.js
+++ b/src/workerd/api/tests/websocket-client-error-test.js
@@ -29,7 +29,7 @@ export default {
 
         if (
           event.message ===
-          'Uncaught Error: WebSocket protocol error; protocolError.statusCode = 1009; protocolError.description = Message is too large: 2097152 > 1048576'
+          'Uncaught Error: WebSocket protocol error; protocolError.statusCode = 1009; protocolError.description = Message is too large: 34603008 > 33554432'
         ) {
           resolve({
             source: 'client-error',

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -482,18 +482,12 @@ WebSocket::Accepted::~Accepted() noexcept(false) {
 //
 // JS-RPC messages are size-limited to 32MiB, and it seems to be working well, so we're setting the
 // WebSocket default max message size to match that.
-//
-// TODO(soon): This is currently autogated, so that we can enable the change in production before
-//   enabling it by default in local development. This is so that people do not inadvertently deploy
-//   something that works locally but breaks when deployed.
 static constexpr size_t WEBSOCKET_MAX_MESSAGE_SIZE = 32u << 20;
 
 void WebSocket::startReadLoop(jsg::Lock& js, kj::Maybe<kj::Own<InputGate::CriticalSection>> cs) {
-  size_t maxMessageSize = kj::WebSocket::SUGGESTED_MAX_MESSAGE_SIZE;
+  size_t maxMessageSize = WEBSOCKET_MAX_MESSAGE_SIZE;
   if (FeatureFlags::get(js).getIncreaseWebsocketMessageSize()) {
     maxMessageSize = 128u << 20;
-  } else if (util::Autogate::isEnabled(util::AutogateKey::WEBSOCKET_MAX_MESSAGE_SIZE_32M)) {
-    maxMessageSize = WEBSOCKET_MAX_MESSAGE_SIZE;
   }
 
   // If the kj::WebSocket happens to be an AbortableWebSocket (see util/abortable.h), then

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4649,7 +4649,7 @@ KJ_TEST("Server: Catch websocket server errors") {
   };
 
   KJ_EXPECT_LOG(ERROR,
-      "jsg.Error: WebSocket protocol error; protocolError.statusCode = 1009; protocolError.description = Message is too large: 2097152 > 1048576");
+      "jsg.Error: WebSocket protocol error; protocolError.statusCode = 1009; protocolError.description = Message is too large: 34603008 > 33554432");
   test.start();
   auto& waitScope = test.getWaitScope();
 
@@ -4669,7 +4669,7 @@ KJ_TEST("Server: Catch websocket server errors") {
     ws->send(smallMessage).wait(waitScope);
     auto smallResponse = ws->receive().wait(waitScope);
     KJ_EXPECT(smallResponse.get<kj::String>() == smallMessage);
-    const auto bigMessage = kj::heapArray<kj::byte>(2 * 1024 * 1024);
+    const auto bigMessage = kj::heapArray<kj::byte>(33 * 1024 * 1024);
     auto sendProm =
         kj::evalNow([&]() { return ws->send(bigMessage); }).then([]() {}, [](kj::Exception ex) {});
     // Message is too big; we should close the connection.

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -25,8 +25,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "streaming-tail-worker"_kj;
     case AutogateKey::TAIL_STREAM_REFACTOR:
       return "tail-stream-refactor"_kj;
-    case AutogateKey::WEBSOCKET_MAX_MESSAGE_SIZE_32M:
-      return "websocket-max-message-size-32m"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -20,8 +20,6 @@ enum class AutogateKey {
   STREAMING_TAIL_WORKER,
   // Enable refactor used to consolidate the different tail worker stream implementations.
   TAIL_STREAM_REFACTOR,
-  // Increase max WebSocket message size to 32MiB.
-  WEBSOCKET_MAX_MESSAGE_SIZE_32M,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
This change is fully rolled out to production, and is stable.

cc @VCNinc