### PR TITLE
[Experimental] Implement writeIntoUint8Array for TextEncoder

### DIFF
--- a/build/deps/v8.MODULE.bazel
+++ b/build/deps/v8.MODULE.bazel
@@ -51,6 +51,7 @@ PATCHES = [
     "0026-Implement-additional-Exception-construction-methods.patch",
     "0027-Export-icudata-file-to-facilitate-embedding-it.patch",
     "0028-bind-icu-to-googlesource.patch",
+    "0029-Add-v8-String-IsFlat-method.patch",
 ]
 
 http_archive(

--- a/patches/v8/0029-Add-v8-String-IsFlat-method.patch
+++ b/patches/v8/0029-Add-v8-String-IsFlat-method.patch
@@ -1,0 +1,38 @@
+From 76d11c3a77b84372ed81b98a69a4a0b5e2fd28e6 Mon Sep 17 00:00:00 2001
+From: James M Snell <jsnell@cloudflare.com>
+Date: Sun, 2 Nov 2025 09:30:02 -0800
+Subject: Add v8::String::IsFlat() method
+
+Signed-off-by: James M Snell <jsnell@cloudflare.com>
+
+diff --git a/include/v8-primitive.h b/include/v8-primitive.h
+index 1bf21e60ad9a99bc98aa6a24c1888f1461ce7b46..f519b2e6c8be3a335a115f19a7bf9344dcb9504f 100644
+--- a/include/v8-primitive.h
++++ b/include/v8-primitive.h
+@@ -163,6 +163,11 @@ class V8_EXPORT String : public Name {
+    */
+   bool ContainsOnlyOneByte() const;
+ 
++  /**
++   * Returns whether this string is known to be flat
++   */
++  bool IsFlat() const;
++
+   /**
+    * Write the contents of the string to an external buffer.
+    * If no arguments are given, expects the buffer to be large
+diff --git a/src/api/api.cc b/src/api/api.cc
+index 6312f7f2b2e46f4dfdc386e85fb2aad293e7d85d..f388b444bc752f9d724996a1a933a0774db946dd 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -5595,6 +5595,10 @@ bool String::IsOneByte() const {
+   return Utils::OpenDirectHandle(this)->IsOneByteRepresentation();
+ }
+ 
++bool String::IsFlat() const {
++  return Utils::OpenDirectHandle(this)->IsFlat();
++}
++
+ // Helpers for ContainsOnlyOneByteHelper
+ template <size_t size>
+ struct OneByteMask;

--- a/src/workerd/api/encoding.h
+++ b/src/workerd/api/encoding.h
@@ -216,7 +216,7 @@ class TextEncoder final: public jsg::Object {
 
   static jsg::Ref<TextEncoder> constructor(jsg::Lock& js);
 
-  jsg::BufferSource encode(jsg::Lock& js, jsg::Optional<jsg::JsString> input);
+  jsg::JsUint8Array encode(jsg::Lock& js, jsg::Optional<jsg::JsString> input);
 
   EncodeIntoResult encodeInto(jsg::Lock& js, jsg::JsString input, jsg::JsUint8Array buffer);
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2706,6 +2706,14 @@ class Lock {
   template <typename T>
   JsObject getPrototypeFor();
 
+  enum class HeapPressure {
+    NONE,         // Heap is well under heap limits.
+    APPROACHING,  // Heap is approaching heap limits.
+    CRITICAL,     // Heap is at or over heap limits.
+  };
+  // Returns the current heap pressure estimation.
+  HeapPressure getHeapPressure();
+
   // ====================================================================================
   JsObject global() KJ_WARN_UNUSED_RESULT;
   JsValue undefined() KJ_WARN_UNUSED_RESULT;
@@ -2997,6 +3005,18 @@ inline v8::Local<v8::Context> JsContext<T>::getHandle(Lock& js) const {
 
 inline Value SelfRef::asValue(Lock& js) const {
   return Value(js.v8Isolate, getHandle(js).As<v8::Value>());
+}
+
+inline static bool operator<(const Lock::HeapPressure a, const Lock::HeapPressure b) {
+  return static_cast<int>(a) < static_cast<int>(b);
+}
+
+inline static bool operator>(const Lock::HeapPressure a, const Lock::HeapPressure b) {
+  return static_cast<int>(a) > static_cast<int>(b);
+}
+
+inline static bool operator==(const Lock::HeapPressure a, const Lock::HeapPressure b) {
+  return static_cast<int>(a) == static_cast<int>(b);
 }
 
 }  // namespace workerd::jsg


### PR DESCRIPTION
This is an experiment for now. Do not merge yet.

Background: When running under high memory pressure, operations like `TextEncoder::encode` can cause additional memory load by flattening the input strings. This is particularly true in React/NextJS SSR during the render phase. The string flattening itself can lead to additional GC thrashing that adds significant additional CPU overhead to the rendering. This PR experiments with detecting when we are in high memory load conditions and using an alternative utf8 encode that avoids the string flattening. It only kicks in under certain conditions (e.g. string isn't already flat, string is over a certain length, memory pressure is over a certain threshold, etc). It's not intended to make encoding faster, it is ended to avoid flattening and the associated GC costs.

There's an additional v8 patch included, so this PR is not expected to pass internal CI until the same patch is landed there.