### PR TITLE
ci: ensure the workers-types release uses the correct npm version for…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24 # needed for a version of npm that supports "trusted publishing".
       - name: Cache
         id: cache
         uses: actions/cache@v4


### PR DESCRIPTION
… trusted publishing