### PR TITLE
Small tweaks to FormData boundary generation

### DIFF
--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -1378,10 +1378,6 @@ jsg::Ref<Response> makeHttpResponse(
 bool isNullBodyStatusCode(uint statusCode);
 bool isRedirectStatusCode(uint statusCode);
 
-kj::String makeRandomBoundaryCharacters();
-// Make a boundary string for FormData serialization.
-// TODO(cleanup): Move to form-data.{h,c++}?
-
 #define EW_HTTP_ISOLATE_TYPES         \
   api::FetchEvent,                    \
   api::Headers,                       \

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -90,6 +90,7 @@ wd_cc_library(
         "//src/workerd/api:data-url",
         "//src/workerd/api/node:exceptions",
         "//src/workerd/util:completion-membrane",
+        "//src/workerd/util:entropy",
         "//src/workerd/util:perfetto",
         "//src/workerd/util:string-buffer",
         "//src/workerd/util:uuid",


### PR DESCRIPTION
Two small changes:

1. The function to generate the formdata bounday only had a single call site. It made sense to inline it and remove the extra function.

2. It previously used the IoContext entropy source for randomness. Updated to use the new cached entropy source since it's more efficient and fresh entropy is not strictly necessary for this.