### PR TITLE
fixing benchmarks setup

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -44,16 +44,16 @@ jobs:
 
       - name: Build benchmarks
         run: |
-          bazel build ${{ env.BAZEL_ARGS }} //src/workerd/tests:all_benchmarks
+          bazel build ${{ env.BAZEL_ARGS }} --build_tag_filters=benchmark-binary //...
 
       - name: Generate benchmark script
         run: |
           echo '#!/bin/bash' > run_benchmarks.sh
-          echo 'set -e' >> run_benchmarks.sh
-          targets=$(bazel query 'deps(//src/workerd/tests:all_benchmarks, 1)' --output=label 2>/dev/null | grep -E '^//src/workerd/tests:bench-' | grep -v '@')
+          echo 'set -ex' >> run_benchmarks.sh
+          targets=$(bazel query 'attr(tags, "benchmark-binary", //...)' --output=label 2>/dev/null)
           for target in $targets; do
             echo "echo 'Running benchmark: $target'" >> run_benchmarks.sh
-            echo "bazel run ${{ env.BAZEL_ARGS }} $target" >> run_benchmarks.sh
+            echo "bazel run ${{ env.BAZEL_ARGS }} $target -- --benchmark_min_time=1s" >> run_benchmarks.sh
           done
           chmod +x run_benchmarks.sh
 

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -2,7 +2,6 @@
 
 def wd_cc_benchmark(
         name,
-        args = [],
         linkopts = [],
         deps = [],
         visibility = None,
@@ -10,9 +9,8 @@ def wd_cc_benchmark(
     """Wrapper for cc_binary that sets common attributes and links the benchmark library.
     """
 
-    native.cc_binary(
+    native.cc_test(
         name = name,
-        args = ["--benchmark_min_time=1s"] + args,
         defines = ["WD_IS_BENCHMARK"],
         # Use shared linkage for benchmarks, matching the approach used for tests. Unfortunately,
         # bazel does not support shared linkage on macOS and it is broken on Windows, so only
@@ -32,7 +30,8 @@ def wd_cc_benchmark(
         ],
         # use the same malloc we use for server
         malloc = "//src/workerd/server:malloc",
-        tags = ["workerd-benchmark"],
+        tags = ["workerd-benchmark", "benchmark-binary"],
+        size = "large",
         **kwargs
     )
 

--- a/justfile
+++ b/justfile
@@ -122,7 +122,7 @@ create-external:
   tools/unix/create-external.sh
 
 bench-all:
-  bazel query 'deps(//src/workerd/tests:all_benchmarks, 1)' --output=label | grep -v 'all_benchmarks' | xargs -I {} bazel run --config=benchmark {}
+  bazel query 'attr(tags, "benchmark-binary", //...)' --output=label | xargs -I {} bazel run --config=benchmark {}
 
 eslint:
   just stream-test \

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -123,22 +123,6 @@ wd_test(
     data = ["performance-test.js"],
 )
 
-filegroup(
-    name = "all_benchmarks",
-    srcs = [
-        ":bench-api-headers",
-        ":bench-global-scope",
-        ":bench-json",
-        ":bench-kj-headers",
-        ":bench-mimetype",
-        ":bench-regex",
-        ":bench-response",
-        ":bench-text-encoder",
-        ":bench-util",
-    ],
-    visibility = ["//visibility:public"],
-)
-
 # REPRL tests using KJ test framework
 wd_cc_library(
     name = "libreprl",


### PR DESCRIPTION
- no more weird filegroup
- benchmarks are run as part of bazel test
- min time is specified only in actual benchmarking run