### PR TITLE
Support sync and async iterables with Response/Request

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -118,6 +118,10 @@ class Navigator: public jsg::Object {
     if (reader.getWebFileSystem()) {
       JSG_LAZY_READONLY_INSTANCE_PROPERTY(storage, getStorage);
     }
+
+    JSG_TS_OVERRIDE({
+      sendBeacon(url: string, body?: BodyInit): boolean;
+    });
   }
 };
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -671,6 +671,9 @@ Body::ExtractedBody Body::extractBody(jsg::Lock& js, Initializer init) {
     KJ_CASE_ONEOF(stream, jsg::Ref<ReadableStream>) {
       return kj::mv(stream);
     }
+    KJ_CASE_ONEOF(gen, jsg::AsyncGeneratorIgnoringStrings<jsg::Value>) {
+      return ReadableStream::from(js, gen.release());
+    }
     KJ_CASE_ONEOF(text, kj::String) {
       contentType = kj::str(MimeType::PLAINTEXT_STRING);
       buffer = kj::mv(text);

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -256,7 +256,8 @@ public:
   // the POST will successfully retransmit.
   using Initializer = kj::OneOf<jsg::Ref<ReadableStream>, kj::String, kj::Array<byte>,
                                 jsg::Ref<Blob>, jsg::Ref<FormData>,
-                                jsg::Ref<URLSearchParams>, jsg::Ref<url::URLSearchParams>>;
+                                jsg::Ref<URLSearchParams>, jsg::Ref<url::URLSearchParams>,
+                                jsg::AsyncGeneratorIgnoringStrings<jsg::Value>>;
 
   struct RefcountedBytes final: public kj::Refcounted {
     kj::Array<kj::byte> bytes;
@@ -382,7 +383,11 @@ public:
     JSG_METHOD(formData);
     JSG_METHOD(blob);
 
-    JSG_TS_DEFINE(type BodyInit = ReadableStream<Uint8Array> | string | ArrayBuffer | ArrayBufferView | Blob | URLSearchParams | FormData);
+    if (flags.getFetchIterableTypeSupport()) {
+      JSG_TS_DEFINE(type BodyInit = ReadableStream<Uint8Array> | string | ArrayBuffer | ArrayBufferView | Blob | URLSearchParams | FormData | Iterable<ArrayBuffer|ArrayBufferView> | AsyncIterable<ArrayBuffer|ArrayBufferView>);
+    } else {
+      JSG_TS_DEFINE(type BodyInit = ReadableStream<Uint8Array> | string | ArrayBuffer | ArrayBufferView | Blob | URLSearchParams | FormData);
+    }
     // All type aliases get inlined when exporting RTTI, but this type alias is included by
     // the official TypeScript types, so users might be depending on it.
     JSG_TS_OVERRIDE({

--- a/src/workerd/api/tests/fetch-test.js
+++ b/src/workerd/api/tests/fetch-test.js
@@ -22,3 +22,24 @@ export const test = {
     });
   },
 };
+
+export const fetchGen = {
+  async test() {
+    const enc = new TextEncoder();
+    async function* gen() {
+      yield enc.encode('Hello ');
+      yield enc.encode('World!');
+    }
+    const resp = new Response(gen());
+    strictEqual(await resp.text(), 'Hello World!');
+
+    const req = new Request('http://example.com', {
+      method: 'POST',
+      body: gen(),
+    });
+    strictEqual(await req.text(), 'Hello World!');
+
+    const resp2 = new Response([enc.encode('Hello '), enc.encode('World!')]);
+    strictEqual(await resp2.text(), 'Hello World!');
+  },
+};

--- a/src/workerd/api/tests/fetch-test.wd-test
+++ b/src/workerd/api/tests/fetch-test.wd-test
@@ -8,7 +8,11 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "fetch-test.js")
         ],
         compatibilityDate = "2024-10-01",
-        compatibilityFlags = ["nodejs_compat", "upper_case_all_http_methods"],
+        compatibilityFlags = [
+          "nodejs_compat",
+          "upper_case_all_http_methods",
+          "fetch_iterable_type_support",
+        ],
       )
     ),
   ],

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1227,4 +1227,18 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # When set, tells JSG to make the prototype of all jsg::Objects immutable.
   # TODO(soon): Add the default on date once the flag is verified to be
   # generally safe.
+
+  fetchIterableTypeSupport @146 :Bool
+    $compatEnableFlag("fetch_iterable_type_support")
+    $compatDisableFlag("no_fetch_iterable_type_support")
+    $compatEnableDate("2025-12-16");
+  # Enables passing sync and async iterables as the body of fetch Request or Response.
+  # Previously, sync iterables like Arrays would be accepted but stringified, and async
+  # iterables would be treated as regular objects and not iterated over at all. With this
+  # flag enabled, sync and async iterables will be properly iterated over and their values
+  # used as the body of the request or response.
+  # The actual compat flag enables the specific AsyncGeneratorIgnoringStrings type wrapper
+  # that allows this behavior and allows sync Generator and AsyncGenerator objects to be
+  # included in kj::OneOf declarations safely with strings and other types. When enabled,
+  # strings are ignored but Arrays will be treated as iterables and not stringified as before.
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2136,6 +2136,7 @@ class GeneratorContext;
 struct JsgConfig {
   bool noSubstituteNull = false;
   bool unwrapCustomThenables = false;
+  bool fetchIterableTypeSupport = false;
 };
 
 static constexpr JsgConfig DEFAULT_JSG_CONFIG = {};

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -383,7 +383,8 @@ FOR_EACH_MAYBE_TYPE(DECLARE_MAYBE_TYPE)
   F(kj::ArrayPtr)                                                                                  \
   F(kj::HashSet)                                                                                   \
   F(jsg::Sequence)                                                                                 \
-  F(jsg::AsyncGenerator)
+  F(jsg::AsyncGenerator)                                                                           \
+  F(jsg::AsyncGeneratorIgnoringStrings)
 
 template <typename Configuration>
 struct BuildRtti<Configuration, jsg::JsArray> {

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -419,6 +419,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
   TypeWrapper(v8::Isolate* isolate, MetaConfiguration&& configuration)
       : TypeWrapperBase<Self, T>(configuration)...,
         MaybeWrapper<Self>(configuration),
+        GeneratorWrapper<Self>(configuration),
         PromiseWrapper<Self>(configuration) {
     isolate->SetData(SET_DATA_TYPE_WRAPPER, this);
     fastApiEnabled = util::Autogate::isEnabled(util::AutogateKey::V8_FAST_API);

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -267,6 +267,7 @@ struct WorkerdApi::Impl final {
           jsgConfig(jsg::JsgConfig{
             .noSubstituteNull = features.getNoSubstituteNull(),
             .unwrapCustomThenables = features.getUnwrapCustomThenables(),
+            .fetchIterableTypeSupport = features.getFetchIterableTypeSupport(),
           }) {}
     operator const CompatibilityFlags::Reader() const {
       return features;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -546,17 +546,7 @@ interface StructuredSerializeOptions {
   transfer?: any[];
 }
 declare abstract class Navigator {
-  sendBeacon(
-    url: string,
-    body?:
-      | ReadableStream
-      | string
-      | (ArrayBuffer | ArrayBufferView)
-      | Blob
-      | FormData
-      | URLSearchParams
-      | URLSearchParams,
-  ): boolean;
+  sendBeacon(url: string, body?: BodyInit): boolean;
   readonly userAgent: string;
   readonly hardwareConcurrency: number;
   readonly language: string;
@@ -1952,7 +1942,9 @@ type BodyInit =
   | ArrayBufferView
   | Blob
   | URLSearchParams
-  | FormData;
+  | FormData
+  | Iterable<ArrayBuffer | ArrayBufferView>
+  | AsyncIterable<ArrayBuffer | ArrayBufferView>;
 declare abstract class Body {
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/body) */
   get body(): ReadableStream | null;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -551,17 +551,7 @@ export interface StructuredSerializeOptions {
   transfer?: any[];
 }
 export declare abstract class Navigator {
-  sendBeacon(
-    url: string,
-    body?:
-      | ReadableStream
-      | string
-      | (ArrayBuffer | ArrayBufferView)
-      | Blob
-      | FormData
-      | URLSearchParams
-      | URLSearchParams,
-  ): boolean;
+  sendBeacon(url: string, body?: BodyInit): boolean;
   readonly userAgent: string;
   readonly hardwareConcurrency: number;
   readonly language: string;
@@ -1957,7 +1947,9 @@ export type BodyInit =
   | ArrayBufferView
   | Blob
   | URLSearchParams
-  | FormData;
+  | FormData
+  | Iterable<ArrayBuffer | ArrayBufferView>
+  | AsyncIterable<ArrayBuffer | ArrayBufferView>;
 export declare abstract class Body {
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/body) */
   get body(): ReadableStream | null;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -533,17 +533,7 @@ interface StructuredSerializeOptions {
   transfer?: any[];
 }
 declare abstract class Navigator {
-  sendBeacon(
-    url: string,
-    body?:
-      | ReadableStream
-      | string
-      | (ArrayBuffer | ArrayBufferView)
-      | Blob
-      | FormData
-      | URLSearchParams
-      | URLSearchParams,
-  ): boolean;
+  sendBeacon(url: string, body?: BodyInit): boolean;
   readonly userAgent: string;
   readonly hardwareConcurrency: number;
   readonly language: string;
@@ -1909,7 +1899,9 @@ type BodyInit =
   | ArrayBufferView
   | Blob
   | URLSearchParams
-  | FormData;
+  | FormData
+  | Iterable<ArrayBuffer | ArrayBufferView>
+  | AsyncIterable<ArrayBuffer | ArrayBufferView>;
 declare abstract class Body {
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/body) */
   get body(): ReadableStream | null;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -538,17 +538,7 @@ export interface StructuredSerializeOptions {
   transfer?: any[];
 }
 export declare abstract class Navigator {
-  sendBeacon(
-    url: string,
-    body?:
-      | ReadableStream
-      | string
-      | (ArrayBuffer | ArrayBufferView)
-      | Blob
-      | FormData
-      | URLSearchParams
-      | URLSearchParams,
-  ): boolean;
+  sendBeacon(url: string, body?: BodyInit): boolean;
   readonly userAgent: string;
   readonly hardwareConcurrency: number;
   readonly language: string;
@@ -1914,7 +1904,9 @@ export type BodyInit =
   | ArrayBufferView
   | Blob
   | URLSearchParams
-  | FormData;
+  | FormData
+  | Iterable<ArrayBuffer | ArrayBufferView>
+  | AsyncIterable<ArrayBuffer | ArrayBufferView>;
 export declare abstract class Body {
   /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/body) */
   get body(): ReadableStream | null;


### PR DESCRIPTION
While passing sync/async iterables to `Request` and `Response` are not part of the standard, Node.js implements it and we've been asked to also.

```js
const enc = new TextEncoder();
// Curently, the generator must yield ArrayBuffer or ArrayBufferView
async function* gen() {
  yield enc.encode('Hello ');
  yield enc.encode('World!');
}
return new Response(gen());

// or

const req = new Request('...', { body: gen() });
```

Note that this will *NOT* give us 100% compat with Node.js on this feature yet. Node.js supports writing strings to the response, e.g. `yield 'foo';` while we still require the values to be `ArrayBuffer` or `ArrayBufferView`. We will be supporting strings as part of a different change that'll take a bit longer to land.