### PR TITLE
Added types for conversion options in ToMarkdown

### DIFF
--- a/src/cloudflare/ai.ts
+++ b/src/cloudflare/ai.ts
@@ -25,4 +25,9 @@ export {
   ToMarkdownService,
   type ConversionResponse,
   type SupportedFileFormat,
+  type ConversionOptions,
+  type ConversionRequestOptions,
+  type EmbeddedImageConversionOptions,
+  type ImageConversionOptions,
+  type MarkdownDocument,
 } from 'cloudflare-internal:to-markdown-api';

--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -6,7 +6,9 @@ import { AiGateway, type GatewayOptions } from 'cloudflare-internal:aig-api';
 import { AutoRAG } from 'cloudflare-internal:autorag-api';
 import {
   ToMarkdownService,
+  type ConversionRequestOptions,
   type ConversionResponse,
+  type MarkdownDocument,
 } from 'cloudflare-internal:to-markdown-api';
 
 interface Fetcher {
@@ -392,19 +394,16 @@ export class Ai {
 
   toMarkdown(): ToMarkdownService;
   async toMarkdown(
-    files: { name: string; blob: Blob }[],
-    options?: { gateway?: GatewayOptions; extraHeaders?: object }
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse[]>;
   async toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: { gateway?: GatewayOptions; extraHeaders?: object }
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse>;
   toMarkdown(
-    files?: { name: string; blob: Blob } | { name: string; blob: Blob }[],
-    options?: { gateway?: GatewayOptions; extraHeaders?: object }
+    files?: MarkdownDocument | MarkdownDocument[],
+    options?: ConversionRequestOptions
   ): ToMarkdownService | Promise<ConversionResponse | ConversionResponse[]> {
     const service = new ToMarkdownService(this.#fetcher);
 

--- a/src/cloudflare/internal/to-markdown-api.ts
+++ b/src/cloudflare/internal/to-markdown-api.ts
@@ -6,20 +6,54 @@ interface Fetcher {
   fetch: typeof fetch;
 }
 
-export type ConversionResponse = {
+export type MarkdownDocument = {
   name: string;
-  mimeType: string;
-} & (
+  blob: Blob;
+};
+
+export type ConversionResponse =
   | {
+      name: string;
+      mimeType: string;
       format: 'markdown';
       tokens: number;
       data: string;
     }
   | {
+      name: string;
+      mimeType: string;
       format: 'error';
       error: string;
-    }
-);
+    };
+
+export type ImageConversionOptions = {
+  descriptionLanguage?: 'en' | 'es' | 'fr' | 'it' | 'pt' | 'de';
+};
+
+export type EmbeddedImageConversionOptions = ImageConversionOptions & {
+  convert?: boolean;
+  maxConvertedImages?: number;
+};
+
+export type ConversionOptions = {
+  html?: {
+    images?: EmbeddedImageConversionOptions & { convertOGImage?: boolean };
+  };
+  docx?: {
+    images?: EmbeddedImageConversionOptions;
+  };
+  image?: ImageConversionOptions;
+  pdf?: {
+    images?: EmbeddedImageConversionOptions;
+    metadata?: boolean;
+  };
+};
+
+export type ConversionRequestOptions = {
+  gateway?: GatewayOptions;
+  extraHeaders?: object;
+  conversionOptions?: ConversionOptions;
+};
 
 export type SupportedFileFormat = {
   mimeType: string;
@@ -39,19 +73,16 @@ export class ToMarkdownService {
   }
 
   async transform(
-    files: { name: string; blob: Blob }[],
-    options?: { gateway?: GatewayOptions; extraHeaders?: object }
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse[]>;
   async transform(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: { gateway?: GatewayOptions; extraHeaders?: object }
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse>;
   async transform(
-    files: { name: string; blob: Blob } | { name: string; blob: Blob }[],
-    options?: { gateway?: GatewayOptions; extraHeaders?: object }
+    files: MarkdownDocument | MarkdownDocument[],
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse | ConversionResponse[]> {
     const input = Array.isArray(files) ? files : [files];
 

--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -3566,23 +3566,11 @@ export declare abstract class Ai<AiModelList extends AiModelListType = AiModels>
   models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
   toMarkdown(): ToMarkdownService;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
 }

--- a/types/defines/to-markdown.d.ts
+++ b/types/defines/to-markdown.d.ts
@@ -1,14 +1,49 @@
+export type MarkdownDocument = {
+  name: string;
+  blob: Blob;
+}
+
 export type ConversionResponse = {
   name: string;
   mimeType: string;
-} & ({
-  format: "markdown";
+  format: 'markdown';
   tokens: number;
   data: string;
 } | {
-  format: "error",
-  error: string,
-});
+  name: string;
+  mimeType: string;
+  format: 'error';
+  error: string;
+};
+
+export type ImageConversionOptions = {
+  descriptionLanguage?: 'en' | 'es' | 'fr' | 'it' | 'pt' | 'de';
+}
+
+export type EmbeddedImageConversionOptions = ImageConversionOptions & {
+  convert?: boolean;
+  maxConvertedImages?: number;
+};
+
+export type ConversionOptions = {
+  html?: {
+    images?: EmbeddedImageConversionOptions & { convertOGImage?: boolean };
+  },
+  docx?: {
+    images?: EmbeddedImageConversionOptions;
+  },
+  image?: ImageConversionOptions;
+  pdf?: {
+    images?: EmbeddedImageConversionOptions;
+    metadata?: boolean;
+  },
+};
+
+export type ConversionRequestOptions = {
+  gateway?: GatewayOptions;
+  extraHeaders?: object;
+  conversionOptions?: ConversionOptions;
+};
 
 export type SupportedFileFormat = {
   mimeType: string;
@@ -17,15 +52,12 @@ export type SupportedFileFormat = {
 
 export declare abstract class ToMarkdownService {
   transform(
-    files: { name: string; blob: Blob }[],
-    options?: { gateway?: GatewayOptions; extraHeaders?: object }
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse[]>;
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: { gateway?: GatewayOptions; extraHeaders?: object }
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions
   ): Promise<ConversionResponse>;
   supported(): Promise<SupportedFileFormat[]>
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -8078,24 +8078,12 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
   toMarkdown(): ToMarkdownService;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
 }
 type GatewayRetries = {
@@ -10306,44 +10294,63 @@ declare module "cloudflare:sockets" {
   ): Socket;
   export { _connect as connect };
 }
-type ConversionResponse = {
+type MarkdownDocument = {
   name: string;
-  mimeType: string;
-} & (
+  blob: Blob;
+};
+type ConversionResponse =
   | {
+      name: string;
+      mimeType: string;
       format: "markdown";
       tokens: number;
       data: string;
     }
   | {
+      name: string;
+      mimeType: string;
       format: "error";
       error: string;
-    }
-);
+    };
+type ImageConversionOptions = {
+  descriptionLanguage?: "en" | "es" | "fr" | "it" | "pt" | "de";
+};
+type EmbeddedImageConversionOptions = ImageConversionOptions & {
+  convert?: boolean;
+  maxConvertedImages?: number;
+};
+type ConversionOptions = {
+  html?: {
+    images?: EmbeddedImageConversionOptions & {
+      convertOGImage?: boolean;
+    };
+  };
+  docx?: {
+    images?: EmbeddedImageConversionOptions;
+  };
+  image?: ImageConversionOptions;
+  pdf?: {
+    images?: EmbeddedImageConversionOptions;
+    metadata?: boolean;
+  };
+};
+type ConversionRequestOptions = {
+  gateway?: GatewayOptions;
+  extraHeaders?: object;
+  conversionOptions?: ConversionOptions;
+};
 type SupportedFileFormat = {
   mimeType: string;
   extension: string;
 };
 declare abstract class ToMarkdownService {
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
   supported(): Promise<SupportedFileFormat[]>;
 }

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -8099,24 +8099,12 @@ export declare abstract class Ai<
   models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
   toMarkdown(): ToMarkdownService;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
 }
 export type GatewayRetries = {
@@ -10273,44 +10261,63 @@ export interface SecretsStoreSecret {
    */
   get(): Promise<string>;
 }
-export type ConversionResponse = {
+export type MarkdownDocument = {
   name: string;
-  mimeType: string;
-} & (
+  blob: Blob;
+};
+export type ConversionResponse =
   | {
+      name: string;
+      mimeType: string;
       format: "markdown";
       tokens: number;
       data: string;
     }
   | {
+      name: string;
+      mimeType: string;
       format: "error";
       error: string;
-    }
-);
+    };
+export type ImageConversionOptions = {
+  descriptionLanguage?: "en" | "es" | "fr" | "it" | "pt" | "de";
+};
+export type EmbeddedImageConversionOptions = ImageConversionOptions & {
+  convert?: boolean;
+  maxConvertedImages?: number;
+};
+export type ConversionOptions = {
+  html?: {
+    images?: EmbeddedImageConversionOptions & {
+      convertOGImage?: boolean;
+    };
+  };
+  docx?: {
+    images?: EmbeddedImageConversionOptions;
+  };
+  image?: ImageConversionOptions;
+  pdf?: {
+    images?: EmbeddedImageConversionOptions;
+    metadata?: boolean;
+  };
+};
+export type ConversionRequestOptions = {
+  gateway?: GatewayOptions;
+  extraHeaders?: object;
+  conversionOptions?: ConversionOptions;
+};
 export type SupportedFileFormat = {
   mimeType: string;
   extension: string;
 };
 export declare abstract class ToMarkdownService {
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
   supported(): Promise<SupportedFileFormat[]>;
 }

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -7474,24 +7474,12 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
   toMarkdown(): ToMarkdownService;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
 }
 type GatewayRetries = {
@@ -9702,44 +9690,63 @@ declare module "cloudflare:sockets" {
   ): Socket;
   export { _connect as connect };
 }
-type ConversionResponse = {
+type MarkdownDocument = {
   name: string;
-  mimeType: string;
-} & (
+  blob: Blob;
+};
+type ConversionResponse =
   | {
+      name: string;
+      mimeType: string;
       format: "markdown";
       tokens: number;
       data: string;
     }
   | {
+      name: string;
+      mimeType: string;
       format: "error";
       error: string;
-    }
-);
+    };
+type ImageConversionOptions = {
+  descriptionLanguage?: "en" | "es" | "fr" | "it" | "pt" | "de";
+};
+type EmbeddedImageConversionOptions = ImageConversionOptions & {
+  convert?: boolean;
+  maxConvertedImages?: number;
+};
+type ConversionOptions = {
+  html?: {
+    images?: EmbeddedImageConversionOptions & {
+      convertOGImage?: boolean;
+    };
+  };
+  docx?: {
+    images?: EmbeddedImageConversionOptions;
+  };
+  image?: ImageConversionOptions;
+  pdf?: {
+    images?: EmbeddedImageConversionOptions;
+    metadata?: boolean;
+  };
+};
+type ConversionRequestOptions = {
+  gateway?: GatewayOptions;
+  extraHeaders?: object;
+  conversionOptions?: ConversionOptions;
+};
 type SupportedFileFormat = {
   mimeType: string;
   extension: string;
 };
 declare abstract class ToMarkdownService {
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
   supported(): Promise<SupportedFileFormat[]>;
 }

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -7493,24 +7493,12 @@ export declare abstract class Ai<
   models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
   toMarkdown(): ToMarkdownService;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   toMarkdown(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
 }
 export type GatewayRetries = {
@@ -9667,44 +9655,63 @@ export interface SecretsStoreSecret {
    */
   get(): Promise<string>;
 }
-export type ConversionResponse = {
+export type MarkdownDocument = {
   name: string;
-  mimeType: string;
-} & (
+  blob: Blob;
+};
+export type ConversionResponse =
   | {
+      name: string;
+      mimeType: string;
       format: "markdown";
       tokens: number;
       data: string;
     }
   | {
+      name: string;
+      mimeType: string;
       format: "error";
       error: string;
-    }
-);
+    };
+export type ImageConversionOptions = {
+  descriptionLanguage?: "en" | "es" | "fr" | "it" | "pt" | "de";
+};
+export type EmbeddedImageConversionOptions = ImageConversionOptions & {
+  convert?: boolean;
+  maxConvertedImages?: number;
+};
+export type ConversionOptions = {
+  html?: {
+    images?: EmbeddedImageConversionOptions & {
+      convertOGImage?: boolean;
+    };
+  };
+  docx?: {
+    images?: EmbeddedImageConversionOptions;
+  };
+  image?: ImageConversionOptions;
+  pdf?: {
+    images?: EmbeddedImageConversionOptions;
+    metadata?: boolean;
+  };
+};
+export type ConversionRequestOptions = {
+  gateway?: GatewayOptions;
+  extraHeaders?: object;
+  conversionOptions?: ConversionOptions;
+};
 export type SupportedFileFormat = {
   mimeType: string;
   extension: string;
 };
 export declare abstract class ToMarkdownService {
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    }[],
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument[],
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse[]>;
   transform(
-    files: {
-      name: string;
-      blob: Blob;
-    },
-    options?: {
-      gateway?: GatewayOptions;
-      extraHeaders?: object;
-    },
+    files: MarkdownDocument,
+    options?: ConversionRequestOptions,
   ): Promise<ConversionResponse>;
   supported(): Promise<SupportedFileFormat[]>;
 }


### PR DESCRIPTION
Adds conversion options to the ToMarkownService handle, available on the AI binding, letting customers control how they want to convert images