### PR TITLE
Refactor Compression stream impl

### DIFF
--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -304,6 +304,19 @@ kj::Promise<void> EncodedAsyncOutputStream::end() {
 }
 
 void EncodedAsyncOutputStream::abort(kj::Exception reason) {
+  KJ_SWITCH_ONEOF(inner) {
+    KJ_CASE_ONEOF(stream, kj::Own<kj::AsyncOutputStream>) {
+      stream->abortWrite(kj::mv(reason));
+    }
+    KJ_CASE_ONEOF(gz, kj::Own<kj::GzipAsyncOutputStream>) {
+      gz->abortWrite(kj::mv(reason));
+    }
+    KJ_CASE_ONEOF(br, kj::Own<kj::BrotliAsyncOutputStream>) {
+      br->abortWrite(kj::mv(reason));
+    }
+    KJ_CASE_ONEOF(e, Ended) {}
+  }
+
   inner.init<Ended>();
 }
 


### PR DESCRIPTION
Have CompressionStream/DecompressionStrem impl extend from kj::AsyncInputStream and capnp::ExplicitEndOutputStream directly instead of ReadableStreamSource and WritableStreamSink to set up for the adapter changes.