### PR TITLE
Create and hold UserRequestSpan inside IoContext::IncomingRequest.

### DIFF
--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -174,6 +174,8 @@ class IoContext_IncomingRequest final {
     return workerTracer;
   }
 
+  SpanParent getCurrentUserTraceSpan();
+
   // The invocation span context is a unique identifier for a specific
   // worker invocation.
   tracing::InvocationSpanContext& getInvocationSpanContext();
@@ -183,6 +185,8 @@ class IoContext_IncomingRequest final {
   kj::Own<RequestObserver> metrics;
   kj::Maybe<kj::Own<BaseTracer>> workerTracer;
   kj::Own<IoChannelFactory> ioChannelFactory;
+
+  SpanParent currentUserTraceSpan = nullptr;
 
   // The invocation span context identifies the trace id, invocation id, and root
   // span for the current request. Every invocation of a worker function always

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -135,11 +135,13 @@ class BaseTracer: public kj::Refcounted {
   // be available afterwards.
   virtual void recordTimestamp(kj::Date timestamp) = 0;
 
-  SpanParent getUserRequestSpan();
+  SpanParent makeUserRequestSpan();
+
+  using MakeUserRequestSpanFunc = kj::Function<SpanParent()>;
 
   // Allow setting the user request span after the tracer has been created so its observer can
   // reference the tracer. This can only be set once.
-  void setUserRequestSpan(SpanParent&& span);
+  void setMakeUserRequestSpanFunc(MakeUserRequestSpanFunc func);
 
   virtual void setJsRpcInfo(const tracing::InvocationSpanContext& context,
       kj::Date timestamp,
@@ -154,8 +156,8 @@ class BaseTracer: public kj::Refcounted {
   // helper method for addSpan() implementations
   void adjustSpanTime(tracing::CompleteSpan& span);
 
-  // The root span for the new tracing format.
-  SpanParent userRequestSpan = SpanParent(nullptr);
+  // Function to create the root span for the new tracing format.
+  kj::Maybe<MakeUserRequestSpanFunc> makeUserRequestSpanFunc;
 
   // Time to be reported for the outcome event time. This will be set before the outcome is
   // dispatched.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2205,9 +2205,10 @@ class Server::WorkerService final: public Service,
     }
 
     KJ_IF_SOME(w, workerTracer) {
-      auto tracerSpanObserver =
-          kj::refcounted<WorkerTracerSpanObserver>(kj::refcounted<SpanSubmitter>(kj::addRef(*w)));
-      w->setUserRequestSpan({kj::mv(tracerSpanObserver)});
+      w->setMakeUserRequestSpanFunc([&w = *w]() {
+        return SpanParent(
+            kj::refcounted<WorkerTracerSpanObserver>(kj::refcounted<SpanSubmitter>(kj::addRef(w))));
+      });
     }
     kj::Own<RequestObserver> observer =
         kj::refcounted<RequestObserverWithTracer>(mapAddRef(workerTracer), waitUntilTasks);


### PR DESCRIPTION
Otherwise, the UserRequestSpan ends up holding a cyclic reference back to the WorkerTracer, which in some cases might not get cleared, leading to a leak.

This also has the benefit that if, for some reason, the event never ends up being delivered, we don't create a span.

Since the construction of this object differs between workerd and the internal codebase, I had to attach a kj::Function to the WorkerTracer to actually construct the object.