### PR TITLE
Implements py test for fastapi with dedicated snapshot

### DIFF
--- a/build/deps/dep_pyodide.bzl
+++ b/build/deps/dep_pyodide.bzl
@@ -44,7 +44,7 @@ filegroup(
 
 SNAPSHOT_R2 = "https://pyodide-capnp-bin.edgeworker.net/"
 
-def _snapshot_http_file(bundle_name, folder, snapshot, integrity, hash):
+def _snapshot_http_file(bundle_name, folder, snapshot, integrity, hash, r2_base = SNAPSHOT_R2):
     if not snapshot:
         return
     if not integrity:
@@ -56,7 +56,7 @@ def _snapshot_http_file(bundle_name, folder, snapshot, integrity, hash):
     http_file(
         name = "pyodide-snapshot-" + snapshot,
         integrity = integrity,
-        url = SNAPSHOT_R2 + folder + key,
+        url = r2_base + folder + key,
     )
 
 def _snapshot_http_files(
@@ -68,10 +68,13 @@ def _snapshot_http_files(
         numpy_snapshot_integrity = None,
         fastapi_snapshot = None,
         fastapi_snapshot_integrity = None,
+        dedicated_fastapi_snapshot = None,
+        dedicated_fastapi_snapshot_integrity = None,
         **_kwds):
     _snapshot_http_file(name, "baseline-snapshot/", baseline_snapshot, baseline_snapshot_integrity, baseline_snapshot_hash)
     _snapshot_http_file(name, "test-snapshot/", numpy_snapshot, numpy_snapshot_integrity, None)
     _snapshot_http_file(name, "test-snapshot/", fastapi_snapshot, fastapi_snapshot_integrity, None)
+    _snapshot_http_file(name, "", dedicated_fastapi_snapshot, dedicated_fastapi_snapshot_integrity, None, VENDOR_R2)
 
 def dep_pyodide():
     for info in PYODIDE_VERSIONS:

--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -164,6 +164,8 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
         "numpy_snapshot_hash": "60c9cb28e6dc1ea6ab38b25471ddaa315b667637c9dd6f94aceb2acc6519c623",
         "fastapi_snapshot": "package_snapshot_fastapi-a6ccb56fe.bin",
         "fastapi_snapshot_hash": "a6ccb56fe9eac265d139727d0134e8d6432c5fe25c8c0b8ec95252b13493b297",
+        "dedicated_fastapi_snapshot": "snapshot_a6b652a95810783f5078b9a5dbd4a07c30718acb4ff724e82c25db7353dd7f2d.bin",
+        "dedicated_fastapi_snapshot_hash": "4af6f012a5fb32f31a426e6f109e88ae85b18ee3dd131e1caaaad989cd962bbe",
         "vendored_packages_for_tests": [
             {
                 # Downloaded from https://pub-25a5b2f2f1b84655b185a505c7a3ad23.r2.dev/beautifulsoup4-vendored-for-ew-testing.zip

--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -76,11 +76,13 @@ def _snapshot_files(
         baseline_snapshot = None,
         numpy_snapshot = None,
         fastapi_snapshot = None,
+        dedicated_fastapi_snapshot = None,
         **_kwds):
     result = []
     result += _snapshot_file(baseline_snapshot)
     result += _snapshot_file(numpy_snapshot)
     result += _snapshot_file(fastapi_snapshot)
+    result += _snapshot_file(dedicated_fastapi_snapshot)
     return result
 
 def python_test_setup():

--- a/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
@@ -20,3 +20,15 @@ vendored_py_wd_test(
     python_flags = ["0.28.2"],
     use_snapshot = "baseline",
 )
+
+# Note: the `existing_dedicated` tests verify that a dedicated snapshot which has been deployed to
+# production continues to work. Because of this the snapshot should never be changed and should
+# remain the same to ensure Workers in production continue to work.
+vendored_py_wd_test(
+    "existing_dedicated_fastapi",
+    feature_flags = ["python_dedicated_snapshot"],
+    make_snapshot = False,
+    python_flags = ["0.28.2"],
+    use_snapshot = "dedicated_fastapi",
+    vendored_package_name = "fastapi",
+)

--- a/src/workerd/server/tests/python/vendor_pkg_tests/existing_dedicated_fastapi.py
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/existing_dedicated_fastapi.py
@@ -1,0 +1,26 @@
+import fastapi
+from fastapi import FastAPI
+from workers import WorkerEntrypoint
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root():
+    message = "This is an example of FastAPI"
+    return {"message": message}
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        import asgi
+
+        return await asgi.fetch(app, request.js_object, self.env)
+
+    async def test(self, a, b, c):
+        assert fastapi.__version__
+        # The dedicated snapshot we are testing contains source code which is different to
+        # below. It will pass the test instead. So we fail this script to show that the snapshot
+        # wasn't loaded correctly.
+        print("FastAPI dedicated snapshot wasn't loaded")
+        raise AssertionError("FastAPI dedicated snapshot wasn't loaded")

--- a/src/workerd/server/tests/python/vendor_pkg_tests/existing_dedicated_fastapi_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/existing_dedicated_fastapi_vendor.wd-test
@@ -1,0 +1,17 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "existing-dedicated-fastapi-vendor-test",
+      worker = (
+        modules = [
+          # The snapshot's main module is also named worker.py. This needs to match.
+          (name = "worker.py", pythonModule = embed "existing_dedicated_fastapi.py"),
+          %PYTHON_VENDORED_MODULES%
+        ],
+        compatibilityDate = "2025-11-01",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/vendor_pkg_tests/vendor_test.bzl
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/vendor_test.bzl
@@ -81,6 +81,7 @@ def vendored_py_wd_test(
         vendored_srcs_target_prefix = None,
         python_flags = "all",
         skip_python_flags = [],
+        vendored_package_name = None,
         **kwds):
     python_flags = compute_python_flags(python_flags, skip_python_flags)
     bzl_name = "%s_vendor_test" % name
@@ -88,11 +89,13 @@ def vendored_py_wd_test(
         test_template = "%s_vendor.wd-test" % name
     if main_py_file == None:
         main_py_file = "%s.py" % name
+    if vendored_package_name == None:
+        vendored_package_name = name
     if vendored_srcs_target_prefix == None:
-        vendored_srcs_target_prefix = "@%s_src" % name
+        vendored_srcs_target_prefix = "@%s_src" % vendored_package_name
 
     for flag in python_flags:
         info = BUNDLE_VERSION_INFO[flag]
-        if name not in info["vendored_packages_for_tests"]:
-            fail("Not found", name, "in", info["vendored_packages_for_tests"])
+        if vendored_package_name not in info["vendored_packages_for_tests"]:
+            fail("Not found", vendored_package_name, "in", info["vendored_packages_for_tests"])
         _vendored_py_wd_test(bzl_name, info["name"], test_template, main_py_file, vendored_srcs_target_prefix, **kwds)


### PR DESCRIPTION
Just to ensure we have coverage for a snapshot that has made its way to production. This uses a snapshot I downloaded from a WorkerBundle in prod.

### Test Plan

```
bazel run @workerd//src/workerd/server/tests/python/vendor_pkg_tests:existing_dedicated_fastapi_vendor_test_0.28.2@
```
