### PR TITLE
Fixes websockets in Python Workers and adds test.

### DIFF
--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -40,6 +40,13 @@ py_wd_test("filter-non-py-files")
 
 py_wd_test("durable-object")
 
+py_wd_test(
+    "durable-object-websocket",
+    make_snapshot = False,
+    # TODO: enabling this will reproduce a strange issue, see comment in EW-9767.
+    use_snapshot = None,
+)
+
 py_wd_test("worker-entrypoint")
 
 py_wd_test(

--- a/src/workerd/server/tests/python/durable-object-websocket/durable-object-websocket.wd-test
+++ b/src/workerd/server/tests/python/durable-object-websocket/durable-object-websocket.wd-test
@@ -1,0 +1,46 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "tester", worker = .testerWorker),
+    (name = "TEST_TMPDIR", disk = (writable = true)),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  compatibilityDate = "2025-11-10",
+
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py"),
+  ],
+
+  durableObjectNamespaces = [
+    ( className = "DurableObjectWebSocket",
+      uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e",
+      enableSql = true ),
+  ],
+
+  durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+
+  bindings = [
+    (name = "ns", durableObjectNamespace = "DurableObjectWebSocket"),
+  ],
+);
+
+
+const testerWorker :Workerd.Worker = (
+  compatibilityDate = "2025-11-10",
+
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+
+  modules = [
+    (name = "tester.js", esModule = embed "tester.js"),
+  ],
+
+  bindings = [
+    ( name = "PYTHON", service = "main" ),
+  ],
+);

--- a/src/workerd/server/tests/python/durable-object-websocket/tester.js
+++ b/src/workerd/server/tests/python/durable-object-websocket/tester.js
@@ -1,0 +1,22 @@
+export default {
+  async test(ctrl, env, ctx) {
+    const resp = await env.PYTHON.fetch('http://example.com/websocket', {
+      headers: { Upgrade: 'websocket' },
+    });
+    const ws = resp.webSocket;
+    if (!ws) {
+      throw new Error('No websocket');
+    }
+    ws.accept();
+    const messagePromise = new Promise((resolve) => {
+      ws.addEventListener('message', (msg) => {
+        console.log('Received in JS Tester: ', msg.data);
+        resolve(msg.data);
+      });
+    });
+    ws.send('test');
+
+    await messagePromise;
+    ws.close();
+  },
+};

--- a/src/workerd/server/tests/python/durable-object-websocket/worker.py
+++ b/src/workerd/server/tests/python/durable-object-websocket/worker.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+from js import WebSocketPair
+from workers import DurableObject, Request, Response, WorkerEntrypoint
+
+
+class DurableObjectWebSocket(DurableObject):
+    def __init__(self, state, env):
+        super().__init__(state, env)
+
+    async def fetch(self, request):
+        assert isinstance(request, Request)
+        web_socket_pair = WebSocketPair.new()
+        client, server = web_socket_pair
+        self.ctx.acceptWebSocket(server)
+        return Response(None, status=101, web_socket=client)
+
+    async def webSocketMessage(self, ws, message):
+        print("Received in Python DO WS message: ", message)
+        ws.send("hello")
+
+    async def webSocketClose(self, ws, code, reason, wasClean):
+        print("Closed in Python DO WS")
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        if request.method == "GET" and request.url.endswith("/websocket"):
+            upgrade_header = request.headers.get("Upgrade")
+            if upgrade_header != "websocket":
+                return Response(
+                    None,
+                    status=426,
+                    status_text="Expected Upgrade",
+                    headers={"Content-Type": "text/plain"},
+                )
+
+            # We are explicitly testing usage via `self.env` here rather than the
+            # argument to `fetch` and using `getByName` rather than `get`.
+            stub = self.env.ns.getByName("A")
+            return await stub.fetch(request)
+        return Response("Not found", status=404)

--- a/src/workerd/server/tests/python/sdk/worker.py
+++ b/src/workerd/server/tests/python/sdk/worker.py
@@ -502,10 +502,10 @@ async def response_unit_tests(env):
         assert str(err) == "Unsupported type in Response: Test"
 
     response_ws = Response(
-        "test", status=201, web_socket=js.WebSocket.new("ws://example.com/ignore")
+        None, status=101, web_socket=js.WebSocket.new("ws://example.com/ignore")
     )
     # TODO: it doesn't seem possible to access webSocket even in JS
-    assert response_ws.status == 201
+    assert response_ws.status == 101
 
 
 async def can_fetch_python_request():


### PR DESCRIPTION
Turns out there were a few different issues which this fixes:

* `getByName` wasn't wrapped properly in our SDK wrappers (also included `jurisdiction` which is also missing)
* the `Response`'s `web_socket` argument wasn't being passed correctly to the JS API

Also added a nicer error message when python_to_rpc is used on an awaitable.

The new durable-object-web-sockets python test creates a DO that accepts WebSocket connections. It also uses a JS worker to connect to that DO. Loosely based on https://developers.cloudflare.com/durable-objects/best-practices/websockets/.

### Test Plan

```
bazel run @workerd//src/workerd/server/tests/python:durable-object-websocket_0.28.2@
```