### PR TITLE
[o11y] Additional hardening against missing outcome event, STW optimizations

### DIFF
--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -113,7 +113,8 @@ class WorkerTracer final: public BaseTracer {
   explicit WorkerTracer(kj::Maybe<kj::Rc<kj::Refcounted>> parentPipeline,
       kj::Own<Trace> trace,
       PipelineLogLevel pipelineLogLevel,
-      kj::Maybe<kj::Own<tracing::TailStreamWriter>> maybeTailStreamWriter);
+      kj::Maybe<kj::Own<tracing::TailStreamWriter>> maybeTailStreamWriter,
+      bool hasBufferedTailWorkers);
   virtual ~WorkerTracer() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(WorkerTracer);
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2148,8 +2148,8 @@ class Server::WorkerService final: public Service,
           kj::none /* scriptVersion */, kj::none /* dispatchNamespace */, kj::none /* scriptId */,
           nullptr /* scriptTags */, mapCopyString(entrypointName), executionModel,
           kj::none /* durableObjectId */);
-      kj::Own<WorkerTracer> tracer = kj::refcounted<WorkerTracer>(
-          kj::none, kj::mv(trace), PipelineLogLevel::FULL, kj::mv(tailStreamWriter));
+      kj::Own<WorkerTracer> tracer = kj::refcounted<WorkerTracer>(kj::none, kj::mv(trace),
+          PipelineLogLevel::FULL, kj::mv(tailStreamWriter), !bufferedTailWorkers.empty());
 
       // When the tracer is complete, deliver traces to any buffered tail workers. We end up
       // creating two references to the WorkerTracer, one held by the observer and one that will be


### PR DESCRIPTION
- Introduce a new WorkerTracer parameter indicating whether any BTWs are
  present. In a follow-up, this will be used to optimize memory management,
  but for now it helps us assert that if we have a tracer with logLevel none,
  we have BTWs (otherwise the tracer would be redundant, indicating waste).
- Log an error if a WorkerTracer is destructed without getting the Outcome event
  even when logLevel == none