### PR TITLE
[o11y] Make STW unused tracer warning log periodically for now

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1083,8 +1083,6 @@ SpanParent IoContext::getCurrentTraceSpan() {
 }
 
 SpanParent IoContext::getCurrentUserTraceSpan() {
-  // TODO(o11y): Add support for retrieving span from storage scope lock for more accurate span
-  // context, as with Jaeger spans.
   if (incomingRequests.empty()) {
     return SpanParent(nullptr);
   } else {

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -150,8 +150,9 @@ WorkerTracer::~WorkerTracer() noexcept(false) {
       // reported" error) or we created a WorkerInterface with WorkerTracer without ever invoking it
       // (which is not incorrect behavior, but likely indicates inefficient code that sets up
       // WorkerInterfaces and then ends up not using it due to an error/incorrect parameters; such
-      // error checking should be done beforehand to ). Log such cases.
-      KJ_LOG(WARNING, "NOSENTRY destructed WorkerTracer with STW without reporting Onset event");
+      // error checking should be done beforehand to avoid unused allocations). Report such cases.
+      LOG_ERROR_PERIODICALLY(
+          "destructed WorkerTracer with STW without reporting Onset event", kj::getStackTrace());
     }
   }
 };


### PR DESCRIPTION
I'm also convinced it should be considered an error, since it sets up new worker interfaces for nothing (considerable overhead when done over RPC). Also clean up a TODO that is no longer planned.