### PR TITLE
Improve error message in Response ctor when webSocket not specified.

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1114,6 +1114,9 @@ jsg::Ref<Response> Response::constructor(jsg::Lock& js,
   }
 
   if (webSocket == kj::none) {
+    if (statusCode == 101) {
+      JSG_FAIL_REQUIRE(RangeError, "Responses with status code 101 must specify a webSocket.");
+    }
     JSG_REQUIRE(statusCode >= 200 && statusCode <= 599, RangeError,
         "Responses may only be constructed with status codes in the range 200 to 599, inclusive.");
   } else {


### PR DESCRIPTION
Something I ran into and found confusing. If you attempt to construct a Response with status code 101 and fail to pass in a web socket to the constructor you'll be met with a "Responses may only be constructed with status codes in the range 200 to 599, inclusive". Which implies that constructing a Response with a status code of 101 is not allowed.

Looks like others found it confusing too:

https://community.cloudflare.com/t/cant-return-status-101-for-websocket/428883

This simple change should make this a little bit more user friendly.