### PR TITLE
Make IoContext tmpDirStoreScope lazy-initialized

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -149,7 +149,6 @@ IoContext::IoContext(ThreadContext& thread,
     kj::Maybe<Worker::Actor&> actorParam,
     kj::Own<LimitEnforcer> limitEnforcerParam)
     : thread(thread),
-      tmpDirStoreScope(TmpDirStoreScope::create()),
       worker(kj::mv(workerParam)),
       actor(actorParam),
       limitEnforcer(kj::mv(limitEnforcerParam)),

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -729,7 +729,10 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   kj::Date now();
 
   TmpDirStoreScope& getTmpDirStoreScope() {
-    return *tmpDirStoreScope;
+    KJ_IF_SOME(scope, tmpDirStoreScope) {
+      return *scope;
+    }
+    return *tmpDirStoreScope.emplace(TmpDirStoreScope::create());
   }
 
   // Returns a promise that resolves once `now() >= when`.
@@ -975,7 +978,7 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
 
   kj::Own<WeakRef> selfRef = kj::refcounted<WeakRef>(kj::Badge<IoContext>(), *this);
 
-  kj::Own<TmpDirStoreScope> tmpDirStoreScope;
+  kj::Maybe<kj::Own<TmpDirStoreScope>> tmpDirStoreScope;
 
   kj::Own<const Worker> worker;
   kj::Maybe<Worker::Actor&> actor;


### PR DESCRIPTION
Most workers won't use it. Create it lazily when needed.