### PR TITLE
benchmarks: add support for capnp benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,7 +26,7 @@ jobs:
     name: Run benchmarks
     runs-on: ubuntu-22.04
     env:
-      BAZEL_ARGS: --config=benchmark --@workerd-google-benchmark//:codspeed_mode=instrumentation --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev
+      BAZEL_ARGS: --config=benchmark --@google_benchmark//:codspeed_mode=instrumentation --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,13 +44,13 @@ jobs:
 
       - name: Build benchmarks
         run: |
-          bazel build ${{ env.BAZEL_ARGS }} --build_tag_filters=benchmark-binary //...
+          bazel build ${{ env.BAZEL_ARGS }} --build_tag_filters=google_benchmark //... @capnp-cpp//...
 
       - name: Generate benchmark script
         run: |
           echo '#!/bin/bash' > run_benchmarks.sh
           echo 'set -ex' >> run_benchmarks.sh
-          targets=$(bazel query 'attr(tags, "benchmark-binary", //...)' --output=label 2>/dev/null)
+          targets=$(bazel query 'attr(tags, "[\[ ]google_benchmark[,\]]", //... + @capnp-cpp//...)' --output=label 2>/dev/null)
           for target in $targets; do
             echo "echo 'Running benchmark: $target'" >> run_benchmarks.sh
             echo "bazel run ${{ env.BAZEL_ARGS }} $target -- --benchmark_min_time=1s" >> run_benchmarks.sh

--- a/build/deps/gen/dep_capnp_cpp.bzl
+++ b/build/deps/gen/dep_capnp_cpp.bzl
@@ -2,11 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/capnproto/capnproto/tarball/e2881d1d8179c097558718dda4ca9139ea0e1d28"
-STRIP_PREFIX = "capnproto-capnproto-e2881d1/c++"
-SHA256 = "1f8f5617f0752d6d29e438b3e1e483e0f76307c21a972fd404f7deb870c86891"
+URL = "https://github.com/capnproto/capnproto/tarball/c6e0a03f7398d985fedcfa40c95d1d9ecb36a92d"
+STRIP_PREFIX = "capnproto-capnproto-c6e0a03/c++"
+SHA256 = "f8ac6c426e63a3be7596b7d5adeb5edcb35dcc198a74af7f6c70d5e7dd7c76e6"
 TYPE = "tgz"
-COMMIT = "e2881d1d8179c097558718dda4ca9139ea0e1d28"
+COMMIT = "c6e0a03f7398d985fedcfa40c95d1d9ecb36a92d"
 
 def dep_capnp_cpp():
     http_archive(

--- a/build/deps/v8.MODULE.bazel
+++ b/build/deps/v8.MODULE.bazel
@@ -105,12 +105,8 @@ local_path_override(
     path = "build/workerd-v8",
 )
 
-# Tell workerd code where to find google-benchmark with CodSpeed.
-#
-# We indirect through `@workerd-google-benchmark` to allow dependents to override how and where
-# google-benchmark is built, similar to the v8 setup above.
-bazel_dep(name = "workerd-google-benchmark")
+bazel_dep(name = "google_benchmark")
 local_path_override(
-    module_name = "workerd-google-benchmark",
+    module_name = "google_benchmark",
     path = "build/google-benchmark",
 )

--- a/build/google-benchmark/MODULE.bazel
+++ b/build/google-benchmark/MODULE.bazel
@@ -1,4 +1,4 @@
-module(name = "workerd-google-benchmark")
+module(name = "google_benchmark")
 
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -26,12 +26,12 @@ def wd_cc_benchmark(
         }),
         visibility = visibility,
         deps = deps + [
-            "@workerd-google-benchmark//:benchmark_main",
+            "@google_benchmark//:benchmark_main",
             "//src/workerd/tests:bench-tools",
         ],
         # use the same malloc we use for server
         malloc = "//src/workerd/server:malloc",
-        tags = ["workerd-benchmark", "benchmark-binary"],
+        tags = ["workerd-benchmark", "google_benchmark"],
         size = "large",
         **kwargs
     )

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -143,7 +143,7 @@
 -Iexternal/+_repo_rules2+simdutf/
 -Iexternal/+_repo_rules+nbytes/include/
 -Iexternal/+_repo_rules+ncrypto/include
--Iexternal/workerd-google-benchmark++_repo_rules+codspeed/google_benchmark/include/
+-Iexternal/google_benchmark++_repo_rules+codspeed/google_benchmark/include/
 -Iexternal/perfetto+/include/
 -Iexternal/perfetto+/include/perfetto/base/build_configs/bazel/
 -Ibazel-bin/external/perfetto+/

--- a/justfile
+++ b/justfile
@@ -126,7 +126,7 @@ create-external:
   tools/unix/create-external.sh
 
 bench-all:
-  bazel query 'attr(tags, "benchmark-binary", //...)' --output=label | xargs -I {} bazel run --config=benchmark {}
+  bazel query 'attr(tags, "[\[ ]google_benchmark[,\]]", //... + @capnp-cpp//...)' --output=label | xargs -I {} bazel run --config=benchmark {}
 
 eslint:
   just stream-test \

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -10,7 +10,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj:kj-test",
-        "@workerd-google-benchmark//:benchmark",
+        "@google_benchmark//:benchmark",
     ],
 )
 


### PR DESCRIPTION
Also rename workerd-google_benchmark - there is no reason to have a different name any project can decide to use a different dependency for that instead the same way we do. Besides we don't prefix other deps with workerd-.

Downstrea of https://github.com/capnproto/capnproto/pull/2449