### PR TITLE
Adds support for bytes passed to Python's Response constructor

### DIFF
--- a/src/workerd/server/tests/python/sdk/worker.py
+++ b/src/workerd/server/tests/python/sdk/worker.py
@@ -476,6 +476,10 @@ async def response_unit_tests(env):
     assert response_none.status == 204
     assert response_none.body is None
 
+    response_bytes = Response(b"test")
+    assert response_bytes.status == 200
+    assert await response_bytes.text() == "test"
+
     class Test:
         def __init__(self, x):
             self.x = x


### PR DESCRIPTION
Discovered here https://github.com/cloudflare/python-workers-examples/pull/49

Enables users to pass in `bytes` in a Python Workers Response 

### Test Plan

```
$ bazel run @workerd//src/workerd/server/tests/python:sdk_0.28.2@
```