### PR TITLE
Implements simple Python Workers benchmark

### DIFF
--- a/samples/python-benchmark/README.md
+++ b/samples/python-benchmark/README.md
@@ -1,0 +1,9 @@
+To run:
+
+```bash
+$ bazel run --config=release @workerd//src/workerd/server:workerd -- serve $PWD/deps/workerd/samples/python-benchmark/config.capnp
+
+$ wrk -t4 -c64 -d30s --latency -s bench.lua http://127.0.0.1:8080
+
+$ curl -v -X POST http://127.0.0.1:8080
+```

--- a/samples/python-benchmark/bench.lua
+++ b/samples/python-benchmark/bench.lua
@@ -1,0 +1,3 @@
+wrk.method = "POST"
+wrk.body   = '{"iters": 500}'
+wrk.headers["Content-Type"] = "application/json"

--- a/samples/python-benchmark/config.capnp
+++ b/samples/python-benchmark/config.capnp
@@ -1,0 +1,24 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+  ],
+
+  sockets = [
+    # Serve HTTP on port 8080.
+    ( name = "http",
+      address = "*:8080",
+      http = (),
+      service = "main"
+    ),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker.py", pythonModule = embed "./worker.py"),
+  ],
+  compatibilityDate = "2025-11-15",
+  compatibilityFlags = ["python_workers"],
+);

--- a/samples/python-benchmark/worker.py
+++ b/samples/python-benchmark/worker.py
@@ -1,0 +1,47 @@
+import json
+
+from js import Response
+from workers import WorkerEntrypoint
+
+DEFAULT_ITERATIONS = 500
+
+
+def json_loop(n: int) -> int:
+    count = 0
+    for i in range(n):
+        obj = {
+            "id": i,
+            "name": "item-" + str(i),
+            "values": [i, i * 2, i * 3],
+            "nested": {"flag": (i % 2 == 0), "index": i},
+        }
+        s = json.dumps(obj)
+        parsed = json.loads(s)
+        count += parsed["id"]
+    return count
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        iters = DEFAULT_ITERATIONS
+
+        try:
+            body_text = await request.text()
+            if body_text:
+                data = json.loads(body_text)
+                iters = int(data.get("iters", iters))
+        except Exception:
+            iters = DEFAULT_ITERATIONS
+
+        result = json_loop(iters)
+
+        return Response.new(
+            json.dumps({"result": result, "iters": iters}),
+            {"content-type": "application/json"},
+        )
+
+
+def test():
+    iters = DEFAULT_ITERATIONS
+    result = json_loop(iters)
+    print(f"Ran json_loop({iters}) -> {result}")


### PR DESCRIPTION
Just a simple Python Worker benchmark that we can run to test out different optimisations. Uses `wrk` for the benchmarking, all is documented in the included README.