### PR TITLE
[ci] Further attempt to fix macOS CI by reducing Bazel parallelism

### DIFF
--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -9,9 +9,9 @@ build:ci --verbose_failures
 # increasing this closer towards the suggested value of 200. Note the number of maximum build jobs
 # is controlled by the --local_resources=cpu flag and still limited to the number of cores by
 # default.
-# TODO (build perf): Temporarily setting this to 16, that might help with CI freezing on macOS
+# TODO (build perf): Temporarily setting this to 8, that might help with CI freezing on macOS
 # release jobs?
-build:ci --jobs=16
+build:ci --jobs=8
 # Do not check for changes in external repository files, should speed up bazel invocations after the first one
 build:ci --noexperimental_check_external_repository_files
 # Only build runfile trees when needed. Runfile trees are useful for directly invoking bazel-built


### PR DESCRIPTION
CI runners have at most 4 vCPUs so we won't be building any slower, this will only reduce parallelism when fetching from/uploading to remote cache.