### PR TITLE
Set a default date for punycode, trace_events, cluster, wasi, and dom…

### DIFF
--- a/src/workerd/api/node/tests/cluster-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/cluster-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "cluster-nodejs-test.js")
         ],
         compatibilityDate = "2025-09-03",
-        compatibilityFlags = ["nodejs_compat", "enable_nodejs_cluster_module", "experimental"],
+        compatibilityFlags = ["nodejs_compat", "enable_nodejs_cluster_module"],
       )
     ),
   ],

--- a/src/workerd/api/node/tests/domain-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/domain-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "domain-nodejs-test.js")
         ],
         compatibilityDate = "2025-09-01",
-        compatibilityFlags = ["nodejs_compat", "enable_nodejs_domain_module", "experimental"]
+        compatibilityFlags = ["nodejs_compat", "enable_nodejs_domain_module"]
       )
     ),
   ],

--- a/src/workerd/api/node/tests/punycode-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/punycode-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "punycode-nodejs-test.js")
         ],
         compatibilityDate = "2024-10-11",
-        compatibilityFlags = ["nodejs_compat", "enable_nodejs_punycode_module", "experimental"],
+        compatibilityFlags = ["nodejs_compat", "enable_nodejs_punycode_module"],
       )
     ),
   ],

--- a/src/workerd/api/node/tests/trace-events-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/trace-events-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "trace-events-nodejs-test.js")
         ],
         compatibilityDate = "2025-09-01",
-        compatibilityFlags = ["nodejs_compat", "enable_nodejs_trace_events_module", "experimental"]
+        compatibilityFlags = ["nodejs_compat", "enable_nodejs_trace_events_module"]
       )
     ),
   ],

--- a/src/workerd/api/node/tests/wasi-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/wasi-nodejs-test.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker", esModule = embed "wasi-nodejs-test.js")
         ],
         compatibilityDate = "2025-09-01",
-        compatibilityFlags = ["nodejs_compat", "enable_nodejs_wasi_module", "experimental"]
+        compatibilityFlags = ["nodejs_compat", "enable_nodejs_wasi_module"]
       )
     ),
   ],

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1080,8 +1080,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   enableNodeJsDomainModule @124 :Bool
     $compatEnableFlag("enable_nodejs_domain_module")
     $compatDisableFlag("disable_nodejs_domain_module")
-    $experimental;
-    # $impliedByAfterDate(name = "nodeJsCompat", date = "2025-10-15");
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2025-12-04");
   # Enables the Node.js non-functional stub domain module. It is required to use this flag with
   # nodejs_compat (or nodejs_compat_v2).
 
@@ -1104,14 +1103,14 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   enableNodeJsPunycodeModule @127 :Bool
     $compatEnableFlag("enable_nodejs_punycode_module")
     $compatDisableFlag("disable_nodejs_punycode_module")
-    $experimental;
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2025-12-04");
   # Enables the Node.js deprecated punycode module. It is required to use this flag with
   # nodejs_compat (or nodejs_compat_v2).
 
   enableNodeJsClusterModule @128 :Bool
     $compatEnableFlag("enable_nodejs_cluster_module")
     $compatDisableFlag("disable_nodejs_cluster_module")
-    $experimental;
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2025-12-04");
   # Enables the Node.js non-functional stub cluster module. It is required to use this flag with
   # nodejs_compat (or nodejs_compat_v2).
 
@@ -1139,7 +1138,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   enableNodeJsWasiModule @132 :Bool
     $compatEnableFlag("enable_nodejs_wasi_module")
     $compatDisableFlag("disable_nodejs_wasi_module")
-    $experimental;
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2025-12-04");
   # Enables the Node.js non-functional stub wasi module. It is required to use this
   # flag with nodejs_compat (or nodejs_compat_v2).
 
@@ -1160,7 +1159,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   enableNodeJsTraceEventsModule @135 :Bool
     $compatEnableFlag("enable_nodejs_trace_events_module")
     $compatDisableFlag("disable_nodejs_trace_events_module")
-    $experimental;
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2025-12-04");
   # Enables the Node.js non-functional stub trace_events module. It is required to use this
   # flag with nodejs_compat (or nodejs_compat_v2).
 


### PR DESCRIPTION
…ains node modules

@anonrig @danlapid @jasnell Those are the modules that are already handled in unenv.

/cc @petebacondarwin 

I picked now + 2w as the default date to give some headroom for reviewing and merging.

ref: https://github.com/cloudflare/workers-sdk/issues/10594