### PR TITLE
Fix tcmalloc crashes on ARM64 Linux

### DIFF
--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -12,6 +12,18 @@ config_setting(
     constraint_values = ["@platforms//os:linux"],
 )
 
+# tcmalloc assumes a 48-bit virtual address space, which may not be available on
+# some ARM64 systems (e.g., devices with 39-bit or 42-bit VA). This causes crashes
+# with "MmapAligned() failed" errors. Only enable tcmalloc on x86_64 Linux.
+# See: https://github.com/google/tcmalloc/blob/master/docs/platforms.md
+config_setting(
+    name = "is_linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 # Flag that can be used to force-disable tcmalloc. Mainly used for ASAN builds.
 # TODO(cleanup): This feels ugly but I've exceeded my timebox for fighting Bazel for now.
 bool_flag(
@@ -28,7 +40,7 @@ selects.config_setting_group(
     name = "really_use_tcmalloc",
     match_all = [
         ":set_use_tcmalloc",
-        ":is_linux",
+        ":is_linux_x86_64",
     ],
 )
 


### PR DESCRIPTION
tcmalloc assumes a 48-bit virtual address space, causing crashes on ARM64 systems with smaller VA space (e.g., 39-bit or 42-bit).

  This PR restricts tcmalloc to x86_64 Linux only. ARM64 will use the default system allocator.

  **Tested on ARM64 Linux (Orange Pi RK3588):**
  - workerd builds and runs successfully
  - 387 tests pass
  - 29 timeouts are unrelated (due to slower ARM64 performance, tests pass when run individually)
  - Hello World example works correctly

  Fixes crashes with error: `MmapAligned() failed - unable to allocate`