### PR TITLE
Refactor CompressionStreamImpl

### DIFF
--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -304,6 +304,18 @@ kj::Promise<void> EncodedAsyncOutputStream::end() {
 }
 
 void EncodedAsyncOutputStream::abort(kj::Exception reason) {
+  KJ_SWITCH_ONEOF(inner) {
+    KJ_CASE_ONEOF(stream, kj::Own<kj::AsyncOutputStream>) {
+      stream->abortWrite(kj::mv(reason));
+    }
+    KJ_CASE_ONEOF(gz, kj::Own<kj::GzipAsyncOutputStream>) {
+      gz->abortWrite(kj::mv(reason));
+    }
+    KJ_CASE_ONEOF(br, kj::Own<kj::BrotliAsyncOutputStream>) {
+      br->abortWrite(kj::mv(reason));
+    }
+    KJ_CASE_ONEOF(e, Ended) {}
+  }
   inner.init<Ended>();
 }
 


### PR DESCRIPTION
Alternative take on the CompressionStreamImpl refactor. Turns out that the system-streams adapters don't cover this type of case correctly... but this still steps in the right direction