### PR TITLE
Consolidate fast api config into JsgConfig

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -17,6 +17,7 @@
 #include <workerd/jsg/ser.h>
 #include <workerd/jsg/url.h>
 #include <workerd/util/abortable.h>
+#include <workerd/util/autogate.h>
 #include <workerd/util/entropy.h>
 #include <workerd/util/http-util.h>
 #include <workerd/util/mimetype.h>

--- a/src/workerd/jsg/fast-api-test.c++
+++ b/src/workerd/jsg/fast-api-test.c++
@@ -170,7 +170,10 @@ struct Test {
 
 CallCounter runTest(Test test) {
   jsg::callCounter.reset();
-  jsg::test::Evaluator<FastMethodContext, FastMethodIsolate> e(v8System);
+  JsgConfig config = {
+    .fastApiEnabled = true,
+  };
+  jsg::test::Evaluator<FastMethodContext, FastMethodIsolate, JsgConfig> e(v8System, config);
 
   auto target = test.target == ""_kjc ? kj::str(test.expr) : kj::str(test.target, ".", test.expr);
   e.expectEval(target, test.expectedReturnType, test.expectedReturnValue);
@@ -234,7 +237,10 @@ KJ_TEST("Fast methods should work with getters/setters") {
 
 KJ_TEST("Fast methods properly catch JSG_FAIL_REQUIRE errors") {
   jsg::callCounter.reset();
-  jsg::test::Evaluator<FastMethodContext, FastMethodIsolate> e(v8System);
+  JsgConfig config = {
+    .fastApiEnabled = true,
+  };
+  jsg::test::Evaluator<FastMethodContext, FastMethodIsolate, JsgConfig> e(v8System, config);
 
   // Test that directly calling the method results in an error
   e.expectEval("throwError(42)", "throws", "TypeError: Test error with code 42");

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -30,12 +30,14 @@ class Evaluator {
   //   in cases that the isolate includes types that require configuration, but currently the
   //   type is always default-constructed. What if you want to specify a test config?
  public:
-  explicit Evaluator(V8System& v8System): v8System(v8System) {}
+  explicit Evaluator(V8System& v8System, ConfigurationType config = {})
+      : v8System(v8System),
+        config(config) {}
 
   IsolateType& getIsolate() {
     // Slightly more efficient to only instantiate each isolate type once (17s vs. 20s):
     static IsolateType isolate(
-        v8System, v8::IsolateGroup::GetDefault(), ConfigurationType(), kj::heap<IsolateObserver>());
+        v8System, v8::IsolateGroup::GetDefault(), config, kj::heap<IsolateObserver>());
     return isolate;
   }
 
@@ -162,6 +164,7 @@ class Evaluator {
 
  private:
   V8System& v8System;
+  ConfigurationType config;
 };
 
 struct NumberBox: public Object {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2151,6 +2151,7 @@ struct JsgConfig {
   bool noSubstituteNull = false;
   bool unwrapCustomThenables = false;
   bool fetchIterableTypeSupport = false;
+  bool fastApiEnabled = false;
 };
 
 static constexpr JsgConfig DEFAULT_JSG_CONFIG = {};

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -19,7 +19,6 @@
 #include <workerd/jsg/value.h>
 #include <workerd/jsg/web-idl.h>
 #include <workerd/jsg/wrappable.h>
-#include <workerd/util/autogate.h>
 
 #include <v8-wasm.h>
 
@@ -412,17 +411,15 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
                    public UnimplementedWrapper,
                    public JsValueWrapper<Self> {
   // TODO(soon): Should the TypeWrapper object be stored on the isolate rather than the context?
-  bool fastApiEnabled = false;
-
  public:
   template <typename MetaConfiguration>
   TypeWrapper(v8::Isolate* isolate, MetaConfiguration&& configuration)
       : TypeWrapperBase<Self, T>(configuration)...,
         MaybeWrapper<Self>(configuration),
         GeneratorWrapper<Self>(configuration),
-        PromiseWrapper<Self>(configuration) {
+        PromiseWrapper<Self>(configuration),
+        config(getConfig(configuration)) {
     isolate->SetData(SET_DATA_TYPE_WRAPPER, this);
-    fastApiEnabled = util::Autogate::isEnabled(util::AutogateKey::V8_FAST_API);
   }
   KJ_DISALLOW_COPY_AND_MOVE(TypeWrapper);
 
@@ -435,7 +432,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
   }
 
   bool isFastApiEnabled() const {
-    return fastApiEnabled;
+    return config.fastApiEnabled;
   }
 
   using TypeWrapperBase<Self, T>::getName...;
@@ -600,6 +597,9 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
   void initReflection(Holder* holder, PropertyReflection<U>&... reflections) {
     (initReflection(holder, reflections), ...);
   }
+
+ private:
+  const JsgConfig config;
 };
 
 template <typename Self, typename... Types>

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -58,6 +58,7 @@
 #include <workerd/rust/transpiler/lib.rs.h>
 #include <workerd/server/actor-id-impl.h>
 #include <workerd/server/fallback-service.h>
+#include <workerd/util/autogate.h>
 #include <workerd/util/thread-scopes.h>
 #include <workerd/util/use-perfetto-categories.h>
 
@@ -268,6 +269,7 @@ struct WorkerdApi::Impl final {
             .noSubstituteNull = features.getNoSubstituteNull(),
             .unwrapCustomThenables = features.getUnwrapCustomThenables(),
             .fetchIterableTypeSupport = features.getFetchIterableTypeSupport(),
+            .fastApiEnabled = util::Autogate::isEnabled(util::AutogateKey::V8_FAST_API),
           }) {}
     operator const CompatibilityFlags::Reader() const {
       return features;


### PR DESCRIPTION
TypeWrapper already uses a configuration mechanism to control its behavior. The fast API mechanism was using a separate mechanism that made TypeWrapper dependent directly on util::Autogate. Simplify by consolidating fast api enablement into JsgConfig.