### PR TITLE
Try to fix macOS CI: Revert "[ci] Update to macOS 26"

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -38,6 +38,12 @@ runs:
         git config --show-scope --show-origin core.symlinks
         git config --system core.longpaths true
         [System.IO.File]::WriteAllLines((Join-Path -Path $env:USERPROFILE -ChildPath '.bazelrc'), 'startup --output_user_root=\\\\?\\C:\\tmp')
+    - name: Setup macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        # Build using Xcode 16.3 (equivalent to Clang 19)
+        sudo xcode-select -s "/Applications/Xcode_16.3.app"
     - name: Configure git hooks
       shell: bash
       # Configure git to quell an irrelevant warning for runners (they never commit / push).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,17 +86,17 @@ jobs:
             bazel-config: release_linux
             target-arch: ARM64
           # Based on runner availability, we build both Apple Silicon and (cross-compiled) x86
-          # release binaries on the macos-26 runner.
+          # release binaries on the macos-15 runner.
           - title: macOS-x64
             os-name: macOS
-            # This configuration is used for cross-compiling – macos-26 is Apple Silicon-based but
+            # This configuration is used for cross-compiling – macos-15 is Apple Silicon-based but
             # we use it to compile the x64 release.
-            image: macos-26
+            image: macos-15
             bazel-config: release_macos_cross_x86_64
             target-arch: X64
           - title: macOS-arm64
             os-name: macOS
-            image: macos-26
+            image: macos-15
             bazel-config: release_macos
             target-arch: ARM64
           - title: windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           [
             { name: linux, arch: X64, image: ubuntu-22.04 },
             { name: linux-arm, arch: ARM64, image: ubuntu-22.04-arm },
-            { name: macOS, arch: ARM64, image: macos-26 },
+            { name: macOS, arch: ARM64, image: macos-15 },
             { name: windows, arch: X64, image: windows-2025 },
           ]
         config: [
@@ -60,7 +60,7 @@ jobs:
           # due to resource constraints, exclude the macOS and x64 Linux debug runners for now.
           # linux-asan and arm64 linux-debug should provide sufficient coverage for building in the
           # debug configuration.
-          - os: { name: macOS, arch: ARM64, image: macos-26 }
+          - os: { name: macOS, arch: ARM64 ,image: macos-15 }
             config: { suffix: -debug }
           - os: { name: linux, arch: X64, image: ubuntu-22.04 }
             config: { suffix: -debug }


### PR DESCRIPTION
Previous attempts to fix macOS CI did not work out – speculatively revert to macOS 15 since this started around the time we upgraded CI to macOS 26.

This reverts commit 5b0d4bdd81aec20f5d43b9f617063f865d018c54.