### PR TITLE
Implement noop versions of the undocumented Console handler callbacks

### DIFF
--- a/src/node/console.ts
+++ b/src/node/console.ts
@@ -12,6 +12,8 @@ import type {
   ConsoleConstructorOptions,
 } from 'node:console';
 
+const noop: VoidFunction = () => {};
+
 // TODO(soon): This class is Node.js compatible but globalThis.console is not.
 // This is because globalThis.console is provided by the v8 runtime.
 // We need to find a way to patch and add createTask and context methods whenever
@@ -27,13 +29,8 @@ const globalConsole = globalThis.console as typeof globalThis.console & {
 
 globalConsole._times = new Map<string, number>();
 globalConsole._ignoreErrors = true;
-globalConsole._stderrErrorHandler = function _stderrErrorHandler(): void {
-  throw new ERR_METHOD_NOT_IMPLEMENTED('Console._stderrErrorHandler');
-};
-
-globalConsole._stdoutErrorHandler = function _stdoutErrorHandler(): void {
-  throw new ERR_METHOD_NOT_IMPLEMENTED('Console._stdoutErrorHandler');
-};
+globalConsole._stderrErrorHandler = noop;
+globalConsole._stdoutErrorHandler = noop;
 
 // We have this assertion because node-internal:public_process has undefined as the type
 globalConsole._stderr = processImpl.stderr as unknown as NodeJS.WritableStream;


### PR DESCRIPTION
The current implementation throws "not implemented" errors when `_stderrErrorHandler` and `_stdoutErrorHandler` are called, which is different to Node.js and the unenv polyfill. Now they are simple noops, inline with unenv.

This change will allow us to safely remove the node:console polyfill from the Cloudflare unenv preset.

For reference:

[Node.js implementation](https://github.com/nodejs/node/blob/768f3ba32a3719070d1376341243e4cdf2383436/lib/internal/console/constructor.js#L242-L251)
[unenv implementation](https://github.com/unjs/unenv/blob/main/src/runtime/node/console.ts#L59-L61)