### PR TITLE
[o11y] Avoid cloning tail event when dispatching it to single tail worker

### DIFF
--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -582,9 +582,6 @@ struct Attribute final {
   explicit Attribute(kj::ConstString name, Values&& values);
 
   template <AttributeValue V>
-  explicit Attribute(kj::ConstString name, V v): Attribute(kj::mv(name), Value(kj::mv(v))) {}
-
-  template <AttributeValue V>
   explicit Attribute(kj::ConstString name, kj::Array<V> vals)
       : Attribute(kj::mv(name), KJ_MAP(v, vals) { return Value(kj::mv(v)); }) {}
 

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -495,8 +495,7 @@ void WorkerTracer::setJsRpcInfo(const tracing::InvocationSpanContext& context,
 
   KJ_IF_SOME(writer, maybeTailStreamWriter) {
     auto tag = tracing::Attribute("jsrpc.method"_kjc, methodName.clone());
-    kj::Array<tracing::Attribute> attrs(&tag, 1, kj::NullArrayDisposer::instance);
-    writer->report(context, kj::mv(attrs), timestamp);
+    writer->report(context, kj::arr(kj::mv(tag)), timestamp);
   }
 }
 


### PR DESCRIPTION
This could be expensive for events that are large/require several memory allocations. This required fixing how we construct the jsrpc.method attribute, the approach there was never fully working which was shadowed by the event being cloned. Also drop an unused Attribute constructor.