### PR TITLE
Add Jaeger tracing for waitForBookmark storage API

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -854,7 +854,10 @@ kj::Promise<kj::String> DurableObjectStorage::onNextSessionRestoreBookmark(kj::S
 }
 
 kj::Promise<void> DurableObjectStorage::waitForBookmark(kj::String bookmark) {
-  return cache->waitForBookmark(bookmark);
+  auto& context = IoContext::current();
+  auto span = context.makeTraceSpan("durable_object_storage_waitForBookmark"_kjc);
+
+  return cache->waitForBookmark(bookmark, span).attach(kj::mv(span));
 }
 
 void DurableObjectStorage::ensureReplicas() {

--- a/src/workerd/io/actor-cache.h
+++ b/src/workerd/io/actor-cache.h
@@ -258,7 +258,7 @@ class ActorCacheInterface: public ActorCacheOps {
         Error, "This Durable Object's storage back-end does not implement point-in-time recovery.");
   }
 
-  virtual kj::Promise<void> waitForBookmark(kj::StringPtr bookmark) {
+  virtual kj::Promise<void> waitForBookmark(kj::StringPtr bookmark, SpanParent parentSpan) {
     JSG_FAIL_REQUIRE(
         Error, "This Durable Object's storage back-end does not implement point-in-time recovery.");
   }

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -932,7 +932,7 @@ kj::Promise<kj::String> ActorSqlite::getCurrentBookmark(SpanParent parentSpan) {
       paddedHex(0), '-', pad);
 }
 
-kj::Promise<void> ActorSqlite::waitForBookmark(kj::StringPtr bookmark) {
+kj::Promise<void> ActorSqlite::waitForBookmark(kj::StringPtr bookmark, SpanParent parentSpan) {
   // This is an ersatz implementation that's good enough for local dev with D1's Session API.
   requireNotBroken();
   return kj::READY_NOW;

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -95,7 +95,7 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
   void cancelDeferredAlarmDeletion() override;
   kj::Maybe<kj::Promise<void>> onNoPendingFlush() override;
   kj::Promise<kj::String> getCurrentBookmark(SpanParent parentSpan) override;
-  kj::Promise<void> waitForBookmark(kj::StringPtr bookmark) override;
+  kj::Promise<void> waitForBookmark(kj::StringPtr bookmark, SpanParent parentSpan) override;
   // See ActorCacheInterface
 
  private:


### PR DESCRIPTION
Add tracing span creation for waitForBookmark at the DurableObjectStorage API layer. Update ActorCacheInterface and ActorSqlite to accept SpanParent parameter for trace context propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)