### PR TITLE
Only print late alarm if time discrepancy is large

### DIFF
--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -842,8 +842,15 @@ kj::OneOf<ActorSqlite::CancelAlarmHandler, ActorSqlite::RunAlarmHandler> ActorSq
         // We have a clean local alarm time that is earlier than the handler's scheduled time,
         // which suggests that either the alarm manager is working with stale data or that local
         // alarm time has somehow gotten out of sync with the scheduled alarm time.
-        LOG_WARNING_PERIODICALLY("NOSENTRY SQLite alarm handler canceled.", scheduledTime, actorId,
-            localAlarmState.orDefault(kj::UNIX_EPOCH));
+
+        // Only log if the alarm manager is significantly late (>10 seconds behind SQLite)
+        // We know localAlarmState has a value here because we're in the branch where it's earlier
+        // than scheduledTime (not equal, and not later).
+        auto localTime = KJ_ASSERT_NONNULL(localAlarmState);
+        if (scheduledTime - localTime > 10 * kj::SECONDS) {
+          LOG_WARNING_PERIODICALLY(
+              "NOSENTRY SQLite alarm handler canceled.", scheduledTime, actorId, localTime);
+        }
 
         // Tell the caller to wait for successful rescheduling before cancelling the current
         // handler invocation.


### PR DESCRIPTION
I suspect some of the remaining instances of this log may be due to the alarm manager polling at time T and learning of an alarm that will run at time T + 12 (for example), the application updating the alarm time to T + 1, the alarm manager not being updated (alarm notifier fails + alarm manager polls too infrequently), and then the alarm looking as though it ran late.