### PR TITLE
[clang-tidy] Add cppcoreguidelines-prefer-member-initializer and more checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,9 +9,13 @@ Checks: >
   -*,
   bugprone-argument-comment,
   bugprone-capturing-this-in-member-variable,
+  bugprone-dynamic-static-initializers,
   bugprone-forward-declaration-namespace,
+  bugprone-invalid-enum-default-initialization,
   bugprone-move-forwarding-reference,
   bugprone-return-const-ref-from-parameter,
+  bugprone-suspicious-*,
+  -bugprone-suspicious-semicolon,
   bugprone-undefined-memory-manipulation,
   bugprone-unhandled-self-assignment,
   bugprone-unused-raii,
@@ -19,6 +23,7 @@ Checks: >
   cppcoreguidelines-c-copy-assignment-signature,
   cppcoreguidelines-misleading-capture-default-by-value,
   cppcoreguidelines-noexcept-destructor,
+  cppcoreguidelines-prefer-member-initializer,
   google-readability-casting,
   misc-confusable-identifiers,
   misc-header-include-cycle,
@@ -36,6 +41,7 @@ Checks: >
   modernize-use-emplace,
   modernize-use-equals-delete,
   modernize-use-nullptr,
+  modernize-use-transparent-functors,
   modernize-use-using,
   performance-*,
   -performance-enum-size,
@@ -48,6 +54,7 @@ Checks: >
   readability-container-size-empty,
   readability-delete-null-pointer,
   readability-duplicate-include,
+  readability-enum-initial-value,
   readability-redundant-*,
   -readability-redundant-inline-specifier,
   -readability-redundant-smartptr-get,
@@ -58,7 +65,10 @@ Checks: >
 # TODO: Fix and enable
 # bugprone-parent-virtual-call
 # bugprone-return-const-ref-from-parameter
+# cppcoreguidelines-interfaces-global-init
 # cppcoreguidelines-missing-std-forward
+# cppcoreguidelines-pro-type-member-init
+# modernize-use-equals-default
 # modernize-use-override
 # modernize-use-ranges
 # readability-avoid-return-with-void-value

--- a/src/workerd/api/node/zlib-util.c++
+++ b/src/workerd/api/node/zlib-util.c++
@@ -39,11 +39,11 @@ class GrowableBuffer final {
   // A copy of kj::Vector with some additional methods for use as a growable buffer with a maximum
   // size
  public:
-  inline explicit GrowableBuffer(size_t _chunkSize, size_t _maxCapacity) {
-    auto maxChunkSize = kj::min(_chunkSize, _maxCapacity);
+  inline explicit GrowableBuffer(size_t _chunkSize, size_t _maxCapacity)
+      : maxCapacity(_maxCapacity) {
+    auto maxChunkSize = kj::min(_chunkSize, maxCapacity);
     builder = kj::heapArrayBuilder<kj::byte>(maxChunkSize);
     chunkSize = maxChunkSize;
-    maxCapacity = _maxCapacity;
   }
 
   size_t size() const {

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -86,8 +86,7 @@ class Socket: public jsg::Object {
         isDefaultFetchPort(isDefaultFetchPort),
         openedResolver(kj::mv(openedPrPair.resolver)),
         openedPromiseCopy(openedPrPair.promise.whenResolved(js)),
-        openedPromise(kj::mv(openedPrPair.promise)),
-        isClosing(false) {};
+        openedPromise(kj::mv(openedPrPair.promise)) {};
 
   jsg::Ref<ReadableStream> getReadable() {
     return readable.addRef();
@@ -211,7 +210,7 @@ class Socket: public jsg::Object {
   jsg::Promise<void> openedPromiseCopy;
   jsg::MemoizedIdentity<jsg::Promise<SocketInfo>> openedPromise;
   // Used to keep track of a pending `close` operation on the socket.
-  bool isClosing;
+  bool isClosing = false;
 
   kj::Promise<kj::Own<kj::AsyncIoStream>> processConnection();
   jsg::Promise<void> maybeCloseWriteSide(jsg::Lock& js);

--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -450,10 +450,9 @@ class ActorCache::GetMultiStreamImpl final: public rpc::ActorStorage::ListStream
       : cache(cache),
         cachedEntries(kj::mv(cachedEntries)),
         keysToFetch(kj::mv(keysToFetchParam)),
+        nextExpectedKey(keysToFetch.begin()),
         fulfiller(kj::mv(fulfiller)),
-        options(options) {
-    nextExpectedKey = keysToFetch.begin();
-  }
+        options(options) {}
 
   kj::Promise<void> values(ValuesContext context) override {
     if (!fulfiller->isWaiting()) {

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -43,7 +43,7 @@ namespace tracing {
 class TraceId final {
  public:
   // A null trace ID. This is only acceptable for use in tests.
-  constexpr TraceId(decltype(nullptr)): low(0), high(0) {}
+  constexpr TraceId(decltype(nullptr)) {}
 
   // A trace ID with the given low and high values.
   constexpr TraceId(uint64_t low, uint64_t high): low(low), high(high) {}

--- a/src/workerd/server/facet-tree-index.c++
+++ b/src/workerd/server/facet-tree-index.c++
@@ -8,9 +8,7 @@ namespace workerd::server {
 using kj::byte;
 using kj::uint;
 
-FacetTreeIndex::FacetTreeIndex(kj::Own<const kj::File> fileParam)
-    : file(kj::mv(fileParam)),
-      offset(0) {
+FacetTreeIndex::FacetTreeIndex(kj::Own<const kj::File> fileParam): file(kj::mv(fileParam)) {
   // Read the file to populate the initial index
 
   auto fileBytes = file->readAllBytes();

--- a/src/workerd/server/facet-tree-index.h
+++ b/src/workerd/server/facet-tree-index.h
@@ -71,7 +71,7 @@ class FacetTreeIndex {
 
   // Offset at which to write the next entry. Typically points to the end of the file (except when
   // a corrupted tail was detected).
-  uint offset;
+  uint offset = 0;
 
   struct EntryPtr;
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1700,9 +1700,7 @@ class RequestObserverWithTracer final: public RequestObserver, public WorkerInte
 
 class SpanSubmitter final: public kj::Refcounted {
  public:
-  SpanSubmitter(kj::Own<WorkerTracer> workerTracer)
-      : predictableSpanId(0),
-        workerTracer(kj::mv(workerTracer)) {}
+  SpanSubmitter(kj::Own<WorkerTracer> workerTracer): workerTracer(kj::mv(workerTracer)) {}
   void submitSpan(tracing::SpanId spanId, tracing::SpanId parentSpanId, const Span& span) {
     // We largely recreate the span here which feels inefficient, but is hard to avoid given the
     // mismatch between the Span type and the full span information required for OTel.
@@ -1725,7 +1723,7 @@ class SpanSubmitter final: public kj::Refcounted {
   KJ_DISALLOW_COPY_AND_MOVE(SpanSubmitter);
 
  private:
-  uint64_t predictableSpanId;
+  uint64_t predictableSpanId = 0;
   kj::Own<WorkerTracer> workerTracer;
 };
 


### PR DESCRIPTION
Meant to add cppcoreguidelines-pro-type-member-init since it would have saved me spending hours from tracking down a test failure, but that would be significantly more work.