### PR TITLE
feat: Add WorkflowStepContext to step.do callback

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -315,15 +315,19 @@ declare namespace CloudflareWorkersModule {
     type: string;
   };
 
+  export type WorkflowStepContext = {
+	  attempt: Readonly<number>;
+  };
+
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
-      callback: () => Promise<T>
+      callback: (ctx: WorkflowStepContext) => Promise<T>
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
-      callback: () => Promise<T>
+      callback: (ctx: WorkflowStepContext) => Promise<T>
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -12160,15 +12160,18 @@ declare namespace CloudflareWorkersModule {
     timestamp: Date;
     type: string;
   };
+  export type WorkflowStepContext = {
+    attempt: Readonly<number>;
+  };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
-      callback: () => Promise<T>,
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
-      callback: () => Promise<T>,
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -12132,15 +12132,18 @@ export declare namespace CloudflareWorkersModule {
     timestamp: Date;
     type: string;
   };
+  export type WorkflowStepContext = {
+    attempt: Readonly<number>;
+  };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
-      callback: () => Promise<T>,
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
-      callback: () => Promise<T>,
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -11556,15 +11556,18 @@ declare namespace CloudflareWorkersModule {
     timestamp: Date;
     type: string;
   };
+  export type WorkflowStepContext = {
+    attempt: Readonly<number>;
+  };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
-      callback: () => Promise<T>,
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
-      callback: () => Promise<T>,
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -11526,15 +11526,18 @@ export declare namespace CloudflareWorkersModule {
     timestamp: Date;
     type: string;
   };
+  export type WorkflowStepContext = {
+    attempt: Readonly<number>;
+  };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
-      callback: () => Promise<T>,
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
-      callback: () => Promise<T>,
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;


### PR DESCRIPTION
Fixes WOR-1047.

We will release a new feat with `step.do()` callback having passed a `WorkflowStepContext` with the number of the current attempt from that step. This PR adds types to that.