### PR TITLE
EMAIL-1327: Make enable_email_sending_queueing not experimental

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1019,8 +1019,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
 
   emailSendingQueuing @116 :Bool
       $compatEnableFlag("enable_email_sending_queuing")
-      $compatDisableFlag("disable_email_sending_queuing")
-      $experimental;
+      $compatDisableFlag("disable_email_sending_queuing");
   # Enables Queuing on the `.send(message: EmailMessage)` function on send_email binding if there's
   # a temporary error on email delivery.
   # Note that by enabling this, user-provided Message-IDs are stripped and


### PR DESCRIPTION
To be merged with corresponding internal PR - this logic is separately gated by the email service, so we're now ready to make this flag non-experimental, however we do not yet wish to set a default enable date.