### PR TITLE
Fix structuredClone() under enhanced_error_serialization.

### DIFF
--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -1740,24 +1740,6 @@ export let logging = {
   },
 };
 
-// DOMException is structured cloneable
-export let domExceptionClone = {
-  test() {
-    const de1 = new DOMException('hello', 'NotAllowedError');
-
-    de1.foo = 'abc';
-
-    const de2 = structuredClone(de1);
-    assert.strictEqual(de1.name, de2.name);
-    assert.strictEqual(de1.message, de2.message);
-    assert.strictEqual(de1.stack, de2.stack);
-    assert.strictEqual(de1.code, de2.code);
-    assert.notStrictEqual(de1, de2);
-    assert.strictEqual(de1.foo, de2.foo);
-    assert.strictEqual(de2.foo, 'abc');
-  },
-};
-
 export let proxiedRpcTarget = {
   async test(controller, env, ctx) {
     // Proxy RPC target.

--- a/src/workerd/api/tests/rpc-error-test.js
+++ b/src/workerd/api/tests/rpc-error-test.js
@@ -1,4 +1,4 @@
-import { notStrictEqual } from 'assert';
+import { notStrictEqual, ok, strictEqual, throws } from 'assert';
 
 export const test = {
   async test(_, env) {
@@ -53,5 +53,49 @@ export const test = {
       // the original stack.
       notStrictEqual(err.stack2, err.stack);
     }
+  },
+};
+
+export let structuredCloneNotBroken = {
+  test(controller, env, ctx) {
+    // At one point, enhanced_error_serialization inadvertently broke structuredClone()'s support
+    // for host objects.
+    let orig = new Headers({ foo: '123', bar: 'abc' });
+    let cloned = structuredClone(orig);
+    ok(cloned instanceof Headers);
+    strictEqual(cloned.get('foo'), '123');
+    strictEqual(cloned.get('bar'), 'abc');
+
+    throws(() => structuredClone(new TextEncoder()), {
+      name: 'DataCloneError',
+      code: DOMException.DATA_CLONE_ERR,
+      message:
+        'Could not serialize object of type "TextEncoder". This type does not support ' +
+        'serialization.',
+    });
+  },
+};
+
+// DOMException is structured cloneable
+export let domExceptionClone = {
+  test() {
+    const de1 = new DOMException('hello', 'NotAllowedError');
+
+    de1.foo = 'abc';
+
+    const de2 = structuredClone(de1);
+    ok(de2 instanceof DOMException);
+    strictEqual(de1.name, de2.name);
+    strictEqual(de1.message, de2.message);
+    strictEqual(de1.stack, de2.stack);
+    strictEqual(de1.code, de2.code);
+    notStrictEqual(de1, de2);
+
+    // TODO(bug): This is supposed to work, but currently doesn't because the "native error"
+    //   handling in jsg::Serializer does not kick in for DOMException. Instead, DOMException's
+    //   own serializer (in dom-exception.c++) is used, and it hasn't been updated to handle
+    //   serializing application properties.
+    // strictEqual(de1.foo, de2.foo);
+    // strictEqual(de2.foo, 'abc');
   },
 };


### PR DESCRIPTION
The comments in ser.c++ suggested that V8 would always treat objects with internal fields as host objects, not calling the `IsHostObject()` callback even when it was enabled. This turns out to be wrong: if HasCustomHostObject() returns true, then IsHostObject() will be called for *all* objects, internal fields or otherwise, and the result respected.

Prior to the introduction of `enhanced_error_serialization`, though, `HasCustomHostObject()` would only return true when `treatClassInstancesAsPlainObjects` was false. This inadvertently neutralized the bug, because all objects with internal fields are also "class instances" (i.e. their prototype is something other than `Object.prototype`). So all API objects continued to be treated as host objects.

But `enhanced_error_serialization` introduced another way that `HasCustomHostObject()` could return true, even when `treatClassInstancesAsPlainObjects` is also true. Unfortuntaley, in this case, API objects (objects with internal fields) _stopped_ being treated as host objects. Hence, all API objects started being serialized as empty objects, since the default serialization behavior for all objects is to ignore the prototype and just serialize the own properties.

The fix is to make sure we check for internal fields in `IsHostObject()`.

Ironically, the test for `DOMException` serialization in `js-rpc-test.js` managed to depend on this bug. `enhanced_error_serialization` as implemented doesn't apply to `DOMException`, since it's a custom API object. But the bug caused it to be serialized as a plain object, which ended up causing its own properties to be preserved, as they should be under `enhanced_error_serialization`. However, its _type_ was not preserved, but this was not actually tested, so the test passed by accident. I have removed this test from `js-rpc-test` and recreated it in `rpc-error-test`, where I also adjusted it to verify the type but not the own properties (leaving the latter as a TODO to fix later).