### PR TITLE
[DO NOT MERGE] Put V8 temporal test in a commit for convenience

### DIFF
--- a/justfile
+++ b/justfile
@@ -79,6 +79,9 @@ new-wpt-test test_name:
   ./tools/cross/format.py
   bazel test //src/wpt:{{test_name}} --test_env=GEN_TEST_CONFIG=1 --test_output=streamed
 
+new-test test_name:
+  ./tools/unix/new-test.sh {{test_name}}
+
 format: rustfmt
   python3 tools/cross/format.py
 

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -554,3 +554,9 @@ wd_test(
     args = ["--experimental"],
     data = ["headers-immutable-prototype-test.js"],
 )
+
+wd_test(
+    src = "v8-temporal-test.wd-test",
+    args = ["--experimental"],
+    data = ["v8-temporal-test.js"],
+)

--- a/src/workerd/api/tests/v8-temporal-test.js
+++ b/src/workerd/api/tests/v8-temporal-test.js
@@ -1,0 +1,10 @@
+import { strictEqual } from 'node:assert';
+
+export const temporalIsAvailable = {
+  test() {
+    const start = Temporal.PlainDate.from('2025-12-02');
+    const end = Temporal.PlainDate.from('2026-01-05');
+    const duration = start.until(end);
+    strictEqual(duration.toString(), 'P34D');
+  },
+};

--- a/src/workerd/api/tests/v8-temporal-test.wd-test
+++ b/src/workerd/api/tests/v8-temporal-test.wd-test
@@ -1,0 +1,16 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "v8-temporal-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "v8-temporal-test.js")
+        ],
+       compatibilityDate = "2025-12-02",
+       compatibilityFlags = ["nodejs_compat_v2"],
+      )
+    ),
+  ],
+  v8Flags = ["--harmony-temporal"],
+);


### PR DESCRIPTION
Adding the V8 flag `--harmony-temporal` won't be needed once V8 enables Temporal by default. I'm just keeping this branch around to make it easier to test stuff.