### PR TITLE
Run V8's code formatter on patches.

### DIFF
--- a/patches/v8/0014-Add-another-slot-in-the-isolate-for-embedder.patch
+++ b/patches/v8/0014-Add-another-slot-in-the-isolate-for-embedder.patch
@@ -6,7 +6,7 @@ Subject: Add another slot in the isolate for embedder
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/include/v8-internal.h b/include/v8-internal.h
-index 9a39f8ede92bad9acf1c390cde2048d7a9eb6a88..efdd0ec674f11a0e68a2e996f6ac0dc66c6ec1e3 100644
+index 9a39f8ede92bad9acf1c390cde2048d7a9eb6a88..10dcd7b24007cf5bfb75cc0e33c777f4964fb76c 100644
 --- a/include/v8-internal.h
 +++ b/include/v8-internal.h
 @@ -918,7 +918,7 @@ class Internals {

--- a/patches/v8/0015-Add-ValueSerializer-SetTreatProxiesAsHostObjects.patch
+++ b/patches/v8/0015-Add-ValueSerializer-SetTreatProxiesAsHostObjects.patch
@@ -83,7 +83,7 @@ index b47d11d402cb7855d8682ba966f3551738e3c621..e638bcea0b5efcfef177e45726dca308
    if (!delegate_) {
      isolate_->Throw(*isolate_->factory()->NewError(
 diff --git a/src/objects/value-serializer.h b/src/objects/value-serializer.h
-index 2d0a746c90522500fcf17d73f3024512b1bb5481..7ec442c5e002e8a7e00c7d0ea5dc3e77744bb55d 100644
+index 2d0a746c90522500fcf17d73f3024512b1bb5481..eb870051ab48a61dcbd558163f945ec1284646dc 100644
 --- a/src/objects/value-serializer.h
 +++ b/src/objects/value-serializer.h
 @@ -111,6 +111,15 @@ class ValueSerializer {
@@ -102,17 +102,16 @@ index 2d0a746c90522500fcf17d73f3024512b1bb5481..7ec442c5e002e8a7e00c7d0ea5dc3e77
   private:
    // Managing allocations of the internal buffer.
    Maybe<bool> ExpandBuffer(size_t required_capacity);
-@@ -161,8 +170,7 @@ class ValueSerializer {
+@@ -161,7 +170,7 @@ class ValueSerializer {
  #endif  // V8_ENABLE_WEBASSEMBLY
    Maybe<bool> WriteSharedObject(DirectHandle<HeapObject> object)
        V8_WARN_UNUSED_RESULT;
 -  Maybe<bool> WriteHostObject(DirectHandle<JSObject> object)
--      V8_WARN_UNUSED_RESULT;
-+  Maybe<bool> WriteHostObject(DirectHandle<JSReceiver> object) V8_WARN_UNUSED_RESULT;
++  Maybe<bool> WriteHostObject(DirectHandle<JSReceiver> object)
+       V8_WARN_UNUSED_RESULT;
  
    /*
-    * Reads the specified keys from the object and writes key-value pairs to the
-@@ -195,6 +203,7 @@ class ValueSerializer {
+@@ -195,6 +204,7 @@ class ValueSerializer {
    bool has_custom_host_objects_ = false;
    bool treat_array_buffer_views_as_host_objects_ = false;
    bool treat_functions_as_host_objects_ = false;

--- a/patches/v8/0026-Implement-additional-Exception-construction-methods.patch
+++ b/patches/v8/0026-Implement-additional-Exception-construction-methods.patch
@@ -6,7 +6,7 @@ Subject: Implement additional Exception construction methods
 Signed-off-by: James M Snell <jsnell@cloudflare.com>
 
 diff --git a/include/v8-exception.h b/include/v8-exception.h
-index 5441a0ab6a403c566e7b0b6002e720c971480893..b9933027aaf9f7842740d6a6742a2c73da65a46a 100644
+index 5441a0ab6a403c566e7b0b6002e720c971480893..5a4f964beb948a5115d7e9065fcb5092e898a99c 100644
 --- a/include/v8-exception.h
 +++ b/include/v8-exception.h
 @@ -48,6 +48,14 @@ class V8_EXPORT Exception {
@@ -16,7 +16,7 @@ index 5441a0ab6a403c566e7b0b6002e720c971480893..b9933027aaf9f7842740d6a6742a2c73
 +  static Local<Value> URIError(Local<String> message,
 +                               Local<Value> options = {});
 +  static Local<Value> EvalError(Local<String> message,
-+                               Local<Value> options = {});
++                                Local<Value> options = {});
 +  static Local<Value> AggregateError(Local<String> message,
 +                                     Local<Value> options = {});
 +  static Local<Value> SuppressedError(Local<String> message,

--- a/patches/v8/0030-Add-v8-String-IsFlat-API.patch
+++ b/patches/v8/0030-Add-v8-String-IsFlat-API.patch
@@ -24,16 +24,14 @@ index 1bf21e60ad9a99bc98aa6a24c1888f1461ce7b46..481313c4de858ea06018f4a38639c876
     * Write the contents of the string to an external buffer.
     * If no arguments are given, expects the buffer to be large
 diff --git a/src/api/api.cc b/src/api/api.cc
-index 3d58c933634e5c9b8bf271c8b7df1dad0ccd672e..56cb7911a9d609133ef964a49198ae8baf4937ed 100644
+index 6312f7f2b2e46f4dfdc386e85fb2aad293e7d85d..9d4c4e288c388239cc8e7b7ad780b38410afebb4 100644
 --- a/src/api/api.cc
 +++ b/src/api/api.cc
-@@ -5619,6 +5619,10 @@ bool String::IsOneByte() const {
+@@ -5595,6 +5595,8 @@ bool String::IsOneByte() const {
    return Utils::OpenDirectHandle(this)->IsOneByteRepresentation();
  }
  
-+bool String::IsFlat() const {
-+  return Utils::OpenDirectHandle(this)->IsFlat();
-+}
++bool String::IsFlat() const { return Utils::OpenDirectHandle(this)->IsFlat(); }
 +
  // Helpers for ContainsOnlyOneByteHelper
  template <size_t size>


### PR DESCRIPTION
V8 uses 'git cl format' to autoformat C++ and other languages. It's easier to work with our patches if they are also formatted this way.