### PR TITLE
Remove error thrown if list of converted files is empty

### DIFF
--- a/src/cloudflare/internal/to-markdown-api.ts
+++ b/src/cloudflare/internal/to-markdown-api.ts
@@ -123,15 +123,15 @@ export class ToMarkdownService {
 
     const data = (await res.json()) as { result: ConversionResponse[] };
 
+    // If the user sent a list of files, return an array of results, otherwise, return just the first object
+    if (Array.isArray(files)) {
+      return data.result;
+    }
+
     if (data.result.length === 0) {
       throw new AiInternalError(
         'Internal Error Converting files into Markdown'
       );
-    }
-
-    // If the user sent a list of files, return an array of results, otherwise, return just the first object
-    if (Array.isArray(files)) {
-      return data.result;
     }
 
     const obj = data.result.at(0);


### PR DESCRIPTION
Before this PR, if the list of converted markdown files that were returned by the call to the internal service was empty we would throw an error.

This makes sense if we only want to convert a single file (the service only accepts a list so we always have to convert a single file to a list of files) because it would mean we got no conversion to return to the user.

For the case where we take a list as input, this doesn't make much sense: it is valid for a user to give us an empty list to begin with.

With this PR, the previous situation becomes valid.