### PR TITLE
Support step context from Python Workflows SDK

### DIFF
--- a/src/pyodide/internal/test_introspection.py
+++ b/src/pyodide/internal/test_introspection.py
@@ -19,6 +19,9 @@ class TestIntrospection(unittest.TestCase):
                 patch.dict("sys.modules", _pyodide_entrypoint_helper=MagicMock())
             )
             stack.enter_context(
+                patch.dict("sys.modules", _cloudflare_compat_flags=MagicMock())
+            )
+            stack.enter_context(
                 patch.dict("sys.modules", {"pyodide": MagicMock(__version__=2)})
             )
             stack.enter_context(

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -2,34 +2,37 @@
 // This file is a BUILTIN module that provides the actual implementation for the
 // python-entrypoint.js USER module.
 
-import {
-  beforeRequest,
-  loadPyodide,
-  clearSignals,
-} from 'pyodide-internal:python';
+import { patch_env_helper } from 'pyodide-internal:envHelpers';
 import { enterJaegerSpan } from 'pyodide-internal:jaeger';
-import { patchLoadPackage } from 'pyodide-internal:setupPackages';
-import {
-  IS_WORKERD,
-  LOCKFILE,
-  TRANSITIVE_REQUIREMENTS,
-  MAIN_MODULE_NAME,
-  WORKERD_INDEX_URL,
-  SHOULD_SNAPSHOT_TO_DISK,
-  WORKFLOWS_ENABLED,
-  LEGACY_GLOBAL_HANDLERS,
-  LEGACY_INCLUDE_SDK,
-  COMPATIBILITY_FLAGS,
-} from 'pyodide-internal:metadata';
 import { default as Limiter } from 'pyodide-internal:limiter';
 import {
-  PythonWorkersInternalError,
+  COMPATIBILITY_FLAGS,
+  IS_WORKERD,
+  LEGACY_GLOBAL_HANDLERS,
+  LEGACY_INCLUDE_SDK,
+  LOCKFILE,
+  MAIN_MODULE_NAME,
+  SHOULD_SNAPSHOT_TO_DISK,
+  TRANSITIVE_REQUIREMENTS,
+  WORKERD_INDEX_URL,
+  WORKFLOWS_ENABLED,
+} from 'pyodide-internal:metadata';
+import {
+  beforeRequest,
+  clearSignals,
+  loadPyodide,
+} from 'pyodide-internal:python';
+import { patchLoadPackage } from 'pyodide-internal:setupPackages';
+import {
+  LOADED_SNAPSHOT_TYPE,
+  maybeCollectDedicatedSnapshot,
+} from 'pyodide-internal:snapshot';
+import {
   PythonUserError,
+  PythonWorkersInternalError,
   reportError,
 } from 'pyodide-internal:util';
-import { LOADED_SNAPSHOT_TYPE } from 'pyodide-internal:snapshot';
 export { createImportProxy } from 'pyodide-internal:serializeJsModule';
-import { patch_env_helper } from 'pyodide-internal:envHelpers';
 
 type PyFuture<T> = Promise<T> & { copy(): PyFuture<T>; destroy(): void };
 
@@ -74,7 +77,6 @@ export type PyodideEntrypointHelper = {
   patchWaitUntil: typeof patchWaitUntil;
   patch_env_helper: (patch: unknown) => Generator<void>;
 };
-import { maybeCollectDedicatedSnapshot } from 'pyodide-internal:snapshot';
 
 // Function to import JavaScript modules from Python
 let _pyodide_entrypoint_helper: PyodideEntrypointHelper | null = null;

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -6,6 +6,7 @@ declare namespace MetadataReader {
     python_dedicated_snapshot?: boolean;
     enable_python_external_sdk?: boolean;
     python_check_rng_state?: boolean;
+    python_workflows_implicit_dependencies?: boolean;
   }
 
   const isWorkerd: () => boolean;

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1335,4 +1335,11 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # checking for null will break. To migrate, either:
   # 1. Add a null check: if (controller.byobRequest) { ... }
   # 2. Explicitly set autoAllocateChunkSize when creating the stream
+
+  pythonWorkflowsImplicitDeps @155 :Bool
+    $compatEnableFlag("python_workflows_implicit_dependencies")
+    $compatDisableFlag("no_python_workflows_implicit_dependencies")
+    $impliedByAfterDate(name = "pythonWorkers", date = "2026-02-25");
+  # replaces depends param on steps to an implicit approach with step callables passed as params
+  # these steps are called internally and act as dependencies
 }

--- a/src/workerd/server/tests/python/workflow-entrypoint/worker.js
+++ b/src/workerd/server/tests/python/workflow-entrypoint/worker.js
@@ -2,9 +2,15 @@ import { RpcTarget } from 'cloudflare:workers';
 import * as assert from 'node:assert';
 
 class Context extends RpcTarget {
+  constructor(shouldSendCtx) {
+    super();
+    this.shouldSendCtx = shouldSendCtx;
+  }
+
   async do(name, fn) {
     try {
-      const result = await fn();
+      const ctx = { attempt: '1', metadata: 'expected_return_metadata' };
+      const result = this.shouldSendCtx ? await fn(ctx) : await fn();
       return result;
     } catch (e) {
       console.log(`Error received: ${e.name} Message: ${e.message}`);
@@ -16,10 +22,34 @@ class Context extends RpcTarget {
 
 export default {
   async test(ctrl, env, ctx) {
-    // JS types
-    const stubStep = new Context();
+    let stubStep = new Context(true);
 
-    const resp = await env.PythonWorkflow.run(
+    // Tests forward compat - i.e.: python workflows should be compatible with steps that pass a ctx argument
+    // this param is optional and searched by name. Meaning it's not positional
+    let resp = await env.PythonWorkflow.run(
+      {
+        foo: 'bar',
+      },
+      stubStep
+    );
+    assert.deepStrictEqual(resp, 'foobar');
+
+    // Tests backwards compat for dependency resolution - previously deps were not following a name based
+    // approach. Instead, they were passed in the same order as they were declared in the depends param
+    // This test also doesn't pass any ctx to steps
+    stubStep = new Context(false);
+    resp = await env.PythonWorkflowDepends.run(
+      {
+        foo: 'bar',
+      },
+      stubStep
+    );
+    assert.deepStrictEqual(resp, 'foobar');
+
+    // Tests forwards compat for dependency resolution - pass ctx onto workflow that runs with the legacy
+    // code path
+    stubStep = new Context(true);
+    resp = await env.PythonWorkflowDepends.run(
       {
         foo: 'bar',
       },

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
@@ -3,13 +3,13 @@ using Workerd = import "/workerd/workerd.capnp";
 const config :Workerd.Config = (
   services = [
     (name = "py", worker = .pyWorker),
+    (name = "pyOld", worker = .pyWorkerOld),
     (name = "js", worker = .jsWorker),
   ],
 );
 
 const pyWorker :Workerd.Worker = (
-
-  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "rpc", "disable_python_no_global_handlers"],
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "python_workflows_implicit_dependencies"],
 
   modules = [
     (name = "workflow.py", pythonModule = embed "workflow.py"),
@@ -20,9 +20,20 @@ const pyWorker :Workerd.Worker = (
   ],
 );
 
-const jsWorker :Workerd.Worker = (
+const pyWorkerOld :Workerd.Worker = (
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "no_python_workflows_implicit_dependencies"],
 
-  compatibilityFlags = ["nodejs_compat", "rpc", "disable_python_no_global_handlers"],
+  modules = [
+    (name = "workflow-old.py", pythonModule = embed "workflow-old.py"),
+  ],
+
+  bindings = [
+    (name = "PythonWorkflowDepends", service = (name = "pyOld", entrypoint = "PythonWorkflowDepends")),
+  ],
+);
+
+const jsWorker :Workerd.Worker = (
+  compatibilityFlags = ["nodejs_compat", "rpc"],
 
   modules = [
     (name = "worker", esModule = embed "worker.js"),
@@ -30,5 +41,6 @@ const jsWorker :Workerd.Worker = (
 
   bindings = [
     (name = "PythonWorkflow", service = (name = "py", entrypoint = "WorkflowEntrypointExample")),
+    (name = "PythonWorkflowDepends", service = (name = "pyOld", entrypoint = "PythonWorkflowDepends")),
   ],
 );

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow-old.py
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow-old.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+from workers import WorkflowEntrypoint
+
+
+class PythonWorkflowDepends(WorkflowEntrypoint):
+    # Tests backward compatibility: legacy depends parameter with positional args
+    # and ctx support in step callbacks.
+    async def run(self, event, step):
+        @step.do("step_1")
+        async def step_1():
+            # tests backwards compat with workflows that don't have ctx in the step callback
+            print("Executing step 1")
+            return "foo"
+
+        @step.do("step_2")
+        async def step_2(ctx):
+            if ctx is not None:
+                assert ctx["attempt"] == "1"
+            print("Executing step 2")
+            return "bar"
+
+        @step.do("step_3", depends=[step_1, step_2], concurrent=True)
+        async def step_3(result1=(), ctx=None, result2=()):
+            if ctx is not None:
+                assert ctx["attempt"] == "1"
+            assert result1 == "foo"
+            assert result2 == "bar"
+            return result1 + result2
+
+        return await step_3()
+
+
+async def test(ctrl, env, ctx):
+    pass


### PR DESCRIPTION
We're adding support for context within `step.do`'s callback. This means adding a new **optional** parameter to the decorated step method, in a way that doesn't break existing Python Workflows.

This solution introspects the signature of the callback and checks for the size of the parameters list given (without `*args` and `**kwargs`). If there are more arguments than resolved dependencies, then the context parameter is injected into the user workflow.

EDIT:

We're also making a bigger change in the sdk regarding dependency resolution. We're following pytest fixtures' approach with a name based approach for steps. This means that we implicitly resolve dependencies based on the param names. Since we're already introspecting the signature for each decorated step, this ensures a consistent approach for declarations. Everything is based on the param name, instead of relying on param positions like previously

Related types PR:

https://github.com/cloudflare/workerd/pull/5625