### PR TITLE
Adds compat flag for changing behaviour of validator.

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1257,4 +1257,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
     $experimental;
   # Enables precise timers with 3ms granularity. This provides more accurate timing for performance
   # measurements and time-sensitive operations.
+
+  validatorReturnsCapnp @149 :Bool
+    $compatEnableFlag("validator_returns_capnp")
+    $compatDisableFlag("disable_validator_returns_capnp")
+    $experimental;
+  # When enabled, the validator will return ValidationReport encoded as capnp rather than JSON.
+  # The ValidationReport will also contain a complete WorkerBundle with validation outputs set on it
+  # (encodedFeatureFlags, memorySnapshot, encodedShardingHints).
 }


### PR DESCRIPTION
This compat flag will be used to roll out a change in the validator which will enable it to return capnp instead of JSON, as well as return the original WorkerBundle with changes made to it, instead of only permitting EWC to make changes to the deployed WorkerBundle.