### PR TITLE
Revert #5608 but keep the tests.

### DIFF
--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -99,10 +99,7 @@ export const env = new Proxy(
     ): PropertyDescriptor | undefined {
       const inner = innerEnv.getCurrentEnv();
       if (inner) {
-        const desc = Reflect.getOwnPropertyDescriptor(inner, prop);
-        if (desc) {
-          return { ...desc, enumerable: true };
-        }
+        return Reflect.getOwnPropertyDescriptor(inner, prop);
       }
       return undefined;
     },
@@ -146,10 +143,7 @@ export const exports = new Proxy(
     ): PropertyDescriptor | undefined {
       const inner = innerEnv.getCurrentExports();
       if (inner) {
-        const desc = Reflect.getOwnPropertyDescriptor(inner, prop);
-        if (desc) {
-          return { ...desc, enumerable: true };
-        }
+        return Reflect.getOwnPropertyDescriptor(inner, prop);
       }
       return undefined;
     },


### PR DESCRIPTION
This reverts the changes to worker.ts in ef0743c563d2690a4ea40a2b05565fe2fed53171 -- but not the tests.

The tests pass without the change, demonstrating that the change did not actually do anything. These properties were already enumerable.