### PR TITLE
Revert "add asan-release builds (#5644)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,6 @@ build --verbose_failures
 build --build_tag_filters=-off-by-default
 test --test_tag_filters=-off-by-default,-requires-fuzzilli
 test:asan --test_tag_filters=-off-by-default,-no-asan,-requires-fuzzilli
-test:asan-release --test_tag_filters=-off-by-default,-no-asan,-requires-fuzzilli
 # exclude enormous tests by default
 build --test_size_filters=-enormous
 
@@ -192,14 +191,6 @@ build:asan --test_env=KJ_CLEAN_SHUTDOWN=1
 # Enable ASan, LSan support in V8
 build:asan --copt="-DV8_USE_ADDRESS_SANITIZER"
 build:asan --per_file_copt='external/v8@-DADDRESS_SANITIZER,-DLEAK_SANITIZER'
-
-# address sanitizer with release optimizations – useful for catching bugs that only manifest
-# with higher optimization levels or to test production-like performance with sanitizers.
-# Overrides sanitizer-common's -Og and -g with release-appropriate settings.
-build:asan-release --config=asan
-build:asan-release --copt="-O3"
-build:asan-release --copt="-g1"
-build:asan-release --strip=never
 
 # fuzzilli (https://github.com/googleprojectzero/fuzzilli/)
 build:fuzzilli --config=asan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,10 +48,6 @@ jobs:
           # Add an Address Sanitizer (ASAN) build on Linux for additional checking.
           - os: { name: linux, arch: X64, image: ubuntu-22.04 }
             config: { suffix: -asan }
-          # Add an Address Sanitizer (ASAN) build with release optimizations to catch
-          # optimization-dependent bugs.
-          - os: { name: linux, arch: X64, image: ubuntu-22.04 }
-            config: { suffix: -asan-release }
           # TODO (later): The custom Windows-debug configuration consistently runs out of disk
           # space on CI, disable it for now. Once https://github.com/bazelbuild/bazel/issues/21615
           # has been resolved we can likely re-enable it and possibly fold up the custom

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -78,10 +78,6 @@ build:ci-linux-asan --config=ci-linux-common --config=ci-limit-storage
 build:ci-linux-asan --config=asan --copt="-g0" --strip=always
 build:ci-linux-arm-asan --config=ci-linux-asan
 
-# asan with release optimizations to catch optimization-dependent bugs
-build:ci-linux-asan-release --config=ci-linux-common --config=ci-limit-storage
-build:ci-linux-asan-release --config=asan-release --copt="-g0" --strip=always
-
 # Speculatively disable asynchronous remote cache uploads on macOS to debug CI job freezes. This is
 # a no-op when remote caching is disabled, so we can always enable it on macOS.
 build:macos --noremote_cache_async

--- a/justfile
+++ b/justfile
@@ -44,17 +44,11 @@ run *args="-- --help":
 build-asan *args="//...":
   just build {{args}} --config=asan
 
-build-asan-release *args="//...":
-  just build {{args}} --config=asan-release
-
 test *args="//...":
   bazel test {{args}}
 
 test-asan *args="//...":
   just test {{args}} --config=asan
-
-test-asan-release *args="//...":
-  just test {{args}} --config=asan-release
 
 # e.g. just stream-test //src/cloudflare:cloudflare.capnp@eslint
 stream-test *args:


### PR DESCRIPTION
This reverts commit 4e6ddc27fc788ce3f1719b2b0e11757042ad52ed.

Asan release build doesn't really make a difference on workerd since we don't run fuzzers on github CI. 