### PR TITLE
Revert SQLITE upgrade back to 3.47

### DIFF
--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -206,32 +206,6 @@ genrule(
 GENERATED_SOURCES += ["keywordhash.h"]
 
 # ========================================================================
-# Constructs ctime.c
-
-genrule(
-    name = "ctime_c",
-    srcs = [],
-    outs = ["ctime.c"],
-    cmd = "tclsh $(location tool/mkctimec.tcl) $(RULEDIR)/ctime.c",
-    tools = ["tool/mkctimec.tcl"],
-)
-
-GENERATED_SOURCES += ["ctime.c"]
-
-# ========================================================================
-# Constructs pragma.h
-
-genrule(
-    name = "pragma_h",
-    srcs = [],
-    outs = ["pragma.h"],
-    cmd = "tclsh $(location tool/mkpragmatab.tcl) $(RULEDIR)/pragma.h",
-    tools = ["tool/mkpragmatab.tcl"],
-)
-
-GENERATED_SOURCES += ["pragma.h"]
-
-# ========================================================================
 # Constructs sqlite3.h.
 
 cc_binary(

--- a/build/deps/deps.MODULE.bazel
+++ b/build/deps/deps.MODULE.bazel
@@ -60,7 +60,7 @@ archive_override(
 bazel_dep(name = "sqlite3")
 
 # We have some patches that aren't included in BCR:
-# https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/sqlite3/3.51.1/patches
+# https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/sqlite3/3.47.0/patches
 archive_override(
     module_name = "sqlite3",
     build_file = "//:build/BUILD.sqlite3",
@@ -69,16 +69,17 @@ archive_override(
         "//:patches/sqlite/0001-row-counts-plain.patch",
         "//:patches/sqlite/0002-macOS-missing-PATH-fix.patch",
         "//:patches/sqlite/0003-sqlite-complete-early-exit.patch",
+        "//:patches/sqlite/0004-invalid-wal-on-rollback-fix.patch",
     ],
     remote_file_integrity = {
-        "MODULE.bazel": "sha256-YgTah0CSnA9l6ERyXOm3/1ljRPSdlk72qn6TE1QyeFs=",
+        "MODULE.bazel": "sha256-TtpmqyHyks3o0WcSJO0XFyKkHfAIF98wq06+urs3oKI=",
     },
     remote_file_urls = {
-        "MODULE.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/sqlite3/3.51.1/MODULE.bazel"],
+        "MODULE.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/sqlite3/3.47.0/MODULE.bazel"],
     },
-    sha256 = "0f8e765ac8ea7c36cf8ea9bffdd5c103564f4a8a635f215f9f783b338a13d971",
-    strip_prefix = "sqlite-src-3510100",
-    url = "https://sqlite.org/2025/sqlite-src-3510100.zip",
+    sha256 = "f59c349bedb470203586a6b6d10adb35f2afefa49f91e55a672a36a09a8fedf7",
+    strip_prefix = "sqlite-src-3470000",
+    url = "https://sqlite.org/2024/sqlite-src-3470000.zip",
 )
 
 bazel_dep(name = "tcmalloc", version = "0.0.0-20250927-12f2552")

--- a/patches/sqlite/0002-macOS-missing-PATH-fix.patch
+++ b/patches/sqlite/0002-macOS-missing-PATH-fix.patch
@@ -1,17 +1,17 @@
-diff -u5 -r sqlite-src-pristine-patched1/tool/mksqlite3c.tcl sqlite-src-modified/tool/mksqlite3c.tcl
---- sqlite-src-pristine-patched1/tool/mksqlite3c.tcl	2025-11-19 08:32:31.802107018 -0600
-+++ sqlite-src-modified/tool/mksqlite3c.tcl	2025-11-19 08:28:09.082039967 -0600
-@@ -87,11 +87,14 @@
+diff --color -u5 -r sqlite-src-3440000-pristine/tool/mksqlite3c.tcl sqlite-src-3440000-modified/tool/mksqlite3c.tcl
+--- sqlite-src-3440000-pristine/tool/mksqlite3c.tcl	2023-11-01 07:31:37
++++ sqlite-src-3440000-modified/tool/mksqlite3c.tcl	2024-03-14 17:36:55
+@@ -84,11 +84,14 @@
  set fname sqlite3.c
  if {$enable_recover} { set fname sqlite3r.c }
- set out [open $fname wb]
+ set out [open $fname w]
  # Force the output to use unix line endings, even on Windows.
- fconfigure $out -translation binary
+ fconfigure $out -translation lf
 -set today [clock format [clock seconds] -format "%Y-%m-%d %H:%M:%S UTC" -gmt 1]
 +# The command below results in "couldn't find HOME environment variable to
 +# expand path" errors on macOS CI runs. today is unused, so it is safe to
 +# comment it out.
-+#set today [clock format [clock seconds] -format "%Y-%m-%d %H:%M:%S UTC" -gmt 1]
++# set today [clock format [clock seconds] -format "%Y-%m-%d %H:%M:%S UTC" -gmt 1]
  puts $out [subst \
  {/******************************************************************************
  ** This file is an amalgamation of many separate C source files from SQLite

--- a/patches/sqlite/0004-invalid-wal-on-rollback-fix.patch
+++ b/patches/sqlite/0004-invalid-wal-on-rollback-fix.patch
@@ -1,0 +1,29 @@
+diff -u5 -r sqlite-src-pristine/src/wal.c sqlite-src-modified/src/wal.c
+--- sqlite-src-pristine/src/wal.c	2024-10-21 09:47:53.000000000 -0700
++++ sqlite-src-modified/src/wal.c	2025-06-17 23:10:43.657220118 -0700
+@@ -3760,10 +3760,11 @@
+         rc = xUndo(pUndoCtx, walFramePgno(pWal, iFrame));
+       }
+       if( iMax!=pWal->hdr.mxFrame ) walCleanupHash(pWal);
+     }
+     SEH_EXCEPT( rc = SQLITE_IOERR_IN_PAGE; )
++    pWal->iReCksum = 0;
+   }
+   return rc;
+ }
+ 
+ /*
+@@ -3807,10 +3808,13 @@
+     pWal->hdr.aFrameCksum[1] = aWalData[2];
+     SEH_TRY {
+       walCleanupHash(pWal);
+     }
+     SEH_EXCEPT( rc = SQLITE_IOERR_IN_PAGE; )
++    if( pWal->iReCksum>pWal->hdr.mxFrame ){
++      pWal->iReCksum = 0;
++    }
+   }
+ 
+   return rc;
+ }
+ 


### PR DESCRIPTION
This reverts:

- 2be60804884a9b488d42d5e4dc426d0f61929665
- c41942a33a707d7367894780c03af3613d6f09aa
- 7b7d604a50b038b261d8ddd02499e11692689cbb
Changes in the sqlite optimizer are causing more rows to be read which is causing excessive CPU usage.