### PR TITLE
[nfc] Combine update-deps.py's templates

### DIFF
--- a/build/deps/gen/dep_buildifier_darwin_amd64.bzl
+++ b/build/deps/gen/dep_buildifier_darwin_amd64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v8.2.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-darwin-amd64"
-SHA256 = "9f8cffceb82f4e6722a32a021cbc9a5344b386b77b9f79ee095c61d087aaea06"
-
 def dep_buildifier_darwin_amd64():
     http_file(
         name = "buildifier-darwin-amd64",
-        url = URL,
+        url = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-darwin-amd64",
+        sha256 = "9f8cffceb82f4e6722a32a021cbc9a5344b386b77b9f79ee095c61d087aaea06",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_buildifier_darwin_arm64.bzl
+++ b/build/deps/gen/dep_buildifier_darwin_arm64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v8.2.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-darwin-arm64"
-SHA256 = "cfab310ae22379e69a3b1810b433c4cd2fc2c8f4a324586dfe4cc199943b8d5a"
-
 def dep_buildifier_darwin_arm64():
     http_file(
         name = "buildifier-darwin-arm64",
-        url = URL,
+        url = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-darwin-arm64",
+        sha256 = "cfab310ae22379e69a3b1810b433c4cd2fc2c8f4a324586dfe4cc199943b8d5a",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_buildifier_linux_amd64.bzl
+++ b/build/deps/gen/dep_buildifier_linux_amd64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v8.2.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-linux-amd64"
-SHA256 = "6ceb7b0ab7cf66fceccc56a027d21d9cc557a7f34af37d2101edb56b92fcfa1a"
-
 def dep_buildifier_linux_amd64():
     http_file(
         name = "buildifier-linux-amd64",
-        url = URL,
+        url = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-linux-amd64",
+        sha256 = "6ceb7b0ab7cf66fceccc56a027d21d9cc557a7f34af37d2101edb56b92fcfa1a",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_buildifier_linux_arm64.bzl
+++ b/build/deps/gen/dep_buildifier_linux_arm64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v8.2.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-linux-arm64"
-SHA256 = "3baa1cf7eb41d51f462fdd1fff3a6a4d81d757275d05b2dd5f48671284e9a1a5"
-
 def dep_buildifier_linux_arm64():
     http_file(
         name = "buildifier-linux-arm64",
-        url = URL,
+        url = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-linux-arm64",
+        sha256 = "3baa1cf7eb41d51f462fdd1fff3a6a4d81d757275d05b2dd5f48671284e9a1a5",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_buildifier_windows_amd64.bzl
+++ b/build/deps/gen/dep_buildifier_windows_amd64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "v8.2.1"
-URL = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-windows-amd64.exe"
-SHA256 = "802104da0bcda0424a397ac5be0004c372665a70289a6d5146e652ee497c0dc6"
-
 def dep_buildifier_windows_amd64():
     http_file(
         name = "buildifier-windows-amd64",
-        url = URL,
+        url = "https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildifier-windows-amd64.exe",
+        sha256 = "802104da0bcda0424a397ac5be0004c372665a70289a6d5146e652ee497c0dc6",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_capnp_cpp.bzl
+++ b/build/deps/gen/dep_capnp_cpp.bzl
@@ -2,17 +2,11 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/capnproto/capnproto/tarball/f779b454d1ac9c3a5ed5567be0faafeda22f4f31"
-STRIP_PREFIX = "capnproto-capnproto-f779b45/c++"
-SHA256 = "341480b75ce8c4b533929efccce1580c0d24593b38c97bc1f6e11b221e4a9abc"
-TYPE = "tgz"
-COMMIT = "f779b454d1ac9c3a5ed5567be0faafeda22f4f31"
-
 def dep_capnp_cpp():
     http_archive(
         name = "capnp-cpp",
-        url = URL,
-        strip_prefix = STRIP_PREFIX,
-        type = TYPE,
-        sha256 = SHA256,
+        url = "https://github.com/capnproto/capnproto/tarball/f779b454d1ac9c3a5ed5567be0faafeda22f4f31",
+        strip_prefix = "capnproto-capnproto-f779b45/c++",
+        sha256 = "341480b75ce8c4b533929efccce1580c0d24593b38c97bc1f6e11b221e4a9abc",
+        type = "tgz",
     )

--- a/build/deps/gen/dep_cargo_bazel_linux_arm64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_linux_arm64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.68.0"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.0/cargo-bazel-aarch64-unknown-linux-gnu"
-SHA256 = "dda338d07a427804d052f193c02411cd9ad02815e099191c38dc9b9068002f98"
-
 def dep_cargo_bazel_linux_arm64():
     http_file(
         name = "cargo_bazel_linux_arm64",
-        url = URL,
+        url = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.1/cargo-bazel-aarch64-unknown-linux-gnu",
+        sha256 = "dda338d07a427804d052f193c02411cd9ad02815e099191c38dc9b9068002f98",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_cargo_bazel_linux_x64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_linux_x64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.68.0"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.0/cargo-bazel-x86_64-unknown-linux-gnu"
-SHA256 = "bdb591a260e552ca6accc34b2073ad503c2d30a634ed2baf5938a1022f9b8cd2"
-
 def dep_cargo_bazel_linux_x64():
     http_file(
         name = "cargo_bazel_linux_x64",
-        url = URL,
+        url = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.1/cargo-bazel-x86_64-unknown-linux-gnu",
+        sha256 = "bdb591a260e552ca6accc34b2073ad503c2d30a634ed2baf5938a1022f9b8cd2",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_cargo_bazel_macos_arm64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_macos_arm64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.68.0"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.0/cargo-bazel-aarch64-apple-darwin"
-SHA256 = "c14c02be61b003414ad52d2c02d6ea09809df146cb8d9923a273d115a2348d75"
-
 def dep_cargo_bazel_macos_arm64():
     http_file(
         name = "cargo_bazel_macos_arm64",
-        url = URL,
+        url = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.1/cargo-bazel-aarch64-apple-darwin",
+        sha256 = "792be3e36221303468895ded3afa9bcb5a022c92f2bfbebd3037301112a33f9c",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_cargo_bazel_macos_x64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_macos_x64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.68.0"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.0/cargo-bazel-x86_64-apple-darwin"
-SHA256 = "ebc374345586ede05ee8a46d1ea284a74147c61a80309b7f602417ea6f45ecb4"
-
 def dep_cargo_bazel_macos_x64():
     http_file(
         name = "cargo_bazel_macos_x64",
-        url = URL,
+        url = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.1/cargo-bazel-x86_64-apple-darwin",
+        sha256 = "1c90d132fd2a81e2f6801b22026e7f4f795daaeaada4223b6bae391666a4231c",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_cargo_bazel_win_x64.bzl
+++ b/build/deps/gen/dep_cargo_bazel_win_x64.bzl
@@ -2,15 +2,11 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "0.68.0"
-URL = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.0/cargo-bazel-x86_64-pc-windows-msvc.exe"
-SHA256 = "c92b0e452e9d6a1061c6d2556567013f9c8683b4875788695ac4de1fbaff3413"
-
 def dep_cargo_bazel_win_x64():
     http_file(
         name = "cargo_bazel_win_x64",
-        url = URL,
-        executable = True,
-        sha256 = SHA256,
         downloaded_file_path = "downloaded.exe",
+        url = "https://github.com/bazelbuild/rules_rust/releases/download/0.68.1/cargo-bazel-x86_64-pc-windows-msvc.exe",
+        sha256 = "9a267ac4704122e5eb2ff5130e43f54fcaf6de7a003dabdf951e68f18ec55bdc",
+        executable = True,
     )

--- a/build/deps/gen/dep_clang_format_darwin_arm64.bzl
+++ b/build/deps/gen/dep_clang_format_darwin_arm64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "llvm-18.1.8"
-URL = "https://github.com/cloudflare/workerd-tools/releases/download/llvm-18.1.8/llvm-18.1.8-darwin-arm64-clang-format"
-SHA256 = "08c90dad18580c61caed43b249704f4e8b1ca3dee6abb197185ecaef298149af"
-
 def dep_clang_format_darwin_arm64():
     http_file(
         name = "clang-format-darwin-arm64",
-        url = URL,
+        url = "https://github.com/cloudflare/workerd-tools/releases/download/llvm-18.1.8/llvm-18.1.8-darwin-arm64-clang-format",
+        sha256 = "08c90dad18580c61caed43b249704f4e8b1ca3dee6abb197185ecaef298149af",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_clang_format_linux_amd64.bzl
+++ b/build/deps/gen/dep_clang_format_linux_amd64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "llvm-18.1.8"
-URL = "https://github.com/cloudflare/workerd-tools/releases/download/llvm-18.1.8/llvm-18.1.8-linux-amd64-clang-format"
-SHA256 = "34677b7593943121858197358481d6941d9be1977e024c9e21862bddef62c762"
-
 def dep_clang_format_linux_amd64():
     http_file(
         name = "clang-format-linux-amd64",
-        url = URL,
+        url = "https://github.com/cloudflare/workerd-tools/releases/download/llvm-18.1.8/llvm-18.1.8-linux-amd64-clang-format",
+        sha256 = "34677b7593943121858197358481d6941d9be1977e024c9e21862bddef62c762",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_clang_format_linux_arm64.bzl
+++ b/build/deps/gen/dep_clang_format_linux_arm64.bzl
@@ -2,14 +2,10 @@
 
 load("@//:build/http.bzl", "http_file")
 
-TAG_NAME = "llvm-18.1.8"
-URL = "https://github.com/cloudflare/workerd-tools/releases/download/llvm-18.1.8/llvm-18.1.8-linux-arm64-clang-format"
-SHA256 = "e1eb317d1ccceb3d1b544a841bfb7a74a52969d8aa033f40b1796af3821c2a96"
-
 def dep_clang_format_linux_arm64():
     http_file(
         name = "clang-format-linux-arm64",
-        url = URL,
+        url = "https://github.com/cloudflare/workerd-tools/releases/download/llvm-18.1.8/llvm-18.1.8-linux-arm64-clang-format",
+        sha256 = "e1eb317d1ccceb3d1b544a841bfb7a74a52969d8aa033f40b1796af3821c2a96",
         executable = True,
-        sha256 = SHA256,
     )

--- a/build/deps/gen/dep_ruff_darwin_arm64.bzl
+++ b/build/deps/gen/dep_ruff_darwin_arm64.bzl
@@ -2,18 +2,12 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "0.12.1"
-URL = "https://github.com/astral-sh/ruff/releases/download/0.12.1/ruff-aarch64-apple-darwin.tar.gz"
-STRIP_PREFIX = "ruff-aarch64-apple-darwin"
-SHA256 = "f33ec69d83f713e0ff2cb720969325bb1553e43978e2f1c21498bd31e11fc643"
-TYPE = "tgz"
-
 def dep_ruff_darwin_arm64():
     http_archive(
         name = "ruff-darwin-arm64",
-        url = URL,
-        strip_prefix = STRIP_PREFIX,
-        type = TYPE,
-        sha256 = SHA256,
         build_file_content = "filegroup(name='file', srcs=['ruff'], visibility=['//visibility:public'])",
+        url = "https://github.com/astral-sh/ruff/releases/download/0.12.1/ruff-aarch64-apple-darwin.tar.gz",
+        strip_prefix = "ruff-aarch64-apple-darwin",
+        sha256 = "f33ec69d83f713e0ff2cb720969325bb1553e43978e2f1c21498bd31e11fc643",
+        type = "tgz",
     )

--- a/build/deps/gen/dep_ruff_linux_amd64.bzl
+++ b/build/deps/gen/dep_ruff_linux_amd64.bzl
@@ -2,18 +2,12 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "0.12.1"
-URL = "https://github.com/astral-sh/ruff/releases/download/0.12.1/ruff-x86_64-unknown-linux-gnu.tar.gz"
-STRIP_PREFIX = "ruff-x86_64-unknown-linux-gnu"
-SHA256 = "61357b8326d116113596a3d8e9f2398c33f0d21e0f99d50d9e03ac9578194d48"
-TYPE = "tgz"
-
 def dep_ruff_linux_amd64():
     http_archive(
         name = "ruff-linux-amd64",
-        url = URL,
-        strip_prefix = STRIP_PREFIX,
-        type = TYPE,
-        sha256 = SHA256,
         build_file_content = "filegroup(name='file', srcs=['ruff'], visibility=['//visibility:public'])",
+        url = "https://github.com/astral-sh/ruff/releases/download/0.12.1/ruff-x86_64-unknown-linux-gnu.tar.gz",
+        strip_prefix = "ruff-x86_64-unknown-linux-gnu",
+        sha256 = "61357b8326d116113596a3d8e9f2398c33f0d21e0f99d50d9e03ac9578194d48",
+        type = "tgz",
     )

--- a/build/deps/gen/dep_ruff_linux_arm64.bzl
+++ b/build/deps/gen/dep_ruff_linux_arm64.bzl
@@ -2,18 +2,12 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "0.12.1"
-URL = "https://github.com/astral-sh/ruff/releases/download/0.12.1/ruff-aarch64-unknown-linux-gnu.tar.gz"
-STRIP_PREFIX = "ruff-aarch64-unknown-linux-gnu"
-SHA256 = "2e42713b3b544c382e969029cf6019c99df09b4069f6a3a828a9be259f3237c0"
-TYPE = "tgz"
-
 def dep_ruff_linux_arm64():
     http_archive(
         name = "ruff-linux-arm64",
-        url = URL,
-        strip_prefix = STRIP_PREFIX,
-        type = TYPE,
-        sha256 = SHA256,
         build_file_content = "filegroup(name='file', srcs=['ruff'], visibility=['//visibility:public'])",
+        url = "https://github.com/astral-sh/ruff/releases/download/0.12.1/ruff-aarch64-unknown-linux-gnu.tar.gz",
+        strip_prefix = "ruff-aarch64-unknown-linux-gnu",
+        sha256 = "2e42713b3b544c382e969029cf6019c99df09b4069f6a3a828a9be259f3237c0",
+        type = "tgz",
     )

--- a/build/deps/gen/dep_rules_rust.bzl
+++ b/build/deps/gen/dep_rules_rust.bzl
@@ -2,12 +2,9 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-URL = "https://github.com/bazelbuild/rules_rust"
-COMMIT = "f3ccfa44f6636aa38e14f095e17d95797ae2f720"
-
 def dep_rules_rust():
     git_repository(
         name = "rules_rust",
-        remote = URL,
-        commit = COMMIT,
+        remote = "https://github.com/bazelbuild/rules_rust",
+        commit = "f3ccfa44f6636aa38e14f095e17d95797ae2f720",
     )

--- a/build/deps/gen/dep_workerd_cxx.bzl
+++ b/build/deps/gen/dep_workerd_cxx.bzl
@@ -2,18 +2,12 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-URL = "https://github.com/cloudflare/workerd-cxx/tarball/916f0e7be8f1d43fe5ece1b72edd3c5844243d7b"
-STRIP_PREFIX = "cloudflare-workerd-cxx-916f0e7"
-SHA256 = "7ddce8e81d0b81adf6f07f18376a6fea9dca42e6b03b2fcf703c62196c270ad0"
-TYPE = "tgz"
-COMMIT = "916f0e7be8f1d43fe5ece1b72edd3c5844243d7b"
-
 def dep_workerd_cxx():
     http_archive(
         name = "workerd-cxx",
-        url = URL,
-        strip_prefix = STRIP_PREFIX,
-        type = TYPE,
-        sha256 = SHA256,
         repo_mapping = {"@crates.io": "@crates_vendor"},
+        url = "https://github.com/cloudflare/workerd-cxx/tarball/916f0e7be8f1d43fe5ece1b72edd3c5844243d7b",
+        strip_prefix = "cloudflare-workerd-cxx-916f0e7",
+        sha256 = "7ddce8e81d0b81adf6f07f18376a6fea9dca42e6b03b2fcf703c62196c270ad0",
+        type = "tgz",
     )

--- a/build/deps/gen/dep_wpt.bzl
+++ b/build/deps/gen/dep_wpt.bzl
@@ -2,18 +2,12 @@
 
 load("@//:build/http.bzl", "http_archive")
 
-TAG_NAME = "wpt-c1ad85a22"
-URL = "https://github.com/cloudflare/workerd-tools/releases/download/wpt-c1ad85a22/wpt-c1ad85a22.tar.gz"
-STRIP_PREFIX = "wpt-c1ad85a22"
-SHA256 = "b91e6024787d3c440525054fe161cdb1f28b6757613ef9ce1ab14685430d947c"
-TYPE = "tgz"
-
 def dep_wpt():
     http_archive(
         name = "wpt",
-        url = URL,
-        strip_prefix = STRIP_PREFIX,
-        type = TYPE,
-        sha256 = SHA256,
         build_file = "@workerd//:build/BUILD.wpt",
+        url = "https://github.com/cloudflare/workerd-tools/releases/download/wpt-c1ad85a22/wpt-c1ad85a22.tar.gz",
+        strip_prefix = "wpt-c1ad85a22",
+        sha256 = "b91e6024787d3c440525054fe161cdb1f28b6757613ef9ce1ab14685430d947c",
+        type = "tgz",
     )


### PR DESCRIPTION
This PR combines most of the different templates we were generating for different types of dependencies. They were all functionally the same as far the build was concerned, just formatted a bit differently. Combining the templates will make it easier to update them to generate bzlmod-compatible output later. 
