### PR TITLE
handle bad/invalid chunks as input more defensively

### DIFF
--- a/src/workerd/api/streams/encoding.c++
+++ b/src/workerd/api/streams/encoding.c++
@@ -58,20 +58,23 @@ jsg::Ref<TextDecoderStream> TextDecoderStream::constructor(
   // The controller will store c++ references to both the readable and writable
   // streams underlying controllers.
   auto transformer = TransformStream::constructor(js,
-      Transformer{.transform = jsg::Function<Transformer::TransformAlgorithm>(
-                      JSG_VISITABLE_LAMBDA((decoder = decoder.addRef()), (decoder),
-                          (jsg::Lock& js, auto chunk, auto controller) {
-                            jsg::BufferSource source(js, chunk);
-                            auto decoded = JSG_REQUIRE_NONNULL(
-                                decoder->decodePtr(js, source.asArrayPtr(), false), TypeError,
-                                "Failed to decode input.");
-                            // Only enqueue if there's actual output - don't emit empty chunks
-                            // for incomplete multi-byte sequences
-                            if (decoded.length(js) > 0) {
-                            controller->enqueue(js, decoded);
-                            }
-                            return js.resolvedPromise();
-                          })),
+      Transformer{.transform = jsg::Function<Transformer::TransformAlgorithm>( JSG_VISITABLE_LAMBDA(
+                      (decoder = decoder.addRef()), (decoder),
+                      (jsg::Lock& js, auto chunk, auto controller) {
+                        JSG_REQUIRE(chunk->IsArrayBuffer() || chunk->IsArrayBufferView(), TypeError,
+                            "This TransformStream is being used as a byte stream, "
+                            "but received a value that is not a BufferSource.");
+                        jsg::BufferSource source(js, chunk);
+                        auto decoded =
+                            JSG_REQUIRE_NONNULL(decoder->decodePtr(js, source.asArrayPtr(), false),
+                                TypeError, "Failed to decode input.");
+                        // Only enqueue if there's actual output - don't emit empty chunks
+                        // for incomplete multi-byte sequences
+                        if (decoded.length(js) > 0) {
+                        controller->enqueue(js, decoded);
+                        }
+                        return js.resolvedPromise();
+                      })),
         .flush = jsg::Function<Transformer::FlushAlgorithm>(
             JSG_VISITABLE_LAMBDA((decoder = decoder.addRef()), (decoder),
                 (jsg::Lock& js, auto controller) {

--- a/src/wpt/encoding-test.ts
+++ b/src/wpt/encoding-test.ts
@@ -104,11 +104,7 @@ export default {
       'a throwing ignoreBOM member should cause the constructor to throw',
     ],
   },
-  'streams/decode-bad-chunks.any.js': {
-    comment: 'Failed V8 assert',
-    //  external/v8/src/api/api-inl.h:163; message = v8::internal::ValueHelper::IsEmpty(that) || IsJSArrayBufferView(v8::internal::Tagged<v8::internal::Object>( v8::internal::ValueHelper::ValueAsAddress(that)))
-    disabledTests: true,
-  },
+  'streams/decode-bad-chunks.any.js': {},
   'streams/decode-ignore-bom.any.js': {},
   'streams/decode-incomplete-input.any.js': {},
   'streams/decode-non-utf8.any.js': {},


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/5394

Failing web-platform test can be found at https://github.com/web-platform-tests/wpt/blob/master/encoding/streams/decode-bad-chunks.any.js. It tests for passing invalid chunk into the stream, and prior to this function we didn't throw the correct error, even though we failed. This change ensures that we are WPT compliant.