### PR TITLE
make sure TextDecoder.decode accepts SharedArrayBuffer

### DIFF
--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -223,6 +223,9 @@ kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBuffer> arrayBuffer);
 // View the contents of the given v8::ArrayBuffer/ArrayBufferView as an ArrayPtr<byte>.
 kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBufferView> arrayBufferView);
 
+// View the contents of the given v8::SharedArrayBuffer as an ArrayPtr<byte>.
+kj::Array<kj::byte> asBytes(v8::Local<v8::SharedArrayBuffer> sharedArrayBuffer);
+
 // Freeze the given object and all its members, making it recursively immutable.
 //
 // WARNING: This function is unsafe to call on user-provided content since if the value is cyclic

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -1058,6 +1058,8 @@ class ArrayBufferWrapper {
       return asBytes(handle.As<v8::ArrayBufferView>());
     } else if (handle->IsArrayBuffer()) {
       return asBytes(handle.As<v8::ArrayBuffer>());
+    } else if (handle->IsSharedArrayBuffer()) {
+      return asBytes(handle.As<v8::SharedArrayBuffer>());
     }
     return kj::none;
   }

--- a/src/wpt/encoding-test.ts
+++ b/src/wpt/encoding-test.ts
@@ -140,11 +140,7 @@ export default {
   },
   'textdecoder-arguments.any.js': {},
   'textdecoder-byte-order-marks.any.js': {},
-  'textdecoder-copy.any.js': {
-    comment:
-      "Failed to execute 'decode' on 'TextDecoder': parameter 1 is not of type 'Array'.",
-    expectedFailures: ['Modify buffer after passing it in (SharedArrayBuffer)'],
-  },
+  'textdecoder-copy.any.js': {},
   'textdecoder-eof.any.js': {},
   'textdecoder-fatal-single-byte.any.js': {},
   'textdecoder-fatal-streaming.any.js': {},


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/5388

This change makes sure that we accept SharedArrayBuffer as an input type to TextDecoder.decode(). 

Failing test file can be found at https://github.com/web-platform-tests/wpt/blob/master/encoding/textdecoder-copy.any.js