### PR TITLE
handle invalid utf-16 surrogates on TextDecoder

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -433,7 +433,9 @@ wd_cc_library(
     srcs = ["encoding.c++"],
     hdrs = ["encoding.h"],
     implementation_deps = [
+        "//src/workerd/io:features",
         "//src/workerd/util:strings",
+        "@simdutf",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -537,6 +539,7 @@ kj_test(
     src = "data-url-test.c++",
     deps = [
         ":data-url",
+        "//src/workerd/io",
     ],
 )
 

--- a/src/workerd/api/encoding.h
+++ b/src/workerd/api/encoding.h
@@ -95,9 +95,10 @@ class AsciiDecoder final: public Decoder {
 // of encodings required by the Encoding specification.
 class IcuDecoder final: public Decoder {
  public:
-  IcuDecoder(Encoding encoding, UConverter* converter, bool ignoreBom)
+  IcuDecoder(Encoding encoding, UConverter* converter, bool fatal, bool ignoreBom)
       : encoding(encoding),
         inner(converter),
+        fatal(fatal),
         ignoreBom(ignoreBom),
         bomSeen(false) {}
   IcuDecoder(IcuDecoder&&) = default;
@@ -124,6 +125,7 @@ class IcuDecoder final: public Decoder {
   Encoding encoding;
   std::unique_ptr<UConverter, ConverterDeleter> inner;
 
+  bool fatal;
   bool ignoreBom;
   bool bomSeen;
 };

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -47,7 +47,6 @@ wd_cc_library(
     ] + ["//src/workerd/api:srcs"],
     hdrs = [
         "compatibility-date.h",
-        "features.h",
         "hibernation-manager.h",
         "io-channels.h",
         "io-context.h",
@@ -90,6 +89,7 @@ wd_cc_library(
         ":actor-storage_capnp",
         ":cdp_capnp",
         ":container_capnp",
+        ":features",
         ":frankenvalue",
         ":io-gate",
         ":io-helpers",
@@ -122,6 +122,19 @@ wd_cc_library(
         "@capnp-cpp//src/kj:kj-async",
         "@ncrypto",
         "@ssl",
+    ],
+)
+
+# Headers only target to avoid having circular dependencies.
+wd_cc_library(
+    name = "features",
+    hdrs = ["features.h"],
+    implementation_deps = [
+        "//src/workerd/jsg",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":compatibility-date_capnp",
     ],
 )
 

--- a/src/wpt/encoding-test.ts
+++ b/src/wpt/encoding-test.ts
@@ -165,21 +165,7 @@ export default {
     ],
   },
   'textdecoder-streaming.any.js': {},
-  'textdecoder-utf16-surrogates.any.js': {
-    comment: 'Investigate why we are not blocking invalid surrogates',
-    expectedFailures: [
-      'utf-16le - lone surrogate lead',
-      'utf-16le - lone surrogate lead (fatal flag set)',
-      'utf-16le - lone surrogate trail',
-      'utf-16le - lone surrogate trail (fatal flag set)',
-      'utf-16le - unmatched surrogate lead',
-      'utf-16le - unmatched surrogate lead (fatal flag set)',
-      'utf-16le - unmatched surrogate trail',
-      'utf-16le - unmatched surrogate trail (fatal flag set)',
-      'utf-16le - swapped surrogate pair',
-      'utf-16le - swapped surrogate pair (fatal flag set)',
-    ],
-  },
+  'textdecoder-utf16-surrogates.any.js': {},
   'textencoder-constructor-non-utf.any.js': {
     comment: 'Investigate this',
     expectedFailures: [


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/5390

Handles invalid utf-16 surrogate pairs and replaces invalid pairs with replacement character if needed. The failing tests are available at https://github.com/web-platform-tests/wpt/blob/master/encoding/textdecoder-utf16-surrogates.any.js