### PR TITLE
Fix TextDecoderStream fatal default and assert.throws with Error constructor

### DIFF
--- a/src/node/internal/internal_assert.ts
+++ b/src/node/internal/internal_assert.ts
@@ -934,9 +934,9 @@ function validateThrownError(
   if (
     error instanceof Function &&
     error.prototype !== undefined &&
-    error.prototype instanceof Error
+    (error === Error || error.prototype instanceof Error)
   ) {
-    // error is a constructor
+    // error is a constructor (Error itself or a subclass of Error)
     if (e instanceof error) {
       return true;
     }

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -83,6 +83,7 @@ wpt_test(
 
 wpt_test(
     name = "encoding",
+    compat_flags = ["pedantic_wpt"],
     config = "encoding-test.ts",
     wpt_directory = "@wpt//:encoding@module",
 )

--- a/src/wpt/compression-test.ts
+++ b/src/wpt/compression-test.ts
@@ -10,12 +10,7 @@ export default {
       'V8 assertion - Cannot construct ArrayBuffer with a BackingStore of SharedArrayBuffer',
     disabledTests: true,
   },
-  'compression-constructor-error.tentative.any.js': {
-    comment: 'TODO investigate this',
-    expectedFailures: [
-      'non-string input should cause the constructor to throw',
-    ],
-  },
+  'compression-constructor-error.tentative.any.js': {},
   'compression-including-empty-chunk.tentative.any.js': {},
   'compression-large-flush-output.any.js': {},
   'compression-multiple-chunks.tentative.any.js': {},
@@ -45,12 +40,7 @@ export default {
     disabledTests: true,
   },
   'decompression-buffersource.tentative.any.js': {},
-  'decompression-constructor-error.tentative.any.js': {
-    comment: 'TODO investigate this',
-    expectedFailures: [
-      'non-string input should cause the constructor to throw',
-    ],
-  },
+  'decompression-constructor-error.tentative.any.js': {},
   'decompression-correct-input.tentative.any.js': {},
   'decompression-corrupt-input.tentative.any.js': {},
   'decompression-empty-input.tentative.any.js': {},

--- a/src/wpt/encoding-test.ts
+++ b/src/wpt/encoding-test.ts
@@ -96,14 +96,7 @@ export default {
       'additional writes should wait for backpressure to be relieved for class TextEncoderStream',
     ],
   },
-  'streams/decode-attributes.any.js': {
-    comment: 'TODO investigate this',
-    expectedFailures: [
-      "setting fatal to 'undefined' should set the attribute to false",
-      'a throwing fatal member should cause the constructor to throw',
-      'a throwing ignoreBOM member should cause the constructor to throw',
-    ],
-  },
+  'streams/decode-attributes.any.js': {},
   'streams/decode-bad-chunks.any.js': {},
   'streams/decode-ignore-bom.any.js': {},
   'streams/decode-incomplete-input.any.js': {},


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/5383

---

Changes are necessary to be more "web" compliant...

- Changes fatal default to false (to be WPT compliant) - might require a compat flag or not...
- node:assert throws with Error constructor now properly handles errors.
