### PR TITLE
Add IoContext::tryCurrent()

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -215,8 +215,7 @@ kj::Promise<void> updateStorageDeletes(
 
 // Return the id of the current actor (or the empty string if there is no current actor).
 kj::Maybe<kj::String> getCurrentActorId() {
-  if (IoContext::hasCurrent()) {
-    IoContext& ioContext = IoContext::current();
+  KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
     KJ_IF_SOME(actor, ioContext.getActor()) {
       KJ_SWITCH_ONEOF(actor.getId()) {
         KJ_CASE_ONEOF(s, kj::String) {

--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -659,8 +659,7 @@ jsg::Promise<jsg::Ref<Cache>> CacheStorage::open(jsg::Lock& js, kj::String cache
   // It is possible here that open() will be called in the global scope in fiddle
   // mode in which case the warning will not be emitted. But that's OK? The warning
   // is not critical by any stretch.
-  if (IoContext::hasCurrent()) {
-    auto& context = IoContext::current();
+  KJ_IF_SOME(context, IoContext::tryCurrent()) {
     if (context.isFiddle()) {
       context.logWarningOnce(CACHE_API_PREVIEW_WARNING);
     }

--- a/src/workerd/api/capnp.c++
+++ b/src/workerd/api/capnp.c++
@@ -634,8 +634,8 @@ CapnpCapability::~CapnpCapability() noexcept(false) {
     //   which is usually sooner (and more deterministic). But logging a warning during
     //   IoContext tear-down is problematic since logWarningOnce() is a method on
     //   IoContext...
-    if (IoContext::hasCurrent()) {
-      IoContext::current().logWarningOnce(
+    KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
+      ioContext.logWarningOnce(
           kj::str("A Cap'n Proto capability of type ", schema.getShortDisplayName(),
               " was not closed properly. You must call close() on all capabilities in order to "
               "let the other side know that you are no longer using them. You cannot rely on "

--- a/src/workerd/api/crypto/dh.c++
+++ b/src/workerd/api/crypto/dh.c++
@@ -77,13 +77,13 @@ kj::Own<DH> initDh(kj::OneOf<kj::Array<kj::byte>, int>& sizeOrKey,
           // Generating a DH key with a reasonable size can be expensive.
           // We will only allow it if there is an active IoContext so that
           // we can enforce a timeout associate with the limit enforcer.
-          JSG_REQUIRE(IoContext::hasCurrent(), Error,
+          auto& ioContext = JSG_REQUIRE_NONNULL(IoContext::tryCurrent(), Error,
               "DiffieHellman key generation requires an active request");
 
           struct Status {
             IoContext& context;
             kj::Maybe<EventOutcome> status;
-          } status{.context = IoContext::current()};
+          } status{.context = ioContext};
 
           auto dh = OSSL_NEW(DH);
           BN_GENCB cb;

--- a/src/workerd/api/crypto/spkac.c++
+++ b/src/workerd/api/crypto/spkac.c++
@@ -21,8 +21,8 @@ bool verifySpkac(kj::ArrayPtr<const kj::byte> input) {
   // Alternatively we could choose to implement our own version of the validation that
   // bypasses BoringSSL's FIPS configuration. For now tho, this does end up matching
   // Node.js' behavior when FIPS is enabled so I guess that's something.
-  if (IoContext::hasCurrent()) {
-    IoContext::current().logWarningOnce(
+  KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
+    ioContext.logWarningOnce(
         "The verifySpkac function is currently of limited value in workers because "
         "the SPKAC signature verification uses MD5, which is not supported in FIPS mode. "
         "All workers run in FIPS mode. Accordingly, this method will currently always "

--- a/src/workerd/api/filesystem.c++
+++ b/src/workerd/api/filesystem.c++
@@ -1939,12 +1939,11 @@ FileFdHandle::~FileFdHandle() noexcept {
     }
 
     // If we have an active IoContext, then we'll go ahead and log a warning.
-    if (IoContext::hasCurrent()) {
-      IoContext::current().logWarning(
-          "A FileHandle was destroyed without being closed. This is "
-          "not recommended and may lead to file descriptors being held "
-          "far longer than necessary. Please make sure to explicitly close "
-          "the FileHandle object explicitly before it is destroyed."_kj);
+    KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
+      ioContext.logWarning("A FileHandle was destroyed without being closed. This is "
+                           "not recommended and may lead to file descriptors being held "
+                           "far longer than necessary. Please make sure to explicitly close "
+                           "the FileHandle object explicitly before it is destroyed."_kj);
     }
   }
 }

--- a/src/workerd/api/headers.c++
+++ b/src/workerd/api/headers.c++
@@ -274,8 +274,7 @@ static_assert(HEADER_HASH_TABLE.find("AcCePt-ChArSeT"_kj) == 1);
 static_assert(std::size(COMMON_HEADER_NAMES) == (Headers::MAX_COMMON_HEADER_ID + 1));
 
 void maybeWarnIfBadHeaderString(kj::StringPtr name, kj::StringPtr str) {
-  if (IoContext::hasCurrent()) {
-    auto& context = IoContext::current();
+  KJ_IF_SOME(context, IoContext::tryCurrent()) {
     if (context.isInspectorEnabled()) {
       if (!simdutf::validate_ascii(str.begin(), str.size())) {
         // The string contains non-ASCII characters. While any 8-bit value is technically valid

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -884,10 +884,8 @@ jsg::Promise<T> rejectedMaybeHandledPromise(
 }
 
 inline kj::Maybe<IoContext&> tryGetIoContext() {
-  if (IoContext::hasCurrent()) {
-    return IoContext::current();
-  }
-  return kj::none;
+  // TODO(cleanup): This function is obsolete; callers should just call IoContext::tryCurrent()
+  return IoContext::tryCurrent();
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -22,8 +22,7 @@ namespace {
 // will not go anywhere, but we'll log the exception message to the console until the problem this
 // papers over is fixed.
 [[noreturn]] void throwTypeErrorAndConsoleWarn(kj::StringPtr message) {
-  if (IoContext::hasCurrent()) {
-    auto& context = IoContext::current();
+  KJ_IF_SOME(context, IoContext::tryCurrent()) {
     if (context.isInspectorEnabled()) {
       context.logWarning(message);
     }

--- a/src/workerd/api/streams/transform.c++
+++ b/src/workerd/api/streams/transform.c++
@@ -15,8 +15,8 @@ namespace workerd::api {
 namespace {
 template <typename T>
 jsg::Function<T> maybeAddFunctor(auto t) {
-  if (IoContext::hasCurrent()) {
-    return jsg::Function<T>(IoContext::current().addFunctor(kj::mv(t)));
+  KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
+    return jsg::Function<T>(ioContext.addFunctor(kj::mv(t)));
   }
   return jsg::Function<T>(kj::mv(t));
 }

--- a/src/workerd/api/tracing-module.c++
+++ b/src/workerd/api/tracing-module.c++
@@ -28,8 +28,7 @@ void JsSpan::setAttribute(
 }
 
 jsg::Ref<JsSpan> TracingModule::startSpan(jsg::Lock& js, kj::String name) {
-  if (IoContext::hasCurrent()) {
-    auto& ioContext = IoContext::current();
+  KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
     auto spanBuilder = ioContext.makeUserTraceSpan(kj::ConstString(kj::mv(name)));
     auto ownedSpan = ioContext.addObject(kj::heap(kj::mv(spanBuilder)));
     return js.alloc<JsSpan>(kj::mv(ownedSpan));

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -702,8 +702,8 @@ JsRpcStub::~JsRpcStub() noexcept(false) {
     //   which is usually sooner (and more deterministic). But logging a warning during
     //   IoContext tear-down is problematic since logWarningOnce() is a method on
     //   IoContext...
-    if (IoContext::hasCurrent()) {
-      IoContext::current().logWarningOnce(
+    KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
+      ioContext.logWarningOnce(
           "An RPC stub was not disposed properly. You must call dispose() on all stubs in order to "
           "let the other side know that you are no longer using them. You cannot rely on "
           "the garbage collector for this because it may take arbitrarily long before actually "
@@ -737,8 +737,8 @@ RpcStubDisposalGroup::~RpcStubDisposalGroup() noexcept(false) {
       // In preview, let's try to warn the developer about the problem.
       //
       // TODO(cleanup): Same comment as in ~JsRpcStub().
-      if (IoContext::hasCurrent()) {
-        IoContext::current().logWarningOnce(
+      KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
+        ioContext.logWarningOnce(
             "An RPC result was not disposed properly. One of the RPC calls you made expects you "
             "to call dispose() on the return value, but you didn't do so. You cannot rely on "
             "the garbage collector for this because it may take arbitrarily long before actually "

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -399,6 +399,9 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   // Throws an exception if there is no current context (see hasCurrent() below).
   static IoContext& current();
 
+  // Like current(), but returns kj::none if there is no current context.
+  static kj::Maybe<IoContext&> tryCurrent();
+
   // True if there is a current IoContext for the thread (current() will not throw).
   static bool hasCurrent();
 

--- a/src/workerd/io/io-own.c++
+++ b/src/workerd/io/io-own.c++
@@ -29,7 +29,7 @@ void DeleteQueue::scheduleAction(jsg::Lock& js, kj::Function<void(jsg::Lock&)>&&
   // The queue was deleted, likely because the IoContext was destroyed and the
   // DeleteQueuePtr was invalidated. We are going to emit a warning and drop the
   // actions on the floor without scheduling them.
-  if (IoContext::hasCurrent()) {
+  KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
     // We are creating an error here just so we can include the JavaScript stack
     // with the warning if it exists. We are not going to throw this error.
     auto err = v8::Exception::Error(
@@ -47,7 +47,7 @@ void DeleteQueue::scheduleAction(jsg::Lock& js, kj::Function<void(jsg::Lock&)>&&
     auto stack = jsg::check(err->Get(js.v8Context(), js.str("stack"_kj)));
 
     // Safe to mutate here since we have the exclusive lock on the queue above.
-    IoContext::current().logWarning(kj::str(stack));
+    ioContext.logWarning(kj::str(stack));
   }
 }
 

--- a/src/workerd/io/io-util.c++
+++ b/src/workerd/io/io-util.c++
@@ -11,8 +11,7 @@
 namespace workerd {
 
 double dateNow() {
-  if (IoContext::hasCurrent()) {
-    auto& ioContext = IoContext::current();
+  KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
     return (ioContext.now() - kj::UNIX_EPOCH) / kj::MILLISECONDS;
   }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1584,8 +1584,8 @@ class RequestObserverWithTracer final: public RequestObserver, public WorkerInte
   ~RequestObserverWithTracer() noexcept(false) {
     KJ_IF_SOME(t, tracer) {
       // for a more precise end time, set the end timestamp now, if available
-      if (IoContext::hasCurrent()) {
-        auto time = IoContext::current().now();
+      KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
+        auto time = ioContext.now();
         t->recordTimestamp(time);
       }
       t->setOutcome(


### PR DESCRIPTION
A common pattern throughout the codebase is to check if there is a current IoContext via IoContext::hasCurrent() before calling IoContext::current(). This change introduces IoContext::tryCurrent() which returns a Maybe<IoContext&> to simplify this pattern and eliminate and remove redundant checks that are redundantly redundant.