### PR TITLE
Add patch_env to Python workers sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ coverage
 perf.data
 
 .claude
+
+# python
+__pycache__

--- a/src/pyodide/internal/envHelpers.ts
+++ b/src/pyodide/internal/envHelpers.ts
@@ -1,0 +1,9 @@
+import innerEnv from 'cloudflare-internal:env';
+
+// A generator that keeps the environment patched until it is resolved.
+// Used to define the patch_env context manager, see
+// src/pyodide/internal/workers-api/src/workers/_workers.py
+export function* patch_env_helper(patch: unknown): Generator<void> {
+  using _ = innerEnv.pythonPatchEnv(patch);
+  yield;
+}

--- a/src/pyodide/internal/util.ts
+++ b/src/pyodide/internal/util.ts
@@ -79,6 +79,12 @@ export function invalidateCaches(Module: Module): void {
   );
 }
 
-export function unreachable(msg: never): never {
+export function unreachable(
+  obj: never,
+  msg: string | undefined = undefined
+): never {
+  if (msg === undefined) {
+    msg = obj;
+  }
   throw new PythonWorkersInternalError(`Unreachable: ${msg}`);
 }

--- a/src/pyodide/internal/workers-api/src/workers/__init__.py
+++ b/src/pyodide/internal/workers-api/src/workers/__init__.py
@@ -20,6 +20,7 @@ from ._workers import (
     fetch,
     handler,
     import_from_javascript,
+    patch_env,
     python_from_rpc,
     python_to_rpc,
 )
@@ -47,6 +48,7 @@ __all__ = [
     "fetch",
     "handler",
     "import_from_javascript",
+    "patch_env",
     "python_from_rpc",
     "python_to_rpc",
 ]

--- a/src/pyodide/internal/workers-api/src/workers/_workers.py
+++ b/src/pyodide/internal/workers-api/src/workers/_workers.py
@@ -6,7 +6,14 @@ import functools
 import inspect
 import json
 from asyncio import create_task, gather
-from collections.abc import Awaitable, Generator, Iterable, MutableMapping
+from collections.abc import (
+    Awaitable,
+    Generator,
+    Iterable,
+    Iterator,
+    MutableMapping,
+    Sequence,
+)
 from contextlib import ExitStack, contextmanager
 from enum import StrEnum
 from http import HTTPMethod, HTTPStatus
@@ -94,6 +101,15 @@ def import_from_javascript(module_name: str) -> Any:
                 f"Failed to import '{module_name}': Only 'cloudflare:workers' and 'cloudflare:sockets' are available until the next python runtime version."
             ) from e
         raise
+
+
+@contextmanager
+def patch_env(
+    d: dict[str, Any] | Sequence[tuple[str, Any]] | None = None, **kwds: dict[str, Any]
+) -> Iterator[None]:
+    if d:
+        kwds = dict(d) | kwds
+    yield from _pyodide_entrypoint_helper.patch_env_helper(to_js(kwds))
 
 
 type JSBody = (

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -27,6 +27,7 @@ import {
   reportError,
 } from 'pyodide-internal:util';
 import { LOADED_SNAPSHOT_TYPE } from 'pyodide-internal:snapshot';
+import { patch_env_helper } from 'pyodide-internal:envHelpers';
 
 type PyFuture<T> = Promise<T> & { copy(): PyFuture<T>; destroy(): void };
 
@@ -65,10 +66,11 @@ function patchWaitUntil(ctx: {
 
 export type PyodideEntrypointHelper = {
   doAnImport: (mod: string) => Promise<any>;
-  cloudflareWorkersModule: any;
+  cloudflareWorkersModule: { env: any };
   cloudflareSocketsModule: any;
   workerEntrypoint: any;
   patchWaitUntil: typeof patchWaitUntil;
+  patch_env_helper: (patch: unknown) => Generator<void>;
 };
 import { maybeCollectDedicatedSnapshot } from 'pyodide-internal:snapshot';
 
@@ -96,6 +98,7 @@ export function setDoAnImport(
     cloudflareSocketsModule,
     workerEntrypoint,
     patchWaitUntil,
+    patch_env_helper,
   };
 }
 

--- a/src/pyodide/tsconfig.json
+++ b/src/pyodide/tsconfig.json
@@ -10,7 +10,8 @@
       "pyodide-internal:generated/emscriptenSetup": [
         "./internal/pool/emscriptenSetup.ts"
       ],
-      "internal:*": ["./types/*"]
+      "internal:*": ["./types/*"],
+      "cloudflare-internal:*": ["./types/cloudflare-internal/*"]
     },
     "typeRoots": ["./types"],
     "noEmit": false,

--- a/src/pyodide/types/cloudflare-internal/env.d.ts
+++ b/src/pyodide/types/cloudflare-internal/env.d.ts
@@ -1,0 +1,6 @@
+const innerEnv: {
+  pythonPatchEnv(patch: unknown): {
+    [Symbol.dispose](): void;
+  };
+};
+export default innerEnv;

--- a/src/workerd/api/modules.c++
+++ b/src/workerd/api/modules.c++
@@ -37,6 +37,11 @@ jsg::JsRef<jsg::JsValue> EnvModule::withEnv(
   });
 }
 
+jsg::Ref<PythonPatchedEnv> EnvModule::pythonPatchEnv(jsg::Lock& js, jsg::Value newEnv) {
+  auto& key = jsg::IsolateBase::from(js.v8Isolate).getEnvAsyncContextKey();
+  return jsg::alloc<PythonPatchedEnv>(js, key, kj::mv(newEnv));
+}
+
 kj::Maybe<jsg::JsObject> EnvModule::getCurrentExports(jsg::Lock& js) {
   auto& key = jsg::IsolateBase::from(js.v8Isolate).getExportsAsyncContextKey();
   // Check async context first - withExports() overrides take precedence over the disable flags.

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -7,6 +7,14 @@ py_wd_test("hello")
 
 py_wd_test("env-param")
 
+py_wd_test(
+    "top-level-env",
+    # TODO: snapshot for env
+    make_snapshot = False,
+    skip_python_flags = ["0.26.0a2"],
+    use_snapshot = None,
+)
+
 py_wd_test("asgi")
 
 py_wd_test("asgi-sse")

--- a/src/workerd/server/tests/python/top-level-env/env.wd-test
+++ b/src/workerd/server/tests/python/top-level-env/env.wd-test
@@ -1,0 +1,21 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "python-hello",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "worker.py")
+        ],
+        bindings = [
+          (
+            name = "secret",
+            text = "thisisasecret"
+          ),
+        ],
+        compatibilityDate = "2024-01-15",
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/top-level-env/worker.py
+++ b/src/workerd/server/tests/python/top-level-env/worker.py
@@ -1,0 +1,52 @@
+from js import Reflect
+from workers import WorkerEntrypoint, env, patch_env
+
+
+def check_normal():
+    assert env.secret == "thisisasecret"
+    assert not hasattr(env, "NAME")
+    assert not hasattr(env, "place")
+    assert not hasattr(env, "extra")
+    assert Reflect.ownKeys(env).to_py() == ["secret"]
+
+
+class Default(WorkerEntrypoint):
+    def test(self):
+        check_normal()
+
+        with patch_env(NAME=1, place="Somewhere"):
+            assert env.NAME == 1
+            assert env.place == "Somewhere"
+            assert not hasattr(env, "secret")
+
+        check_normal()
+
+        with patch_env({"NAME": 1, "place": "Somewhere"}):
+            assert env.NAME == 1
+            assert env.place == "Somewhere"
+            assert not hasattr(env, "secret")
+
+        check_normal()
+
+        with patch_env([("NAME", 1), ("place", "Somewhere")]):
+            assert env.NAME == 1
+            assert env.place == "Somewhere"
+            assert not hasattr(env, "secret")
+
+        check_normal()
+
+        with patch_env({"NAME": 1, "place": "Somewhere"}, extra=22):
+            assert env.NAME == 1
+            assert env.place == "Somewhere"
+            assert env.extra == 22
+            assert not hasattr(env, "secret")
+
+        check_normal()
+
+        try:
+            with patch_env(NAME=1, place="Somewhere"):
+                raise RuntimeError("oops")  # noqa: TRY301
+        except Exception:
+            pass
+
+        check_normal()

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -144,6 +144,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_TRACING_MODULE_ISOLATE_TYPES,
     EW_WORKERD_DEBUG_PORT_CLIENT_ISOLATE_TYPES,
     workerd::api::EnvModule,
+    workerd::api::PythonPatchedEnv,
 
     jsg::TypeWrapperExtension<PromiseWrapper>,
     jsg::InjectConfiguration<CompatibilityFlags::Reader>,


### PR DESCRIPTION
A context manager, to be used like:

```py
with patch_env(key1=value1, key2=value2):
    # env is patched
# env is restored
```