### PR TITLE
Python: Allow importing python compat flag from python source code

### DIFF
--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -47,8 +47,12 @@ export const TRANSITIVE_REQUIREMENTS =
 export const MAIN_MODULE_NAME = MetadataReader.getMainModule();
 
 export type CompatibilityFlags = MetadataReader.CompatibilityFlags;
-export const COMPATIBILITY_FLAGS: MetadataReader.CompatibilityFlags =
-  MetadataReader.getCompatibilityFlags();
+export const COMPATIBILITY_FLAGS: MetadataReader.CompatibilityFlags = {
+  // Compat flags returned from getCompatibilityFlags is immutable,
+  // but in Pyodide 0.26, we modify the JS object that is exposed to the Python through
+  // registerJsModule so we create a new object here by copying the values.
+  ...MetadataReader.getCompatibilityFlags(),
+};
 export const WORKFLOWS_ENABLED: boolean =
   !!COMPATIBILITY_FLAGS.python_workflows;
 const NO_GLOBAL_HANDLERS: boolean =

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -75,3 +75,5 @@ py_wd_test(
     make_snapshot = False,
     use_snapshot = "numpy",
 )
+
+py_wd_test("python-compat-flag")

--- a/src/workerd/server/tests/python/python-compat-flag/python-compat-flag.wd-test
+++ b/src/workerd/server/tests/python/python-compat-flag/python-compat-flag.wd-test
@@ -1,0 +1,14 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "python-compat-flag",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "worker.py"),
+        ],
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/python-compat-flag/worker.py
+++ b/src/workerd/server/tests/python/python-compat-flag/worker.py
@@ -1,0 +1,8 @@
+import _cloudflare_compat_flags
+from workers import WorkerEntrypoint
+
+
+class Default(WorkerEntrypoint):
+    def test(self):
+        assert _cloudflare_compat_flags.python_workflows
+        assert not _cloudflare_compat_flags.python_no_global_handlers


### PR DESCRIPTION
Related: https://github.com/cloudflare/workerd/pull/5678

We would like to make a small breaking change in Python, but it seems like currently importing compat flags are only available in the JS code for Python workers.

This PR enables importing compat flags from python code of Python workers such as

```python
import _cloudflare_compat_flags
_cloudflare_compat_flags.python_workflows
```

This PR includes updating the custom serializer for the snapshot as the compat flag object is exposed as a global object.