### PR TITLE
handle different builtin types in rust jsg registry

### DIFF
--- a/src/rust/api/lib.rs
+++ b/src/rust/api/lib.rs
@@ -22,15 +22,20 @@ mod ffi {
 }
 
 pub fn register_nodejs_modules(registry: Pin<&mut ffi::ModuleRegistry>) {
-    jsg::modules::add_builtin(registry, "node-internal:dns", |isolate| unsafe {
-        let mut lock = jsg::Lock::from_isolate(isolate);
-        let dns_util = jsg::Ref::new(DnsUtil {
-            _state: ResourceState::default(),
-        });
-        let mut dns_util_template = DnsUtilTemplate::new(&mut lock);
+    jsg::modules::add_builtin(
+        registry,
+        "node-internal:dns",
+        |isolate| unsafe {
+            let mut lock = jsg::Lock::from_isolate(isolate);
+            let dns_util = jsg::Ref::new(DnsUtil {
+                _state: ResourceState::default(),
+            });
+            let mut dns_util_template = DnsUtilTemplate::new(&mut lock);
 
-        jsg::wrap_resource(&mut lock, dns_util, &mut dns_util_template).into_ffi()
-    });
+            jsg::wrap_resource(&mut lock, dns_util, &mut dns_util_template).into_ffi()
+        },
+        jsg::modules::ModuleType::INTERNAL,
+    );
 }
 
 #[cfg(test)]

--- a/src/rust/jsg/ffi.h
+++ b/src/rust/jsg/ffi.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <workerd/jsg/modules.capnp.h>
+
 #include <kj-rs/kj-rs.h>
 #include <rust/cxx.h>
 #include <v8.h>
@@ -18,6 +20,7 @@ struct Local;
 struct Global;
 struct Realm;
 enum class ExceptionType : ::std::uint8_t;
+using ModuleType = ::workerd::jsg::ModuleType;
 using ModuleCallback = ::rust::Fn<Local(Isolate*)>;
 using WeakCallback = ::rust::Fn<void(Isolate*, size_t)>;
 
@@ -62,12 +65,15 @@ void fci_set_return_value(FunctionCallbackInfo* args, Local value);
 
 struct ModuleRegistry {
   virtual ~ModuleRegistry() = default;
-  virtual void addBuiltinModule(::rust::Str specifier, ModuleCallback moduleCallback) = 0;
+  virtual void addBuiltinModule(
+      ::rust::Str specifier, ModuleCallback moduleCallback, ModuleType moduleType) = 0;
 };
 
-inline void register_add_builtin_module(
-    ModuleRegistry& registry, ::rust::Str specifier, ModuleCallback callback) {
-  registry.addBuiltinModule(specifier, kj::mv(callback));
+inline void register_add_builtin_module(ModuleRegistry& registry,
+    ::rust::Str specifier,
+    ModuleCallback callback,
+    ModuleType moduleType) {
+  registry.addBuiltinModule(specifier, kj::mv(callback), moduleType);
 }
 
 Global create_resource_template(v8::Isolate* isolate, const ResourceDescriptor& descriptor);

--- a/src/rust/jsg/jsg.h
+++ b/src/rust/jsg/jsg.h
@@ -18,8 +18,8 @@ struct RustModuleRegistry: public ::workerd::rust::jsg::ModuleRegistry {
   virtual ~RustModuleRegistry() = default;
   RustModuleRegistry(Registry& registry): registry(registry) {}
 
-  // todo; add a parameter for jsg::moduletype
-  void addBuiltinModule(::rust::Str specifier, ModuleCallback moduleCallback) override {
+  void addBuiltinModule(
+      ::rust::Str specifier, ModuleCallback moduleCallback, ModuleType moduleType) override {
     registry.addBuiltinModule(kj::str(specifier),
         [kj_specifier = kj::str(specifier), callback = kj::mv(moduleCallback)](
             ::workerd::jsg::Lock& js, ::workerd::jsg::ModuleRegistry::ResolveMethod,
@@ -34,7 +34,7 @@ struct RustModuleRegistry: public ::workerd::rust::jsg::ModuleRegistry {
       return kj::Maybe(
           ModuleInfo(js, kj_specifier, kj::none, ObjectModuleInfo(js, value.As<v8::Object>())));
     },
-        ::workerd::jsg::ModuleType::INTERNAL);
+        moduleType);
   }
 
   Registry& registry;

--- a/src/rust/jsg/modules.rs
+++ b/src/rust/jsg/modules.rs
@@ -1,12 +1,10 @@
 use std::pin::Pin;
 
+pub use ffi::ModuleType;
+
 use crate::v8::ffi;
 
-pub enum Type {
-    INTERNAL,
-}
-
-/// Registers a builtin module with the given specifier.
+/// Registers a builtin module with the given specifier and module type.
 ///
 /// The callback is invoked when JavaScript imports the module, receiving the isolate pointer
 /// and returning a V8 Local handle to the module's exports object.
@@ -14,8 +12,9 @@ pub fn add_builtin(
     registry: Pin<&mut ffi::ModuleRegistry>,
     specifier: &str,
     callback: fn(*mut ffi::Isolate) -> ffi::Local,
+    module_type: ModuleType,
 ) {
     unsafe {
-        ffi::register_add_builtin_module(registry, specifier, callback);
+        ffi::register_add_builtin_module(registry, specifier, callback, module_type);
     }
 }

--- a/src/rust/jsg/v8.rs
+++ b/src/rust/jsg/v8.rs
@@ -24,6 +24,19 @@ pub mod ffi {
         Error,
     }
 
+    /// Module visibility level, corresponds to `workerd::jsg::ModuleType` from modules.capnp.
+    /// Values are automatically assigned by `cxx` because of extern declaration below.
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+    #[repr(u16)]
+    enum ModuleType {
+        BUNDLE,
+        BUILTIN,
+        INTERNAL,
+    }
+    unsafe extern "C++" {
+        type ModuleType;
+    }
+
     unsafe extern "C++" {
         include!("workerd/rust/jsg/ffi.h");
 
@@ -141,6 +154,7 @@ pub mod ffi {
             registry: Pin<&mut ModuleRegistry>,
             specifier: &str,
             callback: unsafe fn(*mut Isolate) -> Local,
+            module_type: ModuleType,
         );
     }
 }


### PR DESCRIPTION
Remove hard coded INTERNAL builtin type and support different types for module registry via rust/jsg integration