### PR TITLE
Fix JSRPC Return event timing to fire when handler returns

### DIFF
--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -33,6 +33,18 @@ wd_test(
     ],
 )
 
+# Test to validate timing semantics for JSRPC streaming responses.
+# This test verifies that Return events occur when the handler returns,
+# NOT when the stream is fully consumed.
+wd_test(
+    src = "jsrpc-timing-test.wd-test",
+    args = ["--experimental"],
+    data = [
+        "jsrpc-timing-test.js",
+        "jsrpc-timing-test-tail.js",
+    ],
+)
+
 # Test for a worker that can log to itself using the isTracer parameter
 wd_test(
     src = "self-logger-test.wd-test",

--- a/src/workerd/api/tests/jsrpc-timing-test-tail.js
+++ b/src/workerd/api/tests/jsrpc-timing-test-tail.js
@@ -1,0 +1,139 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Streaming tail worker that captures timing information for JSRPC invocations.
+// This validates that Return events occur at the expected time.
+//
+// Expected timeline:
+//   T=0:      Onset (invocation starts)
+//   T=~500ms: Return (handler returns the stream)
+//   T=~950ms: Outcome (stream fully consumed)
+
+import * as assert from 'node:assert';
+
+// Store events by invocation ID so we can analyze timing per-invocation
+let invocationEvents = new Map();
+
+export default {
+  tailStream(onsetEvent, env, ctx) {
+    const invocationId = onsetEvent.invocationId;
+    const baseTimestamp = onsetEvent.timestamp.getTime();
+
+    // Initialize event list for this invocation
+    const events = [
+      {
+        type: onsetEvent.event.type,
+        relativeTimeMs: 0,
+        info: onsetEvent.event.info?.type,
+        entrypoint: onsetEvent.event.entrypoint,
+      },
+    ];
+    invocationEvents.set(invocationId, { baseTimestamp, events });
+
+    return (event) => {
+      const relativeTimeMs = event.timestamp.getTime() - baseTimestamp;
+
+      const eventRecord = {
+        type: event.event.type,
+        relativeTimeMs,
+      };
+
+      // Capture additional info for specific event types
+      if (event.event.type === 'return') {
+        eventRecord.returnInfo = event.event.info;
+      } else if (event.event.type === 'outcome') {
+        eventRecord.outcome = event.event.outcome;
+        eventRecord.cpuTime = event.event.cpuTime;
+        eventRecord.wallTime = event.event.wallTime;
+      } else if (event.event.type === 'attributes') {
+        eventRecord.attributes = event.event.info;
+      }
+
+      events.push(eventRecord);
+    };
+  },
+};
+
+export const test = {
+  async test() {
+    // Wait briefly for all tail events to be processed
+    await scheduler.wait(200);
+
+    // Find the StreamingService invocation (the JSRPC call)
+    let streamingServiceEvents = null;
+    for (const [invocationId, data] of invocationEvents.entries()) {
+      const onset = data.events[0];
+      if (onset.entrypoint === 'StreamingService' && onset.info === 'jsrpc') {
+        streamingServiceEvents = data.events;
+        break;
+      }
+    }
+
+    if (!streamingServiceEvents) {
+      console.log('Captured invocations:');
+      for (const [invocationId, data] of invocationEvents.entries()) {
+        console.log(`  ${invocationId}: ${JSON.stringify(data.events[0])}`);
+      }
+      throw new Error(
+        'Could not find StreamingService JSRPC invocation events'
+      );
+    }
+
+    console.log(
+      'StreamingService events:',
+      JSON.stringify(streamingServiceEvents, null, 2)
+    );
+
+    // Find the key events
+    const onset = streamingServiceEvents.find((e) => e.type === 'onset');
+    const returnEvent = streamingServiceEvents.find((e) => e.type === 'return');
+    const outcome = streamingServiceEvents.find((e) => e.type === 'outcome');
+
+    // Validate all events are present
+    assert.ok(onset, 'Missing onset event');
+    assert.ok(outcome, 'Missing outcome event');
+
+    if (!returnEvent) {
+      console.log('WARNING: No return event found for JSRPC invocation!');
+      console.log(
+        'This may indicate setReturn() is not being called for JSRPC.'
+      );
+      throw new Error('Return event not captured for JSRPC invocation');
+    }
+
+    const timeToReturn = returnEvent.relativeTimeMs;
+    const timeToOutcome = outcome.relativeTimeMs;
+    const gap = timeToOutcome - timeToReturn;
+
+    console.log(`timeToReturn: ${timeToReturn}ms`);
+    console.log(`timeToOutcome: ${timeToOutcome}ms`);
+    console.log(`Gap between Return and Outcome: ${gap}ms`);
+
+    // Key validation: Return must happen BEFORE Outcome
+    if (timeToReturn >= timeToOutcome) {
+      throw new Error(
+        `Return event (${timeToReturn}ms) should happen before Outcome (${timeToOutcome}ms). ` +
+          `This indicates Return is fired when stream ends, not when handler returns.`
+      );
+    }
+
+    // Return should happen at least 200ms after onset (handler sleeps for 500ms)
+    if (timeToReturn < 200) {
+      throw new Error(
+        `Return event (${timeToReturn}ms) happened too quickly. ` +
+          `Expected at least 200ms from onset (handler sleeps for 500ms before returning).`
+      );
+    }
+
+    // Return should be significantly before Outcome (at least 200ms gap for stream drain)
+    if (gap < 200) {
+      throw new Error(
+        `Gap between Return (${timeToReturn}ms) and Outcome (${timeToOutcome}ms) is only ${gap}ms. ` +
+          `Expected at least 200ms for stream consumption.`
+      );
+    }
+
+    console.log(`PASS: Return event occurs ${gap}ms before Outcome`);
+  },
+};

--- a/src/workerd/api/tests/jsrpc-timing-test.js
+++ b/src/workerd/api/tests/jsrpc-timing-test.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2017-2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Test to validate timing semantics for JSRPC invocations with streaming responses.
+// This test verifies that the Return event is emitted at the correct time relative
+// to Onset and Outcome events.
+//
+// Expected timeline:
+//   T=0:      Onset (invocation starts)
+//   T=~500ms: Return (handler returns the stream)
+//   T=~950ms: Outcome (stream fully consumed)
+
+import { WorkerEntrypoint } from 'cloudflare:workers';
+
+export class StreamingService extends WorkerEntrypoint {
+  async getStreamWithDelays() {
+    // Sleep 500ms before returning the stream
+    await scheduler.wait(500);
+
+    // Return a ReadableStream that takes ~450ms to drain
+    const encoder = new TextEncoder();
+    let chunksSent = 0;
+
+    const stream = new ReadableStream({
+      async pull(controller) {
+        if (chunksSent >= 3) {
+          controller.close();
+          return;
+        }
+        // Sleep 150ms between chunks (3 chunks = ~450ms to drain)
+        await scheduler.wait(150);
+        controller.enqueue(encoder.encode(`chunk${chunksSent++}\n`));
+      },
+    });
+
+    return stream;
+  }
+}
+
+export default {
+  async test(controller, env, ctx) {
+    // Call the streaming RPC method
+    const stream = await env.StreamingService.getStreamWithDelays();
+
+    // Consume the stream fully
+    const reader = stream.getReader();
+    let chunks = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(new TextDecoder().decode(value));
+    }
+
+    // Verify we got all chunks
+    if (chunks.length !== 3) {
+      throw new Error(`Expected 3 chunks, got ${chunks.length}`);
+    }
+
+    // The actual timing validation is done in the tail worker's test() handler
+  },
+};

--- a/src/workerd/api/tests/jsrpc-timing-test.wd-test
+++ b/src/workerd/api/tests/jsrpc-timing-test.wd-test
@@ -1,0 +1,41 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+# Test to validate timing semantics for JSRPC invocations with streaming responses.
+# This test verifies that the Return event is emitted when the handler returns,
+# NOT when the stream is fully consumed.
+#
+# Expected timeline:
+#   T=0:      Onset event (invocation starts)
+#   T=~500ms: Return event (handler returns ReadableStream after 500ms sleep)
+#   T=~950ms: Outcome event (stream fully consumed after ~450ms more)
+#
+# If Return event occurs at T=~950ms instead of T=~500ms, this indicates a bug
+# where setReturn() is called when capabilities are released rather than
+# when the handler actually returns.
+
+const unitTests :Workerd.Config = (
+  services = [
+    (name = "jsrpc-timing-test", worker = .mainWorker),
+    (name = "tail", worker = .tailWorker),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "jsrpc-timing-test.js")
+  ],
+  compatibilityDate = "2024-01-01",
+  compatibilityFlags = ["nodejs_compat", "experimental", "precise_timers"],
+  bindings = [
+    (name = "StreamingService", service = (name = "jsrpc-timing-test", entrypoint = "StreamingService")),
+  ],
+  streamingTails = ["tail"],
+);
+
+const tailWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "jsrpc-timing-test-tail.js")
+  ],
+  compatibilityDate = "2024-01-01",
+  compatibilityFlags = ["experimental", "nodejs_compat", "precise_timers"],
+);

--- a/src/workerd/api/tests/tail-worker-test.js
+++ b/src/workerd/api/tests/tail-worker-test.js
@@ -130,7 +130,7 @@ export const test = {
       '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"MyActor","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"log","level":"log","message":["baz"]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"functionProperty"}]}{"type":"return"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
       // Test for transient objects - getCounter returns an object with methods
       // All transient calls happen in a single trace event, with only the entrypoint method reported
-      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["getCounter called"]}{"type":"log","level":"log","message":["increment called on transient"]}{"type":"log","level":"log","message":["getValue called on transient"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["getCounter called"]}{"type":"return"}{"type":"log","level":"log","message":["increment called on transient"]}{"type":"log","level":"log","message":["getValue called on transient"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);


### PR DESCRIPTION
Previously, the Return tracing event for JSRPC calls was emitted when the entire session completed (after all streams were consumed and capabilities released). This was incorrect - the Return event should mark when the handler returned a value, not when all data transfer finished.

Move setReturn() from JsRpcSessionCustomEvent::run() completion to EntrypointJsRpcTarget::call() completion. This ensures the Return event fires at the correct time in the request lifecycle.

Add tests that validate:
- Return event occurs before Outcome event
- Return event occurs at least 200ms after onset (handler work time)
- Gap between Return and Outcome is at least 200ms (stream drain time)