### PR TITLE
Add rpc_params_dup_stubs compat flag.

### DIFF
--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -276,6 +276,12 @@ wd_test(
 )
 
 wd_test(
+    src = "js-rpc-params-ownership-test.wd-test",
+    args = ["--experimental"],
+    data = ["js-rpc-params-ownership-test.js"],
+)
+
+wd_test(
     src = "memory-cache-test.wd-test",
     args = ["--experimental"],
     data = ["memory-cache-test.js"],

--- a/src/workerd/api/tests/js-rpc-params-ownership-test.js
+++ b/src/workerd/api/tests/js-rpc-params-ownership-test.js
@@ -1,0 +1,189 @@
+import assert from 'node:assert';
+import { WorkerEntrypoint, RpcTarget, RpcStub } from 'cloudflare:workers';
+
+class Counter extends RpcTarget {
+  count = { value: 0 };
+  dupCounts = { created: 0, disposed: 0 };
+  disposeCount = 0;
+
+  increment(amount = 1) {
+    this.count.value += amount;
+    return this.count.value;
+  }
+
+  [Symbol.dispose]() {
+    ++this.disposeCount;
+  }
+}
+
+class DupableCounter extends Counter {
+  disposed = false;
+
+  dup() {
+    let result = new DupableCounter();
+    result.count = this.count;
+    result.dupCounts = this.dupCounts;
+    ++this.dupCounts.created;
+    return result;
+  }
+
+  [Symbol.dispose]() {
+    if (this.disposed) {
+      throw new Error('duplicate disposal');
+    }
+    this.disposed = true;
+    ++this.dupCounts.disposed;
+    ++this.disposeCount;
+  }
+}
+
+export class TestService extends WorkerEntrypoint {
+  async increment(stub, i) {
+    await stub.increment(i);
+  }
+
+  async roundTrip(stub) {
+    return { stub: stub.dup() };
+  }
+}
+
+// Test that (with the rpc_params_dup_stubs compat flag) passing a stub in RPC params doesn't
+// transfer ownership of the stub.
+export let rpcParamsDontTransferOwnership = {
+  async test(controller, env, ctx) {
+    let counter = new Counter();
+
+    {
+      using stub = new RpcStub(counter);
+
+      // Use the stub in params twice to prove that ownership isn't transferred away.
+      await ctx.exports.TestService.increment(stub, 2);
+      await ctx.exports.TestService.increment(stub, 3);
+
+      // Make extra-sure we can still call the stub.
+      await stub.increment();
+
+      assert.strictEqual(counter.count.value, 6);
+
+      // RpcTarget disposer should not have been called at all.
+      await scheduler.wait(0);
+      assert.strictEqual(counter.disposeCount, 0);
+    }
+
+    // Disposing a stub *asynchrconously* disposes the RpcTarget, so we have to spin the event
+    // loop to observe the disposal.
+    await scheduler.wait(0);
+    assert.strictEqual(counter.disposeCount, 1);
+  },
+};
+
+// Test that placing a plain RpcTarget in RPC params DOES "take ownership", that is, the disposer
+// will be called.
+export let rpcParamsPlainTarget = {
+  async test(controller, env, ctx) {
+    let counter = new Counter();
+
+    await ctx.exports.TestService.increment(counter, 2);
+    await ctx.exports.TestService.increment(counter, 3);
+
+    assert.strictEqual(counter.count.value, 5);
+
+    // Each RPC invocation will have called the disposer.
+    await scheduler.wait(0);
+    assert.strictEqual(counter.disposeCount, 2);
+  },
+};
+
+// Test that placing an RpcTarget with a dup() method in RPC params causes the dup() method to be
+// called, and then the duplicate is later disposed.
+export let rpcParamsDupTarget = {
+  async test(controller, env, ctx) {
+    let counter = new DupableCounter();
+
+    // If we directly pass `counter` to RPC params, it'll be dup()ed.
+    await ctx.exports.TestService.increment(counter, 2);
+    assert.strictEqual(counter.dupCounts.created, 1);
+    await ctx.exports.TestService.increment(counter, 3);
+    assert.strictEqual(counter.dupCounts.created, 2);
+
+    assert.strictEqual(counter.count.value, 5);
+
+    // Dups should have been disposed, but not original.
+    await scheduler.wait(0);
+    assert.strictEqual(counter.dupCounts.disposed, 2);
+    assert.strictEqual(counter.disposed, false);
+  },
+};
+
+// Like rpcParamsDupTarget but the target is wrapped in a Proxy. (This takes a different code
+// path.)
+export let rpcParamsDupProxyTarget = {
+  async test(controller, env, ctx) {
+    let counter = new Proxy(new DupableCounter(), {});
+
+    // If we directly pass `counter` to RPC params, it'll be dup()ed.
+    await ctx.exports.TestService.increment(counter, 2);
+    assert.strictEqual(counter.dupCounts.created, 1);
+    await ctx.exports.TestService.increment(counter, 3);
+    assert.strictEqual(counter.dupCounts.created, 2);
+
+    assert.strictEqual(counter.count.value, 5);
+
+    // Dups should have been disposed, but not original.
+    await scheduler.wait(0);
+    assert.strictEqual(counter.dupCounts.disposed, 2);
+    assert.strictEqual(counter.disposed, false);
+  },
+};
+
+// Like rpcParamsDupTarget but the target is a function.
+export let rpcParamsDupFunction = {
+  async test(controller, env, ctx) {
+    let count = 0;
+    let dupCount = 0;
+    let disposeCount = 0;
+
+    let increment = (i) => {
+      return (count += i);
+    };
+    increment.dup = () => {
+      ++dupCount;
+      return increment;
+    };
+    increment[Symbol.dispose] = function () {
+      ++disposeCount;
+    };
+
+    let counter = { increment };
+
+    // If we directly pass `counter` to RPC params, it'll be dup()ed.
+    await ctx.exports.TestService.increment(counter, 2);
+    assert.strictEqual(dupCount, 1);
+    await ctx.exports.TestService.increment(counter, 3);
+    assert.strictEqual(dupCount, 2);
+
+    assert.strictEqual(count, 5);
+
+    await scheduler.wait(0);
+    assert.strictEqual(disposeCount, 2);
+  },
+};
+
+// Test that returning a stub tansfers ownership of the stub, that is, the system later disposes
+// it.
+export let rpcReturnsTransferOwnership = {
+  async test(controller, env, ctx) {
+    let counter = new Counter();
+
+    {
+      using stub = new RpcStub(counter);
+      using stub2 = (await ctx.exports.TestService.roundTrip(stub)).stub;
+
+      await scheduler.wait(0);
+      assert.strictEqual(counter.disposeCount, 0);
+    }
+
+    await scheduler.wait(0);
+    assert.strictEqual(counter.disposeCount, 1);
+  },
+};

--- a/src/workerd/api/tests/js-rpc-params-ownership-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-params-ownership-test.wd-test
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "js-rpc-params-ownership-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "js-rpc-params-ownership-test.js")
+        ],
+        compatibilityDate = "2025-12-01",
+        compatibilityFlags = [
+          "nodejs_compat",
+          "rpc_params_dup_stubs",
+        ],
+      )
+    ),
+  ],
+  v8Flags = [ "--expose-gc" ],
+);

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -38,10 +38,17 @@ class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandle
  public:
   using GetStreamSinkFunc = kj::Function<rpc::JsValue::StreamSink::Client()>;
 
+  enum StubOwnership { TRANSFER, DUPLICATE };
+
   // `getStreamSinkFunc` will be called at most once, the first time a stream is encountered in
   // serialization, to get the StreamSink that should be used.
-  RpcSerializerExternalHandler(GetStreamSinkFunc getStreamSinkFunc)
-      : getStreamSinkFunc(kj::mv(getStreamSinkFunc)) {}
+  RpcSerializerExternalHandler(StubOwnership stubOwnership, GetStreamSinkFunc getStreamSinkFunc)
+      : stubOwnership(stubOwnership),
+        getStreamSinkFunc(kj::mv(getStreamSinkFunc)) {}
+
+  inline StubOwnership getStubOwnership() {
+    return stubOwnership;
+  }
 
   using BuilderCallback = kj::Function<void(rpc::JsValue::External::Builder)>;
 
@@ -90,6 +97,7 @@ class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandle
       jsg::Lock& js, jsg::Serializer& serializer, v8::Local<v8::Proxy> proxy) override;
 
  private:
+  StubOwnership stubOwnership;
   GetStreamSinkFunc getStreamSinkFunc;
 
   kj::Vector<BuilderCallback> externals;


### PR DESCRIPTION
This flag changes the Worker RPC behavior to match Cap'n Web: When a stub is passed in the params of an RPC method, we should NOT transfer ownership of the stub. Instead, the stub is dup()ed.

The comments explain in more detail why these semantics are superior (and thus why Cap'n Web took them).

Additionally, in the case that the params contain an `RpcTarget`, if that target has a `dup()` method, we call it. This specifically fixes an interoperability bug with Cap'n Web: https://github.com/cloudflare/capnweb/issues/110