### PR TITLE
12-22-25 build cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The compiled binary will be located at `bazel-bin/src/workerd/server/workerd`.
 If you run a Bazel build before you've installed some dependencies (like clang or libc++), and then you install the dependencies, you must resync locally cached toolchains, or clean Bazel's cache, otherwise you might get strange errors:
 
 ```sh
-bazel sync --configure
+bazel fetch --configure --force
 ```
 
 If that fails, you can try:

--- a/build/BUILD.nbytes
+++ b/build/BUILD.nbytes
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_library(
     name = "nbytes",
     srcs = ["src/nbytes.cpp"],

--- a/build/BUILD.simdutf
+++ b/build/BUILD.simdutf
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_library(
     name = "simdutf",
     srcs = ["simdutf.cpp"],

--- a/build/BUILD.zlib
+++ b/build/BUILD.zlib
@@ -5,6 +5,7 @@
 # than x86_64 or arm64
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 zlib_warnings = [
     "-Wno-incompatible-pointer-types",

--- a/deps/rust/BUILD.lolhtml
+++ b/deps/rust/BUILD.lolhtml
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_library(
     name = "lolhtml",
     hdrs = ["@crates_vendor__lol_html_c_api-1.3.0//:include/lol_html.h"],

--- a/src/workerd/api/node/tests/http-agent-nodejs-server.js
+++ b/src/workerd/api/node/tests/http-agent-nodejs-server.js
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 // This is a sidecar that runs alongside the http-client-nodejs-test.* tests.
-// It is executed using the appropriate Node.js version defined in WORKSPACE.
+// It is executed using the appropriate Node.js version defined in build/deps/nodejs.MODULE.bazel.
 const http = require('node:http');
 
 function reportAddress(server) {

--- a/src/workerd/api/node/tests/http-client-nodejs-server.js
+++ b/src/workerd/api/node/tests/http-client-nodejs-server.js
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 // This is a sidecar that runs alongside the http-client-nodejs-test.* tests.
-// It is executed using the appropriate Node.js version defined in WORKSPACE.
+// It is executed using the appropriate Node.js version defined in build/deps/nodejs.MODULE.bazel.
 const http = require('node:http');
 const assert = require('node:assert/strict');
 

--- a/src/workerd/api/node/tests/http-nodejs-server.js
+++ b/src/workerd/api/node/tests/http-nodejs-server.js
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 // This is a sidecar that runs alongside the http-client-nodejs-test.* tests.
-// It is executed using the appropriate Node.js version defined in WORKSPACE.
+// It is executed using the appropriate Node.js version defined in build/deps/nodejs.MODULE.bazel.
 const http = require('node:http');
 const assert = require('node:assert/strict');
 

--- a/src/workerd/api/node/tests/http-outgoing-nodejs-server.js
+++ b/src/workerd/api/node/tests/http-outgoing-nodejs-server.js
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 // This is a sidecar that runs alongside the http-client-nodejs-test.* tests.
-// It is executed using the appropriate Node.js version defined in WORKSPACE.
+// It is executed using the appropriate Node.js version defined in build/deps/nodejs.MODULE.bazel.
 const http = require('node:http');
 const assert = require('node:assert/strict');
 

--- a/src/workerd/api/node/tests/http-server-nodejs-server.js
+++ b/src/workerd/api/node/tests/http-server-nodejs-server.js
@@ -3,7 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 // This is a sidecar that runs alongside the http-client-nodejs-test.* tests.
-// It is executed using the appropriate Node.js version defined in WORKSPACE.
+// It is executed using the appropriate Node.js version defined in build/deps/nodejs.MODULE.bazel.
 const http = require('node:http');
 
 function reportPort(server) {

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -27,7 +27,7 @@ native_binary(
         {
             "@bazel_tools//src/conditions:linux_x86_64": "@clang_tidy_linux_amd64//file:downloaded",
             "@bazel_tools//src/conditions:linux_aarch64": "@clang_tidy_linux_arm64//file:downloaded",
-            "@bazel_tools//src/conditions:darwin_arm64": "@clang_tidy_macos_arm64//file:downloaded",
+            "@bazel_tools//src/conditions:darwin_arm64": "@clang_tidy_darwin_arm64//file:downloaded",
             "@bazel_tools//src/conditions:windows_x64": "@clang_tidy_windows_amd64//file:downloaded",
         },
     ),


### PR DESCRIPTION
Add more missing cc_library imports for Bazel 9
`bazel sync` is deprecated under bzlmod, replace with `bazel fetch` now that we have mostly completed the transition
Fix running clang-tidy under macOS after the repo name changed when clang-tidy moved to bzlmod
Fix comments to point to correct file for node version