### PR TITLE
No need to override the setImmediate/clearImmediate functions

### DIFF
--- a/src/node/internal/internal_timers_global_override.ts
+++ b/src/node/internal/internal_timers_global_override.ts
@@ -16,8 +16,6 @@ import {
   setInterval,
   clearTimeout,
   clearInterval,
-  setImmediate,
-  clearImmediate,
 } from 'node-internal:internal_timers';
 
 globalThis.setTimeout = setTimeout as unknown as typeof globalThis.setTimeout;
@@ -27,5 +25,3 @@ globalThis.clearTimeout =
   clearTimeout as unknown as typeof globalThis.clearTimeout;
 globalThis.clearInterval =
   clearInterval as unknown as typeof globalThis.clearInterval;
-globalThis.setImmediate = setImmediate;
-globalThis.clearImmediate = clearImmediate;

--- a/src/workerd/api/node/tests/timers-global-override-test.wd-test
+++ b/src/workerd/api/node/tests/timers-global-override-test.wd-test
@@ -7,8 +7,8 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "timers-global-override-test.js")
         ],
-        compatibilityDate = "2025-01-01",
-        compatibilityFlags = ["nodejs_compat_v2", "experimental", "enable_nodejs_global_timers"],
+        compatibilityDate = "2025-12-15",
+        compatibilityFlags = ["nodejs_compat", "experimental", "enable_nodejs_global_timers"],
       )
     ),
   ],


### PR DESCRIPTION
When `nodejs_compat` is enabled, `setImmediate/clearImmediate` are already exposed on the `globalThis` and do not need to be overridden. The versions exposed via `node:timers` are not special in any way, they are simply thin wrappers around the built-ins.