### PR TITLE
improve streams wpt coverage

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -1467,7 +1467,7 @@ void WritableImpl<Self>::setup(jsg::Lock& js,
         dealWithRejection(js, kj::mv(self), handle);
       });
 
-  flags.backpressure = getDesiredSize() < 0;
+  flags.backpressure = getDesiredSize() <= 0;
 
   maybeRunAlgorithm(js, startAlgorithm, kj::mv(onSuccess), kj::mv(onFailure), self.addRef());
 }
@@ -3341,6 +3341,10 @@ jsg::Promise<void> WritableStreamJsController::close(jsg::Lock& js, bool markAsH
           js, js.v8TypeError("This WritableStream has been closed."_kj), markAsHandled);
     }
     KJ_CASE_ONEOF(errored, StreamStates::Errored) {
+      if (FeatureFlags::get(js).getPedanticWpt()) {
+        return rejectedMaybeHandledPromise<void>(
+            js, js.v8TypeError("This WritableStream has been errored."_kj), markAsHandled);
+      }
       return rejectedMaybeHandledPromise<void>(js, errored.getHandle(js), markAsHandled);
     }
     KJ_CASE_ONEOF(controller, Controller) {

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -177,13 +177,14 @@ void WritableStreamDefaultWriter::replaceReadyPromise(
   this->readyPromise = KJ_ASSERT_NONNULL(this->readyPromisePending).whenResolved(js);
 }
 
-jsg::Promise<void> WritableStreamDefaultWriter::write(jsg::Lock& js, v8::Local<v8::Value> chunk) {
+jsg::Promise<void> WritableStreamDefaultWriter::write(
+    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> chunk) {
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(i, Initial) {
       KJ_FAIL_ASSERT("this writer was never attached");
     }
     KJ_CASE_ONEOF(stream, Attached) {
-      return stream->getController().write(js, chunk);
+      return stream->getController().write(js, kj::mv(chunk));
     }
     KJ_CASE_ONEOF(r, Released) {
       return js.rejectedPromise<void>(

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -39,7 +39,7 @@ class WritableStreamDefaultWriter: public jsg::Object, public WritableStreamCont
   //   complete on this side if we don't care that they're actually read?
   jsg::Promise<void> close(jsg::Lock& js);
 
-  jsg::Promise<void> write(jsg::Lock& js, v8::Local<v8::Value> chunk);
+  jsg::Promise<void> write(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> chunk);
   void releaseLock(jsg::Lock& js);
 
   JSG_RESOURCE_TYPE(WritableStreamDefaultWriter, CompatibilityFlags::Reader flags) {

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -111,6 +111,7 @@ wpt_test(
 wpt_test(
     name = "streams",
     size = "large",
+    compat_flags = ["pedantic_wpt"],
     config = "streams-test.ts",
     wpt_directory = "@wpt//:streams@module",
 )

--- a/src/wpt/streams-test.ts
+++ b/src/wpt/streams-test.ts
@@ -739,7 +739,6 @@ export default {
       'Aborting a WritableStream puts it in an errored state with the error passed to abort()',
       'if a writer is created for a stream with a pending abort, its ready should be rejected with the abort error',
       'sink abort() should not be called if stream was erroring due to bad strategy before abort() was called',
-      "WritableStream if sink's abort throws, for an abort performed during a write, the promise returned by ws.abort() rejects",
       'writer.abort() while there is an in-flight write, and then finish the write with rejection',
       'writer.abort(), controller.error() while there is an in-flight write, and then finish the write',
       'writer.abort(), controller.error() while there is an in-flight close, and then finish the close',
@@ -774,7 +773,6 @@ export default {
     expectedFailures: [
       'when close is called on a WritableStream in waiting state, ready promise should be fulfilled',
       'releaseLock() should not change the result of sync close()',
-      'close() on an errored stream should reject',
     ],
   },
   'writable-streams/constructor.any.js': {
@@ -815,13 +813,7 @@ export default {
       'ready promise should fire before closed on releaseLock',
     ],
   },
-  'writable-streams/properties.any.js': {
-    comment: 'To be investigated',
-    expectedFailures: [
-      'sink method write should be called with the right number of arguments',
-      "sink method write should be called even when it's located on the prototype chain",
-    ],
-  },
+  'writable-streams/properties.any.js': {},
   'writable-streams/reentrant-strategy.any.js': {
     comment: 'A hanging Promise was canceled.',
     disabledTests: true,
@@ -830,15 +822,12 @@ export default {
     comment: 'To be investigated',
     expectedFailures: [
       "underlying sink's write or close should not be called if start throws",
-      'when start() rejects, writer promises should reject in standard order',
     ],
   },
   'writable-streams/write.any.js': {
     comment: 'To be investigated',
     expectedFailures: [
-      'write() on a stream with HWM 0 should not cause the ready Promise to resolve',
       'WritableStream should transition to waiting until write is acknowledged',
-      "when sink's write throws an error, the stream should become errored and the promise should reject",
     ],
   },
 } satisfies TestRunnerConfig;


### PR DESCRIPTION
Web platform tests are strict about what type of errors are thrown from functions. This pull-request introduces a breaking change put behind a pedantic_wpt