### PR TITLE
Add @all-autogates test variant to wd_test

### DIFF
--- a/build/kj_test.bzl
+++ b/build/kj_test.bzl
@@ -49,7 +49,7 @@ def kj_test(
     )
 
     sh_test(
-        name = test_name,
+        name = test_name + "@",
         size = size,
         srcs = ["//build/fixtures:kj_test.sh"],
         data = [cross_alias] + data,
@@ -57,7 +57,7 @@ def kj_test(
         tags = tags,
     )
     sh_test(
-        name = test_name + "@all-autogates-enabled",
+        name = test_name + "@all-autogates",
         size = size,
         env = {"WORKERD_ALL_AUTOGATES": "1"},
         srcs = ["//build/fixtures:kj_test.sh"],

--- a/src/workerd/api/node/tests/BUILD.bazel
+++ b/src/workerd/api/node/tests/BUILD.bazel
@@ -335,6 +335,8 @@ wd_test(
     src = "dns-nodejs-test.wd-test",
     args = ["--experimental"],
     data = ["dns-nodejs-test.js"],
+    # TODO(jsg-rs): This test breaks when RUST_BACKED_NODE_DNS is enabled.
+    generate_all_autogates_variant = False,
     tags = ["requires-network"],
 )
 

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -341,6 +341,22 @@ wd_test(
     data = ["unsafe-test.js"],
 )
 
+# Test that verifies autogates are ENABLED - only runs in @all-autogates variant
+wd_test(
+    src = "autogate-enabled-test.wd-test",
+    args = ["--experimental"],
+    data = ["autogate-enabled-test.js"],
+    generate_default_variant = False,
+)
+
+# Test that verifies autogates are DISABLED - only runs in default variant
+wd_test(
+    src = "autogate-disabled-test.wd-test",
+    args = ["--experimental"],
+    data = ["autogate-disabled-test.js"],
+    generate_all_autogates_variant = False,
+)
+
 wd_test(
     src = "url-test.wd-test",
     args = ["--experimental"],

--- a/src/workerd/api/tests/autogate-disabled-test.js
+++ b/src/workerd/api/tests/autogate-disabled-test.js
@@ -1,0 +1,18 @@
+// Test that verifies autogates are DISABLED.
+// This test only runs in the default variant (all-autogates variant is disabled).
+
+import { strictEqual } from 'node:assert';
+import unsafe from 'workerd:unsafe';
+
+export const autogateDisabledTest = {
+  test() {
+    // In the default variant, WORKERD_ALL_AUTOGATES env var is NOT set,
+    // so isTestAutogateEnabled() should return false.
+    const isEnabled = unsafe.isTestAutogateEnabled();
+    strictEqual(
+      isEnabled,
+      false,
+      'TEST_WORKERD autogate should be DISABLED in default variant'
+    );
+  },
+};

--- a/src/workerd/api/tests/autogate-disabled-test.wd-test
+++ b/src/workerd/api/tests/autogate-disabled-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "autogate-disabled-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "autogate-disabled-test.js")
+        ],
+        compatibilityDate = "2024-01-01",
+        compatibilityFlags = ["nodejs_compat", "unsafe_module"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/tests/autogate-enabled-test.js
+++ b/src/workerd/api/tests/autogate-enabled-test.js
@@ -1,0 +1,18 @@
+// Test that verifies autogates are ENABLED.
+// This test only runs in the @all-autogates variant (default variant is disabled).
+
+import { strictEqual } from 'node:assert';
+import unsafe from 'workerd:unsafe';
+
+export const autogateEnabledTest = {
+  test() {
+    // In the @all-autogates variant, WORKERD_ALL_AUTOGATES env var is set,
+    // so isTestAutogateEnabled() should return true.
+    const isEnabled = unsafe.isTestAutogateEnabled();
+    strictEqual(
+      isEnabled,
+      true,
+      'TEST_WORKERD autogate should be ENABLED in @all-autogates variant'
+    );
+  },
+};

--- a/src/workerd/api/tests/autogate-enabled-test.wd-test
+++ b/src/workerd/api/tests/autogate-enabled-test.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "autogate-enabled-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "autogate-enabled-test.js")
+        ],
+        compatibilityDate = "2024-01-01",
+        compatibilityFlags = ["nodejs_compat", "unsafe_module"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/unsafe.c++
+++ b/src/workerd/api/unsafe.c++
@@ -3,6 +3,7 @@
 #include <workerd/io/io-context.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/script.h>
+#include <workerd/util/autogate.h>
 
 namespace workerd::api {
 
@@ -201,6 +202,10 @@ jsg::Promise<void> UnsafeModule::abortAllDurableObjects(jsg::Lock& js) {
   // We used to perform the abort asynchronously, but that became no longer necessary when
   // `Worker::Actor`'s destructor stopped requiring taking the isolate lock.
   return js.resolvedPromise();
+}
+
+bool UnsafeModule::isTestAutogateEnabled() {
+  return util::Autogate::isEnabled(util::AutogateKey::TEST_WORKERD);
 }
 
 #ifdef WORKERD_FUZZILLI

--- a/src/workerd/api/unsafe.h
+++ b/src/workerd/api/unsafe.h
@@ -100,8 +100,13 @@ class UnsafeModule: public jsg::Object {
   UnsafeModule(jsg::Lock&, const jsg::Url&) {}
   jsg::Promise<void> abortAllDurableObjects(jsg::Lock& js);
 
+  // Returns true if the TEST_WORKERD autogate is enabled.
+  // This is used to verify that the all-autogates test variant is working correctly.
+  bool isTestAutogateEnabled();
+
   JSG_RESOURCE_TYPE(UnsafeModule) {
     JSG_METHOD(abortAllDurableObjects);
+    JSG_METHOD(isTestAutogateEnabled);
   }
 };
 

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -935,6 +935,13 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
     },
             "Enable predictable mode. This makes workerd behave more deterministically by using "
             "pre-set values instead of random data or timestamps to facilitate testing.")
+        .addOption({"all-autogates"},
+            [this]() {
+      allAutogates = true;
+      return true;
+    },
+            "Enable all autogates. This is useful for testing code paths that are guarded by "
+            "autogates.")
         .expectOptionalArg("<filter>", CLI_METHOD(setTestFilter))
         .callAfterParsing(CLI_METHOD(test))
         .build();
@@ -1453,6 +1460,9 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
     if (predictable) {
       setPredictableModeForTest();
     }
+    if (allAutogates) {
+      util::Autogate::initAllAutogates();
+    }
 
     // Enable loopback sockets in tests only.
     network.enableLoopback();
@@ -1521,6 +1531,7 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
   bool configOnly = false;
   bool noVerbose = false;
   bool predictable = false;
+  bool allAutogates = false;
   kj::Maybe<FileWatcher> watcher;
 
   kj::Own<kj::Filesystem> fs = kj::newDiskFilesystem();

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -41,12 +41,7 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
 }
 
 Autogate::Autogate(capnp::List<capnp::Text>::Reader autogates) {
-  // Init all gates to false.
-  for (AutogateKey i = AutogateKey(0); i < AutogateKey::NumOfKeys;
-       i = AutogateKey(static_cast<int>(i) + 1)) {
-    gates[static_cast<unsigned long>(i)] = false;
-  }
-
+  // gates array is zero-initialized by default.
   for (auto name: autogates) {
     if (!name.startsWith("workerd-autogate-")) {
       LOG_ERROR_ONCE("Autogate configuration includes gate with invalid prefix.");
@@ -80,6 +75,15 @@ void Autogate::initAutogate(capnp::List<capnp::Text>::Reader gates) {
 
 void Autogate::deinitAutogate() {
   globalAutogate = kj::none;
+}
+
+void Autogate::initAllAutogates() {
+  Autogate autogate;
+  for (AutogateKey i = AutogateKey(0); i < AutogateKey::NumOfKeys;
+       i = AutogateKey(static_cast<int>(i) + 1)) {
+    autogate.gates[static_cast<unsigned long>(i)] = true;
+  }
+  globalAutogate = kj::mv(autogate);
 }
 
 void Autogate::initAutogateNamesForTest(std::initializer_list<kj::StringPtr> gateNames) {

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -59,12 +59,16 @@ class Autogate {
   // Convenience method for bin-tests to invoke initAutogate() with an appropriate config.
   static void initAutogateNamesForTest(std::initializer_list<kj::StringPtr> gateNames);
 
+  // Initializes all autogates to true. Used for testing with the --all-autogates flag.
+  static void initAllAutogates();
+
   // Destroys an initialized global Autogate instance. Used only for testing.
   static void deinitAutogate();
 
  private:
-  bool gates[static_cast<unsigned long>(AutogateKey::NumOfKeys)];
+  bool gates[static_cast<unsigned long>(AutogateKey::NumOfKeys)] = {};
 
+  Autogate() = default;
   Autogate(capnp::List<capnp::Text>::Reader autogates);
 };
 


### PR DESCRIPTION
This adds support for running wd_test tests with all autogates enabled, similar to the existing support in the internal repo.