### PR TITLE
Fix use-after-move in runAlarm exception logging

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -497,7 +497,7 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj:
 
         context.getMetrics().reportFailure(e);
 
-        auto description = e.getDescription();
+        auto description = kj::str(e.getDescription());  // because e is moved before this is used
         auto log = !jsg::isTunneledException(description) && !jsg::isDoNotLogException(description);
         auto isUserError = e.getDetail(jsg::EXCEPTION_IS_USER_ERROR) != kj::none;
 


### PR DESCRIPTION
`e` is moved away on line 505, but `description` is logged down below on lines 528 and 540.

This has caused garbage to get logged in production as observed in internal logs.

Ironically this was previously fixed by @mikea in #5479 but then re-broken in #5572 last month.