### PR TITLE
throw appropriate signal.reason on empty

### DIFF
--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -111,6 +111,7 @@ wpt_test(
 wpt_test(
     name = "streams",
     size = "large",
+    compat_flags = ["pedantic_wpt"],
     config = "streams-test.ts",
     wpt_directory = "@wpt//:streams@module",
 )

--- a/src/wpt/streams-test.ts
+++ b/src/wpt/streams-test.ts
@@ -734,7 +734,6 @@ export default {
       "Aborting a WritableStream before it starts should cause the writer's unsettled ready promise to reject",
       "WritableStream if sink's abort throws, the promise returned by multiple writer.abort()s is the same and rejects",
       'when calling abort() twice on the same stream, both should give the same promise that fulfills with undefined',
-      'the abort signal is signalled synchronously - write',
       'Aborting a WritableStream causes any outstanding write() promises to be rejected with the reason supplied',
       'Aborting a WritableStream puts it in an errored state with the error passed to abort()',
       'if a writer is created for a stream with a pending abort, its ready should be rejected with the abort error',


### PR DESCRIPTION
Per the spec, signal.reason should be a DOMException with name AbortError when no reason is provided, but the stored error should remain as the original reason.

This might be a breaking change that requires a compat flag.