### PR TITLE
fix streams byob request handling after close for spec compliance

### DIFF
--- a/src/workerd/api/streams/queue.h
+++ b/src/workerd/api/streams/queue.h
@@ -910,6 +910,12 @@ class ByteQueue final {
 
     v8::Local<v8::Uint8Array> getView(jsg::Lock& js);
 
+    // Returns the byte length of the original underlying ArrayBuffer.
+    size_t getOriginalBufferByteLength(jsg::Lock& js) const;
+
+    // Returns the byte offset of the original view plus bytes filled.
+    size_t getOriginalByteOffsetPlusBytesFilled() const;
+
     JSG_MEMORY_INFO(ByteQueue::ByobRequest) {}
 
    private:

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -2254,7 +2254,10 @@ ReadableStreamBYOBRequest::Impl::Impl(jsg::Lock& js,
     kj::Rc<WeakRef<ReadableByteStreamController>> controller)
     : readRequest(kj::mv(readRequest)),
       controller(kj::mv(controller)),
-      view(js.v8Ref(this->readRequest->getView(js))) {}
+      view(js.v8Ref(this->readRequest->getView(js))),
+      originalBufferByteLength(this->readRequest->getOriginalBufferByteLength(js)),
+      originalByteOffsetPlusBytesFilled(this->readRequest->getOriginalByteOffsetPlusBytesFilled()) {
+}
 
 void ReadableStreamBYOBRequest::Impl::updateView(jsg::Lock& js) {
   jsg::check(view.getHandle(js)->Buffer()->Detach(v8::Local<v8::Value>()));
@@ -2348,7 +2351,35 @@ void ReadableStreamBYOBRequest::respondWithNewView(jsg::Lock& js, jsg::BufferSou
     if (!controller.canCloseOrEnqueue()) {
       JSG_REQUIRE(view.size() == 0, TypeError,
           "The view byte length must be zero after the stream is closed.");
-      KJ_ASSERT(impl.readRequest->isInvalidated());
+
+      if (FeatureFlags::get(js).getPedanticWpt()) {
+        // Per the spec, when the stream is closed:
+        // 1. The view byte length must be zero (TypeError if not)
+        // 2. The underlying buffer must not be detached (TypeError)
+        // 3. The buffer byte length must not be zero (RangeError)
+        // 4. The buffer byte length must match the original (RangeError)
+        auto handle = view.getHandle(js);
+        auto buffer = handle->IsArrayBuffer() ? handle.As<v8::ArrayBuffer>()
+                                              : handle.As<v8::ArrayBufferView>()->Buffer();
+        JSG_REQUIRE(
+            !buffer->WasDetached(), TypeError, "The underlying ArrayBuffer has been detached.");
+
+        JSG_REQUIRE(view.canDetach(js), TypeError, "Unable to use non-detachable ArrayBuffer.");
+        // Use the stored values since the ByobRequest may have been invalidated during close.
+        auto actualBufferByteLength = buffer->ByteLength();
+        JSG_REQUIRE(
+            actualBufferByteLength != 0, RangeError, "The underlying ArrayBuffer is zero-length.");
+        JSG_REQUIRE(actualBufferByteLength == impl.originalBufferByteLength, RangeError,
+            "The underlying ArrayBuffer is not the correct length.");
+        // The view's byte offset must match the original byte offset plus bytes filled.
+        auto viewByteOffset =
+            handle->IsArrayBuffer() ? 0 : handle.As<v8::ArrayBufferView>()->ByteOffset();
+        JSG_REQUIRE(viewByteOffset == impl.originalByteOffsetPlusBytesFilled, RangeError,
+            "The view has an invalid byte offset.");
+      } else {
+        KJ_ASSERT(impl.readRequest->isInvalidated());
+      }
+
       invalidate(js);
     } else {
       bool shouldInvalidate = false;
@@ -2433,6 +2464,17 @@ void ReadableByteStreamController::close(jsg::Lock& js) {
   KJ_IF_SOME(byobRequest, maybeByobRequest) {
     JSG_REQUIRE(!byobRequest->isPartiallyFulfilled(), TypeError,
         "This ReadableStream was closed with a partial read pending.");
+  } else if (FeatureFlags::get(js).getPedanticWpt()) {
+    // If maybeByobRequest is not set, check if there's a pending byob request.
+    // If so, materialize it before closing so it remains accessible after
+    // the state changes to Closed. This is required by the spec for proper
+    // respondWithNewView() error handling in the closed state.
+    // Only do this if the queue doesn't have a partially fulfilled read.
+    KJ_IF_SOME(queue, impl.state.tryGetUnsafe<ByteQueue>()) {
+      if (!queue.hasPartiallyFulfilledRead()) {
+        getByobRequest(js);
+      }
+    }
   }
   impl.close(js);
 }

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -550,6 +550,9 @@ class ReadableStreamBYOBRequest: public jsg::Object {
     kj::Rc<WeakRef<ReadableByteStreamController>> controller;
     jsg::V8Ref<v8::Uint8Array> view;
 
+    size_t originalBufferByteLength;
+    size_t originalByteOffsetPlusBytesFilled;
+
     Impl(jsg::Lock& js,
         kj::Own<ByteQueue::ByobRequest> readRequest,
         kj::Rc<WeakRef<ReadableByteStreamController>> controller);

--- a/src/wpt/streams-test.ts
+++ b/src/wpt/streams-test.ts
@@ -352,26 +352,7 @@ export default {
     ],
   },
 
-  'readable-byte-streams/bad-buffers-and-views.any.js': {
-    comment: 'See individual comments',
-    expectedFailures: [
-      "ReadableStream with byte source: respond() throws if the BYOB request's buffer has been detached (in the closed state)",
-      // TODO(conform): The spec expects us to throw here because the supplied view
-      // has a different offset. Instead, we allow it because the view is zero length
-      // and the controller has been closed (we do the close and zero length check)
-      // first.
-      // assert_throws_js(RangeError, () => c.byobRequest.respondWithNewView(view));
-      'ReadableStream with byte source: respondWithNewView() throws if the supplied view has a different offset (in the closed state)',
-      // TODO(conform): The spec expects this to be a RangeError
-      "ReadableStream with byte source: respondWithNewView() throws if the supplied view's buffer is zero-length (in the closed state)",
-      // TODO(conform): The spec expects this to be a RangeError
-      "ReadableStream with byte source: respondWithNewView() throws if the supplied view's buffer has a different length (in the closed state)",
-      // TODO(conform): We currently do not throw here since reading causes the
-      // view here to be zero length, which is allowed when the stream is closed.
-      //assert_throws_js(TypeError, () => c.byobRequest.respondWithNewView(view));
-      "ReadableStream with byte source: enqueue() throws if the BYOB request's buffer has been detached (in the closed state)",
-    ],
-  },
+  'readable-byte-streams/bad-buffers-and-views.any.js': {},
   'readable-byte-streams/construct-byob-request.any.js': {},
   'readable-byte-streams/crashtests/tee-locked-stream.any.js': {},
   'readable-byte-streams/enqueue-with-detached-buffer.any.js': {},


### PR DESCRIPTION
Fix ReadableByteStreamController to properly handle byob requests after close(), making respondWithNewView() throw correct errors per the WHATWG Streams spec.

Removed premature byob request invalidation because spec required byob requests to remain accessible after close so that respondWithNewView throw correct errors. Had to store original buffer byte length and byte offset as well in order to make it available for validation even after the underlying ByobRequest is invalidated during close.

Had to update several test contexts due to invalid configuration.

Fixes WPT readable-byte-streams/bad-buffers-and-views.any.js