### PR TITLE
update bazel registry to a mirror

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,3 @@
+# Use GitHub as mirror for Bazel binary downloads
+# This works around outages at releases.bazel.build
+BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,9 @@ build --test_size_filters=-enormous
 # corresponds to small,medium,large,enormous tests (medium is default)
 build --test_timeout=3,15,60,240
 
+# Use GitHub mirror for BCR to work around bcr.bazel.build outages
+common --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/
+
 # We're only using bzlmod in a nominal capacity so far
 common --enable_workspace
 


### PR DESCRIPTION
Changing due to incident related to invalid ssl certificate

related to https://github.com/bazelbuild/bazel/issues/28101