### PR TITLE
use correct `this` value for strategy.size

### DIFF
--- a/src/wpt/streams-test.ts
+++ b/src/wpt/streams-test.ts
@@ -768,7 +768,6 @@ export default {
   'writable-streams/general.any.js': {
     comment: 'To be investigated',
     expectedFailures: [
-      "WritableStream's strategy.size should not be called as a method",
       'closed and ready on a released writer',
       'ready promise should fire before closed on releaseLock',
     ],


### PR DESCRIPTION
Streams spec is exteremely pedantic about certain things... Here's one of them. This changes makes the following test pass: WritableStream's strategy.size should not be called as a method