### PR TITLE
desiredSize should be null when the stream is erroring

### DIFF
--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -385,6 +385,7 @@ class WritableImpl {
     uint8_t started : 1 = 0;
     uint8_t starting : 1 = 0;
     uint8_t backpressure : 1 = 0;
+    uint8_t pedanticWpt : 1 = 0;
   };
   Flags flags{};
 
@@ -597,11 +598,16 @@ class WritableStreamDefaultController: public jsg::Object {
 
   void error(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
 
-  ssize_t getDesiredSize();
+  kj::Maybe<ssize_t> getDesiredSize();
 
   jsg::Ref<AbortSignal> getSignal();
 
   kj::Maybe<v8::Local<v8::Value>> isErroring(jsg::Lock& js);
+
+  // Returns true if the stream is in the erroring state. Unlike the overload
+  // that takes a lock, this method does not require a lock since it doesn't
+  // return the error reason.
+  bool isErroring() const;
 
   bool isStarted() {
     return impl.flags.started;

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -112,7 +112,7 @@ jsg::MemoizedIdentity<jsg::Promise<void>>& WritableStreamDefaultWriter::getClose
   return KJ_ASSERT_NONNULL(closedPromise, "the writer was never attached to a stream");
 }
 
-kj::Maybe<int> WritableStreamDefaultWriter::getDesiredSize(jsg::Lock& js) {
+kj::Maybe<int> WritableStreamDefaultWriter::getDesiredSize() {
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(i, Initial) {
       KJ_FAIL_ASSERT("this writer was never attached");

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -23,7 +23,7 @@ class WritableStreamDefaultWriter: public jsg::Object, public WritableStreamCont
 
   jsg::MemoizedIdentity<jsg::Promise<void>>& getClosed();
   jsg::MemoizedIdentity<jsg::Promise<void>>& getReady();
-  kj::Maybe<int> getDesiredSize(jsg::Lock& js);
+  kj::Maybe<int> getDesiredSize();
 
   jsg::Promise<void> abort(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
 

--- a/src/wpt/streams-test.ts
+++ b/src/wpt/streams-test.ts
@@ -745,12 +745,10 @@ export default {
     expectedFailures:
       process.platform === 'win32'
         ? [
-            'controller argument should be passed to start method',
             'WritableStream should be writable and ready should fulfill immediately if the strategy does not apply backpressure',
             "WritableStream can't be constructed with a defined type",
           ]
         : [
-            'controller argument should be passed to start method',
             'WritableStream should be writable and ready should fulfill immediately if the strategy does not apply backpressure',
             "WritableStream can't be constructed with a defined type",
             'underlyingSink argument should be converted after queuingStrategy argument',
@@ -772,7 +770,6 @@ export default {
   'writable-streams/general.any.js': {
     comment: 'To be investigated',
     expectedFailures: [
-      'desiredSize on a writer for an errored stream',
       "WritableStream's strategy.size should not be called as a method",
       'closed and ready on a released writer',
       'ready promise should fire before closed on releaseLock',


### PR DESCRIPTION
Another web-platform tests requirements. I've put it behind pedanticWpt flag...