### PR TITLE
Fix flakiness in channel-token-test.

### DIFF
--- a/src/workerd/server/channel-token-test.c++
+++ b/src/workerd/server/channel-token-test.c++
@@ -94,7 +94,7 @@ KJ_TEST("channel token basics") {
 
   auto corruptedToken = [&](uint index) {
     auto copy = kj::heapArray(token.asPtr());
-    copy[index] = 0;
+    copy[index] ^= 1;
     return copy;
   };
 
@@ -146,7 +146,7 @@ KJ_TEST("channel tokens for storage") {
 
   auto corruptedToken = [&](uint index) {
     auto copy = kj::heapArray(token.asPtr());
-    copy[index] = 0;
+    copy[index] ^= 1;
     return copy;
   };
 


### PR DESCRIPTION
Corrupting a byte by setting it to 0 doesn't always work because 1/256 of the time the byte is already zero, due to the encryption key being random.

Flipping a bit using XOR should always corrupt it.