### PR TITLE
Do not mark worker tracer unused for duplicate alarms.

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -285,6 +285,9 @@ kj::Date IoContext::IncomingRequest::now() {
 
 IoContext::IncomingRequest::~IoContext_IncomingRequest() noexcept(false) {
   if (!wasDelivered) {
+    KJ_IF_SOME(w, workerTracer) {
+      w->markUnused();
+    }
     // Request was never added to context->incomingRequests in the first place.
     return;
   }

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -639,12 +639,6 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarmImpl(
     // TODO(someday) If the request responsible for fulfilling this alarm were to be cancelled, then
     // we could probably take over and try to fulfill it ourselves. Maybe we'd want to loop on
     // `actor.getAlarm()`? We'd have to distinguish between rescheduling and request cancellation.
-
-    // Mark the tracer as unused since we're not actually running this alarm - we're just waiting
-    // for the existing alarm's result.
-    KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-      t.markUnused();
-    }
     auto result = co_await promise;
     co_return result;
   }


### PR DESCRIPTION
Deduplicated alarm requests are undelivered, so they're already marked unused by the undelivered request handling.