### PR TITLE
Improve CI build performance, especially on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           [
             { name: linux, arch: X64, image: ubuntu-22.04 },
             { name: linux-arm, arch: ARM64, image: ubuntu-22.04-arm },
-            { name: macOS, arch: ARM64, image: macos-15 },
+            { name: macOS, arch: ARM64, image: macos-15, use_lld: true },
             { name: windows, arch: X64, image: windows-2025 },
           ]
         config: [
@@ -76,6 +76,7 @@ jobs:
       arch_name: ${{ matrix.os.arch }}
       suffix: ${{ matrix.config.suffix }}
       extra_bazel_args: '--config=ci-test --config=ci-${{matrix.os.name}}${{matrix.config.suffix}}'
+      macos_use_lld: ${{ matrix.os.use_lld || false }}
     secrets:
       BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
       WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -9,9 +9,7 @@ build:ci --verbose_failures
 # increasing this closer towards the suggested value of 200. Note the number of maximum build jobs
 # is controlled by the --local_resources=cpu flag and still limited to the number of cores by
 # default.
-# TODO (build perf): Temporarily setting this to 8, that might help with CI freezing on macOS
-# release jobs?
-build:ci --jobs=8
+build:ci --jobs=32
 # Do not check for changes in external repository files, should speed up bazel invocations after the first one
 build:ci --noexperimental_check_external_repository_files
 # Only build runfile trees when needed. Runfile trees are useful for directly invoking bazel-built
@@ -64,8 +62,8 @@ build:ci-linux-common --copt='-Wno-error=deprecated-declarations'
 build:ci-linux-common --action_env=CC=/usr/lib/llvm-19/bin/clang
 build:ci-linux-common --host_action_env=CC=/usr/lib/llvm-19/bin/clang
 
-build:ci-linux --config=ci-linux-common --remote_download_regex=".*src/workerd/server/workerd.*"
-build:ci-linux-arm --config=ci-linux-common
+build:ci-linux --config=ci-linux-common --config=ci-limit-storage --remote_download_regex=".*src/workerd/server/workerd.*"
+build:ci-linux-arm --config=ci-linux-common --config=ci-limit-storage
 
 build:ci-linux-debug --config=ci-linux-common --config=ci-limit-storage
 build:ci-linux-debug --config=debug --config=rust-debug
@@ -82,14 +80,11 @@ build:ci-linux-arm-asan --config=ci-linux-asan
 test:ci-linux --build_tag_filters=-off-by-default
 test:ci-linux-arm --build_tag_filters=-off-by-default
 
-# Speculatively disable asynchronous remote cache uploads on macOS to debug CI job freezes. This is
-# a no-op when remote caching is disabled, so we can always enable it on macOS.
-build:macos --noremote_cache_async
-
 # Unlike the bazel Unix toolchain the macOS toolchain sets "-O0 -DDEBUG" for fastbuild by
 # default. This is unhelpful for compile speeds and test performance, remove the DEBUG
 # define.
 build:ci-macOS --copt=-UDEBUG
+build:ci-macOS --config=ci-limit-storage
 
 build:ci-macOS-debug --config=debug
 

--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -31,6 +31,7 @@ js_binary(
         ":types_lib",
     ],
     entry_point = "scripts/build-types.js",
+    tags = ["manual"],
 )
 
 js_run_binary(
@@ -43,6 +44,9 @@ js_run_binary(
     ],
     out_dirs = ["definitions"],
     silent_on_success = False,  # Always enable logging for debugging
+    # Exclude from wildcard builds (//...) - type generation is expensive and only needed
+    # for the check-snapshot job which explicitly builds //types.
+    tags = ["manual"],
     tool = ":build_types_bin",
     visibility = ["//visibility:public"],
 )
@@ -54,6 +58,7 @@ js_binary(
     ],
     entry_point = "scripts/build-worker.js",
     node_options = ["--enable-source-maps"],
+    tags = ["manual"],
 )
 
 js_run_binary(
@@ -72,6 +77,8 @@ js_run_binary(
         exclude = ["src/cli/**/*"],
     ),
     outs = ["dist/index.mjs"],
+    # Only used by //types:types which is also manual
+    tags = ["manual"],
     tool = ":build_worker_bin",
 )
 


### PR DESCRIPTION
- Enable LLD linker for macOS (35x faster linking)
- Apply ci-limit-storage to all CI configs (smaller debug info, Some jobs were running out of disk space because they lacked this.)
- Exclude type generation from //... builds (saves ~65s)
- Increase CI parallelism from 8 to 32 jobs
