### PR TITLE
[o11y][nfc] Require getEventInfo() to be defined to ensure EventInfo is present

### DIFF
--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -185,26 +185,26 @@ HibernatableWebSocketCustomEvent::HibernatableWebSocketCustomEvent(
       manager(manager) {}
 
 // TODO(cleanup): Try to reduce duplication with consumeParams()
-kj::Maybe<tracing::EventInfo> HibernatableWebSocketCustomEvent::getEventInfo() const {
+tracing::EventInfo HibernatableWebSocketCustomEvent::getEventInfo() const {
   // Try to extract event type from params if available
   KJ_SWITCH_ONEOF(params) {
     KJ_CASE_ONEOF(socketParams, HibernatableSocketParams) {
       KJ_SWITCH_ONEOF(socketParams.eventType) {
         KJ_CASE_ONEOF(text, HibernatableSocketParams::Text) {
-          return tracing::EventInfo(tracing::HibernatableWebSocketEventInfo(
-              tracing::HibernatableWebSocketEventInfo::Message()));
+          return tracing::HibernatableWebSocketEventInfo(
+              tracing::HibernatableWebSocketEventInfo::Message());
         }
         KJ_CASE_ONEOF(data, HibernatableSocketParams::Data) {
-          return tracing::EventInfo(tracing::HibernatableWebSocketEventInfo(
-              tracing::HibernatableWebSocketEventInfo::Message()));
+          return tracing::HibernatableWebSocketEventInfo(
+              tracing::HibernatableWebSocketEventInfo::Message());
         }
         KJ_CASE_ONEOF(close, HibernatableSocketParams::Close) {
-          return tracing::EventInfo(tracing::HibernatableWebSocketEventInfo(
-              tracing::HibernatableWebSocketEventInfo::Close{close.code, close.wasClean}));
+          return tracing::HibernatableWebSocketEventInfo(
+              tracing::HibernatableWebSocketEventInfo::Close{close.code, close.wasClean});
         }
         KJ_CASE_ONEOF(error, HibernatableSocketParams::Error) {
-          return tracing::EventInfo(tracing::HibernatableWebSocketEventInfo(
-              tracing::HibernatableWebSocketEventInfo::Error()));
+          return tracing::HibernatableWebSocketEventInfo(
+              tracing::HibernatableWebSocketEventInfo::Error());
         }
       }
     }
@@ -214,17 +214,16 @@ kj::Maybe<tracing::EventInfo> HibernatableWebSocketCustomEvent::getEventInfo() c
       switch (payload.which()) {
         case rpc::HibernatableWebSocketEventMessage::Payload::TEXT:
         case rpc::HibernatableWebSocketEventMessage::Payload::DATA:
-          return tracing::EventInfo(tracing::HibernatableWebSocketEventInfo(
-              tracing::HibernatableWebSocketEventInfo::Message()));
+          return tracing::HibernatableWebSocketEventInfo(
+              tracing::HibernatableWebSocketEventInfo::Message());
         case rpc::HibernatableWebSocketEventMessage::Payload::CLOSE: {
           auto close = payload.getClose();
-          return tracing::EventInfo(tracing::HibernatableWebSocketEventInfo(
-              tracing::HibernatableWebSocketEventInfo::Close{
-                close.getCode(), close.getWasClean()}));
+          return tracing::HibernatableWebSocketEventInfo(
+              tracing::HibernatableWebSocketEventInfo::Close{close.getCode(), close.getWasClean()});
         }
         case rpc::HibernatableWebSocketEventMessage::Payload::ERROR:
-          return tracing::EventInfo(tracing::HibernatableWebSocketEventInfo(
-              tracing::HibernatableWebSocketEventInfo::Error()));
+          return tracing::HibernatableWebSocketEventInfo(
+              tracing::HibernatableWebSocketEventInfo::Error());
       }
       KJ_UNREACHABLE;
     }

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -77,7 +77,7 @@ class HibernatableWebSocketCustomEvent final: public WorkerInterface::CustomEven
     return typeId;
   }
 
-  kj::Maybe<tracing::EventInfo> getEventInfo() const override;
+  tracing::EventInfo getEventInfo() const override;
 
   kj::Promise<Result> notSupported() override {
     KJ_UNIMPLEMENTED("hibernatable web socket event not supported");

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -530,7 +530,7 @@ StartQueueEventResponse startQueueEvent(EventTarget& globalEventTarget,
 
 }  // namespace
 
-kj::Maybe<tracing::EventInfo> QueueCustomEvent::getEventInfo() const {
+tracing::EventInfo QueueCustomEvent::getEventInfo() const {
   kj::String queueName;
   uint32_t batchSize;
   KJ_SWITCH_ONEOF(params) {
@@ -544,7 +544,7 @@ kj::Maybe<tracing::EventInfo> QueueCustomEvent::getEventInfo() const {
     }
   }
 
-  return tracing::EventInfo(tracing::QueueEventInfo(kj::mv(queueName), batchSize));
+  return tracing::QueueEventInfo(kj::mv(queueName), batchSize);
 }
 
 kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEvent::run(

--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -353,7 +353,7 @@ class QueueCustomEvent final: public WorkerInterface::CustomEvent, public kj::Re
     return EVENT_TYPE;
   }
 
-  kj::Maybe<tracing::EventInfo> getEventInfo() const override;
+  tracing::EventInfo getEventInfo() const override;
 
   QueueRetryBatch getRetryBatch() const {
     return {.retry = result.retryBatch.retry, .delaySeconds = result.retryBatch.delaySeconds};

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -639,8 +639,8 @@ kj::Promise<void> sendTracesToExportedHandler(kj::Own<IoContext::IncomingRequest
 }
 }  // namespace
 
-kj::Maybe<tracing::EventInfo> TraceCustomEvent::getEventInfo() const {
-  return tracing::EventInfo(tracing::TraceEventInfo(traces));
+tracing::EventInfo TraceCustomEvent::getEventInfo() const {
+  return tracing::TraceEventInfo(traces);
 }
 
 auto TraceCustomEvent::run(kj::Own<IoContext::IncomingRequest> incomingRequest,

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -629,7 +629,7 @@ class TraceCustomEvent final: public WorkerInterface::CustomEvent {
     return typeId;
   }
 
-  kj::Maybe<tracing::EventInfo> getEventInfo() const override;
+  tracing::EventInfo getEventInfo() const override;
 
   kj::Promise<Result> notSupported() override {
     KJ_UNIMPLEMENTED("trace event not supported");

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -468,8 +468,8 @@ class JsRpcSessionCustomEvent final: public WorkerInterface::CustomEvent {
     return typeId;
   }
 
-  kj::Maybe<tracing::EventInfo> getEventInfo() const override {
-    return tracing::EventInfo(tracing::JsRpcEventInfo(nullptr));
+  tracing::EventInfo getEventInfo() const override {
+    return tracing::JsRpcEventInfo(nullptr);
   }
 
   rpc::JsRpcTarget::Client getCap() {

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -907,8 +907,8 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
 };
 }  // namespace
 
-kj::Maybe<EventInfo> TailStreamCustomEvent::getEventInfo() const {
-  return EventInfo(TraceEventInfo(kj::Array<TraceEventInfo::TraceItem>(nullptr)));
+EventInfo TailStreamCustomEvent::getEventInfo() const {
+  return TraceEventInfo(kj::Array<TraceEventInfo::TraceItem>(nullptr));
 }
 
 kj::Promise<WorkerInterface::CustomEvent::Result> TailStreamCustomEvent::run(

--- a/src/workerd/io/trace-stream.h
+++ b/src/workerd/io/trace-stream.h
@@ -43,7 +43,7 @@ class TailStreamCustomEvent final: public WorkerInterface::CustomEvent {
     return typeId;
   }
 
-  kj::Maybe<tracing::EventInfo> getEventInfo() const override;
+  tracing::EventInfo getEventInfo() const override;
 
   void failed(const kj::Exception& e) override {
     capFulfiller->reject(kj::cp(e));

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -798,9 +798,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> WorkerEntrypoint::customEvent(
   // any user code executes (particularly important for actors whose constructors may run
   // during delivered()).
   KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
-    KJ_IF_SOME(eventInfo, event->getEventInfo()) {
-      t.setEventInfo(*incomingRequest, kj::mv(eventInfo));
-    }
+    t.setEventInfo(*incomingRequest, event->getEventInfo());
   }
 
   auto promise = event->run(kj::mv(incomingRequest), entrypointName, kj::mv(props), waitUntilTasks)

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -133,9 +133,7 @@ class WorkerInterface: public kj::HttpService {
 
     // Get event info for tracing.
     // Return none if this event type doesn't need tracing.
-    virtual kj::Maybe<tracing::EventInfo> getEventInfo() const {
-      return kj::none;
-    }
+    virtual tracing::EventInfo getEventInfo() const = 0;
 
     // If the CustomEvent fails before any of the other methods are called, this may be invoked
     // to report the failure reason.


### PR DESCRIPTION
Downstream PR to follow.