### PR TITLE
[build] Overhaul CI configuration

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -35,6 +35,9 @@ runs:
       shell: pwsh
       if: runner.os == 'Windows'
       # Set a custom output root directory to avoid long file name issues.
+      # TODO(cleanup): According to https://github.com/actions/runner-images/blob/win25/20251216.149/images/windows/scripts/build/Configure-DeveloperMode.ps1#L13,
+      # this should already be set on the build image, but prior testing indicated CI speedups with
+      # it, check if it is actually having any effect.
       run: |
         # Enable Developer Mode to allow Bazel to create real symlinks
         reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
       image: ${{ matrix.image }}
       os_name: ${{ matrix.os-name }}
       phase: '-release'
-      extra_bazel_args: '--strip=always --config=${{matrix.bazel-config}} --config=wpt-report'
+      extra_bazel_args: '--strip=always --config=${{matrix.bazel-config}} --config=ci-release --config=wpt-report'
       arch_name: ${{ matrix.target-arch }}
       upload_binary: true
       macos_use_lld: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_bazel.yml
     with:
-      extra_bazel_args: '--config=lint --config=clang-tidy --config=ci-test --config=ci-linux'
+      extra_bazel_args: '--config=lint --config=clang-tidy --config=ci-test --config=ci-linux-common'
       run_tests: false
       parse_headers: true
     secrets:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -139,7 +139,7 @@
       "label": "Bazel run all tests (dbg)",
       "type": "shell",
       "command": "bazel",
-      "args": ["test", "-c", "dbg", "--cache_test_results=no", "//..."],
+      "args": ["test", "-c", "dbg", "--nocache_test_results", "//..."],
       "group": {
         "kind": "test",
         "isDefault": true
@@ -158,7 +158,7 @@
       "label": "Bazel run all tests (fastbuild)",
       "type": "shell",
       "command": "bazel",
-      "args": ["test", "-c", "fastbuild", "--cache_test_results=no", "//..."],
+      "args": ["test", "-c", "fastbuild", "--nocache_test_results", "//..."],
       "group": {
         "kind": "test",
         "isDefault": true
@@ -177,7 +177,7 @@
       "label": "Bazel run all tests (opt)",
       "type": "shell",
       "command": "bazel",
-      "args": ["test", "-c", "opt", "--cache_test_results=no", "//..."],
+      "args": ["test", "-c", "opt", "--nocache_test_results", "//..."],
       "group": {
         "kind": "test",
         "isDefault": true

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -48,7 +48,9 @@ build:ci-windows --config=v8-codegen-opt-windows
 # LLVM produces a bit more debug info on macOS by default to facilitate debugging with
 # LLDB. This is not needed for this use case, so disable it using -fno-standalone-debug –
 # this is already the default for Linux/Windows.
-build:ci-limit-storage --build_tag_filters=-off-by-default,-requires-container-engine,-workerd-benchmark
+build:ci-disable-benchmarks --build_tag_filters=-off-by-default,-requires-container-engine,-workerd-benchmark
+test:ci-disable-benchmarks --test_tag_filters=-off-by-default,-requires-fuzzilli,-requires-container-engine,-workerd-benchmark
+build:ci-limit-storage --config=ci-disable-benchmarks
 build:ci-limit-storage --copt="-g1"
 build:ci-limit-storage --copt="-fno-standalone-debug"
 
@@ -62,8 +64,8 @@ build:ci-linux-common --copt='-Wno-error=deprecated-declarations'
 build:ci-linux-common --action_env=CC=/usr/lib/llvm-19/bin/clang
 build:ci-linux-common --host_action_env=CC=/usr/lib/llvm-19/bin/clang
 
-build:ci-linux --config=ci-linux-common --config=ci-limit-storage --remote_download_regex=".*src/workerd/server/workerd.*"
-build:ci-linux-arm --config=ci-linux-common --config=ci-limit-storage
+build:ci-linux --config=ci-linux-common --remote_download_regex=".*src/workerd/server/workerd.*"
+build:ci-linux-arm --config=ci-linux-common
 
 build:ci-linux-debug --config=ci-linux-common --config=ci-limit-storage
 build:ci-linux-debug --config=debug --config=rust-debug
@@ -77,14 +79,14 @@ build:ci-linux-asan --config=asan --copt="-g0" --strip=always
 build:ci-linux-arm-asan --config=ci-linux-asan
 
 # Build container tests on Linux CI
-test:ci-linux --build_tag_filters=-off-by-default
-test:ci-linux-arm --build_tag_filters=-off-by-default
+build:ci-linux --build_tag_filters=-off-by-default
+build:ci-linux-arm --build_tag_filters=-off-by-default
 
 # Unlike the bazel Unix toolchain the macOS toolchain sets "-O0 -DDEBUG" for fastbuild by
 # default. This is unhelpful for compile speeds and test performance, remove the DEBUG
 # define.
 build:ci-macOS --copt=-UDEBUG
-build:ci-macOS --config=ci-limit-storage
+test:ci-macOS --config=ci-disable-benchmarks
 
 build:ci-macOS-debug --config=debug
 
@@ -110,9 +112,13 @@ test:ci-test --config=wpt-test
 common:wpt-test --test_env=GEN_TEST_REPORT=1
 common:wpt-test --test_env=GEN_TEST_STATS=1
 
-# Config to produce a full WPT report (also disables test caching)
+# Config to produce a full WPT report. Also ensures that test targets are fetched, even under remote_download_minimal.
 common:wpt-report --config=wpt-test
-common:wpt-report --cache_test_results=no
+common:wpt-report --remote_download_regex=".*src/wpt/.*"
 
 # Let tests know they're running in CI
 test:ci-test --test_env=CI=true
+
+# release CI – use remote_download_minimal, but always fetch the workerd binary so we can add it to
+# the release artifacts.
+build:ci-release --remote_download_minimal --remote_download_regex=".*src/workerd/server/workerd.*"

--- a/src/workerd/tests/bench-tools.h
+++ b/src/workerd/tests/bench-tools.h
@@ -13,7 +13,7 @@
 // Configure tcmalloc for deterministic benchmarks on Linux.
 // tcmalloc uses probabilistic heap sampling which can introduce variance in benchmark results.
 // WD_USE_TCMALLOC is defined when tcmalloc is enabled (Linux + use_tcmalloc flag).
-#if defined(WD_USE_TCMALLOC)
+#ifdef WD_USE_TCMALLOC
 #include "tcmalloc/malloc_extension.h"
 
 namespace workerd::bench {


### PR DESCRIPTION
- Use remote_download_minimal to speed up release CI
- Don't disable caching for wpt tests, just need to tell Bazel to fetch the
  outputs.
- Disable building benchmarks when this was already supposed to happen, this is
  achieved by fixing ci-limit-storage so that test_tag_filters is adjusted too.
- Remove ci-limit-storage from ci-linux/ci-linux-arm, it is a no-op there
- Adjust build_tag_filters on ci-linux/ci-linux-arm so that benchmark and
  container tests are built as part of bazel build instead of later in bazel
  test.
- Use ci-linux-common in lint CI to run with default set of build filters, that
  way we don't have to build container targets
- Fix clang-tidy warning now that lint CI applies to benchmark targets