### PR TITLE
Revert "update bazel registry to a mirror"

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,3 +1,0 @@
-# Use GitHub as mirror for Bazel binary downloads
-# This works around outages at releases.bazel.build
-BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,9 +10,6 @@ build --test_size_filters=-enormous
 # corresponds to small,medium,large,enormous tests (medium is default)
 build --test_timeout=3,15,60,240
 
-# Use GitHub mirror for BCR to work around bcr.bazel.build outages
-common --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/
-
 # We're only using bzlmod in a nominal capacity so far
 common --enable_workspace
 


### PR DESCRIPTION
This should no longer be needed now.