### PR TITLE
Reduce Python test time

### DIFF
--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -5,33 +5,41 @@ python_test_setup()
 
 # Each test takes a while to start up, so if possible add additional tests to many-tests or sdk or
 # some other existing test.
-py_wd_test("hello")
+[py_wd_test(directory) for directory in [
+    "hello",
+    "many-tests",
+    "asgi",
+    "asgi-sse",
+    "random",
+    "sdk",
+    "python-rpc",
+    "workflow-entrypoint",
+    "worker-entrypoint",
+    "durable-object",
+]]
 
-py_wd_test("many-tests")
-
-py_wd_test("env-param")
-
-py_wd_test("asgi")
-
-py_wd_test("asgi-sse")
-
-py_wd_test("random")
-
-py_wd_test("subdirectory")
-
-py_wd_test("sdk")
+# These tests all work fine without make_snapshot=False
+# but it saves some time and does not lose any coverage.
+[py_wd_test(
+    directory,
+    make_snapshot = False,
+) for directory in [
+    "env-param",
+    "subdirectory",
+    "undefined-handler",
+    "vendor_dir",
+    "vendor_dir_compat_flag",
+    "filter-non-py-files",
+    "default-class-with-legacy-global-handlers",
+]]
 
 gen_rust_import_tests()
 
-py_wd_test("undefined-handler")
-
-py_wd_test("vendor_dir")
-
-py_wd_test("dont-snapshot-pyodide")
-
-py_wd_test("filter-non-py-files")
-
-py_wd_test("durable-object")
+py_wd_test(
+    "dont-snapshot-pyodide",
+    # Passes on newer Python versions but it tests a 0.26.0a2-specific behavior.
+    python_flags = ["0.26.0a2"],
+)
 
 py_wd_test(
     "durable-object-websocket",
@@ -40,20 +48,10 @@ py_wd_test(
     use_snapshot = None,
 )
 
-py_wd_test("worker-entrypoint")
-
 py_wd_test(
     "jspi",
     skip_python_flags = ["0.26.0a2"],
 )
-
-py_wd_test("python-rpc")
-
-py_wd_test("workflow-entrypoint")
-
-py_wd_test("vendor_dir_compat_flag")
-
-py_wd_test("default-class-with-legacy-global-handlers")
 
 py_wd_test(
     "fastapi",


### PR DESCRIPTION
By not making snapshots for tests that don't need them