### PR TITLE
Limit MacOS memory usage

### DIFF
--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -84,6 +84,7 @@ test:ci-linux-arm --build_tag_filters=-off-by-default
 # default. This is unhelpful for compile speeds and test performance, remove the DEBUG
 # define.
 build:ci-macOS --copt=-UDEBUG
+build:ci-macOS --local_ram_resources=HOST_RAM*.8
 build:ci-macOS --config=ci-limit-storage
 
 build:ci-macOS-debug --config=debug


### PR DESCRIPTION
It seems like our macos jobs keep getting terminated with

"Server terminated abruptly (error code: 14, error message: 'recvmsg:Connection reset by peer', log file: '/private/var/tmp/_bazel_runner/95172a8db72435c774c2789dc64209fb/server/jvm.out')" 
See https://github.com/cloudflare/workerd/actions/runs/20766888885/job/59679325959

Claude seems to think this is due to the OOM killer on macos.

Let's try to limit the memory usage of the CI jobs.