### PR TITLE
Fix require() to return mutable exports for Node.js compat

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -928,8 +928,11 @@ jsg::JsValue ServiceWorkerGlobalScope::getBuffer(jsg::Lock& js) {
       // that set the bufferValue, we let's check again.
       return p.getHandle(js);
     }
-    auto def = module.get(js, "default"_kj);
-    auto obj = KJ_ASSERT_NONNULL(def.tryCast<jsg::JsObject>());
+    // When requireReturnsDefaultExport flag is enabled, resolveModule returns the
+    // default export directly. Otherwise it returns the module namespace.
+    auto obj = module.has(js, "default"_kj)
+        ? KJ_ASSERT_NONNULL(module.get(js, "default"_kj).tryCast<jsg::JsObject>())
+        : module;
     auto buffer = obj.get(js, "Buffer"_kj);
     JSG_REQUIRE(buffer.isFunction(), TypeError, "Invalid node:buffer implementation");
     bufferValue = jsg::JsRef(js, buffer);
@@ -970,7 +973,9 @@ jsg::JsValue ServiceWorkerGlobalScope::getProcess(jsg::Lock& js) {
       // that set the processValue, we let's check again.
       return p.getHandle(js);
     }
-    auto def = module.get(js, "default"_kj);
+    // When requireReturnsDefaultExport flag is enabled, resolveInternalModule returns the
+    // default export directly. Otherwise it returns the module namespace.
+    auto def = module.has(js, "default"_kj) ? module.get(js, "default"_kj) : jsg::JsValue(module);
     JSG_REQUIRE(def.isObject(), TypeError, "Invalid node:process implementation");
     processValue = jsg::JsRef(js, def);
     return def;

--- a/src/workerd/api/node/tests/BUILD.bazel
+++ b/src/workerd/api/node/tests/BUILD.bazel
@@ -229,6 +229,12 @@ wd_test(
 )
 
 wd_test(
+    src = "module-require-mutable-exports-test.wd-test",
+    args = ["--experimental"],
+    data = ["module-require-mutable-exports-test.js"],
+)
+
+wd_test(
     src = "process-exit-test.wd-test",
     args = ["--experimental"],
     data = ["process-exit-test.js"],

--- a/src/workerd/api/node/tests/module-create-require-test.js
+++ b/src/workerd/api/node/tests/module-create-require-test.js
@@ -14,14 +14,28 @@ export const doTheTest = {
     const baz = require('baz');
     const qux = require('worker/qux');
 
-    strictEqual(foo.default, 1);
+    // When require_returns_default_export flag is enabled, require() returns the
+    // default export directly. Otherwise it returns the namespace object.
+    if (Cloudflare.compatibilityFlags.require_returns_default_export) {
+      strictEqual(foo, 1);
+    } else {
+      strictEqual(foo.default, 1);
+    }
     strictEqual(bar, 2);
     strictEqual(baz, 3);
     strictEqual(qux, '4');
 
     const assert = await import('node:assert');
     const required = require('node:assert');
-    strictEqual(assert, required);
+
+    // When require_returns_default_export flag is enabled, require() returns the
+    // default export directly (assert.default === required).
+    // When the flag is disabled, require() returns the namespace (assert === required).
+    if (Cloudflare.compatibilityFlags.require_returns_default_export) {
+      strictEqual(assert.default, required);
+    } else {
+      strictEqual(assert, required);
+    }
 
     throws(() => require('invalid'), {
       message: 'Top-level await in module is not permitted at this time.',

--- a/src/workerd/api/node/tests/module-require-mutable-exports-test.js
+++ b/src/workerd/api/node/tests/module-require-mutable-exports-test.js
@@ -1,0 +1,155 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+import { createRequire } from 'node:module';
+import { strictEqual, notStrictEqual, ok, doesNotThrow } from 'node:assert';
+
+const require = createRequire('/');
+
+export const testTimersPromisesMutable = {
+  async test() {
+    const timersPromises = require('node:timers/promises');
+    const originalSetImmediate = timersPromises.setImmediate;
+    ok(typeof originalSetImmediate === 'function');
+
+    const patchedSetImmediate = async function patchedSetImmediate() {
+      return 'patched';
+    };
+
+    doesNotThrow(() => {
+      timersPromises.setImmediate = patchedSetImmediate;
+    });
+
+    strictEqual(timersPromises.setImmediate, patchedSetImmediate);
+    timersPromises.setImmediate = originalSetImmediate;
+    strictEqual(timersPromises.setImmediate, originalSetImmediate);
+
+    // require() should return the same object as import { default }
+    const { default: timersPromises2 } = await import('node:timers/promises');
+    strictEqual(timersPromises, timersPromises2);
+
+    // But import() returns the namespace object, not the default export
+    const timersPromisesNamespace = await import('node:timers/promises');
+    notStrictEqual(timersPromises, timersPromisesNamespace);
+    strictEqual(timersPromisesNamespace.default, timersPromises);
+  },
+};
+
+// Test that patching the require()'d object doesn't affect the original named exports
+export const testPatchingDoesNotAffectNamedExports = {
+  async test() {
+    const timersPromises = require('node:timers/promises');
+    const originalSetTimeout = timersPromises.setTimeout;
+
+    // Patch the require()'d object
+    const patchedSetTimeout = async function patched() {
+      return 'patched';
+    };
+    timersPromises.setTimeout = patchedSetTimeout;
+
+    // The named export from the module namespace should be unaffected
+    const { setTimeout: namedSetTimeout } = await import(
+      'node:timers/promises'
+    );
+    notStrictEqual(namedSetTimeout, patchedSetTimeout);
+    strictEqual(namedSetTimeout, originalSetTimeout);
+
+    // Restore
+    timersPromises.setTimeout = originalSetTimeout;
+  },
+};
+
+export const testTimersMutable = {
+  test() {
+    const timers = require('node:timers');
+    const originalSetTimeout = timers.setTimeout;
+    ok(typeof originalSetTimeout === 'function');
+
+    const patchedSetTimeout = function patchedSetTimeout() {
+      return 'patched';
+    };
+
+    doesNotThrow(() => {
+      timers.setTimeout = patchedSetTimeout;
+    });
+
+    strictEqual(timers.setTimeout, patchedSetTimeout);
+    timers.setTimeout = originalSetTimeout;
+  },
+};
+
+export const testBufferMutable = {
+  test() {
+    const buffer = require('node:buffer');
+    const originalBuffer = buffer.Buffer;
+    ok(typeof originalBuffer === 'function');
+
+    const patchedBuffer = function PatchedBuffer() {
+      return 'patched';
+    };
+
+    doesNotThrow(() => {
+      buffer.Buffer = patchedBuffer;
+    });
+
+    strictEqual(buffer.Buffer, patchedBuffer);
+    buffer.Buffer = originalBuffer;
+  },
+};
+
+export const testUtilMutable = {
+  test() {
+    const util = require('node:util');
+    const originalPromisify = util.promisify;
+    ok(typeof originalPromisify === 'function');
+
+    const patchedPromisify = function patchedPromisify() {
+      return 'patched';
+    };
+
+    doesNotThrow(() => {
+      util.promisify = patchedPromisify;
+    });
+
+    strictEqual(util.promisify, patchedPromisify);
+    util.promisify = originalPromisify;
+  },
+};
+
+export const testRequireCachesMutableObject = {
+  test() {
+    const timersPromises1 = require('node:timers/promises');
+    const timersPromises2 = require('node:timers/promises');
+
+    strictEqual(timersPromises1, timersPromises2);
+
+    const patchedSetImmediate = async function patched() {
+      return 'patched';
+    };
+    const original = timersPromises1.setImmediate;
+
+    timersPromises1.setImmediate = patchedSetImmediate;
+    strictEqual(timersPromises2.setImmediate, patchedSetImmediate);
+    timersPromises1.setImmediate = original;
+  },
+};
+
+// When require_returns_default_export is enabled, require() should return the
+// default export directly (which is the object with all the functions),
+// not the namespace wrapper with both `default` and named exports.
+export const testRequireReturnsDefaultExport = {
+  test() {
+    const timers = require('node:timers');
+    // With require_returns_default_export enabled, timers should be the
+    // default export object directly, not the namespace wrapper.
+    // The default export IS the object with setTimeout, setInterval, etc.
+    ok(typeof timers.setTimeout === 'function');
+    ok(typeof timers.setInterval === 'function');
+    ok(typeof timers.clearTimeout === 'function');
+    ok(typeof timers.clearInterval === 'function');
+    // The namespace wrapper would have a 'default' property, but when
+    // we return the default export directly, there's no 'default' property
+    // on the returned object (unless the default export itself has one).
+    strictEqual(timers.default, undefined);
+  },
+};

--- a/src/workerd/api/node/tests/module-require-mutable-exports-test.wd-test
+++ b/src/workerd/api/node/tests/module-require-mutable-exports-test.wd-test
@@ -1,0 +1,14 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "module-require-mutable-exports-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "module-require-mutable-exports-test.js")
+        ],
+        compatibilityFlags = ["nodejs_compat", "require_returns_default_export"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1342,4 +1342,17 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
     $impliedByAfterDate(name = "pythonWorkers", date = "2026-02-25");
   # replaces depends param on steps to an implicit approach with step callables passed as params
   # these steps are called internally and act as dependencies
+
+  requireReturnsDefaultExport @156 :Bool
+    $compatEnableFlag("require_returns_default_export")
+    $compatDisableFlag("require_returns_namespace")
+    $compatEnableDate("2026-01-22");
+  # When enabled, require() will return the default export of a module if it exists.
+  # If the default export does not exist, it falls back to returning a mutable
+  # copy of the module namespace object. This matches the behavior that Node.js
+  # uses for require(esm) where the default export is returned when available.
+  # This flag is useful for frameworks like Next.js that expect to patch module exports.
+  #
+  # TODO(later): Once this is no longer experimental, this flag should be implied by
+  # exportCommonJsDefaultNamespace (or vice versa) for consistency.
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1107,6 +1107,9 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     if (features.getEnableNodeJsProcessV2()) {
       lock->setNodeJsProcessV2Enabled();
     }
+    if (features.getRequireReturnsDefaultExport()) {
+      lock->setRequireReturnsDefaultExportEnabled();
+    }
     if (features.getThrowOnUnrecognizedImportAssertion()) {
       lock->setThrowOnUnrecognizedImportAssertion();
     }

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -219,6 +219,10 @@ void Lock::setNodeJsProcessV2Enabled() {
   IsolateBase::from(v8Isolate).setNodeJsProcessV2Enabled({}, true);
 }
 
+void Lock::setRequireReturnsDefaultExportEnabled() {
+  IsolateBase::from(v8Isolate).setRequireReturnsDefaultExportEnabled({}, true);
+}
+
 void Lock::setThrowOnUnrecognizedImportAssertion() {
   IsolateBase::from(v8Isolate).setThrowOnUnrecognizedImportAssertion();
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2647,6 +2647,7 @@ class Lock {
 
   void setNodeJsCompatEnabled();
   void setNodeJsProcessV2Enabled();
+  void setRequireReturnsDefaultExportEnabled();
   void setThrowOnUnrecognizedImportAssertion();
   bool getThrowOnUnrecognizedImportAssertion() const;
   void setToStringTag();

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -449,8 +449,6 @@ class IsolateModuleRegistry final {
   // like the CommonJS require. Returns the instantiated/evaluated module namespace.
   // If an empty v8::MaybeLocal is returned and the default option is given, then an
   // exception has been scheduled.
-  // Note that this returns the module namespace object. In CommonJS, the require()
-  // function will actually return the default export from the module namespace object.
   v8::MaybeLocal<v8::Object> require(
       Lock& js, const ResolveContext& context, RequireOption option = RequireOption::DEFAULT) {
     static constexpr auto evaluate = [](Lock& js, Entry& entry, const Url& id,

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -150,6 +150,12 @@ class ModuleRegistry {
     // For source phase imports - stores the module source object (e.g., WebAssembly.Module)
     kj::Maybe<V8Ref<v8::Object>> maybeModuleSourceObject;
 
+    // Cache for mutable module exports wrapper when require_returns_default_export flag is enabled.
+    // Used to ensure require() returns the same mutable object for the same module.
+    // This enables frameworks like Next.js to patch built-in module exports.
+    // See: https://github.com/cloudflare/workerd/issues/5844
+    mutable kj::Maybe<V8Ref<v8::Object>> maybeMutableExports;
+
     ModuleInfo(jsg::Lock& js,
         v8::Local<v8::Module> module,
         kj::Maybe<SyntheticModuleInfo> maybeSynthetic = kj::none);

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -155,6 +155,10 @@ class IsolateBase {
     nodeJsProcessV2Enabled = enabled;
   }
 
+  inline void setRequireReturnsDefaultExportEnabled(kj::Badge<Lock>, bool enabled) {
+    requireReturnsDefaultExportEnabled = enabled;
+  }
+
   inline bool areWarningsLogged() const {
     return maybeLogger != kj::none;
   }
@@ -168,6 +172,10 @@ class IsolateBase {
 
   inline bool isNodeJsProcessV2Enabled() const {
     return nodeJsProcessV2Enabled;
+  }
+
+  inline bool isRequireReturnsDefaultExportEnabled() const {
+    return requireReturnsDefaultExportEnabled;
   }
 
   inline bool shouldSetToStringTag() const {
@@ -339,6 +347,7 @@ class IsolateBase {
   bool asyncContextTrackingEnabled = false;
   bool nodeJsCompatEnabled = false;
   bool nodeJsProcessV2Enabled = false;
+  bool requireReturnsDefaultExportEnabled = false;
   bool setToStringTag = false;
   bool shouldSetImmutablePrototypeFlag = false;
   bool allowTopLevelAwait = true;

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -849,6 +849,21 @@ v8::Local<v8::String> newExternalTwoByteString(Lock& js, kj::ArrayPtr<const uint
 }
 
 // ======================================================================================
+// Module utilities
+
+JsObject createMutableModuleExports(Lock& js, JsObject moduleNamespace) {
+  auto result = js.objNoProto();
+  auto names = moduleNamespace.getPropertyNames(js, OWN_ONLY, ALL_PROPERTIES, INCLUDE_INDICES);
+
+  for (uint32_t i = 0; i < names.size(); i++) {
+    auto name = names.get(js, i);
+    result.set(js, name, moduleNamespace.get(js, name));
+  }
+
+  return result;
+}
+
+// ======================================================================================
 // Node.js Compat
 
 namespace {
@@ -893,6 +908,10 @@ bool isNodeJsCompatEnabled(jsg::Lock& js) {
 
 bool isNodeJsProcessV2Enabled(jsg::Lock& js) {
   return IsolateBase::from(js.v8Isolate).isNodeJsProcessV2Enabled();
+}
+
+bool isRequireReturnsDefaultExportEnabled(jsg::Lock& js) {
+  return IsolateBase::from(js.v8Isolate).isRequireReturnsDefaultExportEnabled();
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -25,6 +25,7 @@ class Isolate;
 namespace workerd::jsg {
 
 class Lock;
+class JsObject;
 
 using uint = unsigned int;
 
@@ -537,11 +538,22 @@ struct Unimplemented {};
 using WontImplement = Unimplemented;
 
 // ======================================================================================
+// Module utilities
+
+// Creates a mutable copy of a module namespace object for CommonJS compatibility.
+// This is needed because ES module namespaces have read-only properties, but
+// CommonJS require() is expected to return objects with mutable properties.
+// This matches Node.js behavior when requiring an ESM module from CJS.
+// See: https://github.com/cloudflare/workerd/issues/5844
+JsObject createMutableModuleExports(Lock& js, JsObject moduleNamespace);
+
+// ======================================================================================
 // Node.js Compat
 
 kj::Maybe<kj::String> checkNodeSpecifier(kj::StringPtr specifier);
 bool isNodeJsCompatEnabled(jsg::Lock& js);
 bool isNodeJsProcessV2Enabled(jsg::Lock& js);
+bool isRequireReturnsDefaultExportEnabled(jsg::Lock& js);
 
 // The following counter is used to track the number of times a method is called.
 // This is mostly useful for validating/testing v8 fast api methods, but also for


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/5844 (with the help of our friend Claude)

ES module namespaces have read-only properties by specification, but CommonJS require() is expected to return objects with mutable properties.