### PR TITLE
Fix create-vendor-zip handling of None abi

### DIFF
--- a/src/pyodide/create_vendor_zip.py
+++ b/src/pyodide/create_vendor_zip.py
@@ -161,7 +161,7 @@ def main() -> int:
         i2 = " " * 16
         print(i1 + "{")
         print(i2 + f'"name": "{"-".join(args.package_name)}",')
-        print(i2 + f'"abi": "{abi}",')
+        print(i2 + f'"abi": {abi!r},')
         print(i2 + f'"sha256": "{hexdigest(zip_path)}",')
         print(i1 + "},")
         print()


### PR DESCRIPTION
It should say `None` instead of `"None"` for the abi