### PR TITLE
Update Node.js version in GitHub Actions workflow to match workers-sdk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # Match workers-sdk node version
-          node-version: 20.19.1
+          node-version: 20.19.6
           cache: 'pnpm'
       - name: Install workers-sdk dependencies
         run: pnpm install


### PR DESCRIPTION
There was a subtle change in how `FormData` is serialized between Node 20.19.1 and 20.19.6, which makes the snapshot tests change.

After 20.19.6, there is an additional empty line at the end of FormData in snapshots. Updating to this version aligns with workers-sdk.

Here is the PR in Undici where this changed: https://github.com/nodejs/undici/pull/3625

---

From Gemini:

There was a specific change regarding trailing whitespace (CRLF) in FormData serialization between Undici v6.21.2 and v6.22.0.

This change fixes a bug where the final boundary of a multipart/form-data payload was malformed, causing compatibility issues with certain strict servers.

**The Change: Missing CRLF**
In v6.21.2 (and earlier): The FormData serializer omitted the final \r\n (Carriage Return + Line Feed) after the last boundary.

In v6.22.0: The serializer was updated to explicitly append this trailing \r\n to comply with stricter interpretations of the multipart spec.

**Why this matters**
While many servers are lenient and accept the body without the final newline, strict HTTP parsers (often found in older enterprise backends, Java/Spring servers, or specific WAFs) expect the body to end with a newline.