### PR TITLE
Set a default date for _stream_wrap, dgram, inspector, and sqlite mod…

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1130,7 +1130,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   enableNodeJsStreamWrapModule @131 :Bool
     $compatEnableFlag("enable_nodejs_stream_wrap_module")
     $compatDisableFlag("disable_nodejs_stream_wrap_module")
-    $experimental;
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2026-01-29");
   # Enables the Node.js non-functional stub _stream_wrap module. It is required to use this
   # flag with nodejs_compat (or nodejs_compat_v2).
 
@@ -1144,14 +1144,14 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   enableNodeJsDgramModule @133 :Bool
     $compatEnableFlag("enable_nodejs_dgram_module")
     $compatDisableFlag("disable_nodejs_dgram_module")
-    $experimental;
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2026-01-29");
   # Enables the Node.js non-functional stub dgram module. It is required to use this
   # flag with nodejs_compat (or nodejs_compat_v2).
 
   enableNodeJsInspectorModule @134 :Bool
     $compatEnableFlag("enable_nodejs_inspector_module")
     $compatDisableFlag("disable_nodejs_inspector_module")
-    $experimental;
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2026-01-29");
   # Enables the Node.js non-functional stub inspector module. It is required to use this
   # flag with nodejs_compat (or nodejs_compat_v2).
 
@@ -1179,7 +1179,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   enableNodeJsSqliteModule @138 :Bool
     $compatEnableFlag("enable_nodejs_sqlite_module")
     $compatDisableFlag("disable_nodejs_sqlite_module")
-    $experimental;
+    $impliedByAfterDate(name = "nodeJsCompat", date = "2026-01-29");
   # Enables the Node.js non-functional stub sqlite module. It is required to use this
   # flag with nodejs_compat (or nodejs_compat_v2).
 
@@ -1311,9 +1311,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
     $compatEnableFlag("enable_nodejs_global_timers")
     $compatDisableFlag("no_nodejs_global_timers")
     $experimental;
-  # When enabled, all 6 timer functions (setTimeout, setInterval, clearTimeout,
-  # clearInterval, setImmediate, clearImmediate) are available on globalThis as
-  # Node.js-compatible versions from node:timers. setTimeout and setInterval return
-  # Timeout objects with methods like refresh(), ref(), unref(), and hasRef().
+  # When enabled, setTimeout, setInterval, clearTimeout, and clearInterval
+  # are available on globalThis as Node.js-compatible versions from node:timers.
+  # setTimeout and setInterval return Timeout objects with methods like
+  # refresh(), ref(), unref(), and hasRef().
   # This flag requires nodejs_compat or nodejs_compat_v2 to be enabled.
 }


### PR DESCRIPTION
…ules

Similar to the previous https://github.com/cloudflare/workerd/pull/5567

Has more native modules have been integrated into workers-sdk, we can move them out of experimental and add a default enable date 2026-01-29 here.

@danlapid I took the opportunity to clean up the mess [I caused on the timers flag (setImmediate is not impacted by that)](https://github.com/cloudflare/workerd/pull/5751#pullrequestreview-3607542292).

/cc @petebacondarwin @anonrig @jasnell 

