### PR TITLE
Adds check for socket closure at the start of startTls.

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -326,7 +326,8 @@ jsg::Promise<void> Socket::close(jsg::Lock& js) {
 jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOptions) {
   JSG_REQUIRE(
       secureTransport != SecureTransportKind::ON, TypeError, "Cannot startTls on a TLS socket.");
-  // TODO: Track closed state of socket properly and assert that it hasn't been closed here.
+  JSG_REQUIRE(connectionStream != kj::none, TypeError,
+      "The connection was closed before startTls could be started.");
   JSG_REQUIRE(domain != nullptr, TypeError, "startTls can only be called once.");
   auto invalidOptKindMsg =
       "The `secureTransport` socket option must be set to 'starttls' for startTls to be used.";


### PR DESCRIPTION
Now that the `connectionStream` is set to `kj::none` when the socket is closed (or otherwise the stream is taken ownership of), we can detect this and solve this TODO item.