### PR TITLE
Remove the redundant `@` from Python wd-tests.

### DIFF
--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -81,7 +81,7 @@ def _py_wd_test_helper(
 
     wd_test(
         src = templated_src,
-        name = name_flag + "@",
+        name = name_flag,
         args = args,
         python_snapshot_test = make_snapshot,
         data = data,


### PR DESCRIPTION
Something changed recently to turn test commands that used to work:

```
bazel run @workerd//src/workerd/server/tests/python:hello_0.28.2@
```

to fail and for two `@` to be needed to run the test:

```
bazel run @workerd//src/workerd/server/tests/python:hello_0.28.2@@
```

This PR fixes this.