### PR TITLE
py_wd_test: Fix `make_snapshot=False` with default use_snapshot setting

### DIFF
--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -50,7 +50,8 @@ def _py_wd_test_helper(
             use_snapshot = None
         else:
             use_snapshot = "baseline"
-            feature_flags = feature_flags + ["python_dedicated_snapshot"]
+            if make_snapshot:
+                feature_flags = feature_flags + ["python_dedicated_snapshot"]
     if use_snapshot:
         version_info = BUNDLE_VERSION_INFO[python_flag]
 


### PR DESCRIPTION
We should only add the dedicated snapshot flag if we are making a snapshot.