### PR TITLE
worker-loader-test requires network

### DIFF
--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -598,6 +598,7 @@ wd_test(
     src = "worker-loader-test.wd-test",
     args = ["--experimental"],
     data = ["worker-loader-test.js"],
+    tags = ["requires-network"],
 )
 
 wd_test(


### PR DESCRIPTION
After running all the tests locally, I found one test that slipped through the cracks due to Bazel caching. The test `//src/workerd/api/tests/worker-loader-test@` fetches files from the internet, like `https://pyodide-capnp-bin.edgeworker.net/pyodide_0.26.0a2_2024-03-01_75.capnp.bin`. I don't like this very much, but let's allow it to do so for now.
