### PR TITLE
Fixes UAF when destroying AsyncIoStream backing EncodedAsyncInputStream.

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -567,6 +567,14 @@ kj_test(
 )
 
 kj_test(
+    src = "system-streams-test.c++",
+    deps = [
+        "//src/workerd/io",
+        "//src/workerd/tests:test-fixture",
+    ],
+)
+
+kj_test(
     src = "actor-state-iocontext-test.c++",
     deps = [
         "//src/workerd/io",

--- a/src/workerd/api/system-streams-test.c++
+++ b/src/workerd/api/system-streams-test.c++
@@ -1,0 +1,55 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "system-streams.h"
+
+#include <workerd/io/io-context.h>
+#include <workerd/tests/test-fixture.h>
+
+#include <kj/test.h>
+
+namespace workerd::api {
+namespace {
+
+KJ_TEST("EncodedAsyncInputStream cancel with pending read on AsyncPipe") {
+  // This test reproduces a use-after-free crash that occurred when:
+  // 1. A read operation is started on an EncodedAsyncInputStream backed by an AsyncPipe
+  // 2. The stream is cancelled (e.g., via Socket::close())
+  // 3. The AsyncPipe is destroyed while the read is still pending
+  //
+  // Without the fix (kj::Canceler in EncodedAsyncInputStream), the BlockedRead destructor
+  // would try to access the freed AsyncPipe, causing a use-after-free.
+
+  TestFixture fixture;
+  fixture.runInIoContext([](const TestFixture::Environment& env) -> kj::Promise<void> {
+    // Create an in-memory pipe (AsyncPipe)
+    auto pipe = kj::newTwoWayPipe();
+
+    // Create an EncodedAsyncInputStream wrapping one end of the pipe
+    kj::Own<kj::AsyncInputStream> inputStream = kj::mv(pipe.ends[0]);
+    auto stream = newSystemStream(kj::mv(inputStream), StreamEncoding::IDENTITY, env.context);
+
+    // Start a read operation - this will block because no data has been written to the pipe
+    kj::byte buffer[100];
+    auto readPromise = stream->tryRead(buffer, 1, sizeof(buffer));
+
+    // Cancel the stream - this simulates what Socket::close() does
+    stream->cancel(KJ_EXCEPTION(DISCONNECTED, "stream cancelled"));
+
+    // Now destroy the other end of the pipe - this destroys the AsyncPipe
+    // Without the fix, this would cause a use-after-free when the BlockedRead
+    // destructor tries to access the freed pipe.
+    pipe.ends[1] = nullptr;
+
+    // The read promise should be cancelled - try to wait for it
+    // It should reject with the cancellation exception
+    return readPromise.then(
+        [](size_t) { KJ_FAIL_ASSERT("read should have been cancelled"); }, [](kj::Exception&& e) {
+      // Expected the read to be cancelled
+    });
+  });
+}
+
+}  // namespace
+}  // namespace workerd::api

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -47,6 +47,8 @@ class EncodedAsyncInputStream final: public ReadableStreamSource {
   // brotli streams.
   kj::Maybe<Tee> tryTee(uint64_t limit) override;
 
+  void cancel(kj::Exception reason) override;
+
  private:
   friend class EncodedAsyncOutputStream;
 
@@ -54,6 +56,7 @@ class EncodedAsyncInputStream final: public ReadableStreamSource {
 
   kj::Own<kj::AsyncInputStream> inner;
   StreamEncoding encoding;
+  kj::Canceler canceler;
 
   IoContext& ioContext;
 };
@@ -69,7 +72,8 @@ kj::Promise<size_t> EncodedAsyncInputStream::tryRead(
   ensureIdentityEncoding();
 
   return kj::evalNow([&]() {
-    return inner->tryRead(buffer, minBytes, maxBytes).attach(ioContext.registerPendingEvent());
+    return canceler.wrap(inner->tryRead(buffer, minBytes, maxBytes))
+        .attach(ioContext.registerPendingEvent());
   }).catch_([](kj::Exception&& exception) -> kj::Promise<size_t> {
     KJ_IF_SOME(e,
         translateKjException(exception,
@@ -116,6 +120,13 @@ kj::Maybe<ReadableStreamSource::Tee> EncodedAsyncInputStream::tryTee(uint64_t li
   result.branches[0] = newSystemStream(newTeeErrorAdapter(kj::mv(tee.branches[0])), encoding);
   result.branches[1] = newSystemStream(newTeeErrorAdapter(kj::mv(tee.branches[1])), encoding);
   return kj::mv(result);
+}
+
+void EncodedAsyncInputStream::cancel(kj::Exception reason) {
+  // Cancel any pending read operations. This will cause the wrapped promises to be rejected
+  // with a cancellation exception, which properly cleans up the BlockedRead state in AsyncPipe
+  // before the pipe itself is destroyed.
+  canceler.cancel(kj::mv(reason));
 }
 
 void EncodedAsyncInputStream::ensureIdentityEncoding() {


### PR DESCRIPTION
This PR is a synthesis of a real UAF we experienced due to the Socket closure changes implemented in https://github.com/cloudflare/workerd/pull/5885. The `system-streams-test` attempts to reproduce the state in which the Socket's ReadableStream finds itself in, the resulting UAF is equivalent to the UAF stack trace we saw in production: https://gist.github.com/dom96/23d4068d760b9075639e72b6b1971bbf.

To fix this it seems we need a way to signal to the ReadableStream that it should cease waiting on a read. We do this using a kj::Canceler. This resolves the UAF in the unit test implemented here. The Socket code calls the ReadableStream's `cancel` method too, ordinarily this method seems to be a no-op, which this PR changes.

### Test Plan

```
$ bazel test @workerd//src/workerd/api:system-streams-test@ --config=asan
```