### PR TITLE
Log warning if attempt to connect to Hyperdrive fails

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -443,6 +443,13 @@ void Socket::handleProxyStatus(
       if (isDefaultFetchPort) {
         msg = kj::str(msg, ". It looks like you might be trying to connect to a HTTP-based service",
             " — consider using fetch instead");
+      } else if (remoteAddress.contains(".hyperdrive.local"_kj)) {
+        // No attempts to connect to Hyperdrive should end up here, since they go through the other
+        // version of handleProxyStatus. If they end up here somehow, log about it to get some
+        // context that can aid in debugging.
+        LOG_WARNING_PERIODICALLY(
+            "attempt to connect to Hyperdrive failed to trigger connectOverride", remoteAddress,
+            status.statusCode, status.statusText);
       }
       handleProxyError(js, JSG_KJ_EXCEPTION(FAILED, Error, msg));
     } else {


### PR DESCRIPTION
Specifically, if it fails due to not triggering the getConnectOverride code path.

Depending on what we find here, we may eventually need to add more to what we log to help debug this, but I'd rather err on the side of not logging too much (and possibly taking longer to track the issue down) than to make a bunch of extra changes to get access to more info to log (complicating the code in the process) and possibly log something we shouldn't.

This current change will tell us:
1. if the reports we've seen about issues connecting to hyperdrive are actually using a hyperdrive address (based on whether or not we see any of these logs show up)
2. if we do see them, we'll get a sampling of context about when/where they're happening
3. if we do see them, if there's anything weird/mangled about the host or incorrect about the port (which needs to be 5432, going by the current implementation of hyperdrive.c++)

@prydt @ReppCodes 