### PR TITLE
EMAIL-1313 Update Email Sending return type

### DIFF
--- a/types/defines/email.d.ts
+++ b/types/defines/email.d.ts
@@ -1,4 +1,14 @@
 /**
+ * The returned data after sending an email
+ */
+interface EmailSendResult {
+  /**
+   * The Email Message ID
+   */
+  messageId: string;
+}
+
+/**
  * An email message that can be sent from a Worker.
  */
 interface EmailMessage {
@@ -40,20 +50,20 @@ interface ForwardableEmailMessage extends EmailMessage {
    * @param headers A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
    * @returns A promise that resolves when the email message is forwarded.
    */
-  forward(rcptTo: string, headers?: Headers): Promise<void>;
+  forward(rcptTo: string, headers?: Headers): Promise<EmailSendResult>;
   /**
    * Reply to the sender of this email message with a new EmailMessage object.
    * @param message The reply message.
    * @returns A promise that resolves when the email message is replied.
    */
-  reply(message: EmailMessage): Promise<void>;
+  reply(message: EmailMessage): Promise<EmailSendResult>;
 }
 
 /**
  * A binding that allows a Worker to send email messages.
  */
 interface SendEmail {
-  send(message: EmailMessage): Promise<void>;
+  send(message: EmailMessage): Promise<EmailSendResult>;
 }
 
 declare abstract class EmailEvent extends ExtendableEvent {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -11322,6 +11322,15 @@ declare abstract class D1PreparedStatement {
 // ignored when `Disposable` is included in the standard lib.
 interface Disposable {}
 /**
+ * The returned data after sending an email
+ */
+interface EmailSendResult {
+  /**
+   * The Email Message ID
+   */
+  messageId: string;
+}
+/**
  * An email message that can be sent from a Worker.
  */
 interface EmailMessage {
@@ -11362,19 +11371,19 @@ interface ForwardableEmailMessage extends EmailMessage {
    * @param headers A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
    * @returns A promise that resolves when the email message is forwarded.
    */
-  forward(rcptTo: string, headers?: Headers): Promise<void>;
+  forward(rcptTo: string, headers?: Headers): Promise<EmailSendResult>;
   /**
    * Reply to the sender of this email message with a new EmailMessage object.
    * @param message The reply message.
    * @returns A promise that resolves when the email message is replied.
    */
-  reply(message: EmailMessage): Promise<void>;
+  reply(message: EmailMessage): Promise<EmailSendResult>;
 }
 /**
  * A binding that allows a Worker to send email messages.
  */
 interface SendEmail {
-  send(message: EmailMessage): Promise<void>;
+  send(message: EmailMessage): Promise<EmailSendResult>;
 }
 declare abstract class EmailEvent extends ExtendableEvent {
   readonly message: ForwardableEmailMessage;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -11350,6 +11350,15 @@ export declare abstract class D1PreparedStatement {
 // ignored when `Disposable` is included in the standard lib.
 export interface Disposable {}
 /**
+ * The returned data after sending an email
+ */
+export interface EmailSendResult {
+  /**
+   * The Email Message ID
+   */
+  messageId: string;
+}
+/**
  * An email message that can be sent from a Worker.
  */
 export interface EmailMessage {
@@ -11390,19 +11399,19 @@ export interface ForwardableEmailMessage extends EmailMessage {
    * @param headers A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
    * @returns A promise that resolves when the email message is forwarded.
    */
-  forward(rcptTo: string, headers?: Headers): Promise<void>;
+  forward(rcptTo: string, headers?: Headers): Promise<EmailSendResult>;
   /**
    * Reply to the sender of this email message with a new EmailMessage object.
    * @param message The reply message.
    * @returns A promise that resolves when the email message is replied.
    */
-  reply(message: EmailMessage): Promise<void>;
+  reply(message: EmailMessage): Promise<EmailSendResult>;
 }
 /**
  * A binding that allows a Worker to send email messages.
  */
 export interface SendEmail {
-  send(message: EmailMessage): Promise<void>;
+  send(message: EmailMessage): Promise<EmailSendResult>;
 }
 export declare abstract class EmailEvent extends ExtendableEvent {
   readonly message: ForwardableEmailMessage;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -10716,6 +10716,15 @@ declare abstract class D1PreparedStatement {
 // ignored when `Disposable` is included in the standard lib.
 interface Disposable {}
 /**
+ * The returned data after sending an email
+ */
+interface EmailSendResult {
+  /**
+   * The Email Message ID
+   */
+  messageId: string;
+}
+/**
  * An email message that can be sent from a Worker.
  */
 interface EmailMessage {
@@ -10756,19 +10765,19 @@ interface ForwardableEmailMessage extends EmailMessage {
    * @param headers A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
    * @returns A promise that resolves when the email message is forwarded.
    */
-  forward(rcptTo: string, headers?: Headers): Promise<void>;
+  forward(rcptTo: string, headers?: Headers): Promise<EmailSendResult>;
   /**
    * Reply to the sender of this email message with a new EmailMessage object.
    * @param message The reply message.
    * @returns A promise that resolves when the email message is replied.
    */
-  reply(message: EmailMessage): Promise<void>;
+  reply(message: EmailMessage): Promise<EmailSendResult>;
 }
 /**
  * A binding that allows a Worker to send email messages.
  */
 interface SendEmail {
-  send(message: EmailMessage): Promise<void>;
+  send(message: EmailMessage): Promise<EmailSendResult>;
 }
 declare abstract class EmailEvent extends ExtendableEvent {
   readonly message: ForwardableEmailMessage;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -10742,6 +10742,15 @@ export declare abstract class D1PreparedStatement {
 // ignored when `Disposable` is included in the standard lib.
 export interface Disposable {}
 /**
+ * The returned data after sending an email
+ */
+export interface EmailSendResult {
+  /**
+   * The Email Message ID
+   */
+  messageId: string;
+}
+/**
  * An email message that can be sent from a Worker.
  */
 export interface EmailMessage {
@@ -10782,19 +10791,19 @@ export interface ForwardableEmailMessage extends EmailMessage {
    * @param headers A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
    * @returns A promise that resolves when the email message is forwarded.
    */
-  forward(rcptTo: string, headers?: Headers): Promise<void>;
+  forward(rcptTo: string, headers?: Headers): Promise<EmailSendResult>;
   /**
    * Reply to the sender of this email message with a new EmailMessage object.
    * @param message The reply message.
    * @returns A promise that resolves when the email message is replied.
    */
-  reply(message: EmailMessage): Promise<void>;
+  reply(message: EmailMessage): Promise<EmailSendResult>;
 }
 /**
  * A binding that allows a Worker to send email messages.
  */
 export interface SendEmail {
-  send(message: EmailMessage): Promise<void>;
+  send(message: EmailMessage): Promise<EmailSendResult>;
 }
 export declare abstract class EmailEvent extends ExtendableEvent {
   readonly message: ForwardableEmailMessage;


### PR DESCRIPTION
Email Routing and Sending related methods will now return an object containing a message ID when sending the email is successful.

Before merging checklist:
- [x] Email team is okay with wording