### PR TITLE
use simulation in codspeed due to deprecation

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,7 +26,7 @@ jobs:
     name: Run benchmarks
     runs-on: ubuntu-22.04-16core
     env:
-      BAZEL_ARGS: --config=benchmark --@google_benchmark//:codspeed_mode=instrumentation --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev
+      BAZEL_ARGS: --config=benchmark --@google_benchmark//:codspeed_mode=simulation --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,7 +60,7 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: instrumentation
+          mode: simulation
           run: ./run_benchmarks.sh
 
       - name: Bazel shutdown


### PR DESCRIPTION
It seems instrumentation is now deprecated and pending to be removed.