### PR TITLE
[build] Allow downstream projects to depend on workerd via bzlmod

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,0 @@
-# No longer used in the workerd repo.
-# This file remains for now as some dependents use WORKSPACE and expect to find it.
-workspace(name = "workerd")

--- a/build/is_pyodide_bzlmod.bzl
+++ b/build/is_pyodide_bzlmod.bzl
@@ -1,2 +1,0 @@
-# workerd uses bzlmod for pyodide (and everything else)
-is_pyodide_bzlmod = True

--- a/src/pyodide/helpers.bzl
+++ b/src/pyodide/helpers.bzl
@@ -338,8 +338,8 @@ def _python_bundle(version, *, pyodide_asm_wasm = None, pyodide_asm_js = None, p
         outs = [_out_path("pyodide.capnp.bin", version)],
         cmd = " ".join([
             # Annoying logic to deal with different paths in workerd vs downstream.
-            # Either need "-I src" in workerd or -I external/workerd/src downstream
-            "INCLUDE=$$(stat src > /dev/null 2>&1 && echo src || echo external/workerd/src);",
+            # Either need "-I src" in workerd or -I external/+dep_workerd+workerd/src downstream
+            "INCLUDE=$$(stat src > /dev/null 2>&1 && echo src || echo external/+dep_workerd+workerd/src);",
             "$(execpath @capnp-cpp//src/capnp:capnp_tool)",
             "eval",
             "$(location :pyodide@%s.capnp)" % version,

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("//:build/kj_test.bzl", "kj_test")
 load("//:build/wd_capnp_library.bzl", "wd_capnp_library")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")

--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -1,4 +1,3 @@
-load("@//:build/is_pyodide_bzlmod.bzl", "is_pyodide_bzlmod")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("//:build/python_metadata.bzl", "BUNDLE_VERSION_INFO")
@@ -35,13 +34,8 @@ def _py_wd_test_helper(
     data = data + ["@all_pyodide_wheels_%s//:whls" % pkg_tag]
     args = args + ["--pyodide-package-disk-cache-dir"]
 
-    # TODO(cleanup): We support both mangled and non-mangled wheels paths for now, clean up once
-    # downstream repo fully uses bzlmod
-    if is_pyodide_bzlmod:
-        # +pyodide+ is a bzlmod canonical repository name
-        args.append("../+pyodide+all_pyodide_wheels_%s" % pkg_tag)
-    else:
-        args.append("../all_pyodide_wheels_%s" % pkg_tag)
+    # +pyodide+ is a bzlmod canonical repository name
+    args.append("../+pyodide+all_pyodide_wheels_%s" % pkg_tag)
 
     load_snapshot = None
     pyodide_version = BUNDLE_VERSION_INFO[python_flag]["real_pyodide_version"]

--- a/types/src/utils.ts
+++ b/types/src/utils.ts
@@ -1,10 +1,11 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-// When building types from the upstream repo all paths need to be prepended by external/workerd/
+// When building types from the upstream repo all paths need to be prepended by
+// external/+dep_workerd+workerd/
 export function getFilePath(f: string): string {
-  if (existsSync("external/workerd")) {
-    return path.join("external", "workerd", f);
+  if (existsSync("external/+dep_workerd+workerd")) {
+    return path.join("external", "+dep_workerd+workerd", f);
   } else {
     return f;
   }


### PR DESCRIPTION
Removes vestigal remains of workspace support. Also see the downstream PR.