### PR TITLE
fix no_unique_address msvc warning

### DIFF
--- a/src/workerd/util/state-machine.h
+++ b/src/workerd/util/state-machine.h
@@ -6,9 +6,9 @@
 
 // MSVC uses a different attribute name for no_unique_address
 #if _MSC_VER
-#define KJ_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#define WD_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #else
-#define KJ_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#define WD_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 
 // State Machine Abstraction built on kj::OneOf.
@@ -1671,8 +1671,8 @@ class StateMachine {
 
   // Pending state support (only allocated when HAS_PENDING is true)
   // Using _::Empty instead of char for proper [[no_unique_address]] optimization
-  KJ_NO_UNIQUE_ADDRESS std::conditional_t<HAS_PENDING, StateUnion, _::Empty> pendingState{};
-  KJ_NO_UNIQUE_ADDRESS std::conditional_t<HAS_PENDING, uint32_t, _::Empty> operationCount{};
+  WD_NO_UNIQUE_ADDRESS std::conditional_t<HAS_PENDING, StateUnion, _::Empty> pendingState{};
+  WD_NO_UNIQUE_ADDRESS std::conditional_t<HAS_PENDING, uint32_t, _::Empty> operationCount{};
 
   void requireUnlocked() const {
     KJ_REQUIRE(transitionLockCount == 0,


### PR DESCRIPTION
Fixes a warning

```
bazel-out/x64_windows-opt/bin/src/workerd/util/_virtual_includes/state-machine\workerd/util/state-machine.h(1667,5): warning: unknown attribute 'no_unique_address' ignored [-Wunknown-attributes]
 1667 |   [[no_unique_address]] std::conditional_t<HAS_PENDING, StateUnion, _::Empty> pendingState{};
      |     ^~~~~~~~~~~~~~~~~
bazel-out/x64_windows-opt/bin/src/workerd/util/_virtual_includes/state-machine\workerd/util/state-machine.h(1668,5): warning: unknown attribute 'no_unique_address' ignored [-Wunknown-attributes]
 1668 |   [[no_unique_address]] std::conditional_t<HAS_PENDING, uint32_t, _::Empty> operationCount{};
      |     ^~~~~~~~~~~~~~~~~
2 warnings generated.
```