### PR TITLE
types: Allow AnalyticsEngineDataPoint doubles to be null

### DIFF
--- a/src/workerd/api/analytics-engine.h
+++ b/src/workerd/api/analytics-engine.h
@@ -45,7 +45,9 @@ class AnalyticsEngine: public jsg::Object {
     // have a maximum of 20 elements.
 
     JSG_STRUCT(indexes, doubles, blobs);
-    JSG_STRUCT_TS_OVERRIDE(AnalyticsEngineDataPoint);
+    JSG_STRUCT_TS_OVERRIDE(AnalyticsEngineDataPoint {
+      doubles?: (number | null)[];
+    });
   };
 
   // Send an Analytics Engine-compatible event to the configured logfwdr socket.

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -786,7 +786,7 @@ interface AnalyticsEngineDataset {
 }
 interface AnalyticsEngineDataPoint {
   indexes?: ((ArrayBuffer | string) | null)[];
-  doubles?: number[];
+  doubles?: (number | null)[];
   blobs?: ((ArrayBuffer | string) | null)[];
 }
 /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -791,7 +791,7 @@ export interface AnalyticsEngineDataset {
 }
 export interface AnalyticsEngineDataPoint {
   indexes?: ((ArrayBuffer | string) | null)[];
-  doubles?: number[];
+  doubles?: (number | null)[];
   blobs?: ((ArrayBuffer | string) | null)[];
 }
 /**

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -743,7 +743,7 @@ interface AnalyticsEngineDataset {
 }
 interface AnalyticsEngineDataPoint {
   indexes?: ((ArrayBuffer | string) | null)[];
-  doubles?: number[];
+  doubles?: (number | null)[];
   blobs?: ((ArrayBuffer | string) | null)[];
 }
 /**

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -748,7 +748,7 @@ export interface AnalyticsEngineDataset {
 }
 export interface AnalyticsEngineDataPoint {
   indexes?: ((ArrayBuffer | string) | null)[];
-  doubles?: number[];
+  doubles?: (number | null)[];
   blobs?: ((ArrayBuffer | string) | null)[];
 }
 /**


### PR DESCRIPTION
Fixes [#5889](https://github.com/cloudflare/workerd/issues/5889).

From the issue:
```
Currently, the doubles property in AnalyticsEngineDataPoint is strictly typed as number[]. This is inconsistent with the indexes and blobs fields, which both allow null values to represent missing data in specific positions.

Since Workers Analytics Engine supports sparse arrays, the current type definition forces a friction point for TypeScript users.
```