### PR TITLE
tune tcmalloc for benchmarks

### DIFF
--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -6,7 +6,7 @@ load("//:build/wd_test.bzl", "wd_test")
 wd_cc_library(
     name = "bench-tools",
     hdrs = ["bench-tools.h"],
-    local_defines = select({
+    defines = select({
         "//src/workerd/server:really_use_tcmalloc": ["WD_USE_TCMALLOC"],
         "//conditions:default": [],
     }),

--- a/src/workerd/tests/bench-tools.h
+++ b/src/workerd/tests/bench-tools.h
@@ -13,7 +13,7 @@
 // Configure tcmalloc for deterministic benchmarks on Linux.
 // tcmalloc uses probabilistic heap sampling which can introduce variance in benchmark results.
 // WD_USE_TCMALLOC is defined when tcmalloc is enabled (Linux + use_tcmalloc flag).
-#if defined(WD_USE_TCMALLOC) && defined(WD_IS_BENCHMARK)
+#if defined(WD_USE_TCMALLOC)
 #include "tcmalloc/malloc_extension.h"
 
 namespace workerd::bench {
@@ -36,7 +36,7 @@ struct TcmallocBenchmarkConfig {
 inline TcmallocBenchmarkConfig tcmallocBenchmarkConfig;
 
 }  // namespace workerd::bench
-#endif  // defined(WD_USE_TCMALLOC) && defined(WD_IS_BENCHMARK)
+#endif  // defined(WD_USE_TCMALLOC)
 
 // Define a benchmark. Use microseconds instead of nanoseconds by default, most tests run long
 // enough to not need ns precision.


### PR DESCRIPTION
Tcmalloc is extremely flaky while running benchmarks. This change would reduce the probability of outliers at the cost of diverging from production. For benchmarks that need tcmalloc to use the default values, they have to avoid including bench-tools.

Recommended by Codspeed folks.