### PR TITLE
chore: Use up-to-date API for memory accounting

### DIFF
--- a/build/deps/v8.MODULE.bazel
+++ b/build/deps/v8.MODULE.bazel
@@ -53,6 +53,7 @@ PATCHES = [
     "0028-bind-icu-to-googlesource.patch",
     "0029-optimize-ascii-fast-path-in-WriteUtf8V2.patch",
     "0030-Add-v8-String-IsFlat-API.patch",
+    "0031-Disable-ExternalMemoryAccounter-destructor-check.patch",
 ]
 
 http_archive(

--- a/patches/v8/0031-Disable-ExternalMemoryAccounter-destructor-check.patch
+++ b/patches/v8/0031-Disable-ExternalMemoryAccounter-destructor-check.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aditya Tewari <adityaatewari@gmail.com>
+Date: Wed, 15 Jan 2025 00:00:00 -0800
+Subject: Disable ExternalMemoryAccounter destructor check
+
+workerd's design allows external memory to outlive the isolate in certain
+cases. The ExternalMemoryAccounter destructor's DCHECK_EQ assertion requires
+memory to return to zero, which conflicts with this design pattern.
+
+This patch disables the assertion while maintaining proper memory accounting
+through explicit Increase/Decrease calls.
+
+diff --git a/src/api/api.cc b/src/api/api.cc
+index 946a2154e793b1def5e783fd0eea2a286fa4ee54..0000000000000000000000000000000000000000 100644
+--- a/src/api/api.cc
++++ b/src/api/api.cc
+@@ -12342,7 +12342,8 @@ void ExternalMemoryAccounter::Update(Isolate* isolate, int64_t delta) {
+ 
+ ExternalMemoryAccounter::~ExternalMemoryAccounter() {
+ #ifdef V8_ENABLE_MEMORY_ACCOUNTING_CHECKS
+-  DCHECK_EQ(amount_of_external_memory_, 0U);
++  // Disabled: workerd allows external memory to outlive isolates
++  // DCHECK_EQ(amount_of_external_memory_, 0U);
+ #endif
+ }
+ 

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -366,14 +366,7 @@ void ExternalMemoryTarget::maybeDeferAdjustment(ssize_t amount) const {
     // making such a change, and that's us, and we're not.
     KJ_ASSERT(v8::Locker::IsLocked(target));
 
-    // TODO(cleanup): This is deprecated, but the replacement, v8::ExternalMemoryAccounter,
-    //   explicitly requires that the adjustment returns to zero before it is destroyed. That
-    //   isn't what we want, because we explicitly want external memory to be allowed to live
-    //   beyond the isolate in some cases. Perhaps we need to patch V8 to un-deprecate
-    //   AdjustAmountOfExternalAllocatedMemory(), or directly expose the underlying
-    //   AdjustAmountOfExternalAllocatedMemoryImpl(), which is what ExternalMemoryAccounter
-    //   uses anyway.
-    target->AdjustAmountOfExternalAllocatedMemory(amount);
+    accounter.Update(isolate, amount);
   } else {
     // We don't hold the isolate lock. Instead, record the adjustment to be applied the next time
     // the isolate lock is acquired.
@@ -389,7 +382,7 @@ void ExternalMemoryTarget::adjustNow(Lock& js, ssize_t amount) const {
   }
 #endif
   if (amount == 0) return;
-  js.v8Isolate->AdjustAmountOfExternalAllocatedMemory(amount);
+  accounter.Update(js.v8Isolate, amount);
 }
 
 void ExternalMemoryTarget::detach() const {
@@ -403,7 +396,7 @@ ExternalMemoryAdjustment ExternalMemoryTarget::getAdjustment(size_t amount) cons
 void ExternalMemoryTarget::applyDeferredMemoryUpdate() const {
   int64_t amount = pendingExternalMemoryUpdate.exchange(0, std::memory_order_relaxed);
   if (amount != 0) {
-    isolate.load(std::memory_order_relaxed)->AdjustAmountOfExternalAllocatedMemory(amount);
+    accounter.Update(isolate.load(std::memory_order_relaxed), amount);
   }
 }
 
@@ -439,6 +432,7 @@ ExternalMemoryAdjustment::ExternalMemoryAdjustment(
   if (amount == 0) return;
   maybeDeferAdjustment(amount);
 }
+
 ExternalMemoryAdjustment::ExternalMemoryAdjustment(ExternalMemoryAdjustment&& other)
     : externalMemory(kj::mv(other.externalMemory)),
       amount(other.amount) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2207,7 +2207,7 @@ class ExternalMemoryAdjustment;
 // reference is nulled out when the isolate is destroyed.
 class ExternalMemoryTarget: public kj::AtomicRefcounted {
  public:
-  ExternalMemoryTarget(v8::Isolate* isolate): isolate(isolate) {}
+  ExternalMemoryTarget(v8::Isolate* isolate): isolate(isolate), accounter() {}
 
   ExternalMemoryAdjustment getAdjustment(size_t amount) const;
 
@@ -2236,6 +2236,8 @@ class ExternalMemoryTarget: public kj::AtomicRefcounted {
   static_assert(std::atomic<int64_t>::is_always_lock_free);
 
   friend class ExternalMemoryAdjustment;
+
+  mutable v8::ExternalMemoryAccounter accounter;
 };
 
 // RAII class to adjust the amount of external memory attributed to an isolate.


### PR DESCRIPTION
- Add a v8 PR to disable destructor check in `ExternalMemoryAccounter`
- Replaces uses of `AdjustAmountOfExternalAllocatedMemoryImpl` with using the `v8::ExternalMemoryAccounter` in `ExternalMemoryTarget`.