### PR TITLE
Make pytest test work with Pyodide 0.26

### DIFF
--- a/src/pyodide/internal/metadatafs.ts
+++ b/src/pyodide/internal/metadatafs.ts
@@ -66,10 +66,9 @@ export function createMetadataFS(Module: Module): object {
       return Array.from(node.tree.keys());
     },
     lookup(parent, name) {
+      // Parent is not a directory so we always raise ENOENT (44)
       if (parent.tree == undefined) {
-        throw new PythonWorkersInternalError(
-          'cannot lookup directory, tree is undefined'
-        );
+        throw new Module.FS.ErrnoError(44);
       }
       const res = parent.tree.get(name);
       if (res === undefined) {

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -14,7 +14,6 @@ vendored_py_wd_test(
     data = glob(["pytest/tests/**"]),
     level = 0,
     main_py_file = "pytest/main.py",
-    skip_python_flags = ["0.26.0a2"],
     test_template = "pytest/pytest.wd-test",
 )
 

--- a/src/workerd/server/tests/python/pytest/tests/test_env.py
+++ b/src/workerd/server/tests/python/pytest/tests/test_env.py
@@ -2,7 +2,11 @@ import pytest
 from js import Date, Reflect
 from workers import env, import_from_javascript, patch_env
 
+from pyodide import __version__
 from pyodide.ffi import create_proxy, to_js
+
+if __version__ == "0.26.0a2":
+    pytest.skip("Not supported on 0.26.0a2", allow_module_level=True)
 
 
 @pytest.mark.asyncio

--- a/src/workerd/server/tests/python/pytest/tests/test_import_from_javascript.py
+++ b/src/workerd/server/tests/python/pytest/tests/test_import_from_javascript.py
@@ -2,6 +2,7 @@ import pytest
 from js import setTimeout
 from workers import import_from_javascript
 
+from pyodide import __version__
 from pyodide.ffi import create_once_callable
 
 
@@ -30,6 +31,7 @@ def test_import_from_javascript():
     setTimeout(create_once_callable(f), 1)
 
 
+@pytest.mark.skipif(__version__ == "0.26.0a2", reason="Requires JSPI")
 def test_import_vectorize():
     # Assert that imports that depend on JSPI work as expected
     vectorize = import_from_javascript("cloudflare:vectorize")


### PR DESCRIPTION
It's failing because some ciode does `stat("folder/some.file/something.else")` and it looks up "some.file"
correctly but then our code fatally fails when looking up `something.else` because it's not a directory.

Doesn't happen on Pyodide 0.28 because it uses Emscripten 4.x and I rewrote a bunch of the file system
code in Emscripten 4.x. As a result, the generic file system detects that `some.file` is not a directory and
raises the ENOENT error automatically now. But before it was the responsibility of the FS backend.