### PR TITLE
Fix bug in cache ttl validation

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -749,7 +749,7 @@ kj::Maybe<kj::String> Request::serializeCfBlobJson(jsg::Lock& js) {
     case CacheMode::NOSTORE:
       if (obj.has(js, "cacheTtl")) {
         jsg::JsValue oldTtl = obj.get(js, "cacheTtl");
-        JSG_REQUIRE(oldTtl == js.num(NOCACHE_TTL), TypeError,
+        JSG_REQUIRE(oldTtl.strictEquals(js.num(NOCACHE_TTL)), TypeError,
             kj::str("CacheTtl: ", oldTtl, ", is not compatible with cache: ",
                 getCacheModeName(cacheMode).orDefault("none"_kj), " header."));
       } else {


### PR DESCRIPTION
When using cache: no-store header and cacheTtl is correctly set to -1 this validation would fail with a nonsensical "TypeError: CacheTtl: -1, is not compatible with cache: no-store header." 
This is because operator== compares identity of the values, not their contents.