### PR TITLE
Reapply "chore: avoid warnings for External Allocated Memory"

### DIFF
--- a/build/deps/v8.MODULE.bazel
+++ b/build/deps/v8.MODULE.bazel
@@ -53,6 +53,7 @@ PATCHES = [
     "0028-bind-icu-to-googlesource.patch",
     "0029-optimize-ascii-fast-path-in-WriteUtf8V2.patch",
     "0030-Add-v8-String-IsFlat-API.patch",
+    "0031-Expose-AdjustAmountOfExternalAllocatedMemoryImpl.patch",
 ]
 
 http_archive(

--- a/patches/v8/0031-Expose-AdjustAmountOfExternalAllocatedMemoryImpl.patch
+++ b/patches/v8/0031-Expose-AdjustAmountOfExternalAllocatedMemoryImpl.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aditya Tewari <adityaatewari@gmail.com>
+Date: Wed, 15 Jan 2025 12:00:00 +0000
+Subject: Expose AdjustAmountOfExternalAllocatedMemoryImpl as public API
+
+The deprecated AdjustAmountOfExternalAllocatedMemory is being replaced
+by ExternalMemoryAccounter, but ExternalMemoryAccounter requires that
+adjustments return to zero before destruction. This is incompatible with
+workerd's design where external memory may outlive the isolate.
+
+V8 already has AdjustAmountOfExternalAllocatedMemoryImpl as a private
+method. This patch simply makes it public for embedder use.
+
+Signed-off-by: Aditya Tewari <adityaatewari@gmail.com>
+
+diff --git a/include/v8-isolate.h b/include/v8-isolate.h
+index b38a37c86a5f977d783ee44b2c6559849fd2a797..0000000000000000000000000000000000000000 100644
+--- a/include/v8-isolate.h
++++ b/include/v8-isolate.h
+@@ -1105,6 +1105,14 @@ class V8_EXPORT Isolate {
+    */
+   size_t GetHeapSize();
+ 
++  /**
++   * Adjusts external memory without destructor constraints.
++   * This directly calls the internal implementation without the
++   * zero-balance requirement of ExternalMemoryAccounter.
++   * Use when external memory may outlive the isolate.
++   */
++  int64_t AdjustAmountOfExternalAllocatedMemoryImpl(int64_t change_in_bytes);
++
+   /**
+    * Returns heap profiler for this isolate. Will return NULL until the isolate
+    * is initialized.
+@@ -1893,7 +1901,6 @@ class V8_EXPORT Isolate {
+ 
+   internal::ValueHelper::InternalRepresentationType GetDataFromSnapshotOnce(
+       size_t index);
+-  int64_t AdjustAmountOfExternalAllocatedMemoryImpl(int64_t change_in_bytes);
+   void HandleExternalMemoryInterrupt();
+ };
+ 

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -366,14 +366,12 @@ void ExternalMemoryTarget::maybeDeferAdjustment(ssize_t amount) const {
     // making such a change, and that's us, and we're not.
     KJ_ASSERT(v8::Locker::IsLocked(target));
 
-    // TODO(cleanup): This is deprecated, but the replacement, v8::ExternalMemoryAccounter,
-    //   explicitly requires that the adjustment returns to zero before it is destroyed. That
-    //   isn't what we want, because we explicitly want external memory to be allowed to live
-    //   beyond the isolate in some cases. Perhaps we need to patch V8 to un-deprecate
-    //   AdjustAmountOfExternalAllocatedMemory(), or directly expose the underlying
-    //   AdjustAmountOfExternalAllocatedMemoryImpl(), which is what ExternalMemoryAccounter
-    //   uses anyway.
-    target->AdjustAmountOfExternalAllocatedMemory(amount);
+    // We use AdjustAmountOfExternalAllocatedMemoryImpl() instead of ExternalMemoryAccounter
+    // because we explicitly want external memory to be allowed to live beyond the isolate
+    // in some cases. The Impl variant bypasses the destructor check that
+    // ExternalMemoryAccounter enforces (requiring adjustment to return to zero).
+    // See patches/v8/0031-Expose-AdjustAmountOfExternalAllocatedMemoryImpl.patch
+    target->AdjustAmountOfExternalAllocatedMemoryImpl(amount);
   } else {
     // We don't hold the isolate lock. Instead, record the adjustment to be applied the next time
     // the isolate lock is acquired.
@@ -389,7 +387,7 @@ void ExternalMemoryTarget::adjustNow(Lock& js, ssize_t amount) const {
   }
 #endif
   if (amount == 0) return;
-  js.v8Isolate->AdjustAmountOfExternalAllocatedMemory(amount);
+  js.v8Isolate->AdjustAmountOfExternalAllocatedMemoryImpl(amount);
 }
 
 void ExternalMemoryTarget::detach() const {
@@ -403,7 +401,7 @@ ExternalMemoryAdjustment ExternalMemoryTarget::getAdjustment(size_t amount) cons
 void ExternalMemoryTarget::applyDeferredMemoryUpdate() const {
   int64_t amount = pendingExternalMemoryUpdate.exchange(0, std::memory_order_relaxed);
   if (amount != 0) {
-    isolate.load(std::memory_order_relaxed)->AdjustAmountOfExternalAllocatedMemory(amount);
+    isolate.load(std::memory_order_relaxed)->AdjustAmountOfExternalAllocatedMemoryImpl(amount);
   }
 }
 


### PR DESCRIPTION
This reverts commit 9c03cb53bced1f7a0e69051fdccb630a14fa300e.