### PR TITLE
EMAIL-1332: Add Email MessageBuilder types

### DIFF
--- a/types/defines/email.d.ts
+++ b/types/defines/email.d.ts
@@ -59,11 +59,34 @@ interface ForwardableEmailMessage extends EmailMessage {
   reply(message: EmailMessage): Promise<EmailSendResult>;
 }
 
+/** A file attachment for an email message */
+type EmailAttachment =
+	| { disposition: 'inline'; contentId: string; filename: string; type: string; content: string | ArrayBuffer | ArrayBufferView }
+	| { disposition: 'attachment'; contentId?: undefined; filename: string; type: string; content: string | ArrayBuffer | ArrayBufferView };
+
+/** An Email Address */
+interface EmailAddress {
+	name: string;
+	email: string;
+}
+
 /**
  * A binding that allows a Worker to send email messages.
  */
 interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
+  send(builder: {
+		from: string | EmailAddress;
+		to: string | string[];
+		subject: string;
+		replyTo?: string | EmailAddress;
+		cc?: string | string[];
+		bcc?: string | string[];
+		headers?: Record<string, string>;
+		text?: string;
+		html?: string;
+		attachments?: EmailAttachment[];
+	}): Promise<EmailSendResult>;
 }
 
 declare abstract class EmailEvent extends ExtendableEvent {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -11379,11 +11379,44 @@ interface ForwardableEmailMessage extends EmailMessage {
    */
   reply(message: EmailMessage): Promise<EmailSendResult>;
 }
+/** A file attachment for an email message */
+type EmailAttachment =
+  | {
+      disposition: "inline";
+      contentId: string;
+      filename: string;
+      type: string;
+      content: string | ArrayBuffer | ArrayBufferView;
+    }
+  | {
+      disposition: "attachment";
+      contentId?: undefined;
+      filename: string;
+      type: string;
+      content: string | ArrayBuffer | ArrayBufferView;
+    };
+/** An Email Address */
+interface EmailAddress {
+  name: string;
+  email: string;
+}
 /**
  * A binding that allows a Worker to send email messages.
  */
 interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
+  send(builder: {
+    from: string | EmailAddress;
+    to: string | string[];
+    subject: string;
+    replyTo?: string | EmailAddress;
+    cc?: string | string[];
+    bcc?: string | string[];
+    headers?: Record<string, string>;
+    text?: string;
+    html?: string;
+    attachments?: EmailAttachment[];
+  }): Promise<EmailSendResult>;
 }
 declare abstract class EmailEvent extends ExtendableEvent {
   readonly message: ForwardableEmailMessage;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -11407,11 +11407,44 @@ export interface ForwardableEmailMessage extends EmailMessage {
    */
   reply(message: EmailMessage): Promise<EmailSendResult>;
 }
+/** A file attachment for an email message */
+export type EmailAttachment =
+  | {
+      disposition: "inline";
+      contentId: string;
+      filename: string;
+      type: string;
+      content: string | ArrayBuffer | ArrayBufferView;
+    }
+  | {
+      disposition: "attachment";
+      contentId?: undefined;
+      filename: string;
+      type: string;
+      content: string | ArrayBuffer | ArrayBufferView;
+    };
+/** An Email Address */
+export interface EmailAddress {
+  name: string;
+  email: string;
+}
 /**
  * A binding that allows a Worker to send email messages.
  */
 export interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
+  send(builder: {
+    from: string | EmailAddress;
+    to: string | string[];
+    subject: string;
+    replyTo?: string | EmailAddress;
+    cc?: string | string[];
+    bcc?: string | string[];
+    headers?: Record<string, string>;
+    text?: string;
+    html?: string;
+    attachments?: EmailAttachment[];
+  }): Promise<EmailSendResult>;
 }
 export declare abstract class EmailEvent extends ExtendableEvent {
   readonly message: ForwardableEmailMessage;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -10773,11 +10773,44 @@ interface ForwardableEmailMessage extends EmailMessage {
    */
   reply(message: EmailMessage): Promise<EmailSendResult>;
 }
+/** A file attachment for an email message */
+type EmailAttachment =
+  | {
+      disposition: "inline";
+      contentId: string;
+      filename: string;
+      type: string;
+      content: string | ArrayBuffer | ArrayBufferView;
+    }
+  | {
+      disposition: "attachment";
+      contentId?: undefined;
+      filename: string;
+      type: string;
+      content: string | ArrayBuffer | ArrayBufferView;
+    };
+/** An Email Address */
+interface EmailAddress {
+  name: string;
+  email: string;
+}
 /**
  * A binding that allows a Worker to send email messages.
  */
 interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
+  send(builder: {
+    from: string | EmailAddress;
+    to: string | string[];
+    subject: string;
+    replyTo?: string | EmailAddress;
+    cc?: string | string[];
+    bcc?: string | string[];
+    headers?: Record<string, string>;
+    text?: string;
+    html?: string;
+    attachments?: EmailAttachment[];
+  }): Promise<EmailSendResult>;
 }
 declare abstract class EmailEvent extends ExtendableEvent {
   readonly message: ForwardableEmailMessage;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -10799,11 +10799,44 @@ export interface ForwardableEmailMessage extends EmailMessage {
    */
   reply(message: EmailMessage): Promise<EmailSendResult>;
 }
+/** A file attachment for an email message */
+export type EmailAttachment =
+  | {
+      disposition: "inline";
+      contentId: string;
+      filename: string;
+      type: string;
+      content: string | ArrayBuffer | ArrayBufferView;
+    }
+  | {
+      disposition: "attachment";
+      contentId?: undefined;
+      filename: string;
+      type: string;
+      content: string | ArrayBuffer | ArrayBufferView;
+    };
+/** An Email Address */
+export interface EmailAddress {
+  name: string;
+  email: string;
+}
 /**
  * A binding that allows a Worker to send email messages.
  */
 export interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
+  send(builder: {
+    from: string | EmailAddress;
+    to: string | string[];
+    subject: string;
+    replyTo?: string | EmailAddress;
+    cc?: string | string[];
+    bcc?: string | string[];
+    headers?: Record<string, string>;
+    text?: string;
+    html?: string;
+    attachments?: EmailAttachment[];
+  }): Promise<EmailSendResult>;
 }
 export declare abstract class EmailEvent extends ExtendableEvent {
   readonly message: ForwardableEmailMessage;


### PR DESCRIPTION
Now that this is supported locally (ref: https://github.com/cloudflare/workers-sdk/pull/11942) and ungated in production, these types are ready to be updated.

cc @LuisDuarte1 @penalosa 