### PR TITLE
improve streams queue test harness

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -530,6 +530,19 @@ wd_cc_library(
         "basics-test.c++",
         "crypto/aes-test.c++",
         "crypto/impl-test.c++",
+    ]
+]
+
+[
+    kj_test(
+        src = f,
+        deps = [
+            "//src/workerd/io",
+            "//src/workerd/io:promise-wrapper",
+            "//src/workerd/tests:test-fixture",
+        ],
+    )
+    for f in [
         "streams/queue-test.c++",
         "streams/standard-test.c++",
     ]

--- a/src/workerd/api/streams/queue-test.c++
+++ b/src/workerd/api/streams/queue-test.c++
@@ -6,23 +6,14 @@
 
 #include <workerd/jsg/jsg-test.h>
 #include <workerd/jsg/jsg.h>
+#include <workerd/tests/test-fixture.h>
 
 namespace workerd::api {
 namespace {
 
-jsg::V8System v8System;
-
-struct QueueContext: public jsg::Object, public jsg::ContextGlobal {
-  JSG_RESOURCE_TYPE(QueueContext) {}
-};
-JSG_DECLARE_ISOLATE_TYPE(QueueIsolate, QueueContext);
-
 void preamble(auto callback) {
-  QueueIsolate isolate(v8System, kj::heap<jsg::IsolateObserver>());
-  isolate.runInLockScope([&](QueueIsolate::Lock& lock) {
-    JSG_WITHIN_CONTEXT_SCOPE(lock, lock.newContext<QueueContext>().getHandle(lock),
-        [&](jsg::Lock& js) { callback(js); });
-  });
+  TestFixture fixture;
+  fixture.runInIoContext([&](const TestFixture::Environment& env) { callback(env.js); });
 }
 
 using ReadContinuation = jsg::Promise<ReadResult>(ReadResult&&);

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -4,23 +4,14 @@
 #include <workerd/jsg/jsg-test.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/observer.h>
+#include <workerd/tests/test-fixture.h>
 
 namespace workerd::api {
 namespace {
 
-jsg::V8System v8System;
-
-struct RsContext: public jsg::Object, public jsg::ContextGlobal {
-  JSG_RESOURCE_TYPE(RsContext) {}
-};
-JSG_DECLARE_ISOLATE_TYPE(RsIsolate, RsContext, ReadResult);
-
 void preamble(auto callback) {
-  RsIsolate isolate(v8System, kj::heap<jsg::IsolateObserver>());
-  isolate.runInLockScope([&](RsIsolate::Lock& lock) {
-    JSG_WITHIN_CONTEXT_SCOPE(
-        lock, lock.newContext<RsContext>().getHandle(lock), [&](jsg::Lock& js) { callback(js); });
-  });
+  TestFixture fixture;
+  fixture.runInIoContext([&](const TestFixture::Environment& env) { callback(env.js); });
 }
 
 v8::Local<v8::Value> toBytes(jsg::Lock& js, kj::String str) {


### PR DESCRIPTION
Using test fixture is always better since it handles edge cases such as: https://github.com/cloudflare/workerd/pull/5769

Since test setup doesn't have a full worker context, FeatureFlags::get(js) fails with "not running javascript" on any new tests that practices relevant changes (with FeatureFlags usage)