### PR TITLE
[build] Fix V8 related bzlmod paths, switch to new bazel-lib

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,7 +47,7 @@ build --incompatible_remote_local_fallback_for_remote_cache
 # Our dependencies (ICU, zlib, etc.) produce a lot of these warnings, so we disable them.
 build --per_file_copt='external@-Wno-error'
 build --per_file_copt='external@-Wno-suggest-override'
-build --per_file_copt='external/v8@-Wno-unused-function'
+build --per_file_copt='external/.*v8@-Wno-unused-function'
 build --per_file_copt='external/zlib@-Wno-deprecated-non-prototype'
 build --host_per_file_copt='external/zlib@-Wno-deprecated-non-prototype'
 build --per_file_copt=external/protobuf@-Wno-deprecated-declarations
@@ -73,29 +73,31 @@ build:v8-codegen-opt-windows --per_file_copt=external/abseil-cpp@/O2
 build:v8-codegen-opt-windows --per_file_copt=external/zlib@/O2
 
 # In Google projects, exceptions are not used as a rule. Disabling them is more consistent with the
-# canonical V8 build and improves code size. Paths are adjusted for bzlmod mangling.
+# canonical V8 build and improves code size. Paths are adjusted for bzlmod mangling – V8 and ICU use
+# a wildcard for this as the prefix is some variation of +_repo_rules3+ where the number can change
+# when refactoring MODULE.bazel – setting this directly would be too brittle
 build:unix --per_file_copt=external/abseil-cpp@-fno-exceptions
 build:unix --per_file_copt=external/protobuf@-fno-exceptions
 build:unix --per_file_copt=external/tcmalloc@-fno-exceptions
-build:unix --per_file_copt=external/com_googlesource_chromium_icu@-fno-exceptions
+build:unix --per_file_copt=external/.*com_googlesource_chromium_icu@-fno-exceptions
 build:unix --per_file_copt=external/perfetto@-fno-exceptions
 build:unix --per_file_copt=external/boringssl@-fno-exceptions
-build:unix --per_file_copt=external/v8@-fno-exceptions
+build:unix --per_file_copt=external/.*v8@-fno-exceptions
 build:unix --per_file_copt=external/ada-url@-fno-exceptions
 build:unix --per_file_copt=external/+http+simdutf@-fno-exceptions
 build:windows --per_file_copt=external/abseil-cpp@/clang:-fno-exceptions
 build:windows --per_file_copt=external/protobuf@/clang:-fno-exceptions
 build:windows --per_file_copt=external/tcmalloc@/clang:-fno-exceptions
-build:windows --per_file_copt=external/com_googlesource_chromium_icu@/clang:-fno-exceptions
+build:windows --per_file_copt=external/.*com_googlesource_chromium_icu@/clang:-fno-exceptions
 build:windows --per_file_copt=external/perfetto@/clang:-fno-exceptions
 build:windows --per_file_copt=external/boringssl@/clang:-fno-exceptions
-build:windows --per_file_copt=external/v8@/clang:-fno-exceptions
+build:windows --per_file_copt=external/.*v8@/clang:-fno-exceptions
 build:windows --per_file_copt=external/ada-url@/clang:-fno-exceptions
 build:windows --per_file_copt=external/+http+simdutf@/clang:-fno-exceptions
 
 # V8 torque is an exception from this policy, see v8 BUILD.gn.
-build:unix --per_file_copt=external/v8/src/torque@-fexceptions
-build:windows --per_file_copt=external/v8/src/torque@/clang:-fexceptions
+build:unix --per_file_copt=external/.*v8/src/torque@-fexceptions
+build:windows --per_file_copt=external/.*v8/src/torque@/clang:-fexceptions
 
 # Limit transitive header includes within libc++. This improves compliance with IWYU, helps avoid
 # errors with downstream projects that implicitly define this already and reduces total include size.
@@ -195,7 +197,7 @@ build:asan --test_env=ASAN_OPTIONS=abort_on_error=true
 build:asan --test_env=KJ_CLEAN_SHUTDOWN=1
 # Enable ASan, LSan support in V8
 build:asan --copt="-DV8_USE_ADDRESS_SANITIZER"
-build:asan --per_file_copt='external/v8@-DADDRESS_SANITIZER,-DLEAK_SANITIZER'
+build:asan --per_file_copt='external/.*v8@-DADDRESS_SANITIZER,-DLEAK_SANITIZER'
 
 # fuzzilli (https://github.com/googleprojectzero/fuzzilli/)
 build:fuzzilli --config=asan

--- a/build/deps/build_deps.jsonc
+++ b/build/deps/build_deps.jsonc
@@ -3,18 +3,13 @@
   "repositories": [
     // bazel_deps from MODULE.bazel
     {
-      "name": "aspect_bazel_lib",
-      "type": "bazel_dep",
-      // 2.22.4 causes resolution issues, breaking the build entirely.
-      // If you can't trust a patch release anymore, what can you trust?
-      "freeze_version": "2.22.2"
-    },
-    {
       "name": "aspect_rules_lint",
       "type": "bazel_dep"
     },
+    // bazel_lib was formerly known as aspect_bazel_lib, new versions starting with v3 are released
+    // under the new name which should now be used.
     {
-      "name": "bazel_features",
+      "name": "bazel_lib",
       "type": "bazel_dep"
     },
     {

--- a/build/deps/gen/build_deps.MODULE.bazel
+++ b/build/deps/gen/build_deps.MODULE.bazel
@@ -10,9 +10,6 @@ bazel_dep(name = "abseil-cpp", version = "20260107.0")
 # apple_support
 bazel_dep(name = "apple_support", version = "2.1.0")
 
-# aspect_bazel_lib
-bazel_dep(name = "aspect_bazel_lib", version = "2.22.2")
-
 # aspect_rules_esbuild
 bazel_dep(name = "aspect_rules_esbuild", version = "0.25.0")
 
@@ -25,8 +22,8 @@ bazel_dep(name = "aspect_rules_lint", version = "1.13.0")
 # aspect_rules_ts
 bazel_dep(name = "aspect_rules_ts", version = "3.8.3")
 
-# bazel_features
-bazel_dep(name = "bazel_features", version = "1.39.0")
+# bazel_lib
+bazel_dep(name = "bazel_lib", version = "3.1.1")
 
 # bazel_skylib
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/build/js_file.bzl
+++ b/build/js_file.bzl
@@ -2,8 +2,8 @@
 Give a collection of js files a JsInfo provider so it can be used as a dependency for aspect_rules.
 """
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
+load("@bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action")
 
 _ATTRS = {
     "srcs": attr.label_list(

--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -1,6 +1,6 @@
 # After updating this file, make sure to run "bazel mod tidy"
-load("@aspect_bazel_lib//lib:base64.bzl", "base64")
-load("@aspect_bazel_lib//lib:strings.bzl", "chr")
+load("@bazel_lib//lib:base64.bzl", "base64")
+load("@bazel_lib//lib:strings.bzl", "chr")
 load("//:build/python/packages_20240829_4.bzl", "PACKAGES_20240829_4")
 load("//:build/python/packages_20250808.bzl", "PACKAGES_20250808")
 


### PR DESCRIPTION
- Remove unused bazel_features dependency

Downstream PR to follow.