### PR TITLE
Fixup a minor assertion in the streams impl

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -611,9 +611,9 @@ jsg::Promise<ReadResult> deferControllerStateChange(jsg::Lock& js,
     decrementCount = false;
     --controller.pendingReadCount;
 
-    KJ_ASSERT(!js.v8Isolate->IsExecutionTerminating());
-
-    if (!controller.isReadPending()) {
+    // Skip pending state callbacks if execution is being terminated (e.g., CPU time limit)
+    // since we can't safely execute JavaScript in that state.
+    if (!controller.isReadPending() && !js.v8Isolate->IsExecutionTerminating()) {
       KJ_IF_SOME(state, controller.maybePendingState) {
         KJ_SWITCH_ONEOF(state) {
           KJ_CASE_ONEOF(closed, StreamStates::Closed) {


### PR DESCRIPTION
The assert was incorrectly checking for a state that can occur in production when the cpu limiter is hit. Handle, don't assert.