### PR TITLE
Add missing union overloads to FormData type definitions

### DIFF
--- a/src/workerd/api/form-data.h
+++ b/src/workerd/api/form-data.h
@@ -157,9 +157,11 @@ public:
 
     if (flags.getFormDataParserSupportsFiles()) {
       JSG_TS_OVERRIDE({
+        append(name: string, value: string | Blob): void;
         append(name: string, value: string): void;
         append(name: string, value: Blob, filename?: string): void;
 
+        set(name: string, value: string | Blob): void;
         set(name: string, value: string): void;
         set(name: string, value: Blob, filename?: string): void;
 
@@ -173,9 +175,11 @@ public:
         get(name: string): string | null;
         getAll(name: string): string[];
 
+        append(name: string, value: string | Blob): void;
         append(name: string, value: string): void;
         append(name: string, value: Blob, filename?: string): void;
 
+        set(name: string, value: string | Blob): void;
         set(name: string, value: string): void;
         set(name: string, value: Blob, filename?: string): void;
 


### PR DESCRIPTION
Fixes #5934

Updated `FormData` types based on https://github.com/microsoft/TypeScript/blob/d9d9eeafa0a2bb1fd327b3af15edacade7544e5f/src/lib/dom.generated.d.ts#L12573-L12615