### PR TITLE
Add new AI Search binding

### DIFF
--- a/src/cloudflare/ai.ts
+++ b/src/cloudflare/ai.ts
@@ -31,3 +31,17 @@ export {
   type ImageConversionOptions,
   type MarkdownDocument,
 } from 'cloudflare-internal:to-markdown-api';
+
+export {
+  AiSearchAccountService,
+  AiSearchInstanceService,
+  AiSearchInternalError,
+  AiSearchNotFoundError,
+  AiSearchNameNotSetError,
+  type AiSearchSearchRequest,
+  type AiSearchChatCompletionsRequest,
+  type AiSearchSearchResponse,
+  type AiSearchListResponse,
+  type AiSearchConfig,
+  type AiSearchInstance,
+} from 'cloudflare-internal:ai-search-api';

--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -4,6 +4,7 @@
 
 import { AiGateway, type GatewayOptions } from 'cloudflare-internal:aig-api';
 import { AutoRAG } from 'cloudflare-internal:autorag-api';
+import { AiSearchAccountService } from 'cloudflare-internal:ai-search-api';
 import {
   ToMarkdownService,
   type ConversionRequestOptions,
@@ -121,6 +122,7 @@ function findReadableStreamKeys(
 
 export class Ai {
   #fetcher: Fetcher;
+  #aiSearchService: AiSearchAccountService | null = null;
 
   /*
    * @deprecated this option is deprecated, do not use this
@@ -137,6 +139,14 @@ export class Ai {
 
   constructor(fetcher: Fetcher) {
     this.#fetcher = fetcher;
+  }
+
+  // Lazy initialization of AI Search service
+  get aiSearch(): AiSearchAccountService {
+    if (!this.#aiSearchService) {
+      this.#aiSearchService = new AiSearchAccountService(this.#fetcher);
+    }
+    return this.#aiSearchService;
   }
 
   async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {

--- a/src/cloudflare/internal/ai-search-api.ts
+++ b/src/cloudflare/internal/ai-search-api.ts
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+interface Fetcher {
+  fetch: typeof fetch;
+}
+
+// Error classes
+export class AiSearchInternalError extends Error {
+  constructor(message: string, name = 'AiSearchInternalError') {
+    super(message);
+    this.name = name;
+  }
+}
+
+export class AiSearchNotFoundError extends Error {
+  constructor(message: string, name = 'AiSearchNotFoundError') {
+    super(message);
+    this.name = name;
+  }
+}
+
+export class AiSearchNameNotSetError extends Error {
+  constructor(message: string, name = 'AiSearchNameNotSetError') {
+    super(message);
+    this.name = name;
+  }
+}
+
+async function parseError(
+  res: Response,
+  defaultMsg = 'Internal Error',
+  errorCls = AiSearchInternalError
+): Promise<Error> {
+  const content = await res.text();
+
+  try {
+    const parsedContent = JSON.parse(content) as {
+      errors: { message: string }[];
+    };
+
+    return new errorCls(parsedContent.errors.at(0)?.message || defaultMsg);
+  } catch {
+    return new AiSearchInternalError(content);
+  }
+}
+
+// Filter types (shared with AutoRAG for compatibility)
+export type ComparisonFilter = {
+  key: string;
+  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
+  value: string | number | boolean;
+};
+
+export type CompoundFilter = {
+  type: 'and' | 'or';
+  filters: ComparisonFilter[];
+};
+
+// V2 API Type Definitions
+
+export type AiSearchSearchRequest = {
+  messages: Array<{
+    role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
+    content: string | null;
+  }>;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: 'vector' | 'keyword' | 'hybrid';
+      match_threshold?: number; // 0-1, default 0.4
+      max_num_results?: number; // 1-50, default 10
+      filters?: CompoundFilter | ComparisonFilter;
+      context_expansion?: number; // 0-3, default 0
+      [key: string]: unknown; // Future extensibility
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown; // Future extensibility
+    };
+    reranking?: {
+      enabled?: boolean; // default false
+      model?: '@cf/baai/bge-reranker-base' | '';
+      match_threshold?: number; // 0-1, default 0.4
+      [key: string]: unknown; // Future extensibility
+    };
+    [key: string]: unknown; // Future extensibility - allows new top-level options
+  };
+};
+
+export type AiSearchChatCompletionsRequest = {
+  messages: Array<{
+    role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
+    content: string | null;
+  }>;
+  model?: string;
+  stream?: boolean;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: 'vector' | 'keyword' | 'hybrid';
+      match_threshold?: number;
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      context_expansion?: number;
+      [key: string]: unknown; // Future extensibility
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown; // Future extensibility
+    };
+    reranking?: {
+      enabled?: boolean;
+      model?: '@cf/baai/bge-reranker-base' | '';
+      match_threshold?: number;
+      [key: string]: unknown; // Future extensibility
+    };
+    [key: string]: unknown; // Future extensibility
+  };
+  [key: string]: unknown; // additionalProperties allowed for future extensibility
+};
+
+export type AiSearchSearchResponse = {
+  search_query: string;
+  chunks: Array<{
+    id: string;
+    type: string;
+    score: number; // 0-1
+    text: string;
+    item: {
+      timestamp?: number;
+      key: string;
+      metadata?: Record<string, unknown>;
+    };
+    scoring_details?: {
+      keyword_score?: number; // 0-1
+      vector_score?: number; // 0-1
+    };
+  }>;
+};
+
+export type AiSearchListResponse = Array<{
+  id: string;
+  internal_id?: string;
+  account_id?: string;
+  account_tag?: string;
+  enable?: boolean; // default true
+  type?: 'r2' | 'web-crawler';
+  source?: string;
+  [key: string]: unknown; // Allow additional fields from API
+}>;
+
+export type AiSearchConfig = {
+  id: string; // 1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$
+  type: 'r2' | 'web-crawler';
+  source: string;
+  source_params?: object;
+  token_id?: string; // UUID format
+  ai_gateway_id?: string;
+  rewrite_query?: boolean; // default false
+  reranking?: boolean; // default false
+  embedding_model?: string;
+  ai_search_model?: string;
+};
+
+export type AiSearchInstance = {
+  id: string;
+  enable?: boolean;
+  type?: 'r2' | 'web-crawler';
+  source?: string;
+  [key: string]: unknown;
+};
+
+// Account-level service
+export class AiSearchAccountService {
+  readonly #fetcher: Fetcher;
+
+  constructor(fetcher: Fetcher) {
+    this.#fetcher = fetcher;
+  }
+
+  async list(): Promise<AiSearchListResponse> {
+    const res = await this.#fetcher.fetch(
+      'https://workers-binding.ai/ai-search/instances',
+      {
+        method: 'GET',
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+
+    if (!res.ok) {
+      throw await parseError(res);
+    }
+
+    const data = (await res.json()) as { result: AiSearchListResponse };
+    return data.result;
+  }
+
+  get(name: string): AiSearchInstanceService {
+    return new AiSearchInstanceService(this.#fetcher, name);
+  }
+
+  async create(config: AiSearchConfig): Promise<AiSearchInstanceService> {
+    const res = await this.#fetcher.fetch(
+      'https://workers-binding.ai/ai-search/instances',
+      {
+        method: 'POST',
+        body: JSON.stringify(config),
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+
+    if (!res.ok) {
+      throw await parseError(res);
+    }
+
+    return new AiSearchInstanceService(this.#fetcher, config.id);
+  }
+}
+
+// Instance-level service
+export class AiSearchInstanceService {
+  readonly #fetcher: Fetcher;
+  readonly #instanceId: string;
+
+  constructor(fetcher: Fetcher, instanceId: string) {
+    this.#fetcher = fetcher;
+    this.#instanceId = instanceId;
+  }
+
+  async search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse> {
+    if (!this.#instanceId) {
+      throw new AiSearchNameNotSetError('AI Search instance name not defined');
+    }
+
+    const res = await this.#fetcher.fetch(
+      `https://workers-binding.ai/ai-search/instances/${this.#instanceId}/search`,
+      {
+        method: 'POST',
+        body: JSON.stringify(params),
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+
+    if (!res.ok) {
+      if (res.status === 404) {
+        throw await parseError(
+          res,
+          'AI Search instance not found',
+          AiSearchNotFoundError
+        );
+      }
+      throw await parseError(res);
+    }
+
+    const data = (await res.json()) as { result: AiSearchSearchResponse };
+    return data.result;
+  }
+
+  async chatCompletions(
+    params: AiSearchChatCompletionsRequest
+  ): Promise<Response | object> {
+    if (!this.#instanceId) {
+      throw new AiSearchNameNotSetError('AI Search instance name not defined');
+    }
+
+    const res = await this.#fetcher.fetch(
+      `https://workers-binding.ai/ai-search/instances/${this.#instanceId}/chat/completions`,
+      {
+        method: 'POST',
+        body: JSON.stringify(params),
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+
+    if (!res.ok) {
+      if (res.status === 404) {
+        throw await parseError(
+          res,
+          'AI Search instance not found',
+          AiSearchNotFoundError
+        );
+      }
+      throw await parseError(res);
+    }
+
+    // Return Response if streaming, otherwise parse JSON
+    if (params.stream === true) {
+      return res;
+    }
+
+    const data = (await res.json()) as { result: object };
+    return data.result;
+  }
+
+  async delete(): Promise<void> {
+    if (!this.#instanceId) {
+      throw new AiSearchNameNotSetError('AI Search instance name not defined');
+    }
+
+    const res = await this.#fetcher.fetch(
+      `https://workers-binding.ai/ai-search/instances/${this.#instanceId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+
+    if (!res.ok) {
+      if (res.status === 404) {
+        throw await parseError(
+          res,
+          'AI Search instance not found',
+          AiSearchNotFoundError
+        );
+      }
+      throw await parseError(res);
+    }
+  }
+}

--- a/src/cloudflare/internal/test/ai-search/BUILD.bazel
+++ b/src/cloudflare/internal/test/ai-search/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//:build/wd_test.bzl", "wd_test")
+load("//src/workerd/server/tests/python:py_wd_test.bzl", "py_wd_test")
+
+wd_test(
+    src = "ai-search-api-test.wd-test",
+    args = ["--experimental"],
+    data = glob(["*.js"]),
+)
+
+py_wd_test(
+    size = "large",
+    src = "python-ai-search-api-test.wd-test",
+    args = ["--experimental"],
+    data = glob([
+        "*.js",
+        "*.py",
+    ]),
+    make_snapshot = False,
+    use_snapshot = None,
+)

--- a/src/cloudflare/internal/test/ai-search/ai-search-api-test.js
+++ b/src/cloudflare/internal/test/ai-search/ai-search-api-test.js
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import * as assert from 'node:assert';
+
+export const tests = {
+  async test(_, env) {
+    // Test list()
+    {
+      const instances = await env.ai.aiSearch.list();
+      assert.ok(Array.isArray(instances));
+      assert.equal(instances.length, 1);
+      assert.equal(instances[0].id, 'my-ai-search');
+      assert.equal(instances[0].type, 'r2');
+      assert.equal(instances[0].source, 'my-bucket');
+    }
+
+    // Test search()
+    {
+      const searchResp = await env.ai.aiSearch.get('my-ai-search').search({
+        messages: [{ role: 'user', content: 'How many woodchucks?' }],
+        ai_search_options: {
+          retrieval: {
+            max_num_results: 10,
+            match_threshold: 0.4,
+          },
+        },
+      });
+
+      assert.equal(searchResp.search_query, 'How many woodchucks?');
+      assert.ok(Array.isArray(searchResp.chunks));
+      assert.equal(searchResp.chunks.length, 1);
+      assert.equal(searchResp.chunks[0].id, 'chunk-1');
+      assert.equal(searchResp.chunks[0].type, 'text');
+      assert.equal(searchResp.chunks[0].score, 0.85);
+      assert.equal(searchResp.chunks[0].text, 'Two woodchucks per passenger.');
+      assert.equal(searchResp.chunks[0].item.key, 'woodchuck_policy.txt');
+      assert.equal(searchResp.chunks[0].item.metadata.region, 'North America');
+      assert.equal(
+        searchResp.chunks[0].item.metadata.author,
+        'Wildlife Department'
+      );
+      assert.equal(searchResp.chunks[0].scoring_details.keyword_score, 0.8);
+      assert.equal(searchResp.chunks[0].scoring_details.vector_score, 0.9);
+    }
+
+    // Test chatCompletions() - non-streaming
+    {
+      const chatResp = await env.ai.aiSearch
+        .get('my-ai-search')
+        .chatCompletions({
+          messages: [{ role: 'user', content: 'How many woodchucks?' }],
+          model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+          stream: false,
+          ai_search_options: {
+            retrieval: {
+              max_num_results: 5,
+            },
+          },
+        });
+
+      assert.ok(chatResp);
+      assert.ok(chatResp.response);
+      assert.equal(
+        chatResp.response,
+        'Based on the documents, two woodchucks are allowed.'
+      );
+    }
+
+    // Test chatCompletions() - streaming
+    {
+      const chatStreamResp = await env.ai.aiSearch
+        .get('my-ai-search')
+        .chatCompletions({
+          messages: [{ role: 'user', content: 'How many woodchucks?' }],
+          stream: true,
+        });
+
+      assert.ok(chatStreamResp instanceof Response);
+      assert.equal(
+        chatStreamResp.headers.get('content-type'),
+        'text/event-stream'
+      );
+    }
+
+    // Test create()
+    {
+      const created = await env.ai.aiSearch.create({
+        id: 'new-search',
+        type: 'r2',
+        source: 'my-new-bucket',
+      });
+
+      assert.ok(created);
+    }
+
+    // Test delete()
+    {
+      await env.ai.aiSearch.get('my-ai-search').delete();
+      // If no error is thrown, the test passes
+      assert.ok(true);
+    }
+
+    // Test error handling - instance not found
+    {
+      try {
+        await env.ai.aiSearch.get('non-existent').search({
+          messages: [{ role: 'user', content: 'test' }],
+        });
+        assert.fail('Should have thrown an error');
+      } catch (error) {
+        assert.ok(error instanceof Error);
+        assert.equal(error.name, 'AiSearchNotFoundError');
+      }
+    }
+  },
+};

--- a/src/cloudflare/internal/test/ai-search/ai-search-api-test.py
+++ b/src/cloudflare/internal/test/ai-search/ai-search-api-test.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+from js import Object
+
+from pyodide.ffi import to_js
+
+
+async def test(context, env):
+    # Test list()
+    # Convert JS array to Python list to avoid Pyodide borrowed proxy lifecycle issues
+    instances = list(await env.ai.aiSearch.list())
+    assert len(instances) == 1
+    assert instances[0].id == "my-ai-search"
+
+    # Get instance reference once to avoid Pyodide proxy lifecycle issues
+    instance = env.ai.aiSearch.get("my-ai-search")
+
+    # Test search()
+    # Use to_js() with dict_converter to properly convert nested Python dicts/lists
+    # to JS objects, avoiding Pyodide borrowed proxy lifecycle issues
+    search_resp = await instance.search(
+        to_js(
+            {
+                "messages": [{"role": "user", "content": "How many woodchucks?"}],
+                "ai_search_options": {"retrieval": {"max_num_results": 10}},
+            },
+            dict_converter=Object.fromEntries,
+        )
+    )
+    assert search_resp.search_query == "How many woodchucks?"
+    assert len(search_resp.chunks) == 1
+    assert search_resp.chunks[0].text == "Two woodchucks per passenger."
+
+    # Test chatCompletions()
+    chat_resp = await instance.chatCompletions(
+        to_js(
+            {
+                "messages": [{"role": "user", "content": "How many woodchucks?"}],
+                "model": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+                "stream": False,
+            },
+            dict_converter=Object.fromEntries,
+        )
+    )
+    assert chat_resp.response == "Based on the documents, two woodchucks are allowed."

--- a/src/cloudflare/internal/test/ai-search/ai-search-api-test.wd-test
+++ b/src/cloudflare/internal/test/ai-search/ai-search-api-test.wd-test
@@ -1,0 +1,34 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "ai-search-api-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "ai-search-api-test.js")
+        ],
+        compatibilityFlags = ["nodejs_compat"],
+        bindings = [
+          (
+            name = "ai",
+            wrapped = (
+              moduleName = "cloudflare-internal:ai-api",
+              innerBindings = [(
+                name = "fetcher",
+                service = "ai-search-mock"
+              )],
+            )
+          )
+        ],
+      )
+    ),
+    ( name = "ai-search-mock",
+      worker = (
+        compatibilityFlags = ["experimental", "nodejs_compat"],
+        modules = [
+          (name = "worker", esModule = embed "ai-search-mock.js")
+        ],
+      )
+    )
+  ]
+);

--- a/src/cloudflare/internal/test/ai-search/ai-search-mock.js
+++ b/src/cloudflare/internal/test/ai-search/ai-search-mock.js
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const method = request.method;
+
+    // List instances: GET /ai-search/instances
+    if (method === 'GET' && url.pathname === '/ai-search/instances') {
+      return Response.json({
+        success: true,
+        result: [
+          {
+            id: 'my-ai-search',
+            enable: true,
+            type: 'r2',
+            source: 'my-bucket',
+          },
+        ],
+      });
+    }
+
+    // Create instance: POST /ai-search/instances
+    if (method === 'POST' && url.pathname === '/ai-search/instances') {
+      const body = await request.json();
+      return Response.json({
+        success: true,
+        result: {
+          id: body.id,
+          type: body.type,
+          source: body.source,
+        },
+      });
+    }
+
+    // Delete instance: DELETE /ai-search/instances/{id}
+    if (
+      method === 'DELETE' &&
+      url.pathname.match(/^\/ai-search\/instances\/[^/]+$/)
+    ) {
+      return Response.json({
+        success: true,
+        result: {},
+      });
+    }
+
+    // Search: POST /ai-search/instances/{id}/search
+    if (method === 'POST' && url.pathname.includes('/search')) {
+      // Check if instance ID is non-existent
+      if (url.pathname.includes('/non-existent/')) {
+        return Response.json(
+          {
+            success: false,
+            errors: [{ message: 'AI Search instance not found' }],
+          },
+          { status: 404 }
+        );
+      }
+
+      return Response.json({
+        success: true,
+        result: {
+          search_query: 'How many woodchucks?',
+          chunks: [
+            {
+              id: 'chunk-1',
+              type: 'text',
+              score: 0.85,
+              text: 'Two woodchucks per passenger.',
+              item: {
+                timestamp: 1234567890,
+                key: 'woodchuck_policy.txt',
+                metadata: {
+                  region: 'North America',
+                  author: 'Wildlife Department',
+                },
+              },
+              scoring_details: {
+                keyword_score: 0.8,
+                vector_score: 0.9,
+              },
+            },
+          ],
+        },
+      });
+    }
+
+    // Chat Completions: POST /ai-search/instances/{id}/chat/completions
+    if (method === 'POST' && url.pathname.includes('/chat/completions')) {
+      // Check if instance ID is non-existent
+      if (url.pathname.includes('/non-existent/')) {
+        return Response.json(
+          {
+            success: false,
+            errors: [{ message: 'AI Search instance not found' }],
+          },
+          { status: 404 }
+        );
+      }
+
+      const body = await request.json();
+
+      // Return streaming response if stream=true
+      if (body.stream === true) {
+        return new Response('data: {"result": "streaming"}\n\n', {
+          headers: {
+            'content-type': 'text/event-stream',
+          },
+        });
+      }
+
+      // Return non-streaming response
+      return Response.json({
+        success: true,
+        result: {
+          response: 'Based on the documents, two woodchucks are allowed.',
+        },
+      });
+    }
+
+    // Default: 404
+    return Response.json(
+      {
+        success: false,
+        errors: [{ message: 'Not found' }],
+      },
+      { status: 404 }
+    );
+  },
+};

--- a/src/cloudflare/internal/test/ai-search/python-ai-search-api-test.wd-test
+++ b/src/cloudflare/internal/test/ai-search/python-ai-search-api-test.wd-test
@@ -1,0 +1,34 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "ai-search-api-test",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "ai-search-api-test.py")
+        ],
+        compatibilityFlags = ["nodejs_compat", %PYTHON_FEATURE_FLAGS, "disable_python_no_global_handlers"],
+        bindings = [
+          (
+            name = "ai",
+            wrapped = (
+              moduleName = "cloudflare-internal:ai-api",
+              innerBindings = [(
+                name = "fetcher",
+                service = "ai-search-mock"
+              )],
+            )
+          )
+        ],
+      )
+    ),
+    ( name = "ai-search-mock",
+      worker = (
+        compatibilityFlags = ["experimental", "nodejs_compat"],
+        modules = [
+          (name = "worker", esModule = embed "ai-search-mock.js")
+        ],
+      )
+    )
+  ]
+);

--- a/src/workerd/api/node/tests/module-require-mutable-exports-test.js
+++ b/src/workerd/api/node/tests/module-require-mutable-exports-test.js
@@ -48,9 +48,8 @@ export const testPatchingDoesNotAffectNamedExports = {
     timersPromises.setTimeout = patchedSetTimeout;
 
     // The named export from the module namespace should be unaffected
-    const { setTimeout: namedSetTimeout } = await import(
-      'node:timers/promises'
-    );
+    const { setTimeout: namedSetTimeout } =
+      await import('node:timers/promises');
     notStrictEqual(namedSetTimeout, patchedSetTimeout);
     strictEqual(namedSetTimeout, originalSetTimeout);
 

--- a/types/defines/ai-search.d.ts
+++ b/types/defines/ai-search.d.ts
@@ -1,0 +1,192 @@
+// AI Search V2 API Error Interfaces
+export interface AiSearchInternalError extends Error {}
+export interface AiSearchNotFoundError extends Error {}
+export interface AiSearchNameNotSetError extends Error {}
+
+// Filter types (shared with AutoRAG for compatibility)
+export type ComparisonFilter = {
+  key: string;
+  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
+  value: string | number | boolean;
+};
+
+export type CompoundFilter = {
+  type: 'and' | 'or';
+  filters: ComparisonFilter[];
+};
+
+// AI Search V2 Request Types
+export type AiSearchSearchRequest = {
+  messages: Array<{
+    role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
+    content: string | null;
+  }>;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: 'vector' | 'keyword' | 'hybrid';
+      /** Match threshold (0-1, default 0.4) */
+      match_threshold?: number;
+      /** Maximum number of results (1-50, default 10) */
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      /** Context expansion (0-3, default 0) */
+      context_expansion?: number;
+      [key: string]: unknown;
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown;
+    };
+    reranking?: {
+      /** Enable reranking (default false) */
+      enabled?: boolean;
+      model?: '@cf/baai/bge-reranker-base' | '';
+      /** Match threshold (0-1, default 0.4) */
+      match_threshold?: number;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+
+export type AiSearchChatCompletionsRequest = {
+  messages: Array<{
+    role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
+    content: string | null;
+  }>;
+  model?: string;
+  stream?: boolean;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: 'vector' | 'keyword' | 'hybrid';
+      match_threshold?: number;
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      context_expansion?: number;
+      [key: string]: unknown;
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown;
+    };
+    reranking?: {
+      enabled?: boolean;
+      model?: '@cf/baai/bge-reranker-base' | '';
+      match_threshold?: number;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+// AI Search V2 Response Types
+export type AiSearchSearchResponse = {
+  search_query: string;
+  chunks: Array<{
+    id: string;
+    type: string;
+    /** Match score (0-1) */
+    score: number;
+    text: string;
+    item: {
+      timestamp?: number;
+      key: string;
+      metadata?: Record<string, unknown>;
+    };
+    scoring_details?: {
+      /** Keyword match score (0-1) */
+      keyword_score?: number;
+      /** Vector similarity score (0-1) */
+      vector_score?: number;
+    };
+  }>;
+};
+
+export type AiSearchListResponse = Array<{
+  id: string;
+  internal_id?: string;
+  account_id?: string;
+  account_tag?: string;
+  /** Whether the instance is enabled (default true) */
+  enable?: boolean;
+  type?: 'r2' | 'web-crawler';
+  source?: string;
+  [key: string]: unknown;
+}>;
+
+export type AiSearchConfig = {
+  /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
+  id: string;
+  type: 'r2' | 'web-crawler';
+  source: string;
+  source_params?: object;
+  /** Token ID (UUID format) */
+  token_id?: string;
+  ai_gateway_id?: string;
+  /** Enable query rewriting (default false) */
+  rewrite_query?: boolean;
+  /** Enable reranking (default false) */
+  reranking?: boolean;
+  embedding_model?: string;
+  ai_search_model?: string;
+};
+
+export type AiSearchInstance = {
+  id: string;
+  enable?: boolean;
+  type?: 'r2' | 'web-crawler';
+  source?: string;
+  [key: string]: unknown;
+};
+
+// AI Search Instance Service - Instance-level operations
+export declare abstract class AiSearchInstanceService {
+  /**
+   * Search the AI Search instance for relevant chunks.
+   * @param params Search request with messages and AI search options
+   * @returns Search response with matching chunks
+   */
+  search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
+
+  /**
+   * Generate chat completions with AI Search context.
+   * @param params Chat completions request with optional streaming
+   * @returns Response object (if streaming) or chat completion result
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest
+  ): Promise<Response | object>;
+
+  /**
+   * Delete this AI Search instance.
+   */
+  delete(): Promise<void>;
+}
+
+// AI Search Account Service - Account-level operations
+export declare abstract class AiSearchAccountService {
+  /**
+   * List all AI Search instances in the account.
+   * @returns Array of AI Search instances
+   */
+  list(): Promise<AiSearchListResponse>;
+
+  /**
+   * Get an AI Search instance by ID.
+   * @param name Instance ID
+   * @returns Instance service for performing operations
+   */
+  get(name: string): AiSearchInstanceService;
+
+  /**
+   * Create a new AI Search instance.
+   * @param config Instance configuration
+   * @returns Instance service for performing operations
+   */
+  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+}

--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -5452,6 +5452,50 @@ export type AiModelListType = Record<string, any>;
 export declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
+
+  /**
+   * Access the AI Search API for managing AI-powered search instances.
+   *
+   * This is the new API that replaces AutoRAG with better namespace separation:
+   * - Account-level operations: `list()`, `create()`
+   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
+   *
+   * @example
+   * ```typescript
+   * // List all AI Search instances
+   * const instances = await env.AI.aiSearch.list();
+   *
+   * // Search an instance
+   * const results = await env.AI.aiSearch.get('my-search').search({
+   *   messages: [{ role: 'user', content: 'What is the policy?' }],
+   *   ai_search_options: {
+   *     retrieval: { max_num_results: 10 }
+   *   }
+   * });
+   *
+   * // Generate chat completions with AI Search context
+   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
+   *   messages: [{ role: 'user', content: 'What is the policy?' }],
+   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+   * });
+   * ```
+   */
+  aiSearch: AiSearchAccountService;
+
+  /**
+   * @deprecated AutoRAG has been replaced by AI Search.
+   * Use `env.AI.aiSearch` instead for better API design and new features.
+   *
+   * Migration guide:
+   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
+   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
+   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
+   *
+   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
+   *
+   * @see AiSearchAccountService
+   * @param autoragId Optional instance ID (omit for account-level operations)
+   */
   autorag(autoragId: string): AutoRAG;
   run<Name extends keyof AiModelList, Options extends AiOptions, InputOptions extends AiModelList[Name]["inputs"]>(
     model: Name,

--- a/types/defines/autorag.d.ts
+++ b/types/defines/autorag.d.ts
@@ -1,17 +1,31 @@
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
+ * @see AiSearchInternalError
+ */
 export interface AutoRAGInternalError extends Error {}
+
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
+ * @see AiSearchNotFoundError
+ */
 export interface AutoRAGNotFoundError extends Error {}
+
+/**
+ * @deprecated This error type is no longer used in the AI Search API.
+ */
 export interface AutoRAGUnauthorizedError extends Error {}
+
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
+ * @see AiSearchNameNotSetError
+ */
 export interface AutoRAGNameNotSetError extends Error {}
 
-export type ComparisonFilter = {
-  key: string;
-  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
-  value: string | number | boolean;
-};
-export type CompoundFilter = {
-  type: 'and' | 'or';
-  filters: ComparisonFilter[];
-};
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchSearchRequest with the new API instead.
+ * @see AiSearchSearchRequest
+ */
 export type AutoRagSearchRequest = {
   query: string;
   filters?: CompoundFilter | ComparisonFilter;
@@ -26,16 +40,34 @@ export type AutoRagSearchRequest = {
   };
   rewrite_query?: boolean;
 };
+
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchChatCompletionsRequest with the new API instead.
+ * @see AiSearchChatCompletionsRequest
+ */
 export type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
   system_prompt?: string;
 };
+
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchChatCompletionsRequest with stream: true instead.
+ * @see AiSearchChatCompletionsRequest
+ */
 export type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
   'stream'
 > & {
   stream: true;
 };
+
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchSearchResponse with the new API instead.
+ * @see AiSearchSearchResponse
+ */
 export type AutoRagSearchResponse = {
   object: 'vector_store.search_results.page';
   search_query: string;
@@ -53,6 +85,11 @@ export type AutoRagSearchResponse = {
   next_page: string | null;
 };
 
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchListResponse with the new API instead.
+ * @see AiSearchListResponse
+ */
 export type AutoRagListResponse = {
   id: string;
   enable: boolean;
@@ -63,15 +100,56 @@ export type AutoRagListResponse = {
   status: string;
 }[];
 
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * The new API returns different response formats for chat completions.
+ */
 export type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
 
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use the new AI Search API instead: `env.AI.aiSearch`
+ *
+ * Migration guide:
+ * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
+ * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
+ * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
+ *
+ * @see AiSearchAccountService
+ * @see AiSearchInstanceService
+ */
 export declare abstract class AutoRAG {
+  /**
+   * @deprecated Use `env.AI.aiSearch.list()` instead.
+   * @see AiSearchAccountService.list
+   */
   list(): Promise<AutoRagListResponse>;
+
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
+   * Note: The new API uses a messages array instead of a query string.
+   * @see AiSearchInstanceService.search
+   */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
+
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
+
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
+
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(
     params: AutoRagAiSearchRequest
   ): Promise<AutoRagAiSearchResponse | Response>;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4486,6 +4486,184 @@ interface EventCounts {
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
 }
+// AI Search V2 API Error Interfaces
+interface AiSearchInternalError extends Error {}
+interface AiSearchNotFoundError extends Error {}
+interface AiSearchNameNotSetError extends Error {}
+// Filter types (shared with AutoRAG for compatibility)
+type ComparisonFilter = {
+  key: string;
+  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+  value: string | number | boolean;
+};
+type CompoundFilter = {
+  type: "and" | "or";
+  filters: ComparisonFilter[];
+};
+// AI Search V2 Request Types
+type AiSearchSearchRequest = {
+  messages: Array<{
+    role: "system" | "developer" | "user" | "assistant" | "tool";
+    content: string | null;
+  }>;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: "vector" | "keyword" | "hybrid";
+      /** Match threshold (0-1, default 0.4) */
+      match_threshold?: number;
+      /** Maximum number of results (1-50, default 10) */
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      /** Context expansion (0-3, default 0) */
+      context_expansion?: number;
+      [key: string]: unknown;
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown;
+    };
+    reranking?: {
+      /** Enable reranking (default false) */
+      enabled?: boolean;
+      model?: "@cf/baai/bge-reranker-base" | "";
+      /** Match threshold (0-1, default 0.4) */
+      match_threshold?: number;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+type AiSearchChatCompletionsRequest = {
+  messages: Array<{
+    role: "system" | "developer" | "user" | "assistant" | "tool";
+    content: string | null;
+  }>;
+  model?: string;
+  stream?: boolean;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: "vector" | "keyword" | "hybrid";
+      match_threshold?: number;
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      context_expansion?: number;
+      [key: string]: unknown;
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown;
+    };
+    reranking?: {
+      enabled?: boolean;
+      model?: "@cf/baai/bge-reranker-base" | "";
+      match_threshold?: number;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+// AI Search V2 Response Types
+type AiSearchSearchResponse = {
+  search_query: string;
+  chunks: Array<{
+    id: string;
+    type: string;
+    /** Match score (0-1) */
+    score: number;
+    text: string;
+    item: {
+      timestamp?: number;
+      key: string;
+      metadata?: Record<string, unknown>;
+    };
+    scoring_details?: {
+      /** Keyword match score (0-1) */
+      keyword_score?: number;
+      /** Vector similarity score (0-1) */
+      vector_score?: number;
+    };
+  }>;
+};
+type AiSearchListResponse = Array<{
+  id: string;
+  internal_id?: string;
+  account_id?: string;
+  account_tag?: string;
+  /** Whether the instance is enabled (default true) */
+  enable?: boolean;
+  type?: "r2" | "web-crawler";
+  source?: string;
+  [key: string]: unknown;
+}>;
+type AiSearchConfig = {
+  /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
+  id: string;
+  type: "r2" | "web-crawler";
+  source: string;
+  source_params?: object;
+  /** Token ID (UUID format) */
+  token_id?: string;
+  ai_gateway_id?: string;
+  /** Enable query rewriting (default false) */
+  rewrite_query?: boolean;
+  /** Enable reranking (default false) */
+  reranking?: boolean;
+  embedding_model?: string;
+  ai_search_model?: string;
+};
+type AiSearchInstance = {
+  id: string;
+  enable?: boolean;
+  type?: "r2" | "web-crawler";
+  source?: string;
+  [key: string]: unknown;
+};
+// AI Search Instance Service - Instance-level operations
+declare abstract class AiSearchInstanceService {
+  /**
+   * Search the AI Search instance for relevant chunks.
+   * @param params Search request with messages and AI search options
+   * @returns Search response with matching chunks
+   */
+  search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
+  /**
+   * Generate chat completions with AI Search context.
+   * @param params Chat completions request with optional streaming
+   * @returns Response object (if streaming) or chat completion result
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest,
+  ): Promise<Response | object>;
+  /**
+   * Delete this AI Search instance.
+   */
+  delete(): Promise<void>;
+}
+// AI Search Account Service - Account-level operations
+declare abstract class AiSearchAccountService {
+  /**
+   * List all AI Search instances in the account.
+   * @returns Array of AI Search instances
+   */
+  list(): Promise<AiSearchListResponse>;
+  /**
+   * Get an AI Search instance by ID.
+   * @param name Instance ID
+   * @returns Instance service for performing operations
+   */
+  get(name: string): AiSearchInstanceService;
+  /**
+   * Create a new AI Search instance.
+   * @param config Instance configuration
+   * @returns Instance service for performing operations
+   */
+  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+}
 type AiImageClassificationInput = {
   image: number[];
 };
@@ -9983,6 +10161,48 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
+  /**
+   * Access the AI Search API for managing AI-powered search instances.
+   *
+   * This is the new API that replaces AutoRAG with better namespace separation:
+   * - Account-level operations: `list()`, `create()`
+   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
+   *
+   * @example
+   * ```typescript
+   * // List all AI Search instances
+   * const instances = await env.AI.aiSearch.list();
+   *
+   * // Search an instance
+   * const results = await env.AI.aiSearch.get('my-search').search({
+   *   messages: [{ role: 'user', content: 'What is the policy?' }],
+   *   ai_search_options: {
+   *     retrieval: { max_num_results: 10 }
+   *   }
+   * });
+   *
+   * // Generate chat completions with AI Search context
+   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
+   *   messages: [{ role: 'user', content: 'What is the policy?' }],
+   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+   * });
+   * ```
+   */
+  aiSearch: AiSearchAccountService;
+  /**
+   * @deprecated AutoRAG has been replaced by AI Search.
+   * Use `env.AI.aiSearch` instead for better API design and new features.
+   *
+   * Migration guide:
+   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
+   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
+   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
+   *
+   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
+   *
+   * @see AiSearchAccountService
+   * @param autoragId Optional instance ID (omit for account-level operations)
+   */
   autorag(autoragId: string): AutoRAG;
   run<
     Name extends keyof AiModelList,
@@ -10139,19 +10359,30 @@ declare abstract class AiGateway {
   ): Promise<Response>;
   getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
 }
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
+ * @see AiSearchInternalError
+ */
 interface AutoRAGInternalError extends Error {}
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
+ * @see AiSearchNotFoundError
+ */
 interface AutoRAGNotFoundError extends Error {}
+/**
+ * @deprecated This error type is no longer used in the AI Search API.
+ */
 interface AutoRAGUnauthorizedError extends Error {}
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
+ * @see AiSearchNameNotSetError
+ */
 interface AutoRAGNameNotSetError extends Error {}
-type ComparisonFilter = {
-  key: string;
-  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
-  value: string | number | boolean;
-};
-type CompoundFilter = {
-  type: "and" | "or";
-  filters: ComparisonFilter[];
-};
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchSearchRequest with the new API instead.
+ * @see AiSearchSearchRequest
+ */
 type AutoRagSearchRequest = {
   query: string;
   filters?: CompoundFilter | ComparisonFilter;
@@ -10166,16 +10397,31 @@ type AutoRagSearchRequest = {
   };
   rewrite_query?: boolean;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchChatCompletionsRequest with the new API instead.
+ * @see AiSearchChatCompletionsRequest
+ */
 type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
   system_prompt?: string;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchChatCompletionsRequest with stream: true instead.
+ * @see AiSearchChatCompletionsRequest
+ */
 type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
   "stream"
 > & {
   stream: true;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchSearchResponse with the new API instead.
+ * @see AiSearchSearchResponse
+ */
 type AutoRagSearchResponse = {
   object: "vector_store.search_results.page";
   search_query: string;
@@ -10192,6 +10438,11 @@ type AutoRagSearchResponse = {
   has_more: boolean;
   next_page: string | null;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchListResponse with the new API instead.
+ * @see AiSearchListResponse
+ */
 type AutoRagListResponse = {
   id: string;
   enable: boolean;
@@ -10201,14 +10452,51 @@ type AutoRagListResponse = {
   paused: boolean;
   status: string;
 }[];
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * The new API returns different response formats for chat completions.
+ */
 type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use the new AI Search API instead: `env.AI.aiSearch`
+ *
+ * Migration guide:
+ * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
+ * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
+ * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
+ *
+ * @see AiSearchAccountService
+ * @see AiSearchInstanceService
+ */
 declare abstract class AutoRAG {
+  /**
+   * @deprecated Use `env.AI.aiSearch.list()` instead.
+   * @see AiSearchAccountService.list
+   */
   list(): Promise<AutoRagListResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
+   * Note: The new API uses a messages array instead of a query string.
+   * @see AiSearchInstanceService.search
+   */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(
     params: AutoRagAiSearchRequest,
   ): Promise<AutoRagAiSearchResponse | Response>;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -3880,6 +3880,184 @@ declare abstract class Performance {
   /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
   now(): number;
 }
+// AI Search V2 API Error Interfaces
+interface AiSearchInternalError extends Error {}
+interface AiSearchNotFoundError extends Error {}
+interface AiSearchNameNotSetError extends Error {}
+// Filter types (shared with AutoRAG for compatibility)
+type ComparisonFilter = {
+  key: string;
+  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+  value: string | number | boolean;
+};
+type CompoundFilter = {
+  type: "and" | "or";
+  filters: ComparisonFilter[];
+};
+// AI Search V2 Request Types
+type AiSearchSearchRequest = {
+  messages: Array<{
+    role: "system" | "developer" | "user" | "assistant" | "tool";
+    content: string | null;
+  }>;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: "vector" | "keyword" | "hybrid";
+      /** Match threshold (0-1, default 0.4) */
+      match_threshold?: number;
+      /** Maximum number of results (1-50, default 10) */
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      /** Context expansion (0-3, default 0) */
+      context_expansion?: number;
+      [key: string]: unknown;
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown;
+    };
+    reranking?: {
+      /** Enable reranking (default false) */
+      enabled?: boolean;
+      model?: "@cf/baai/bge-reranker-base" | "";
+      /** Match threshold (0-1, default 0.4) */
+      match_threshold?: number;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+type AiSearchChatCompletionsRequest = {
+  messages: Array<{
+    role: "system" | "developer" | "user" | "assistant" | "tool";
+    content: string | null;
+  }>;
+  model?: string;
+  stream?: boolean;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: "vector" | "keyword" | "hybrid";
+      match_threshold?: number;
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      context_expansion?: number;
+      [key: string]: unknown;
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown;
+    };
+    reranking?: {
+      enabled?: boolean;
+      model?: "@cf/baai/bge-reranker-base" | "";
+      match_threshold?: number;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+// AI Search V2 Response Types
+type AiSearchSearchResponse = {
+  search_query: string;
+  chunks: Array<{
+    id: string;
+    type: string;
+    /** Match score (0-1) */
+    score: number;
+    text: string;
+    item: {
+      timestamp?: number;
+      key: string;
+      metadata?: Record<string, unknown>;
+    };
+    scoring_details?: {
+      /** Keyword match score (0-1) */
+      keyword_score?: number;
+      /** Vector similarity score (0-1) */
+      vector_score?: number;
+    };
+  }>;
+};
+type AiSearchListResponse = Array<{
+  id: string;
+  internal_id?: string;
+  account_id?: string;
+  account_tag?: string;
+  /** Whether the instance is enabled (default true) */
+  enable?: boolean;
+  type?: "r2" | "web-crawler";
+  source?: string;
+  [key: string]: unknown;
+}>;
+type AiSearchConfig = {
+  /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
+  id: string;
+  type: "r2" | "web-crawler";
+  source: string;
+  source_params?: object;
+  /** Token ID (UUID format) */
+  token_id?: string;
+  ai_gateway_id?: string;
+  /** Enable query rewriting (default false) */
+  rewrite_query?: boolean;
+  /** Enable reranking (default false) */
+  reranking?: boolean;
+  embedding_model?: string;
+  ai_search_model?: string;
+};
+type AiSearchInstance = {
+  id: string;
+  enable?: boolean;
+  type?: "r2" | "web-crawler";
+  source?: string;
+  [key: string]: unknown;
+};
+// AI Search Instance Service - Instance-level operations
+declare abstract class AiSearchInstanceService {
+  /**
+   * Search the AI Search instance for relevant chunks.
+   * @param params Search request with messages and AI search options
+   * @returns Search response with matching chunks
+   */
+  search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
+  /**
+   * Generate chat completions with AI Search context.
+   * @param params Chat completions request with optional streaming
+   * @returns Response object (if streaming) or chat completion result
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest,
+  ): Promise<Response | object>;
+  /**
+   * Delete this AI Search instance.
+   */
+  delete(): Promise<void>;
+}
+// AI Search Account Service - Account-level operations
+declare abstract class AiSearchAccountService {
+  /**
+   * List all AI Search instances in the account.
+   * @returns Array of AI Search instances
+   */
+  list(): Promise<AiSearchListResponse>;
+  /**
+   * Get an AI Search instance by ID.
+   * @param name Instance ID
+   * @returns Instance service for performing operations
+   */
+  get(name: string): AiSearchInstanceService;
+  /**
+   * Create a new AI Search instance.
+   * @param config Instance configuration
+   * @returns Instance service for performing operations
+   */
+  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+}
 type AiImageClassificationInput = {
   image: number[];
 };
@@ -9377,6 +9555,48 @@ type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
+  /**
+   * Access the AI Search API for managing AI-powered search instances.
+   *
+   * This is the new API that replaces AutoRAG with better namespace separation:
+   * - Account-level operations: `list()`, `create()`
+   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
+   *
+   * @example
+   * ```typescript
+   * // List all AI Search instances
+   * const instances = await env.AI.aiSearch.list();
+   *
+   * // Search an instance
+   * const results = await env.AI.aiSearch.get('my-search').search({
+   *   messages: [{ role: 'user', content: 'What is the policy?' }],
+   *   ai_search_options: {
+   *     retrieval: { max_num_results: 10 }
+   *   }
+   * });
+   *
+   * // Generate chat completions with AI Search context
+   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
+   *   messages: [{ role: 'user', content: 'What is the policy?' }],
+   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+   * });
+   * ```
+   */
+  aiSearch: AiSearchAccountService;
+  /**
+   * @deprecated AutoRAG has been replaced by AI Search.
+   * Use `env.AI.aiSearch` instead for better API design and new features.
+   *
+   * Migration guide:
+   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
+   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
+   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
+   *
+   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
+   *
+   * @see AiSearchAccountService
+   * @param autoragId Optional instance ID (omit for account-level operations)
+   */
   autorag(autoragId: string): AutoRAG;
   run<
     Name extends keyof AiModelList,
@@ -9533,19 +9753,30 @@ declare abstract class AiGateway {
   ): Promise<Response>;
   getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
 }
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
+ * @see AiSearchInternalError
+ */
 interface AutoRAGInternalError extends Error {}
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
+ * @see AiSearchNotFoundError
+ */
 interface AutoRAGNotFoundError extends Error {}
+/**
+ * @deprecated This error type is no longer used in the AI Search API.
+ */
 interface AutoRAGUnauthorizedError extends Error {}
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
+ * @see AiSearchNameNotSetError
+ */
 interface AutoRAGNameNotSetError extends Error {}
-type ComparisonFilter = {
-  key: string;
-  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
-  value: string | number | boolean;
-};
-type CompoundFilter = {
-  type: "and" | "or";
-  filters: ComparisonFilter[];
-};
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchSearchRequest with the new API instead.
+ * @see AiSearchSearchRequest
+ */
 type AutoRagSearchRequest = {
   query: string;
   filters?: CompoundFilter | ComparisonFilter;
@@ -9560,16 +9791,31 @@ type AutoRagSearchRequest = {
   };
   rewrite_query?: boolean;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchChatCompletionsRequest with the new API instead.
+ * @see AiSearchChatCompletionsRequest
+ */
 type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
   system_prompt?: string;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchChatCompletionsRequest with stream: true instead.
+ * @see AiSearchChatCompletionsRequest
+ */
 type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
   "stream"
 > & {
   stream: true;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchSearchResponse with the new API instead.
+ * @see AiSearchSearchResponse
+ */
 type AutoRagSearchResponse = {
   object: "vector_store.search_results.page";
   search_query: string;
@@ -9586,6 +9832,11 @@ type AutoRagSearchResponse = {
   has_more: boolean;
   next_page: string | null;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchListResponse with the new API instead.
+ * @see AiSearchListResponse
+ */
 type AutoRagListResponse = {
   id: string;
   enable: boolean;
@@ -9595,14 +9846,51 @@ type AutoRagListResponse = {
   paused: boolean;
   status: string;
 }[];
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * The new API returns different response formats for chat completions.
+ */
 type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use the new AI Search API instead: `env.AI.aiSearch`
+ *
+ * Migration guide:
+ * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
+ * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
+ * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
+ *
+ * @see AiSearchAccountService
+ * @see AiSearchInstanceService
+ */
 declare abstract class AutoRAG {
+  /**
+   * @deprecated Use `env.AI.aiSearch.list()` instead.
+   * @see AiSearchAccountService.list
+   */
   list(): Promise<AutoRagListResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
+   * Note: The new API uses a messages array instead of a query string.
+   * @see AiSearchInstanceService.search
+   */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(
     params: AutoRagAiSearchRequest,
   ): Promise<AutoRagAiSearchResponse | Response>;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -3889,6 +3889,184 @@ export declare abstract class Performance {
   /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
   now(): number;
 }
+// AI Search V2 API Error Interfaces
+export interface AiSearchInternalError extends Error {}
+export interface AiSearchNotFoundError extends Error {}
+export interface AiSearchNameNotSetError extends Error {}
+// Filter types (shared with AutoRAG for compatibility)
+export type ComparisonFilter = {
+  key: string;
+  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+  value: string | number | boolean;
+};
+export type CompoundFilter = {
+  type: "and" | "or";
+  filters: ComparisonFilter[];
+};
+// AI Search V2 Request Types
+export type AiSearchSearchRequest = {
+  messages: Array<{
+    role: "system" | "developer" | "user" | "assistant" | "tool";
+    content: string | null;
+  }>;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: "vector" | "keyword" | "hybrid";
+      /** Match threshold (0-1, default 0.4) */
+      match_threshold?: number;
+      /** Maximum number of results (1-50, default 10) */
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      /** Context expansion (0-3, default 0) */
+      context_expansion?: number;
+      [key: string]: unknown;
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown;
+    };
+    reranking?: {
+      /** Enable reranking (default false) */
+      enabled?: boolean;
+      model?: "@cf/baai/bge-reranker-base" | "";
+      /** Match threshold (0-1, default 0.4) */
+      match_threshold?: number;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+};
+export type AiSearchChatCompletionsRequest = {
+  messages: Array<{
+    role: "system" | "developer" | "user" | "assistant" | "tool";
+    content: string | null;
+  }>;
+  model?: string;
+  stream?: boolean;
+  ai_search_options?: {
+    retrieval?: {
+      retrieval_type?: "vector" | "keyword" | "hybrid";
+      match_threshold?: number;
+      max_num_results?: number;
+      filters?: CompoundFilter | ComparisonFilter;
+      context_expansion?: number;
+      [key: string]: unknown;
+    };
+    query_rewrite?: {
+      enabled?: boolean;
+      model?: string;
+      rewrite_prompt?: string;
+      [key: string]: unknown;
+    };
+    reranking?: {
+      enabled?: boolean;
+      model?: "@cf/baai/bge-reranker-base" | "";
+      match_threshold?: number;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+// AI Search V2 Response Types
+export type AiSearchSearchResponse = {
+  search_query: string;
+  chunks: Array<{
+    id: string;
+    type: string;
+    /** Match score (0-1) */
+    score: number;
+    text: string;
+    item: {
+      timestamp?: number;
+      key: string;
+      metadata?: Record<string, unknown>;
+    };
+    scoring_details?: {
+      /** Keyword match score (0-1) */
+      keyword_score?: number;
+      /** Vector similarity score (0-1) */
+      vector_score?: number;
+    };
+  }>;
+};
+export type AiSearchListResponse = Array<{
+  id: string;
+  internal_id?: string;
+  account_id?: string;
+  account_tag?: string;
+  /** Whether the instance is enabled (default true) */
+  enable?: boolean;
+  type?: "r2" | "web-crawler";
+  source?: string;
+  [key: string]: unknown;
+}>;
+export type AiSearchConfig = {
+  /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
+  id: string;
+  type: "r2" | "web-crawler";
+  source: string;
+  source_params?: object;
+  /** Token ID (UUID format) */
+  token_id?: string;
+  ai_gateway_id?: string;
+  /** Enable query rewriting (default false) */
+  rewrite_query?: boolean;
+  /** Enable reranking (default false) */
+  reranking?: boolean;
+  embedding_model?: string;
+  ai_search_model?: string;
+};
+export type AiSearchInstance = {
+  id: string;
+  enable?: boolean;
+  type?: "r2" | "web-crawler";
+  source?: string;
+  [key: string]: unknown;
+};
+// AI Search Instance Service - Instance-level operations
+export declare abstract class AiSearchInstanceService {
+  /**
+   * Search the AI Search instance for relevant chunks.
+   * @param params Search request with messages and AI search options
+   * @returns Search response with matching chunks
+   */
+  search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
+  /**
+   * Generate chat completions with AI Search context.
+   * @param params Chat completions request with optional streaming
+   * @returns Response object (if streaming) or chat completion result
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest,
+  ): Promise<Response | object>;
+  /**
+   * Delete this AI Search instance.
+   */
+  delete(): Promise<void>;
+}
+// AI Search Account Service - Account-level operations
+export declare abstract class AiSearchAccountService {
+  /**
+   * List all AI Search instances in the account.
+   * @returns Array of AI Search instances
+   */
+  list(): Promise<AiSearchListResponse>;
+  /**
+   * Get an AI Search instance by ID.
+   * @param name Instance ID
+   * @returns Instance service for performing operations
+   */
+  get(name: string): AiSearchInstanceService;
+  /**
+   * Create a new AI Search instance.
+   * @param config Instance configuration
+   * @returns Instance service for performing operations
+   */
+  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+}
 export type AiImageClassificationInput = {
   image: number[];
 };
@@ -9389,6 +9567,48 @@ export declare abstract class Ai<
 > {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
+  /**
+   * Access the AI Search API for managing AI-powered search instances.
+   *
+   * This is the new API that replaces AutoRAG with better namespace separation:
+   * - Account-level operations: `list()`, `create()`
+   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
+   *
+   * @example
+   * ```typescript
+   * // List all AI Search instances
+   * const instances = await env.AI.aiSearch.list();
+   *
+   * // Search an instance
+   * const results = await env.AI.aiSearch.get('my-search').search({
+   *   messages: [{ role: 'user', content: 'What is the policy?' }],
+   *   ai_search_options: {
+   *     retrieval: { max_num_results: 10 }
+   *   }
+   * });
+   *
+   * // Generate chat completions with AI Search context
+   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
+   *   messages: [{ role: 'user', content: 'What is the policy?' }],
+   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+   * });
+   * ```
+   */
+  aiSearch: AiSearchAccountService;
+  /**
+   * @deprecated AutoRAG has been replaced by AI Search.
+   * Use `env.AI.aiSearch` instead for better API design and new features.
+   *
+   * Migration guide:
+   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
+   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
+   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
+   *
+   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
+   *
+   * @see AiSearchAccountService
+   * @param autoragId Optional instance ID (omit for account-level operations)
+   */
   autorag(autoragId: string): AutoRAG;
   run<
     Name extends keyof AiModelList,
@@ -9545,19 +9765,30 @@ export declare abstract class AiGateway {
   ): Promise<Response>;
   getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
 }
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
+ * @see AiSearchInternalError
+ */
 export interface AutoRAGInternalError extends Error {}
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
+ * @see AiSearchNotFoundError
+ */
 export interface AutoRAGNotFoundError extends Error {}
+/**
+ * @deprecated This error type is no longer used in the AI Search API.
+ */
 export interface AutoRAGUnauthorizedError extends Error {}
+/**
+ * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
+ * @see AiSearchNameNotSetError
+ */
 export interface AutoRAGNameNotSetError extends Error {}
-export type ComparisonFilter = {
-  key: string;
-  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
-  value: string | number | boolean;
-};
-export type CompoundFilter = {
-  type: "and" | "or";
-  filters: ComparisonFilter[];
-};
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchSearchRequest with the new API instead.
+ * @see AiSearchSearchRequest
+ */
 export type AutoRagSearchRequest = {
   query: string;
   filters?: CompoundFilter | ComparisonFilter;
@@ -9572,16 +9803,31 @@ export type AutoRagSearchRequest = {
   };
   rewrite_query?: boolean;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchChatCompletionsRequest with the new API instead.
+ * @see AiSearchChatCompletionsRequest
+ */
 export type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
   system_prompt?: string;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchChatCompletionsRequest with stream: true instead.
+ * @see AiSearchChatCompletionsRequest
+ */
 export type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
   "stream"
 > & {
   stream: true;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchSearchResponse with the new API instead.
+ * @see AiSearchSearchResponse
+ */
 export type AutoRagSearchResponse = {
   object: "vector_store.search_results.page";
   search_query: string;
@@ -9598,6 +9844,11 @@ export type AutoRagSearchResponse = {
   has_more: boolean;
   next_page: string | null;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use AiSearchListResponse with the new API instead.
+ * @see AiSearchListResponse
+ */
 export type AutoRagListResponse = {
   id: string;
   enable: boolean;
@@ -9607,14 +9858,51 @@ export type AutoRagListResponse = {
   paused: boolean;
   status: string;
 }[];
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * The new API returns different response formats for chat completions.
+ */
 export type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
+/**
+ * @deprecated AutoRAG has been replaced by AI Search.
+ * Use the new AI Search API instead: `env.AI.aiSearch`
+ *
+ * Migration guide:
+ * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
+ * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
+ * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
+ *
+ * @see AiSearchAccountService
+ * @see AiSearchInstanceService
+ */
 export declare abstract class AutoRAG {
+  /**
+   * @deprecated Use `env.AI.aiSearch.list()` instead.
+   * @see AiSearchAccountService.list
+   */
   list(): Promise<AutoRagListResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
+   * Note: The new API uses a messages array instead of a query string.
+   * @see AiSearchInstanceService.search
+   */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
+  /**
+   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
+   * @see AiSearchInstanceService.chatCompletions
+   */
   aiSearch(
     params: AutoRagAiSearchRequest,
   ): Promise<AutoRagAiSearchResponse | Response>;


### PR DESCRIPTION
We have renamed AutoRAG to AI Search and updated the binding accordingly, adding several new features in the process. 
To maintain backwards compatibility without compability flags, in a follow up pr, i will replace the autorag class to proxy legacy requests to the new ai search binding and transform the output to match original behaviors.
Older autorag methods have also been commented with typescript @deprecated so users can start migrating to the new version.

usage:
```ts
await env.AI.aiSearch.list()                              // Account-level
await env.AI.aiSearch.get("my-search").search(params)     // Instance-level
await env.AI.aiSearch.get("my-search").chatCompletions(params)   // Instance-level

await env.AI.aiSearch.create({
        id: 'new-search',
        type: 'r2',
        source: 'my-bucket',
});
await env.AI.aiSearch.get("my-search").delete()
```