### PR TITLE
Allow Request as second parameter in Request constructor types

### DIFF
--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -824,28 +824,28 @@ class Request final: public Body {
             constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
             clone(): Request<CfHostMetadata, Cf>;
             cache?: "no-store" | "no-cache" | "reload";
-            get cf(): Cf | undefined;
+            cf?: Cf;
           });
         } else if (flags.getCacheNoCache()) {
           JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
             constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
             clone(): Request<CfHostMetadata, Cf>;
             cache?: "no-store" | "no-cache";
-            get cf(): Cf | undefined;
+            cf?: Cf;
           });
         } else {
           JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
             constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
             clone(): Request<CfHostMetadata, Cf>;
             cache?: "no-store";
-            get cf(): Cf | undefined;
+            cf?: Cf;
           });
         }
       } else {
         JSG_TS_OVERRIDE(<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> {
           constructor(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>);
           clone(): Request<CfHostMetadata, Cf>;
-          get cf(): Cf | undefined;
+          cf?: Cf;
         });
       }
 

--- a/src/workerd/api/tests/http-test-ts.ts
+++ b/src/workerd/api/tests/http-test-ts.ts
@@ -47,6 +47,37 @@ async function assertFetchCacheRejectsError(
   );
 }
 
+// Test that the Request constructor accepts a Request object as the second parameter.
+// This validates the TypeScript type definitions are correct.
+// Reference: https://github.com/cloudflare/workerd/issues/5940
+export const requestConstructorWithRequestAsInit = {
+  async test() {
+    // Create an original request
+    const originalRequest = new Request('https://example.com/original', {
+      method: 'POST',
+      headers: { 'X-Custom-Header': 'test-value' },
+    });
+
+    // TypeScript should allow passing a Request as the second parameter
+    const newRequest = new Request(
+      'https://example.com/new-url',
+      originalRequest
+    );
+
+    assert.strictEqual(newRequest.url, 'https://example.com/new-url');
+    assert.strictEqual(newRequest.method, 'POST');
+    assert.strictEqual(newRequest.headers.get('X-Custom-Header'), 'test-value');
+
+    // Also test with clone() which is a common pattern
+    const clonedAsInit = new Request(
+      'https://example.com/another-url',
+      originalRequest.clone()
+    );
+    assert.strictEqual(clonedAsInit.url, 'https://example.com/another-url');
+    assert.strictEqual(clonedAsInit.method, 'POST');
+  },
+};
+
 export const cacheMode = {
   async test(_ctrl: any, env: any, _ctx: any) {
     const allowedCacheModes: Set<RequestCache> = new Set([

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -2103,7 +2103,7 @@ interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/signal)
    */
   signal: AbortSignal;
-  cf: Cf | undefined;
+  cf?: Cf;
   /**
    * The **`integrity`** read-only property of the Request interface contains the subresource integrity value of the request.
    *

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -2109,7 +2109,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/signal)
    */
   signal: AbortSignal;
-  cf: Cf | undefined;
+  cf?: Cf;
   /**
    * The **`integrity`** read-only property of the Request interface contains the subresource integrity value of the request.
    *

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -2058,7 +2058,7 @@ interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/signal)
    */
   signal: AbortSignal;
-  cf: Cf | undefined;
+  cf?: Cf;
   /**
    * The **`integrity`** read-only property of the Request interface contains the subresource integrity value of the request.
    *

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -2064,7 +2064,7 @@ export interface Request<
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/signal)
    */
   signal: AbortSignal;
-  cf: Cf | undefined;
+  cf?: Cf;
   /**
    * The **`integrity`** read-only property of the Request interface contains the subresource integrity value of the request.
    *


### PR DESCRIPTION
Fixes #5940

Make Request structurally compatible with RequestInit by changing the cf property from `cf: Cf | undefined` to `cf?: Cf`. This allows passing a Request object as the second parameter to the Request constructor without needing an explicit union type.