### PR TITLE
Always invoke bazel build for prettier (fix lint)

### DIFF
--- a/tools/cross/format.py
+++ b/tools/cross/format.py
@@ -122,9 +122,7 @@ def clang_format(files: list[Path], check: bool = False) -> bool:
 
 def prettier(files: list[Path], check: bool = False) -> bool:
     PRETTIER = BAZEL_BIN / "node_modules/prettier/bin/prettier.cjs"
-
-    if not PRETTIER.exists():
-        subprocess.run(["bazel", "build", "//:node_modules/prettier"])
+    subprocess.run(["bazel", "build", "//:node_modules/prettier"])
     cmd = [PRETTIER, "--log-level=warn", "--check" if check else "--write"]
     result = subprocess.run(cmd + files, cwd=ROOT)
     return result.returncode == 0


### PR DESCRIPTION
We recently updated the prettier version which breaks linting if an older cached version is used on a PR.

This PR is a quick dirty fix that always tells Bazel to build prettier before we use it. It won't waste time to rebuild it if unneeded, but it will add a check that slows things down cause Bazel.

If we're fine with this solution, I'll change all the linters. If not, I'll revert it and implement the solution we decide on, but we need to unscrew the build for now.