### PR TITLE
fix buildifier executable path not working on windsurf

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,10 +18,10 @@
     "--query-driver=**",
     "--clang-tidy"
   ],
-  "clang-format.executable": "${workspaceRoot}/bazel-bin/build/deps/formatters/clang-format",
-  "bazel.buildifierExecutable": "${workspaceRoot}/bazel-bin/build/deps/formatters/buildifier",
+  "clang-format.executable": "./bazel-bin/build/deps/formatters/clang-format",
+  "bazel.buildifierExecutable": "./bazel-bin/build/deps/formatters/buildifier",
   "ruff.path": [
-    "${workspaceRoot}/bazel-bin/build/deps/formatters/ruff"
+    "./bazel-bin/build/deps/formatters/ruff"
   ],
   "rust-analyzer.workspace.discoverConfig": {
     "command": [


### PR DESCRIPTION
I was constantly getting this error on Linux + Windsurf. This change fixes it for me.

![unnamed](https://github.com/user-attachments/assets/fb2a5a0e-04a0-45e2-915d-7866e6666009)
