### PR TITLE
[build] Unconditionally optimize V8, describe and fix macOS segfault

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,24 +62,40 @@ build --cxxopt=-DKJ_WARN_REFCOUNTED_ATTACH=1
 # TODO(cleanup): Causes warnings with LLVM20, fix and enable again
 build --copt=-Wno-nontrivial-memaccess
 
-# Increasing the optimization level of V8 significantly speeds up Python tests in GitHub Actions.
-# This is an optional performance hack intended for CI, although it might also be useful for local
-# development.
-build:v8-codegen-opt --per_file_copt=v8/src@-O2
+# Unconditionally optimize V8 heap.cc on macOS – when optimization or inlining are disabled, this
+# file appears to cause segfaults at workerd startup on macOS.
+# TODO(cleanup): Investigate why this happens, our patches do not modify heap.cc itself so the bug
+# might be introduced through a header included in heap.cc, through the Bazel build configuration or
+# a bug in Apple LLVM.
+build:macos --per_file_copt=v8/src/heap/heap.cc@-O3
+
+# Increasing the optimization level of V8 significantly speeds up tests using V8 a lot, especially
+# python tests. This is useful for both CI and local development and enabled by default, but still
+# kept in a separate configuration to make it easy to disable.
+build:v8-codegen-opt --per_file_copt=v8/src@-O3
 # V8 is heavily using absl for hashing now, optimize it too.
-build:v8-codegen-opt --per_file_copt=external/abseil-cpp@-O2
+build:v8-codegen-opt --per_file_copt=external/abseil-cpp@-O3
 # zlib and tcmalloc (for Linux) are also CPU-intensive, optimize them too.
-build:v8-codegen-opt --per_file_copt=external/tcmalloc@-O2
-build:v8-codegen-opt --per_file_copt=external/zlib@-O2
+build:v8-codegen-opt --per_file_copt=external/tcmalloc@-O3
+build:v8-codegen-opt --per_file_copt=external/zlib@-O3
 # BoringSSL is CPU-intensive for crypto tests, optimize it too.
-build:v8-codegen-opt --per_file_copt=external/boringssl@-O2
+build:v8-codegen-opt --per_file_copt=external/boringssl@-O3
 # simdutf is used for fast string encoding/decoding
-build:v8-codegen-opt --per_file_copt=external/+http+simdutf@-O2
-build:v8-codegen-opt-windows --per_file_copt=v8/src@/O2
-build:v8-codegen-opt-windows --per_file_copt=external/abseil-cpp@/O2
-build:v8-codegen-opt-windows --per_file_copt=external/zlib@/O2
-build:v8-codegen-opt-windows --per_file_copt=external/boringssl@/O2
-build:v8-codegen-opt-windows --per_file_copt=external/+http+simdutf@/O2
+build:v8-codegen-opt --per_file_copt=external/+http+simdutf@-O3
+# ICU and perfetto are generally updated with V8 and rarely need to be updated, optimize them too.
+build:v8-codegen-opt --per_file_copt=external/.*com_googlesource_chromium_icu@-O3
+build:v8-codegen-opt --per_file_copt=external/perfetto@-O3
+
+build:v8-codegen-opt-windows --per_file_copt=v8/src@/O2,/clang:-O3
+build:v8-codegen-opt-windows --per_file_copt=external/abseil-cpp@/O2,/clang:-O3
+build:v8-codegen-opt-windows --per_file_copt=external/zlib@/O2,/clang:-O3
+build:v8-codegen-opt-windows --per_file_copt=external/boringssl@/O2,/clang:-O3
+build:v8-codegen-opt-windows --per_file_copt=external/+http+simdutf@/O2,/clang:-O3
+build:v8-codegen-opt-windows --per_file_copt=external/.*com_googlesource_chromium_icu@/O2,/clang:-O3
+build:v8-codegen-opt-windows --per_file_copt=external/perfetto@/O2,/clang:-O3
+
+build:unix --config=v8-codegen-opt
+build:windows  --config=v8-codegen-opt-windows
 
 # In Google projects, exceptions are not used as a rule. Disabling them is more consistent with the
 # canonical V8 build and improves code size. Paths are adjusted for bzlmod mangling – V8 and ICU use
@@ -455,8 +471,6 @@ build:coverage --per_file_copt=external/.*@-fno-profile-instr-generate,-fno-cove
 build:coverage --test_env=KJ_CLEAN_SHUTDOWN=1
 # Use -O1 for faster compilation - coverage builds don't need heavy optimization
 build:coverage --copt=-O1
-# External dependencies can use -O2 since they're not instrumented anyway
-build:coverage --config=v8-codegen-opt
 # Reduce debug info for faster compilation and smaller binaries
 build:coverage --copt=-g1
 # Use limited coverage mode for smaller binaries and faster execution (used by Chromium)

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -31,11 +31,6 @@ build:ci --disk_cache=~/bazel-disk-cache
 
 # test CI jobs don't need any top-level artifacts and just verify things
 build:ci-test --remote_download_minimal
-# Enable v8-codegen-opt for test so that python tests run in an acceptable time frame but not for
-# release builds – this sets -O2 and release should keep -O3. For Windows, we can enable /O2
-# unconditionally, release already uses that and just adds "/clang:-O3" on top of it.
-build:ci-test --config=v8-codegen-opt
-build:ci-windows --config=v8-codegen-opt-windows
 
 # limit storage usage on ci
 # Exclude large benchmarking binaries created in debug and asan configurations to avoid


### PR DESCRIPTION
- v8-codegen-opt is very useful in local builds too, enable it by default.
- Use -O3, which doesn't take much longer to compile – V8 is rarely recompiled, we benefit from the higher performance and won't need to find a way to undo the -O2 setting in the case of release builds
- Work around macOS segfault and add TODO