### PR TITLE
Optional types for GPT-OSS models

### DIFF
--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -671,6 +671,12 @@ export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
 export type StreamOptions = {
   include_obfuscation?: boolean;
 };
+/** Marks keys from T that aren't in U as optional never */
+export type Without<T, U> = {
+  [P in Exclude<keyof T, keyof U>]?: never;
+};
+/** Either T or U, but not both (mutually exclusive) */
+export type XOR<T, U> = (T & Without<U, T>) | (U & Without<T, U>);
 export type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -4289,12 +4295,12 @@ export declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 export interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -5181,6 +5181,12 @@ type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
 type StreamOptions = {
   include_obfuscation?: boolean;
 };
+/** Marks keys from T that aren't in U as optional never */
+type Without<T, U> = {
+  [P in Exclude<keyof T, keyof U>]?: never;
+};
+/** Either T or U, but not both (mutually exclusive) */
+type XOR<T, U> = (T & Without<U, T>) | (U & Without<T, U>);
 type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -8815,12 +8821,12 @@ declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -5191,6 +5191,12 @@ export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
 export type StreamOptions = {
   include_obfuscation?: boolean;
 };
+/** Marks keys from T that aren't in U as optional never */
+export type Without<T, U> = {
+  [P in Exclude<keyof T, keyof U>]?: never;
+};
+/** Either T or U, but not both (mutually exclusive) */
+export type XOR<T, U> = (T & Without<U, T>) | (U & Without<T, U>);
 export type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -8825,12 +8831,12 @@ export declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 export interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -4575,6 +4575,12 @@ type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
 type StreamOptions = {
   include_obfuscation?: boolean;
 };
+/** Marks keys from T that aren't in U as optional never */
+type Without<T, U> = {
+  [P in Exclude<keyof T, keyof U>]?: never;
+};
+/** Either T or U, but not both (mutually exclusive) */
+type XOR<T, U> = (T & Without<U, T>) | (U & Without<T, U>);
 type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -8209,12 +8215,12 @@ declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -4585,6 +4585,12 @@ export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | null;
 export type StreamOptions = {
   include_obfuscation?: boolean;
 };
+/** Marks keys from T that aren't in U as optional never */
+export type Without<T, U> = {
+  [P in Exclude<keyof T, keyof U>]?: never;
+};
+/** Either T or U, but not both (mutually exclusive) */
+export type XOR<T, U> = (T & Without<U, T>) | (U & Without<T, U>);
 export type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
   | {
       text: string | string[];
@@ -8219,12 +8225,12 @@ export declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
   postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 export declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-  inputs: ResponsesInput;
-  postProcessedOutputs: ResponsesOutput;
+  inputs: XOR<ResponsesInput, AiTextGenerationInput>;
+  postProcessedOutputs: XOR<ResponsesOutput, AiTextGenerationOutput>;
 }
 export interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
   /**


### PR DESCRIPTION
```
GPT-OSS now supports both Responses and Chat/Completions formats, this
will allow users to get type completions for both of them.
```