### PR TITLE
fix setTimeout inconsistencies

### DIFF
--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -2,6 +2,12 @@ load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("//:build/wd_test.bzl", "wd_test")
 
 wd_test(
+    src = "settimeout-test.wd-test",
+    args = ["--experimental"],
+    data = ["settimeout-test.js"],
+)
+
+wd_test(
     src = "actor-alarms-delete-test.wd-test",
     args = ["--experimental"],
     data = ["actor-alarms-delete-test.js"],

--- a/src/workerd/api/tests/settimeout-test.js
+++ b/src/workerd/api/tests/settimeout-test.js
@@ -1,0 +1,18 @@
+import { ok } from 'node:assert';
+
+// Allow up to 10ms of jitter because the precise_timers compat flag
+// can introduce +/-3ms of variance in timer resolution, and coverage
+// builds add additional overhead.
+const JITTER = 10;
+
+export default {
+  async test() {
+    const t0 = Date.now();
+    await new Promise((accept) => setTimeout(accept, 100));
+    const t1 = Date.now();
+    ok(t1 - t0 >= 100 - JITTER, `Received a difference of ${t1 - t0}`);
+    await new Promise((accept) => setTimeout(accept, 100));
+    const t2 = Date.now();
+    ok(t2 - t1 >= 100 - JITTER, `Received a difference of ${t2 - t1}`);
+  },
+};

--- a/src/workerd/api/tests/settimeout-test.wd-test
+++ b/src/workerd/api/tests/settimeout-test.wd-test
@@ -1,0 +1,14 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "settimeout-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "settimeout-test.js")
+        ],
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -332,6 +332,7 @@ class TestServer final: private kj::Filesystem, private kj::EntropySource, priva
         timer(kj::origin<kj::TimePoint>()),
         server(*this,
             timer,
+            timer,
             mockNetwork,
             *this,
             Worker::LoggingOptions(consoleMode),

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -175,12 +175,14 @@ void throwDynamicEntrypointTransferError() {
 
 Server::Server(kj::Filesystem& fs,
     kj::Timer& timer,
+    const kj::MonotonicClock& monotonicClock,
     kj::Network& network,
     kj::EntropySource& entropySource,
     Worker::LoggingOptions loggingOptions,
     kj::Function<void(kj::String)> reportConfigError)
     : fs(fs),
       timer(timer),
+      monotonicClock(monotonicClock),
       network(network),
       entropySource(entropySource),
       reportConfigError(kj::mv(reportConfigError)),
@@ -1886,6 +1888,7 @@ class Server::WorkerService final: public Service,
   WorkerService(ChannelTokenHandler& channelTokenHandler,
       kj::Maybe<kj::StringPtr> serviceName,
       ThreadContext& threadContext,
+      const kj::MonotonicClock& monotonicClock,
       kj::Own<const Worker> worker,
       kj::Maybe<kj::HashSet<kj::String>> defaultEntrypointHandlers,
       kj::HashMap<kj::String, kj::HashSet<kj::String>> namedEntrypoints,
@@ -1897,6 +1900,7 @@ class Server::WorkerService final: public Service,
       : channelTokenHandler(channelTokenHandler),
         serviceName(serviceName),
         threadContext(threadContext),
+        monotonicClock(monotonicClock),
         ioChannels(kj::mv(linkCallback)),
         worker(kj::mv(worker)),
         defaultEntrypointHandlers(kj::mv(defaultEntrypointHandlers)),
@@ -3124,6 +3128,7 @@ class Server::WorkerService final: public Service,
   kj::Maybe<kj::StringPtr> serviceName;
 
   ThreadContext& threadContext;
+  const kj::MonotonicClock& monotonicClock;
 
   // LinkedIoChannels owns the SqliteDatabase::Vfs, so make sure it is destroyed last.
   kj::OneOf<LinkCallback, LinkedIoChannels> ioChannels;
@@ -3381,7 +3386,15 @@ class Server::WorkerService final: public Service,
   }
 
   kj::Promise<void> atTime(kj::Date when) override {
-    return threadContext.getUnsafeTimer().afterDelay(when - now());
+    auto delay = when - now();
+    // We can't use `afterDelay(delay)` here because kj::Timer::afterDelay() is equivalent to
+    // `atTime(timer.now() + delay)`, and kj::Timer::now() only advances when the event loop
+    // polls for I/O. If JavaScript executed for a significant amount of time since the last
+    // poll (e.g. compiling/running a script before the first setTimeout), timer.now() will be
+    // stale and the delay will effectively be shortened by that staleness, causing the timer
+    // to fire too early. Instead, we compute the target time using a fresh reading from the
+    // monotonic clock so the delay is measured from the actual present.
+    return threadContext.getUnsafeTimer().atTime(monotonicClock.now() + delay);
   }
 
   kj::Promise<void> afterLimitTimeout(kj::Duration t) override {
@@ -4721,10 +4734,10 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
   if (!def.isDynamic) serviceName = name;
 
   auto result = kj::refcounted<WorkerService>(channelTokenHandler, serviceName,
-      globalContext->threadContext, kj::mv(worker), kj::mv(errorReporter.defaultEntrypoint),
-      kj::mv(errorReporter.namedEntrypoints), kj::mv(errorReporter.actorClasses),
-      kj::mv(linkCallback), KJ_BIND_METHOD(*this, abortAllActors), kj::mv(dockerPath),
-      def.isDynamic);
+      globalContext->threadContext, monotonicClock, kj::mv(worker),
+      kj::mv(errorReporter.defaultEntrypoint), kj::mv(errorReporter.namedEntrypoints),
+      kj::mv(errorReporter.actorClasses), kj::mv(linkCallback),
+      KJ_BIND_METHOD(*this, abortAllActors), kj::mv(dockerPath), def.isDynamic);
   result->initActorNamespaces(def.localActorConfigs, network);
   co_return result;
 }
@@ -5875,7 +5888,7 @@ kj::Promise<bool> Server::test(jsg::V8System& v8System,
     //   stderr wouldn't work.
     KJ_LOG(DBG, kj::str("[ TEST ] "_kj, name));
     auto req = service.startRequest({});
-    auto start = kj::systemPreciseMonotonicClock().now();
+    auto start = monotonicClock.now();
 
     bool result = co_await req->test();
     if (result) {
@@ -5884,7 +5897,7 @@ kj::Promise<bool> Server::test(jsg::V8System& v8System,
       ++failCount;
     }
 
-    auto end = kj::systemPreciseMonotonicClock().now();
+    auto end = monotonicClock.now();
     auto duration = end - start;
 
     KJ_LOG(DBG, kj::str(result ? "[ PASS ] "_kj : "[ FAIL ] "_kj, name, " (", duration, ")"));

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -38,6 +38,7 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
  public:
   Server(kj::Filesystem& fs,
       kj::Timer& timer,
+      const kj::MonotonicClock& monotonicClock,
       kj::Network& network,
       kj::EntropySource& entropySource,
       Worker::LoggingOptions loggingOptions,
@@ -134,6 +135,9 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
  private:
   kj::Filesystem& fs;
   kj::Timer& timer;
+  // monotonicClock must produce time values consistent with those produced by timer whenever
+  // timer updates, but monotonicClock updates continuously (not just when system I/O is polled).
+  const kj::MonotonicClock& monotonicClock;
   kj::Network& network;
   kj::EntropySource& entropySource;
   kj::Function<void(kj::String)> reportConfigError;

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -685,6 +685,7 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
         argv(argv),
         server(kj::heap<Server>(*fs,
             io.provider->getTimer(),
+            kj::systemPreciseMonotonicClock(),
             network,
             entropySource,
             Worker::LoggingOptions(Worker::ConsoleMode::STDOUT),


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/6019

WorkerService::atTime() was scheduling timers using kj::Timer::afterDelay(delay), which internally computes the target time as timer.now() + delay. However, kj::Timer::now() only updates when the event loop polls for I/O — it stays frozen while JavaScript is executing. If significant CPU time elapsed since the last poll (e.g. compiling and running a script before the first setTimeout), timer.now() would be stale by that amount, causing afterDelay() to schedule the timer at a target time that was effectively in the past relative to the real monotonic clock. This made the first setTimeout(fn, 100) resolve in as little as 1ms of wall-clock time, while subsequent calls (which ran after the event loop had polled and refreshed the timer) worked correctly. 