### PR TITLE
Add compat flag that causes deleteAll to delete alarms as well as data

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -568,7 +568,10 @@ jsg::Promise<void> DurableObjectStorage::deleteAll(
   auto traceContext = context.makeUserTraceSpan("durable_object_storage_deleteAll"_kjc);
   auto options = configureOptions(kj::mv(maybeOptions).orDefault(PutOptions{}));
 
-  auto deleteAll = cache->deleteAll(options, context.getCurrentTraceSpan());
+  DeleteAllOptions deleteAllOptions{
+    .deleteAlarm = FeatureFlags::get(js).getDeleteAllDeletesAlarm(),
+  };
+  auto deleteAll = cache->deleteAll(options, context.getCurrentTraceSpan(), deleteAllOptions);
 
   context.addTask(updateStorageDeletes(context, currentActorMetrics(), kj::mv(deleteAll.count)));
 

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -14,6 +14,12 @@ wd_test(
 )
 
 wd_test(
+    src = "delete-all-deletes-alarm-test.wd-test",
+    args = ["--experimental"],
+    data = ["delete-all-deletes-alarm-test.js"],
+)
+
+wd_test(
     src = "actor-alarms-test.wd-test",
     args = ["--experimental"],
     data = ["actor-alarms-test.js"],

--- a/src/workerd/api/tests/delete-all-deletes-alarm-test.js
+++ b/src/workerd/api/tests/delete-all-deletes-alarm-test.js
@@ -1,0 +1,70 @@
+// Tests that the delete_all_deletes_alarm compat flag correctly controls whether
+// deleteAll() also deletes alarms. This file is used by two test services: one
+// with the flag enabled and one with it disabled. The EXPECT_ALARM_DELETED binding
+// tells this code which behavior to expect.
+
+import * as assert from 'node:assert';
+
+export class DurableObjectExample {
+  constructor(state) {
+    this.state = state;
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    const expectDeleted = url.searchParams.get('expectDeleted') === 'true';
+
+    // Set an alarm for 10 minutes from now.
+    const alarmTime = Date.now() + 10 * 60 * 1000;
+    await this.state.storage.setAlarm(alarmTime);
+    assert.equal(await this.state.storage.getAlarm(), alarmTime);
+
+    // Also put some KV data so deleteAll has something to delete.
+    await this.state.storage.put('key', 'value');
+
+    // Call deleteAll().
+    await this.state.storage.deleteAll();
+
+    // KV data should always be deleted.
+    assert.equal(await this.state.storage.get('key'), undefined);
+
+    const alarmAfter = await this.state.storage.getAlarm();
+
+    if (expectDeleted) {
+      // With the compat flag enabled, the alarm should be deleted.
+      assert.equal(
+        alarmAfter,
+        null,
+        `Expected alarm to be null after deleteAll(), got ${alarmAfter}`
+      );
+    } else {
+      // Without the compat flag, the alarm should be preserved.
+      assert.equal(
+        alarmAfter,
+        alarmTime,
+        `Expected alarm to be preserved after deleteAll(), got ${alarmAfter}`
+      );
+      // Clean up the alarm so it doesn't fire during the test.
+      await this.state.storage.deleteAlarm();
+    }
+
+    return new Response('OK');
+  }
+
+  async alarm() {
+    // Should not be invoked during the test.
+    throw new Error('alarm handler unexpectedly invoked');
+  }
+}
+
+export const test = {
+  async test(ctrl, env, ctx) {
+    let id = env.ns.idFromName('A');
+    let obj = env.ns.get(id);
+    let res = await obj.fetch(
+      `http://foo/test?expectDeleted=${env.EXPECT_ALARM_DELETED}`
+    );
+    let text = await res.text();
+    assert.equal(text, 'OK');
+  },
+};

--- a/src/workerd/api/tests/delete-all-deletes-alarm-test.wd-test
+++ b/src/workerd/api/tests/delete-all-deletes-alarm-test.wd-test
@@ -1,0 +1,38 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "delete-all-deletes-alarm-enabled",
+      worker = (
+        modules = [
+          ( name = "worker", esModule = embed "delete-all-deletes-alarm-test.js" )
+        ],
+        compatibilityFlags = ["experimental", "nodejs_compat", "delete_all_deletes_alarm"],
+        durableObjectNamespaces = [
+          (className = "DurableObjectExample", uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e"),
+        ],
+        durableObjectStorage = (inMemory = void),
+        bindings = [
+          (name = "ns", durableObjectNamespace = "DurableObjectExample"),
+          (name = "EXPECT_ALARM_DELETED", text = "true"),
+        ],
+      )
+    ),
+    ( name = "delete-all-preserves-alarm-disabled",
+      worker = (
+        modules = [
+          ( name = "worker", esModule = embed "delete-all-deletes-alarm-test.js" )
+        ],
+        compatibilityFlags = ["experimental", "nodejs_compat", "delete_all_preserves_alarm"],
+        durableObjectNamespaces = [
+          (className = "DurableObjectExample", uniqueKey = "310bd0cbd803ef7883a1ee9d86cce06f"),
+        ],
+        durableObjectStorage = (inMemory = void),
+        bindings = [
+          (name = "ns", durableObjectNamespace = "DurableObjectExample"),
+          (name = "EXPECT_ALARM_DELETED", text = "false"),
+        ],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/actor-sqlite-test.c++
+++ b/src/workerd/io/actor-sqlite-test.c++
@@ -1341,6 +1341,170 @@ KJ_TEST("calling deleteAll() during an implicit transaction preserves alarm stat
   KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
 }
 
+KJ_TEST("deleteAll with deleteAlarm option deletes alarm") {
+  // Tests that deleteAll() with deleteAlarm=true deletes the alarm along with KV data,
+  // instead of preserving the alarm as it does by default.
+  ActorSqliteTest test;
+
+  // Initialize alarm state to 1ms.
+  test.setAlarm(oneMs);
+  test.pollAndExpectCalls({"scheduleRun(1ms)"})[0]->fulfill();
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+  KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
+
+  // Call deleteAll() with deleteAlarm=true.
+  ActorCache::DeleteAllResults results = test.actor.deleteAll({}, nullptr, {.deleteAlarm = true});
+
+  // The alarm should now be deleted.
+  KJ_ASSERT(expectSync(test.getAlarm()) == kj::none);
+
+  // Commit should include scheduling the alarm cancellation.
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({"scheduleRun(none)"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+
+  KJ_ASSERT(results.count.wait(test.ws) == 0);
+  KJ_ASSERT(expectSync(test.getAlarm()) == kj::none);
+}
+
+KJ_TEST("deleteAll without deleteAlarm option preserves alarm") {
+  // Tests that deleteAll() without deleteAlarm (the default) preserves the alarm,
+  // which is the existing behavior.
+  ActorSqliteTest test;
+
+  // Initialize alarm state to 1ms.
+  test.setAlarm(oneMs);
+  test.pollAndExpectCalls({"scheduleRun(1ms)"})[0]->fulfill();
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+  KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
+
+  // Call deleteAll() without deleteAlarm (default behavior).
+  ActorCache::DeleteAllResults results = test.actor.deleteAll({}, nullptr);
+
+  // The alarm should be preserved.
+  KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
+
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+
+  KJ_ASSERT(results.count.wait(test.ws) == 0);
+  KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
+}
+
+KJ_TEST("deleteAll with deleteAlarm during alarm handler cancels deferred delete") {
+  // Tests that calling deleteAll() with deleteAlarm=true while an alarm handler is running
+  // correctly deletes the alarm and cancels the deferred alarm deletion (haveDeferredDelete).
+  // When the handler's DeferredAlarmDeleter is dropped, it should NOT write a null alarm row
+  // since deleteAll already handled the deletion.
+  ActorSqliteTest test;
+
+  // Initialize alarm state to 1ms.
+  test.setAlarm(oneMs);
+  test.pollAndExpectCalls({"scheduleRun(1ms)"})[0]->fulfill();
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+  KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
+
+  {
+    auto armResult = test.actor.armAlarmHandler(oneMs, nullptr, testCurrentTime);
+    KJ_ASSERT(armResult.is<ActorSqlite::RunAlarmHandler>());
+
+    // During the handler, getAlarm() should return none (deferred delete is active).
+    KJ_ASSERT(expectSync(test.getAlarm()) == kj::none);
+
+    // Call deleteAll() with deleteAlarm=true while the handler is running.
+    auto results = test.actor.deleteAll({}, nullptr, {.deleteAlarm = true});
+
+    // getAlarm() should still return none.
+    KJ_ASSERT(expectSync(test.getAlarm()) == kj::none);
+
+    // Drop the DeferredAlarmDeleter (simulating handler success). Since deleteAll already
+    // cleared haveDeferredDelete, this should NOT write to the metadata table.
+  }
+
+  // The deleteAll commit should go through commitImpl(), which detects the alarm moved to none
+  // and schedules the cancellation.
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({"scheduleRun(none)"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+
+  KJ_ASSERT(expectSync(test.getAlarm()) == kj::none);
+}
+
+KJ_TEST("deleteAll without deleteAlarm during alarm handler still has deferred delete") {
+  // Tests that calling deleteAll() without deleteAlarm while an alarm handler is running
+  // restores the alarm in metadata but leaves haveDeferredDelete active. When the handler
+  // finishes, the deferred deletion deletes the restored alarm.
+  ActorSqliteTest test;
+
+  // Initialize alarm state to 1ms.
+  test.setAlarm(oneMs);
+  test.pollAndExpectCalls({"scheduleRun(1ms)"})[0]->fulfill();
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+  KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
+
+  {
+    auto armResult = test.actor.armAlarmHandler(oneMs, nullptr, testCurrentTime);
+    KJ_ASSERT(armResult.is<ActorSqlite::RunAlarmHandler>());
+
+    // During the handler, getAlarm() should return none (deferred delete is active).
+    KJ_ASSERT(expectSync(test.getAlarm()) == kj::none);
+
+    // Call deleteAll() without deleteAlarm while the handler is running.
+    // This restores the alarm in metadata, but haveDeferredDelete is still true.
+    test.actor.deleteAll({}, nullptr);
+
+    // getAlarm() still returns none because haveDeferredDelete is still active.
+    KJ_ASSERT(expectSync(test.getAlarm()) == kj::none);
+
+    // Drop the DeferredAlarmDeleter (simulating handler success). This triggers
+    // maybeDeleteDeferredAlarm() which deletes the restored alarm.
+  }
+
+  // The deleteAll commit goes first, then the deferred alarm deletion triggers its own commit
+  // with alarm scheduling.
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({"scheduleRun(none)"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+
+  KJ_ASSERT(expectSync(test.getAlarm()) == kj::none);
+}
+
+KJ_TEST("deleteAll deleteAlarm does not schedule alarm cancellation if setAlarm interleaves") {
+  ActorSqliteTest test;
+
+  // Initialize alarm state to 1ms.
+  test.setAlarm(oneMs);
+  test.pollAndExpectCalls({"scheduleRun(1ms)"})[0]->fulfill();
+  test.pollAndExpectCalls({"commit"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+  KJ_ASSERT(expectSync(test.getAlarm()) == oneMs);
+
+  // Start deleteAll with deleteAlarm=true and hold the commit.
+  test.actor.deleteAll({}, nullptr, {.deleteAlarm = true});
+  auto deleteAllCommit = kj::mv(test.pollAndExpectCalls({"commit"})[0]);
+
+  // While deleteAll commit is in-flight, set a later alarm.
+  test.setAlarm(twoMs);
+  auto setAlarmCommit = kj::mv(test.pollAndExpectCalls({"commit"})[0]);
+  test.pollAndExpectCalls({});
+  KJ_ASSERT(expectSync(test.getAlarm()) == twoMs);
+
+  // Completing the deleteAll commit should NOT schedule a cancel because setAlarm interleaved.
+  deleteAllCommit->fulfill();
+  test.pollAndExpectCalls({});
+
+  // Completing the setAlarm commit should schedule the new alarm time.
+  setAlarmCommit->fulfill();
+  test.pollAndExpectCalls({"scheduleRun(2ms)"})[0]->fulfill();
+  test.pollAndExpectCalls({});
+
+  KJ_ASSERT(expectSync(test.getAlarm()) == twoMs);
+}
+
 KJ_TEST("rolling back transaction leaves alarm in expected state") {
   ActorSqliteTest test;
 

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -756,7 +756,7 @@ kj::Own<ActorCacheInterface::Transaction> ActorSqlite::startTransaction() {
 }
 
 ActorCacheInterface::DeleteAllResults ActorSqlite::deleteAll(
-    WriteOptions options, SpanParent traceSpan) {
+    WriteOptions options, SpanParent traceSpan, DeleteAllOptions deleteAllOptions) {
   requireNotBroken();
   disableAllowUnconfirmed(options, "deleteAll is not supported");
 
@@ -764,8 +764,7 @@ ActorCacheInterface::DeleteAllResults ActorSqlite::deleteAll(
   currentCommitSpan = kj::mv(traceSpan);
 
   // kv.deleteAll() clears the database, so we need to save and possibly restore alarm state in
-  // the metadata table, to try to match the behavior of ActorCache, which preserves the set alarm
-  // when running deleteAll().
+  // the metadata table to maintain behavior from before the deleteAllDeletesAlarm compat flag.
   auto localAlarmState = metadata.getAlarm();
   if (localAlarmState != kj::none) {
     LOG_WARNING_PERIODICALLY("NOSENTRY deleteAll() called on ActorSqlite with an alarm still set");
@@ -813,7 +812,12 @@ ActorCacheInterface::DeleteAllResults ActorSqlite::deleteAll(
         // We don't want to commit the deletion without that transaction.
         return kj::READY_NOW;
       } else {
-        return commitCallback();
+        // Use commitImpl() rather than commitCallback() so that alarm scheduling is handled.
+        // This is important when deleteAll() deletes an alarm: commitImpl() detects that
+        // metadata.getAlarm() moved to kj::none and notifies the scheduler via
+        // requestScheduledAlarm(kj::none, ...).
+        auto precommitAlarmState = startPrecommitAlarmScheduling();
+        return commitImpl(kj::mv(precommitAlarmState), currentCommitSpan.addRef());
       }
     }),
         currentCommitSpan.addRef()));
@@ -822,19 +826,28 @@ ActorCacheInterface::DeleteAllResults ActorSqlite::deleteAll(
 
   uint count = kv.deleteAll();
 
-  // TODO(correctness): Since workerd doesn't have a separate durability step, in the unlikely
-  // event of a failure here, between deleteAll() and setAlarm(), we could theoretically lose the
-  // current alarm state when running under workerd.  Not sure if there's a practical way to avoid
-  // this.
-
   // Reset alarm state, if necessary.  If no alarm is set, OK to just leave metadata table
   // uninitialized.
   if (localAlarmState != kj::none) {
-    if (metadata.setAlarm(localAlarmState, options.allowUnconfirmed)) {
+    if (deleteAllOptions.deleteAlarm) {
+      // The caller wants the alarm deleted along with KV data. Since kv.deleteAll() already
+      // wiped the database (including the alarm metadata), metadata.getAlarm() will naturally
+      // return kj::none without creating any tables or rows. Increment alarmVersion so in‑flight
+      // commits don’t perform stale post‑commit alarm scheduling, and the deleteAll commit can sync
+      // cancellation.
       ++alarmVersion;
-      if (debugAlarmSync) {
-        KJ_LOG(WARNING, "NOSENTRY DEBUG_ALARM: deleteAll restored alarm", logDate(localAlarmState),
-            alarmVersion);
+      haveDeferredDelete = false;
+    } else {
+      // TODO(correctness): Since workerd doesn't have a separate durability step, in the unlikely
+      // event of a failure here, between deleteAll() and setAlarm(), we could theoretically lose the
+      // current alarm state when running under workerd.  Not sure if there's a practical way to avoid
+      // this.
+      if (metadata.setAlarm(localAlarmState, options.allowUnconfirmed)) {
+        ++alarmVersion;
+        if (debugAlarmSync) {
+          KJ_LOG(WARNING, "NOSENTRY DEBUG_ALARM: deleteAll restored alarm",
+              logDate(localAlarmState), alarmVersion);
+        }
       }
     }
   }

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -91,7 +91,8 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
   // See ActorCacheOps.
 
   kj::Own<ActorCacheInterface::Transaction> startTransaction() override;
-  DeleteAllResults deleteAll(WriteOptions options, SpanParent traceSpan) override;
+  DeleteAllResults deleteAll(
+      WriteOptions options, SpanParent traceSpan, DeleteAllOptions deleteAllOptions = {}) override;
   kj::Maybe<kj::Promise<void>> evictStale(kj::Date now) override;
   void shutdown(kj::Maybe<const kj::Exception&> maybeException) override;
   kj::OneOf<CancelAlarmHandler, RunAlarmHandler> armAlarmHandler(kj::Date scheduledTime,

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1386,4 +1386,14 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # When enabled, containers attached to Durable Objects do NOT share the host PID namespace
   # (they get their own isolated PID namespace). When disabled (the default), containers share
   # the host PID namespace.
+
+  deleteAllDeletesAlarm @161 :Bool
+    $compatEnableFlag("delete_all_deletes_alarm")
+    $compatDisableFlag("delete_all_preserves_alarm")
+    $compatEnableDate("2026-02-24");
+  # When enabled, calling storage.deleteAll() on a Durable Object also deletes
+  # any scheduled alarm, in addition to deleting all stored key-value data.
+  #
+  # Previously, deleteAll() preserved the alarm state. This was surprising
+  # behavior since the intent of deleteAll() is to clear all state.
 }


### PR DESCRIPTION
This has been requested on multiple occasions now and is a more reasonable default behavior than leaving alarms behind.

I was also able to structure things such that this leaves the object entirely empty after the deleteAll, which is a nice side effect.

---

This was largely done by Claude, although with a fair bit of back and forth and a handful of manual fixes. Here's the series of prompts used (excluding ones about minor things like running / fixing / addition extra tests), since that likely helps convey how things got here:

```
Currently when an actor / Durable Object calls deleteAll(), it deletes all of the stored data in the actor but does not delete the alarm if one is set/stored. We would like to change that, such that deleteAll deletes any scheduled alarm in addition to deleting all data. We want to do this for both storage engines available to Durable Objects. Can you please create an implementation plan for changing that behavior, gated behind a compatibility date?

The code you added allows the cache->setAlarm() call to overlap with the cache->deleteAll() call, but I'm worried that this is unsafe because it may be possible for the setAlarm() to complete and the deleteAll() to fail. Can you check through the code in ActorCache to confirm whether that's a possible problem?

Thanks! The new alarm deletion logic looks better. There's one thing I'm still curious about. For sqlite-backed actors, the alarm time is also stored in ActorStorage (which is backed by cockroachdb), which is responsible for ensuring the actor is woken up at the appropriate time. Two questions:
  1. Does the new code delete the alarm from ActorStorage?
  2. If not, what will happen when the alarm gets invoked at the time that's still stored in ActorStorage? Will the actor's constructor be run or will we notice that the alarm has been deleted before that?

Does calling setAlarm(kj::none, ...) cause the database to be non-empty after the deleteAll? It would really be preferable if the database state could be left entirely empty rather than writing a null alarm time row into it if that's what's now happening.

Can you please add test coverage for the case where an alarm handler is running (and thus there is a deferred delete) when deleteAll is called with the new compat flag set?

In the most recent workerd commit, a couple of tests were added relating to whether alarms are deleted when deleteAll is called in the durable object. Can you please add a test case to actor-cache-test that if the deleteAll request to storage fails that the alarm is not deleted?

I'm suspicious of the code in ActorCache::flushImplDeleteAll that sets the alarm time to null after the deleteAll has completed. What if the user's JS code called setAlarm() to some non-null time after deleteAll was called? It would be incorrect to null out the alarm in that case. Can you please a add a test that exercises this code path, where deleteAll is called with deleteAlarm=true but then setAlarm() is called before the deleteAlarm finishes?

Thanks! I notice that we're setting the currentAlarmTime to CLEAN in ActorCache::deleteAll, and that if we didn't then this fix wouldn't have been needed. Why do we need to set currentAlarmTime to CLEAN in ActorCache::deleteAll? Is that important for some other reason?
> yes this was needed to avoid deleting the alarm before calling flushImplDeleteAll

The latest commit appears to change the handling of requestedDeleteAll in ensureFlushScheduled when lru.options.neverFlush is true. Is that a meaningful change in behavior? Why do we need to add any requestedDeleteAll handling there beyond doing something with the deleteAlarm field?
> this was filling in missing functionality

// In a fresh instance for code review
Can you please review the current diff in this repository and the most recent two commits in the workerd submodule? The change is intended to provide a new compatibility flag that deletes any existing alarm when deleteAll is called on a Durable Object. It should ensure that the alarm is never deleted unless all the data has also been successfully deleted, and in the case of sqlite durable objects it should leave the database in an empty, uninitialized state.
```

@jclee @MellowYarker as the people who have touched the actor-sqlite.c++ alarm code the most, since I'm less familiar with that code. I'm quite familiar with the actor-cache code and feel good about how that looks after the multiple rounds of back and forth with claude. Just one of you reviewing should be sufficient though, I don't think it needs double review.