### PR TITLE
fix build warning on non-linux machines

### DIFF
--- a/src/workerd/tests/test-reprl.c++
+++ b/src/workerd/tests/test-reprl.c++
@@ -17,6 +17,7 @@ using bazel::tools::cpp::runfiles::Runfiles;
 namespace workerd {
 namespace {
 
+#ifdef __linux__
 void print_splitter() {
   printf("---------------------------------\n");
 }
@@ -61,6 +62,7 @@ void expect_failure(struct reprl_context* ctx, const char* code) {
     KJ_FAIL_REQUIRE("Execution unexpectedly succeeded", code);
   }
 }
+#endif  // __linux__
 
 KJ_TEST("REPRL basic functionality") {
 #ifdef __linux__


### PR DESCRIPTION
Fixes the build warning on non-linux machines

```
src/workerd/tests/test-reprl.c++:53:6: warning: unused function 'expect_success' [-Wunused-function]
   53 | void expect_success(struct reprl_context* ctx, const char* code) {
      |      ^~~~~~~~~~~~~~
src/workerd/tests/test-reprl.c++:59:6: warning: unused function 'expect_failure' [-Wunused-function]
   59 | void expect_failure(struct reprl_context* ctx, const char* code) {
      |      ^~~~~~~~~~~~~~
2 warnings generated. 
```