### PR TITLE
Log periodically when deleteAll is called with an alarm still set

### DIFF
--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -2056,6 +2056,12 @@ ActorCache::DeleteAllResults ActorCache::deleteAll(WriteOptions options, SpanPar
     evictOrOomIfNeeded(lock);
   }
 
+  KJ_IF_SOME(t, currentAlarmTime.tryGet<KnownAlarmTime>()) {
+    if (t.time != kj::none) {
+      LOG_WARNING_PERIODICALLY("NOSENTRY deleteAll() called on ActorCache with an alarm still set");
+    }
+  }
+
   return DeleteAllResults{.backpressure = getBackpressure(), .count = kj::mv(result)};
 }
 

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -767,6 +767,9 @@ ActorCacheInterface::DeleteAllResults ActorSqlite::deleteAll(
   // the metadata table, to try to match the behavior of ActorCache, which preserves the set alarm
   // when running deleteAll().
   auto localAlarmState = metadata.getAlarm();
+  if (localAlarmState != kj::none) {
+    LOG_WARNING_PERIODICALLY("NOSENTRY deleteAll() called on ActorSqlite with an alarm still set");
+  }
 
   // deleteAll() cannot be part of a transaction because it deletes the database altogether. So,
   // we have to close our transactions or fail.


### PR DESCRIPTION
This is a companion to the compatibility date being added in #6044, to gather more data on the prevalence of this happening.