### PR TITLE
EW-9330 Implement connect() handler

### DIFF
--- a/samples/tcp-ingress/README.md
+++ b/samples/tcp-ingress/README.md
@@ -1,0 +1,10 @@
+# REPL Server
+
+This sample contains a simple TCP server based on the connect() handler. When a connection gets
+established on port 8081, it simply pipes the input stream to the output.
+
+## How to use
+```
+./bazel-bin/src/workerd/server/workerd serve samples/tcp-ingress/config.capnp --experimental
+echo "Hello World!" | nc localhost 8081
+```

--- a/samples/tcp-ingress/config.capnp
+++ b/samples/tcp-ingress/config.capnp
@@ -1,0 +1,20 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const tcpIngressExample :Workerd.Config = (
+  services = [
+    (name = "main", worker = .worker),
+  ],
+
+  sockets = [
+    ( name = "http", address = "*:8080", http = (), service = "main" ),
+    ( name = "tcp", address = "*:8081", tcp = (), service = "main" )
+  ]
+);
+
+const worker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "worker.js")
+  ],
+  compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+  compatibilityDate = "2026-03-01",
+);

--- a/samples/tcp-ingress/worker.js
+++ b/samples/tcp-ingress/worker.js
@@ -1,0 +1,11 @@
+
+export default {
+  async fetch(req) {
+    return new Response("ok");
+  },
+
+  async connect(socket) {
+    // pipe the input stream to the output
+    await socket.readable.pipeTo(socket.writable);
+  }
+};

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -108,6 +108,7 @@ class DurableObject final: public Fetcher {
 
     JSG_TS_DEFINE(interface DurableObject {
       fetch(request: Request): Response | Promise<Response>;
+      connect?(socket: Socket): void | Promise<void>;
       alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
       webSocketMessage?(ws: WebSocket, message: string | ArrayBuffer): void | Promise<void>;
       webSocketClose?(ws: WebSocket, code: number, reason: string, wasClean: boolean): void | Promise<void>;
@@ -115,7 +116,7 @@ class DurableObject final: public Fetcher {
     });
     JSG_TS_OVERRIDE(
       type DurableObjectStub<T extends Rpc.DurableObjectBranded | undefined = undefined> =
-        Fetcher<T, "alarm" | "webSocketMessage" | "webSocketClose" | "webSocketError">
+        Fetcher<T, "alarm" | "connect" | "webSocketMessage" | "webSocketClose" | "webSocketError">
         & {
           readonly id: DurableObjectId;
           readonly name?: string;

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -15,6 +15,7 @@
 #endif
 #include <workerd/api/hibernatable-web-socket.h>
 #include <workerd/api/scheduled.h>
+#include <workerd/api/sockets.h>
 #include <workerd/api/system-streams.h>
 #include <workerd/api/trace.h>
 #include <workerd/api/util.h>
@@ -86,6 +87,7 @@ jsg::LenientOptional<T> mapAddRef(jsg::Lock& js, jsg::LenientOptional<T>& functi
 ExportedHandler ExportedHandler::clone(jsg::Lock& js) {
   return ExportedHandler{
     .fetch{mapAddRef(js, fetch)},
+    .connect{mapAddRef(js, connect)},
     .tail{mapAddRef(js, tail)},
     .trace{mapAddRef(js, trace)},
     .tailStream{mapAddRef(js, tailStream)},
@@ -116,6 +118,49 @@ ServiceWorkerGlobalScope::ServiceWorkerGlobalScope()
 void ServiceWorkerGlobalScope::clear() {
   removeAllHandlers();
   unhandledRejections.clear();
+}
+
+kj::Promise<void> ServiceWorkerGlobalScope::connect(kj::String host,
+    const kj::HttpHeaders& headers,
+    kj::AsyncIoStream& connection,
+    kj::HttpService::ConnectResponse& response,
+    Worker::Lock& lock,
+    kj::Maybe<ExportedHandler&> exportedHandler) {
+  ExportedHandler& eh = JSG_REQUIRE_NONNULL(exportedHandler, Error,
+      "Connect ingress is not currently supported with Service Workers syntax.");
+  KJ_REQUIRE(FeatureFlags::get(lock).getWorkerdExperimental(),
+      "connect handling requires the experimental flag.");
+
+  KJ_IF_SOME(handler, eh.connect) {
+    // Has a connect handler!
+    response.accept(200, "OK", headers);
+
+    // Using neuterable stream to manage lifetime of stream promises
+    auto ownConnection = newNeuterableIoStream(connection);
+
+    auto& ioContext = IoContext::current();
+    jsg::Lock& js = lock;
+
+    // TLS support is not implemented so far. Note that setupSocket() expects the domain parameter
+    // to be set to the expected host name using startTLS, so that it can be provided to the TLS
+    // callback, so we'd need to change that or figure out a way to get the host domain.
+    auto nullTlsStarter = kj::heap<kj::TlsStarterCallback>();
+    // We set isDefaultFetchPort to false here – sockets.c++ sets it for ports 443 and 8080 to
+    // provide a more descriptive error message for HTTP, but this is not relevant on the TCP server
+    // side.
+    jsg::Ref<Socket> jsSocket = setupSocket(js, kj::mv(ownConnection), kj::none, kj::none,
+        kj::mv(nullTlsStarter), SecureTransportKind::OFF, kj::none, false, kj::none);
+    // handleProxyStatus() is required to indicate that the socket was opened properly. Since the
+    // connection is already open at this point, exception handling is not required.
+    jsSocket->handleProxyStatus(js, kj::Promise<kj::Maybe<kj::Exception>>(kj::none));
+
+    kj::Maybe<SpanBuilder> span = ioContext.makeTraceSpan("connect_handler"_kjc);
+    auto promise = handler(js, kj::mv(jsSocket), eh.env.addRef(js), eh.getCtx());
+    return ioContext.awaitJs(js, kj::mv(promise)).attach(kj::mv(span));
+  }
+  lock.logWarningOnce("Received a connect event but we lack a handler. "
+                      "Did you remember to export a connect() function?");
+  JSG_FAIL_REQUIRE(Error, "Handler does not export a connect() function.");
 }
 
 kj::Promise<DeferredProxy<void>> ServiceWorkerGlobalScope::request(kj::HttpMethod method,

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -350,6 +350,10 @@ struct ExportedHandler {
       jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
   jsg::LenientOptional<jsg::Function<FetchHandler>> fetch;
 
+  using ConnectHandler = jsg::Promise<void>(
+      jsg::Ref<Socket> socket, jsg::Value env, jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
+  jsg::LenientOptional<jsg::Function<ConnectHandler>> connect;
+
   using TailHandler = kj::Promise<void>(kj::Array<jsg::Ref<TraceItem>> events,
       jsg::Value env,
       jsg::Optional<jsg::Ref<ExecutionContext>> ctx);
@@ -389,6 +393,7 @@ struct ExportedHandler {
   jsg::SelfRef self;
 
   JSG_STRUCT(fetch,
+      connect,
       tail,
       trace,
       tailStream,
@@ -406,6 +411,7 @@ struct ExportedHandler {
 
   JSG_STRUCT_TS_DEFINE(
     type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown, Props = unknown> = (request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>, env: Env, ctx: ExecutionContext<Props>) => Response | Promise<Response>;
+    type ExportedHandlerConnectHandler<Env = unknown, Props = unknown> = (socket: Socket, env: Env, ctx: ExecutionContext<Props>) => void | Promise<void>;
     type ExportedHandlerTailHandler<Env = unknown, Props = unknown> = (events: TraceItem[], env: Env, ctx: ExecutionContext<Props>) => void | Promise<void>;
     type ExportedHandlerTraceHandler<Env = unknown, Props = unknown> = (traces: TraceItem[], env: Env, ctx: ExecutionContext<Props>) => void | Promise<void>;
     type ExportedHandlerTailStreamHandler<Env = unknown, Props = unknown> = (event : TailStream.TailEvent<TailStream.Onset>, env: Env, ctx: ExecutionContext<Props>) => TailStream.TailEventHandlerType | Promise<TailStream.TailEventHandlerType>;
@@ -416,6 +422,7 @@ struct ExportedHandler {
   JSG_STRUCT_TS_OVERRIDE(<Env = unknown, QueueHandlerMessage = unknown, CfHostMetadata = unknown, Props = unknown> {
     email?: EmailExportedHandler<Env, Props>;
     fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata, Props>;
+    connect?: ExportedHandlerConnectHandler<Env, Props>;
     tail?: ExportedHandlerTailHandler<Env, Props>;
     trace?: ExportedHandlerTraceHandler<Env, Props>;
     tailStream?: ExportedHandlerTailStreamHandler<Env, Props>;
@@ -514,6 +521,14 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
       kj::Maybe<jsg::Ref<AbortSignal>> abortSignal);
   // TODO(cleanup): Factor out the shared code used between old-style event listeners vs. module
   //   exports and move that code somewhere more appropriate.
+
+  // Received TCP/socket ingress (called from C++, not JS).
+  kj::Promise<void> connect(kj::String host,
+      const kj::HttpHeaders& headers,
+      kj::AsyncIoStream& connection,
+      kj::HttpService::ConnectResponse& response,
+      Worker::Lock& lock,
+      kj::Maybe<ExportedHandler&> exportedHandler);
 
   // Received sendTraces (called from C++, not JS).
   void sendTraces(kj::ArrayPtr<kj::Own<Trace>> traces,

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -84,11 +84,11 @@ class StreamWorkerInterface;
 
 jsg::Ref<Socket> setupSocket(jsg::Lock& js,
     kj::Own<kj::AsyncIoStream> connection,
-    kj::String remoteAddress,
+    kj::Maybe<kj::String> remoteAddress,
     jsg::Optional<SocketOptions> options,
     kj::Own<kj::TlsStarterCallback> tlsStarter,
     SecureTransportKind secureTransport,
-    kj::String domain,
+    kj::Maybe<kj::String> domain,
     bool isDefaultFetchPort,
     kj::Maybe<jsg::PromiseResolverPair<SocketInfo>> maybeOpenedPrPair) {
   auto& ioContext = IoContext::current();
@@ -323,10 +323,10 @@ jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOp
       secureTransport != SecureTransportKind::ON, TypeError, "Cannot startTls on a TLS socket.");
   JSG_REQUIRE(connectionData != kj::none, TypeError,
       "The connection was closed before startTls could be started.");
-  JSG_REQUIRE(domain != nullptr, TypeError, "startTls can only be called once.");
   auto invalidOptKindMsg =
       "The `secureTransport` socket option must be set to 'starttls' for startTls to be used.";
   JSG_REQUIRE(secureTransport == SecureTransportKind::STARTTLS, TypeError, invalidOptKindMsg);
+  JSG_REQUIRE(domain != kj::none, TypeError, "startTls can only be called once.");
 
   // The current socket's writable buffers need to be flushed. The socket's WritableStream is backed
   // by an AsyncIoStream which doesn't implement any buffering, so we don't need to worry about
@@ -346,10 +346,10 @@ jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOp
           // flush to complete. While it is unlikely to be GC'd while we are waiting because
           // the user code *likely* is holding a active reference to it at this point, we
           // don't want to take any chances. This prevents a possible UAF.
-          JSG_VISITABLE_LAMBDA(
-              (self = JSG_THIS, domain = kj::heapString(domain), tlsOptions = kj::mv(tlsOptions),
-                  openedResolver = openedPrPair.resolver.addRef(js),
-                  remoteAddress = kj::str(remoteAddress)),
+          JSG_VISITABLE_LAMBDA((self = JSG_THIS, domain = kj::heapString(KJ_ASSERT_NONNULL(domain)),
+                                   tlsOptions = kj::mv(tlsOptions),
+                                   openedResolver = openedPrPair.resolver.addRef(js),
+                                   remoteAddress = mapCopyString(remoteAddress)),
               (self, openedResolver), (jsg::Lock & js) mutable {
                 auto& context = IoContext::current();
 
@@ -381,7 +381,7 @@ jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOp
 
                 // Fork the starter promise because we need to create two separate things waiting
                 // on it below. The first is resolving the openedResolver with a JS promise that
-                // wraps one branch, the secnod is the kj::Promise that we use to resolve the
+                // wraps one branch, the second is the kj::Promise that we use to resolve the
                 // secureStream for the promised stream. This keeps us from having to bounce in and
                 // out of the JS isolate lock.
                 auto forkedPromise = KJ_ASSERT_NONNULL(*tlsStarter)(acceptedHostname).fork();
@@ -410,9 +410,9 @@ jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOp
   // The existing tlsStarter gets consumed and we won't need it again. Pass in an empty tlsStarter
   // to `setupSocket`.
   auto newTlsStarter = kj::heap<kj::TlsStarterCallback>();
-  return setupSocket(js, kj::newPromisedStream(kj::mv(secureStreamPromise)), kj::str(remoteAddress),
-      kj::mv(options), kj::mv(newTlsStarter), SecureTransportKind::ON, kj::mv(domain),
-      isDefaultFetchPort, kj::mv(openedPrPair));
+  return setupSocket(js, kj::newPromisedStream(kj::mv(secureStreamPromise)),
+      mapCopyString(remoteAddress), kj::mv(options), kj::mv(newTlsStarter), SecureTransportKind::ON,
+      kj::mv(domain), isDefaultFetchPort, kj::mv(openedPrPair));
 }
 
 void Socket::handleProxyStatus(
@@ -436,7 +436,7 @@ void Socket::handleProxyStatus(
       if (isDefaultFetchPort) {
         msg = kj::str(msg, ". It looks like you might be trying to connect to a HTTP-based service",
             " — consider using fetch instead");
-      } else if (remoteAddress.contains(".hyperdrive.local"_kj)) {
+      } else if (remoteAddress.orDefault(kj::String()).contains(".hyperdrive.local"_kj)) {
         // No attempts to connect to Hyperdrive should end up here, since they go through the other
         // version of handleProxyStatus. If they end up here somehow, log about it to get some
         // context that can aid in debugging.
@@ -450,7 +450,7 @@ void Socket::handleProxyStatus(
       // because there's no useful value we can provide.
       openedResolver.resolve(js,
           SocketInfo{
-            .remoteAddress = kj::str(remoteAddress),
+            .remoteAddress = mapCopyString(remoteAddress),
             .localAddress = kj::none,
           });
     }
@@ -478,7 +478,7 @@ void Socket::handleProxyStatus(jsg::Lock& js, kj::Promise<kj::Maybe<kj::Exceptio
       // because there's no useful value we can provide.
       openedResolver.resolve(js,
           SocketInfo{
-            .remoteAddress = kj::str(remoteAddress),
+            .remoteAddress = mapCopyString(remoteAddress),
             .localAddress = kj::none,
           });
     }

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -60,7 +60,7 @@ class Socket: public jsg::Object {
   Socket(jsg::Lock& js,
       IoContext& context,
       kj::Own<kj::RefcountedWrapper<kj::Own<kj::AsyncIoStream>>> connectionStream,
-      kj::String remoteAddress,
+      kj::Maybe<kj::String> remoteAddress,
       jsg::Ref<ReadableStream> readableParam,
       jsg::Ref<WritableStream> writable,
       jsg::PromiseResolverPair<void> closedPrPair,
@@ -68,7 +68,7 @@ class Socket: public jsg::Object {
       jsg::Optional<SocketOptions> options,
       kj::Own<kj::TlsStarterCallback> tlsStarter,
       SecureTransportKind secureTransport,
-      kj::String domain,
+      kj::Maybe<kj::String> domain,
       bool isDefaultFetchPort,
       jsg::PromiseResolverPair<SocketInfo> openedPrPair)
       : connectionData(context.addObject(kj::heap<ConnectionData>(
@@ -200,12 +200,12 @@ class Socket: public jsg::Object {
   // Memoized copy that is returned by the `closed` attribute.
   jsg::MemoizedIdentity<jsg::Promise<void>> closedPromise;
   jsg::Optional<SocketOptions> options;
-  kj::String remoteAddress;
+  kj::Maybe<kj::String> remoteAddress;
   // Set to true when the socket is upgraded to a secure one.
   bool upgraded = false;
   SecureTransportKind secureTransport;
   // The domain/ip this socket is connected to. Used for startTls.
-  kj::String domain;
+  kj::Maybe<kj::String> domain;
   // Whether the port this socket connected to is 80/443. Used for nicer errors.
   bool isDefaultFetchPort;
   // This fulfiller is used to resolve the `openedPromise` below.
@@ -245,11 +245,11 @@ class Socket: public jsg::Object {
 
 jsg::Ref<Socket> setupSocket(jsg::Lock& js,
     kj::Own<kj::AsyncIoStream> connection,
-    kj::String remoteAddress,
+    kj::Maybe<kj::String> remoteAddress,
     jsg::Optional<SocketOptions> options,
     kj::Own<kj::TlsStarterCallback> tlsStarter,
     SecureTransportKind secureTransport,
-    kj::String domain,
+    kj::Maybe<kj::String> domain,
     bool isDefaultFetchPort,
     kj::Maybe<jsg::PromiseResolverPair<SocketInfo>> maybeOpenedPrPair);
 

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -20,6 +20,18 @@ wd_test(
 )
 
 wd_test(
+    src = "connect-handler-test.wd-test",
+    args = ["--experimental"],
+    data = [
+        "connect-handler-test.js",
+        "connect-handler-test-proxy.js",
+    ],
+    # Test uses TCP sockets for ports 8081-8083 and may fail when running concurrently with other
+    # tests that do so.
+    tags = ["exclusive"],
+)
+
+wd_test(
     src = "actor-alarms-test.wd-test",
     args = ["--experimental"],
     data = ["actor-alarms-test.js"],
@@ -42,7 +54,10 @@ wd_test(
         "tail-worker-test-invalid.js",
         "tail-worker-test-jsrpc.js",
         "websocket-hibernation.js",
+        "connect-handler-test.js",
+        "connect-handler-test-proxy.js",
     ],
+    tags = ["exclusive"],
 )
 
 # Test to validate timing semantics for JSRPC streaming responses.
@@ -333,6 +348,7 @@ wd_test(
     src = "js-rpc-test.wd-test",
     args = ["--experimental"],
     data = ["js-rpc-test.js"],
+    tags = ["exclusive"],
 )
 
 wd_test(
@@ -583,6 +599,7 @@ wd_test(
         "--no-verbose",
     ],
     data = ["js-rpc-test.js"],
+    tags = ["exclusive"],
 )
 
 wd_test(

--- a/src/workerd/api/tests/connect-handler-test-proxy.js
+++ b/src/workerd/api/tests/connect-handler-test-proxy.js
@@ -1,0 +1,22 @@
+import { connect } from 'cloudflare:sockets';
+import { WorkerEntrypoint } from 'cloudflare:workers';
+
+export class ConnectProxy extends WorkerEntrypoint {
+  async connect(socket) {
+    // proxy for ConnectEndpoint instance on port 8083.
+    let upstream = connect('localhost:8083');
+    await Promise.all([
+      socket.readable.pipeTo(upstream.writable),
+      upstream.readable.pipeTo(socket.writable),
+    ]);
+  }
+}
+
+export class ConnectEndpoint extends WorkerEntrypoint {
+  async connect(socket) {
+    const enc = new TextEncoder();
+    let writer = socket.writable.getWriter();
+    await writer.write(enc.encode('hello-from-endpoint'));
+    await writer.close();
+  }
+}

--- a/src/workerd/api/tests/connect-handler-test.js
+++ b/src/workerd/api/tests/connect-handler-test.js
@@ -1,0 +1,45 @@
+import { connect } from 'cloudflare:sockets';
+import { ok, strictEqual } from 'assert';
+
+export const connectHandler = {
+  async test() {
+    // Check that the connect handler can send a message through a socket
+    const socket = connect('localhost:8081');
+    await socket.opened;
+    const dec = new TextDecoder();
+    let result = '';
+    for await (const chunk of socket.readable) {
+      result += dec.decode(chunk, { stream: true });
+    }
+    result += dec.decode();
+    strictEqual(result, 'hello');
+    await socket.closed;
+  },
+};
+
+export const connectHandlerProxy = {
+  async test() {
+    // Check that we can get a message proxied through a connect handler. This call connects us with
+    // an instance of Server, which serves as a proxy for an instance of OtherServer, as defined in
+    // connect-handler-test-proxy.js.
+    const socket = connect('localhost:8082');
+    await socket.opened;
+    const dec = new TextDecoder();
+    let result = '';
+    for await (const chunk of socket.readable) {
+      result += dec.decode(chunk, { stream: true });
+    }
+    result += dec.decode();
+    strictEqual(result, 'hello-from-endpoint');
+    await socket.closed;
+  },
+};
+
+export default {
+  async connect(socket) {
+    const enc = new TextEncoder();
+    let writer = socket.writable.getWriter();
+    await writer.write(enc.encode('hello'));
+    await writer.close();
+  },
+};

--- a/src/workerd/api/tests/connect-handler-test.wd-test
+++ b/src/workerd/api/tests/connect-handler-test.wd-test
@@ -1,0 +1,36 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "connect-handler-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "connect-handler-test.js"),
+        ],
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+      )
+    ),
+    ( name = "connect-handler-test-proxy",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "connect-handler-test-proxy.js"),
+        ],
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+      )
+    ),
+    ( name = "connect-handler-test-endpoint",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "connect-handler-test-proxy.js"),
+        ],
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+      )
+    ),
+    ( name = "internet", network = ( allow = ["private"] ) )
+  ],
+  sockets = [
+    (name = "tcp", address = "*:8081", tcp = (), service = "connect-handler-test"),
+    (name = "tcp", address = "*:8082", tcp = (), service = (name = "connect-handler-test-proxy", entrypoint = "ConnectProxy")),
+    (name = "tcp", address = "*:8083", tcp = (), service = (name = "connect-handler-test-endpoint", entrypoint = "ConnectEndpoint"))
+  ]
+);

--- a/src/workerd/api/tests/js-rpc-socket-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-socket-test.wd-test
@@ -72,6 +72,7 @@ const unitTests :Workerd.Config = (
         http = (capnpConnectHost = "cappy")
       )
     ),
+    ( name = "internet", network = ( allow = ["private"] ) ),
   ],
   sockets = [
     ( name = "MyService-loop",
@@ -99,6 +100,8 @@ const unitTests :Workerd.Config = (
       service = (name = "js-rpc-test", entrypoint = "GreeterFactory"),
       http = (capnpConnectHost = "cappy")
     ),
+    # For testing connect() handler
+    (name = "tcp", address = "*:8081", tcp = (), service = "js-rpc-test")
   ],
   v8Flags = [ "--expose-gc" ],
 );

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -194,6 +194,13 @@ export class MyService extends WorkerEntrypoint {
     return new Response('method = ' + req.method + ', url = ' + req.url);
   }
 
+  async connect(socket) {
+    const enc = new TextEncoder();
+    let writer = socket.writable.getWriter();
+    await writer.write(enc.encode('hello'));
+    await writer.close();
+  }
+
   // Define a property to test behavior of property accessors.
   get nonFunctionProperty() {
     return { foo: 123 };
@@ -629,6 +636,20 @@ export let extendingEntrypointClasses = {
     // Verify that we can instantiate classes that inherit built-in classes.
     let svc = new MyService(ctx, env);
     assert.equal(svc instanceof WorkerEntrypoint, true);
+  },
+};
+export let connectBinding = {
+  async test(controller, env, ctx) {
+    let socket = await env.MyService.connect('localhost:8081');
+    await socket.opened;
+    const dec = new TextDecoder();
+    let result = '';
+    for await (const chunk of socket.readable) {
+      result += dec.decode(chunk, { stream: true });
+    }
+    result += dec.decode();
+    assert.strictEqual(result, 'hello');
+    await socket.closed;
   },
 };
 

--- a/src/workerd/api/tests/tail-worker-test-receiver.js
+++ b/src/workerd/api/tests/tail-worker-test-receiver.js
@@ -32,7 +32,7 @@ export const test = {
 
     // The shared tail worker we configured only produces onset and outcome events, so every trace is identical here.
     // Number of traces based on how often main tail worker is invoked from previous tests
-    let numTraces = 28;
+    let numTraces = 31;
     let basicTrace =
       '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"trace","traces":[]}}{"type":"return"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}';
     assert.deepStrictEqual(

--- a/src/workerd/api/tests/tail-worker-test.js
+++ b/src/workerd/api/tests/tail-worker-test.js
@@ -131,6 +131,10 @@ export const test = {
       // Test for transient objects - getCounter returns an object with methods
       // All transient calls happen in a single trace event, with only the entrypoint method reported
       '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["getCounter called"]}{"type":"return"}{"type":"log","level":"log","message":["increment called on transient"]}{"type":"log","level":"log","message":["getValue called on transient"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      // tests/connect-handler-test.js: connect events
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"connectHandler","scriptTags":[],"info":{"type":"custom"}}{"type":"spanOpen","name":"connect","spanId":"0000000000000001"}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"connect"}}{"type":"return"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+      '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"connectHandlerProxy","scriptTags":[],"info":{"type":"custom"}}{"type":"spanOpen","name":"connect","spanId":"0000000000000001"}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
     ];
 
     assert.deepStrictEqual(response, expected);

--- a/src/workerd/api/tests/tail-worker-test.wd-test
+++ b/src/workerd/api/tests/tail-worker-test.wd-test
@@ -32,6 +32,32 @@ const unitTests :Workerd.Config = (
     (name = "alarms", worker = .alarmsWorker),
     (name = "hiber", worker = .hiberWorker),
     (name = "js-rpc-test", worker = .jsRpcWorker),
+    ( name = "connect-handler-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "connect-handler-test.js"),
+        ],
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+        streamingTails = ["log"],
+      )
+    ),
+    ( name = "connect-handler-test-proxy",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "connect-handler-test-proxy.js"),
+        ],
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+      )
+    ),
+    ( name = "connect-handler-test-endpoint",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "connect-handler-test-proxy.js"),
+        ],
+        compatibilityFlags = ["nodejs_compat_v2", "experimental"],
+      )
+    ),
+    ( name = "internet", network = ( allow = ["private"] ) ),
     (name = "TEST_TMPDIR", disk = (writable = true)),
     # Dummy buffered tail worker (gets traces from alarms worker and produces trace for main tracer)
     (name = "buffered", worker = .logBuffered, ),
@@ -50,6 +76,11 @@ const unitTests :Workerd.Config = (
       ),
     )
   ],
+  sockets = [
+    (name = "tcp", address = "*:8081", tcp = (), service = "connect-handler-test"),
+    (name = "tcp", address = "*:8082", tcp = (), service = (name = "connect-handler-test-proxy", entrypoint = "ConnectProxy")),
+    (name = "tcp", address = "*:8083", tcp = (), service = (name = "connect-handler-test-endpoint", entrypoint = "ConnectEndpoint"))
+  ]
 );
 
 const alarmsWorker :Workerd.Worker = (

--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -164,6 +164,9 @@ kj::Maybe<TraceItem::EventInfo> getTraceEvent(jsg::Lock& js, const Trace& trace)
       KJ_CASE_ONEOF(scheduled, tracing::ScheduledEventInfo) {
         return kj::Maybe(js.alloc<TraceItem::ScheduledEventInfo>(trace, scheduled));
       }
+      KJ_CASE_ONEOF(connect, tracing::ConnectEventInfo) {
+        return kj::Maybe(jsg::alloc<TraceItem::ConnectEventInfo>(js, trace, connect));
+      }
       KJ_CASE_ONEOF(alarm, tracing::AlarmEventInfo) {
         return kj::Maybe(js.alloc<TraceItem::AlarmEventInfo>(trace, alarm));
       }
@@ -248,6 +251,9 @@ kj::Maybe<TraceItem::EventInfo> TraceItem::getEvent(jsg::Lock& js) {
         return info.addRef();
       }
       KJ_CASE_ONEOF(info, jsg::Ref<CustomEventInfo>) {
+        return info.addRef();
+      }
+      KJ_CASE_ONEOF(info, jsg::Ref<ConnectEventInfo>) {
         return info.addRef();
       }
     }
@@ -749,6 +755,9 @@ void TraceItem::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
       KJ_CASE_ONEOF(info, jsg::Ref<HibernatableWebSocketEventInfo>) {
         tracker.trackField("eventInfo", info);
       }
+      KJ_CASE_ONEOF(info, jsg::Ref<ConnectEventInfo>) {
+        tracker.trackField("eventInfo", info);
+      }
     }
   }
   for (const auto& log: logs) {
@@ -806,5 +815,8 @@ void TraceItem::HibernatableWebSocketEventInfo::visitForMemoryInfo(
     }
   }
 }
+
+TraceItem::ConnectEventInfo::ConnectEventInfo(
+    jsg::Lock& js, const Trace& trace, const tracing::ConnectEventInfo& eventInfo) {}
 
 }  // namespace workerd::api

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -73,6 +73,7 @@ class TraceItem final: public jsg::Object {
 
   class FetchEventInfo;
   class JsRpcEventInfo;
+  class ConnectEventInfo;
   class ScheduledEventInfo;
   class AlarmEventInfo;
   class QueueEventInfo;
@@ -85,6 +86,7 @@ class TraceItem final: public jsg::Object {
 
   using EventInfo = kj::OneOf<jsg::Ref<FetchEventInfo>,
       jsg::Ref<JsRpcEventInfo>,
+      jsg::Ref<ConnectEventInfo>,
       jsg::Ref<ScheduledEventInfo>,
       jsg::Ref<AlarmEventInfo>,
       jsg::Ref<QueueEventInfo>,
@@ -285,6 +287,14 @@ class TraceItem::JsRpcEventInfo final: public jsg::Object {
 
  private:
   kj::String rpcMethod;
+};
+
+class TraceItem::ConnectEventInfo final: public jsg::Object {
+ public:
+  explicit ConnectEventInfo(
+      jsg::Lock& js, const Trace& trace, const tracing::ConnectEventInfo& eventInfo);
+
+  JSG_RESOURCE_TYPE(ConnectEventInfo) {}
 };
 
 class TraceItem::ScheduledEventInfo final: public jsg::Object {
@@ -650,12 +660,12 @@ class TraceCustomEvent final: public WorkerInterface::CustomEvent {
 
 #define EW_TRACE_ISOLATE_TYPES                                                                     \
   api::ScriptVersion, api::TailEvent, api::TraceItem, api::TraceItem::AlarmEventInfo,              \
-      api::TraceItem::CustomEventInfo, api::TraceItem::ScheduledEventInfo,                         \
-      api::TraceItem::QueueEventInfo, api::TraceItem::EmailEventInfo,                              \
-      api::TraceItem::TailEventInfo, api::TraceItem::TailEventInfo::TailItem,                      \
-      api::TraceItem::FetchEventInfo, api::TraceItem::FetchEventInfo::Request,                     \
-      api::TraceItem::FetchEventInfo::Response, api::TraceItem::JsRpcEventInfo,                    \
-      api::TraceItem::HibernatableWebSocketEventInfo,                                              \
+      api::TraceItem::ConnectEventInfo, api::TraceItem::CustomEventInfo,                           \
+      api::TraceItem::ScheduledEventInfo, api::TraceItem::QueueEventInfo,                          \
+      api::TraceItem::EmailEventInfo, api::TraceItem::TailEventInfo,                               \
+      api::TraceItem::TailEventInfo::TailItem, api::TraceItem::FetchEventInfo,                     \
+      api::TraceItem::FetchEventInfo::Request, api::TraceItem::FetchEventInfo::Response,           \
+      api::TraceItem::JsRpcEventInfo, api::TraceItem::HibernatableWebSocketEventInfo,              \
       api::TraceItem::HibernatableWebSocketEventInfo::Message,                                     \
       api::TraceItem::HibernatableWebSocketEventInfo::Close,                                       \
       api::TraceItem::HibernatableWebSocketEventInfo::Error, api::TraceLog, api::TraceException,   \

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -24,6 +24,7 @@ namespace {
   V(CFJSON, "cfJson")                                                                              \
   V(CLOSE, "close")                                                                                \
   V(CODE, "code")                                                                                  \
+  V(CONNECT, "connect")                                                                            \
   V(COUNT, "count")                                                                                \
   V(CPUTIME, "cpuTime")                                                                            \
   V(CRON, "cron")                                                                                  \
@@ -292,6 +293,12 @@ jsg::JsValue ToJs(jsg::Lock& js, const HibernatableWebSocketEventInfo& info, Str
   return obj;
 }
 
+jsg::JsValue ToJs(jsg::Lock& js, const ConnectEventInfo& info, StringCache& cache) {
+  auto obj = js.obj();
+  obj.set(js, TYPE_STR, cache.get(js, CONNECT_STR));
+  return obj;
+}
+
 jsg::JsValue ToJs(jsg::Lock& js, const CustomEventInfo& info, StringCache& cache) {
   auto obj = js.obj();
   obj.set(js, TYPE_STR, cache.get(js, CUSTOM_STR));
@@ -384,6 +391,9 @@ jsg::JsValue ToJs(jsg::Lock& js, const Onset& onset, StringCache& cache) {
     }
     KJ_CASE_ONEOF(hws, HibernatableWebSocketEventInfo) {
       obj.set(js, INFO_STR, ToJs(js, hws, cache));
+    }
+    KJ_CASE_ONEOF(connect, ConnectEventInfo) {
+      obj.set(js, INFO_STR, ToJs(js, connect, cache));
     }
     KJ_CASE_ONEOF(custom, CustomEventInfo) {
       obj.set(js, INFO_STR, ToJs(js, custom, cache));

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -326,6 +326,16 @@ static kj::HttpMethod validateMethod(capnp::HttpMethod method) {
 
 }  // namespace
 
+ConnectEventInfo::ConnectEventInfo() {}
+
+ConnectEventInfo::ConnectEventInfo(rpc::Trace::ConnectEventInfo::Reader reader) {}
+
+void ConnectEventInfo::copyTo(rpc::Trace::ConnectEventInfo::Builder builder) const {}
+
+ConnectEventInfo ConnectEventInfo::clone() const {
+  return ConnectEventInfo();
+}
+
 FetchEventInfo::FetchEventInfo(
     kj::HttpMethod method, kj::String url, kj::String cfJson, kj::Array<Header> headers)
     : method(method),
@@ -781,6 +791,10 @@ void Trace::copyTo(rpc::Trace::Builder builder) const {
         auto jsRpcBuilder = eventInfoBuilder.initJsRpc();
         jsRpc.copyTo(jsRpcBuilder);
       }
+      KJ_CASE_ONEOF(connect, tracing::ConnectEventInfo) {
+        auto connectBuilder = eventInfoBuilder.initConnect();
+        connect.copyTo(connectBuilder);
+      }
       KJ_CASE_ONEOF(scheduled, tracing::ScheduledEventInfo) {
         auto scheduledBuilder = eventInfoBuilder.initScheduled();
         scheduled.copyTo(scheduledBuilder);
@@ -890,6 +904,9 @@ void Trace::mergeFrom(rpc::Trace::Reader reader, PipelineLogLevel pipelineLogLev
         break;
       case rpc::Trace::EventInfo::Which::JS_RPC:
         eventInfo = tracing::JsRpcEventInfo(e.getJsRpc());
+        break;
+      case rpc::Trace::EventInfo::Which::CONNECT:
+        eventInfo = tracing::ConnectEventInfo(e.getConnect());
         break;
       case rpc::Trace::EventInfo::Which::SCHEDULED:
         eventInfo = tracing::ScheduledEventInfo(e.getScheduled());
@@ -1107,6 +1124,9 @@ Onset::Info readOnsetInfo(const rpc::Trace::Onset::Info::Reader& info) {
     case rpc::Trace::Onset::Info::JS_RPC: {
       return JsRpcEventInfo(info.getJsRpc());
     }
+    case rpc::Trace::Onset::Info::CONNECT: {
+      return ConnectEventInfo(info.getConnect());
+    }
     case rpc::Trace::Onset::Info::SCHEDULED: {
       return ScheduledEventInfo(info.getScheduled());
     }
@@ -1136,6 +1156,9 @@ void writeOnsetInfo(const Onset::Info& info, rpc::Trace::Onset::Info::Builder& i
   KJ_SWITCH_ONEOF(info) {
     KJ_CASE_ONEOF(fetch, FetchEventInfo) {
       fetch.copyTo(infoBuilder.initFetch());
+    }
+    KJ_CASE_ONEOF(connect, ConnectEventInfo) {
+      connect.copyTo(infoBuilder.initConnect());
     }
     KJ_CASE_ONEOF(jsrpc, JsRpcEventInfo) {
       jsrpc.copyTo(infoBuilder.initJsRpc());
@@ -1288,6 +1311,9 @@ EventInfo cloneEventInfo(const EventInfo& info) {
   KJ_SWITCH_ONEOF(info) {
     KJ_CASE_ONEOF(fetch, FetchEventInfo) {
       return fetch.clone();
+    }
+    KJ_CASE_ONEOF(connect, ConnectEventInfo) {
+      return connect.clone();
     }
     KJ_CASE_ONEOF(jsrpc, JsRpcEventInfo) {
       return jsrpc.clone();

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -362,6 +362,15 @@ struct JsRpcEventInfo final {
   kj::String toString() const;
 };
 
+class ConnectEventInfo {
+ public:
+  explicit ConnectEventInfo();
+  explicit ConnectEventInfo(rpc::Trace::ConnectEventInfo::Reader reader);
+
+  void copyTo(rpc::Trace::ConnectEventInfo::Builder builder) const;
+  ConnectEventInfo clone() const;
+};
+
 // Describes a scheduled request
 struct ScheduledEventInfo final {
   explicit ScheduledEventInfo(double scheduledTime, kj::String cron);
@@ -577,6 +586,7 @@ using EventInfo = kj::OneOf<FetchEventInfo,
     EmailEventInfo,
     TraceEventInfo,
     HibernatableWebSocketEventInfo,
+    ConnectEventInfo,
     CustomEventInfo>;
 
 EventInfo cloneEventInfo(const EventInfo& info);

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -249,6 +249,30 @@ void WorkerEntrypoint::init(kj::Own<const Worker> worker,
                         .attach(kj::mv(actor));
 }
 
+kj::Exception exceptionToPropagate(bool isInternalException, kj::Exception&& exception) {
+  if (isInternalException) {
+    // We've already logged it here, the only thing that matters to the client is that we failed
+    // due to an internal error. Note that this does not need to be labeled "remote." since jsg
+    // will sanitize it as an internal error. Note that we use `setDescription()` to preserve
+    // the exception type for `jsg::exceptionToJs(...)` downstream.
+    exception.setDescription(kj::str("worker_do_not_log; Request failed due to internal error"));
+    return kj::mv(exception);
+  } else {
+    // We do not care how many remote capnp servers this went through since we are returning
+    // it to the worker via jsg.
+    // TODO(someday) We also do this stripping when making the tunneled exception for
+    // `jsg::isTunneledException(...)`. It would be lovely if we could simply store some type
+    // instead of `loggedExceptionEarlier`. It would save use some work.
+    auto description = jsg::stripRemoteExceptionPrefix(exception.getDescription());
+    if (!description.startsWith("remote.")) {
+      // If we already were annotated as remote from some other worker entrypoint, no point
+      // adding an additional prefix.
+      exception.setDescription(kj::str("remote.", description));
+    }
+    return kj::mv(exception);
+  }
+}
+
 kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
     kj::StringPtr url,
     const kj::HttpHeaders& headers,
@@ -435,31 +459,6 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
       }
     }
 
-    auto exceptionToPropagate = [&]() {
-      if (isInternalException) {
-        // We've already logged it here, the only thing that matters to the client is that we failed
-        // due to an internal error. Note that this does not need to be labeled "remote." since jsg
-        // will sanitize it as an internal error. Note that we use `setDescription()` to preserve
-        // the exception type for `jsg::exceptionToJs(...)` downstream.
-        exception.setDescription(
-            kj::str("worker_do_not_log; Request failed due to internal error"));
-        return kj::mv(exception);
-      } else {
-        // We do not care how many remote capnp servers this went through since we are returning
-        // it to the worker via jsg.
-        // TODO(someday) We also do this stripping when making the tunneled exception for
-        // `jsg::isTunneledException(...)`. It would be lovely if we could simply store some type
-        // instead of `loggedExceptionEarlier`. It would save use some work.
-        auto description = jsg::stripRemoteExceptionPrefix(exception.getDescription());
-        if (!description.startsWith("remote.")) {
-          // If we already were annotated as remote from some other worker entrypoint, no point
-          // adding an additional prefix.
-          exception.setDescription(kj::str("remote.", description));
-        }
-        return kj::mv(exception);
-      }
-    };
-
     if (wrappedResponse->isSent()) {
       // We can't fail open if the response was already sent, so set `failOpenService` null so that
       // that branch isn't taken below.
@@ -471,7 +470,7 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
       // TODO(cleanup): We'd really like to tunnel exceptions any time a worker is calling another
       // worker, not just for actors (and W2W below), but getting that right will require cleaning
       // up error handling more generally.
-      return exceptionToPropagate();
+      return exceptionToPropagate(isInternalException, kj::mv(exception));
     } else KJ_IF_SOME(service, failOpenService) {
       // Fall back to origin.
 
@@ -505,7 +504,7 @@ kj::Promise<void> WorkerEntrypoint::request(kj::HttpMethod method,
       // Like with the isActor check, we want to return exceptions back to the caller.
       // We don't want to handle this case the same as the isActor case though, since we want
       // fail-open to operate normally, which means this case must happen after fail-open handling.
-      return exceptionToPropagate();
+      return exceptionToPropagate(isInternalException, kj::mv(exception));
     } else {
       // Return error.
 
@@ -542,19 +541,17 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
   auto incomingRequest =
       kj::mv(KJ_REQUIRE_NONNULL(this->incomingRequest, "connect() can only be called once"));
   this->incomingRequest = kj::none;
-  // Whenever we implement incoming connections over the `connect` handler we need to remember to
-  // add tracing `onset` and `return` events using setEventInfo()/setReturn(), as with the other
-  // event types here.
-  incomingRequest->delivered();
   auto& context = incomingRequest->getContext();
+  auto featureFlags = context.getWorker().getIsolate().getApi().getFeatureFlags();
 
-  KJ_DEFER({
-    // Since we called incomingRequest->delivered, we are obliged to call `drain()`.
-    auto promise = incomingRequest->drain().attach(kj::mv(incomingRequest));
-    waitUntilTasks.add(maybeAddGcPassForTest(context, kj::mv(promise)));
-  });
+  if (featureFlags.getConnectPassThrough()) {
+    incomingRequest->delivered();
 
-  if (context.getWorker().getIsolate().getApi().getFeatureFlags().getConnectPassThrough()) {
+    KJ_DEFER({
+      // Since we called incomingRequest->delivered, we are obliged to call `drain()`.
+      auto promise = incomingRequest->drain().attach(kj::mv(incomingRequest));
+      waitUntilTasks.add(maybeAddGcPassForTest(context, kj::mv(promise)));
+    });
     // connect_pass_through feature flag means we should just forward the connect request on to
     // the global outbound.
 
@@ -564,9 +561,100 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
     // Note: Intentionally return without co_await so that the `incomingRequest` is destroyed,
     //   because we don't have any need to keep the context around.
     return next->connect(host, headers, connection, response, settings);
+  } else if (!featureFlags.getWorkerdExperimental()) {
+    JSG_FAIL_REQUIRE(TypeError, "Incoming CONNECT on a worker not supported");
   }
 
-  JSG_FAIL_REQUIRE(TypeError, "Incoming CONNECT on a worker not supported");
+  // TODO(soon): Implement basic TLS support for connect handler.
+  JSG_REQUIRE(!settings.useTls, Error, "Incoming CONNECT with TLS not supported");
+  // Capture workerTracer, see request() for rationale.
+  kj::Maybe<BaseTracer&> workerTracer;
+
+  bool isActor = context.getActor() != kj::none;
+
+  KJ_IF_SOME(t, incomingRequest->getWorkerTracer()) {
+    t.setEventInfo(*incomingRequest, tracing::ConnectEventInfo());
+    workerTracer = t;
+  }
+  incomingRequest->delivered();
+
+  auto metricsForCatch = kj::addRef(incomingRequest->getMetrics());
+
+  return context
+      .run(
+          [this, &headers, &context, &connection, &response, entrypointName = entrypointName,
+              versionInfo = kj::mv(versionInfo), host = kj::str(host)](Worker::Lock& lock) mutable {
+    jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
+
+    return lock.getGlobalScope().connect(kj::mv(host), headers, connection, response, lock,
+        lock.getExportedHandler(
+            entrypointName, kj::mv(versionInfo), kj::mv(props), context.getActor()));
+  })
+      .then([&context, workerTracer]() {
+    KJ_IF_SOME(t, workerTracer) {
+      t.setReturn(context.now());
+    }
+  })
+      .catch_([this, &context](kj::Exception&& exception) mutable -> kj::Promise<void> {
+    // Log JS exceptions to the JS console, if fiddle is attached. This also has the effect of
+    // logging internal errors to syslog.
+    loggedExceptionEarlier = true;
+    context.logUncaughtExceptionAsync(UncaughtExceptionSource::REQUEST_HANDLER, kj::cp(exception));
+
+    // Do not allow the exception to escape the isolate without waiting for the output gate to
+    // open. Note that in the success path, this is taken care of in `FetchEvent::respondWith()`.
+    return context.waitForOutputLocks().then(
+        [exception = kj::mv(exception)]() mutable -> kj::Promise<void> {
+      return kj::mv(exception);
+    });
+  })
+      .attach(kj::defer([this, incomingRequest = kj::mv(incomingRequest), &context]() mutable {
+    // The request has been canceled, but allow it to continue executing in the background.
+    auto promise = incomingRequest->drain().attach(kj::mv(incomingRequest));
+    waitUntilTasks.add(maybeAddGcPassForTest(context, kj::mv(promise)));
+  }))
+      .catch_([this, isActor, &response, metrics = kj::mv(metricsForCatch), workerTracer](
+                  kj::Exception&& exception) mutable -> kj::Promise<void> {
+    // Don't return errors to end user.
+    auto isInternalException = !jsg::isTunneledException(exception.getDescription()) &&
+        !jsg::isDoNotLogException(exception.getDescription());
+    if (!loggedExceptionEarlier) {
+      // This exception seems to have originated during the deferred proxy task, so it was not
+      // logged to the IoContext earlier.
+      if (exception.getType() != kj::Exception::Type::DISCONNECTED && isInternalException) {
+        LOG_EXCEPTION("workerEntrypoint", exception);
+      } else {
+        KJ_LOG(INFO, exception);  // Run with --verbose to see exception logs.
+      }
+    }
+
+    if (isActor || tunnelExceptions) {
+      // We want to tunnel exceptions from actors back to the caller.
+      // TODO(cleanup): We'd really like to tunnel exceptions any time a worker is calling another
+      // worker, not just for actors (and W2W below), but getting that right will require cleaning
+      // up error handling more generally.
+      return exceptionToPropagate(isInternalException, kj::mv(exception));
+    } else {
+      // Return error.
+
+      // We're catching the exception and replacing it with 5xx, but metrics should still indicate
+      // an exception.
+      metrics->reportFailure(exception);
+
+      kj::HttpHeaders headers(threadContext.getHeaderTable());
+      if (exception.getType() == kj::Exception::Type::OVERLOADED) {
+        response.reject(503, "Service Unavailable", headers, static_cast<uint64_t>(0));
+      } else {
+        response.reject(500, "Internal Server Error", headers, static_cast<uint64_t>(0));
+      }
+      // TODO(o11y): Should we also indicate a return response code for TCP?
+      KJ_IF_SOME(t, workerTracer) {
+        t.setReturn(kj::none);
+      }
+
+      return kj::READY_NOW;
+    }
+  });
 }
 
 kj::Promise<void> WorkerEntrypoint::prewarm(kj::StringPtr url) {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -97,6 +97,7 @@ struct Trace @0x8e8d911203762d34 {
     email @16 :EmailEventInfo;
     trace @18 :TraceEventInfo;
     hibernatableWebSocket @20 :HibernatableWebSocketEventInfo;
+    connect @29 :ConnectEventInfo;
   }
   struct FetchEventInfo {
     method @0 :HttpMethod;
@@ -112,6 +113,9 @@ struct Trace @0x8e8d911203762d34 {
 
   struct JsRpcEventInfo {
     methodName @0 :Text;
+  }
+
+  struct ConnectEventInfo {
   }
 
   struct ScheduledEventInfo {
@@ -270,6 +274,7 @@ struct Trace @0x8e8d911203762d34 {
       email @5 :EmailEventInfo;
       trace @6 :TraceEventInfo;
       hibernatableWebSocket @7 :HibernatableWebSocketEventInfo;
+      connect @9 :ConnectEventInfo;
       custom @8 :CustomEventInfo;
     }
     }

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -33,6 +33,7 @@
 #include <workerd/server/fallback-service.h>
 #include <workerd/util/http-util.h>
 #include <workerd/util/mimetype.h>
+#include <workerd/util/stream-utils.h>
 #include <workerd/util/use-perfetto-categories.h>
 #include <workerd/util/uuid.h>
 #include <workerd/util/websocket-error-handler.h>
@@ -5338,17 +5339,20 @@ class Server::HttpListener final: public kj::Refcounted {
         kj::AsyncIoStream& connection,
         ConnectResponse& response,
         kj::HttpConnectSettings settings) override {
+      TRACE_EVENT("workerd", "Connection:connect()");
       KJ_IF_SOME(h, parent.rewriter->getCapnpConnectHost()) {
         if (h == host) {
           // Client is requesting to open a capnp session!
           response.accept(200, "OK", kj::HttpHeaders(parent.headerTable));
-          return parent.acceptCapnpConnection(connection);
+          co_return co_await parent.acceptCapnpConnection(connection);
         }
       }
 
-      // TODO(someday): Deliver connect() event to to worker? For now we call the default
-      //   implementation which throws an exception.
-      return kj::HttpService::connect(host, headers, connection, response, kj::mv(settings));
+      IoChannelFactory::SubrequestMetadata metadata;
+      metadata.cfBlobJson = mapCopyString(cfBlobJson);
+
+      auto worker = parent.service->startRequest(kj::mv(metadata));
+      co_return co_await worker->connect(host, headers, connection, response, kj::mv(settings));
     }
 
     // ---------------------------------------------------------------------------
@@ -5368,6 +5372,57 @@ class Server::HttpListener final: public kj::Refcounted {
   };
 };
 
+class Server::TcpListener final: public kj::Refcounted {
+ public:
+  TcpListener(Server& owner,
+      kj::Own<kj::ConnectionReceiver> listener,
+      kj::Own<Service> service,
+      kj::HttpHeaderTable& headerTable,
+      kj::StringPtr addrStr)
+      : owner(owner),
+        listener(kj::mv(listener)),
+        service(kj::mv(service)),
+        headerTable(headerTable),
+        addrStr(addrStr) {}
+
+  kj::Promise<void> run() {
+    TRACE_EVENT("workerd", "TcpListener::run");
+    for (;;) {
+      kj::AuthenticatedStream stream = co_await listener->acceptAuthenticated();
+      TRACE_EVENT("workerd", "TcpListener handle connection");
+
+      IoChannelFactory::SubrequestMetadata metadata;
+      auto req = service->startRequest(kj::mv(metadata));
+      auto response = kj::heap<ResponseWrapper>();
+      kj::HttpHeaders headers(headerTable);
+      owner.tasks.add(req->connect(addrStr, headers, *stream.stream, *response, {})
+                          .attach(kj::mv(stream.stream), kj::mv(response))
+                          .attach(kj::mv(req)));
+    }
+  }
+
+ private:
+  Server& owner;
+  kj::Own<kj::ConnectionReceiver> listener;
+  kj::Own<Service> service;
+  kj::HttpHeaderTable& headerTable;
+  kj::StringPtr addrStr;
+
+  struct ResponseWrapper final: public kj::HttpService::ConnectResponse {
+    void accept(
+        uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+      // Ok.. we're accepting the connection... anything to do?
+    }
+    kj::Own<kj::AsyncOutputStream> reject(uint statusCode,
+        kj::StringPtr statusText,
+        const kj::HttpHeaders& headers,
+        kj::Maybe<uint64_t> expectedBodySize = kj::none) override {
+      // Doh... we're rejecting the connection... anything to do?
+      return newNullOutputStream();
+    }
+  };
+};
+
 kj::Promise<void> Server::listenHttp(kj::Own<kj::ConnectionReceiver> listener,
     kj::Own<Service> service,
     kj::StringPtr physicalProtocol,
@@ -5375,6 +5430,13 @@ kj::Promise<void> Server::listenHttp(kj::Own<kj::ConnectionReceiver> listener,
   auto obj =
       kj::refcounted<HttpListener>(*this, kj::mv(listener), kj::mv(service), physicalProtocol,
           kj::mv(rewriter), globalContext->headerTable, timer, globalContext->httpOverCapnpFactory);
+  co_return co_await obj->run();
+}
+
+kj::Promise<void> Server::listenTcp(
+    kj::Own<kj::ConnectionReceiver> listener, kj::Own<Service> service, kj::StringPtr addrStr) {
+  auto obj = kj::refcounted<TcpListener>(
+      *this, kj::mv(listener), kj::mv(service), globalContext->headerTable, addrStr);
   co_return co_await obj->run();
 }
 
@@ -5846,6 +5908,15 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
         physicalProtocol = "https";
         goto validSocket;
       }
+      case config::Socket::TCP: {
+        auto tcp = sock.getTcp();
+        // No default port
+        // No physical protocol mention here.
+        if (tcp.hasTlsOptions()) {
+          tls = makeTlsContext(tcp.getTlsOptions());
+        }
+        goto validSocket;
+      }
     }
     reportConfigError(kj::str("Encountered unknown socket type in \"", name,
         "\". Was the config compiled with a "
@@ -5877,9 +5948,15 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
     auto rewriter = kj::heap<HttpRewriter>(httpOptions, headerTableBuilder);
 
     auto handle = kj::coCapture(
-        [this, service = kj::mv(service), rewriter = kj::mv(rewriter), physicalProtocol, name](
+        [this, service = kj::mv(service), rewriter = kj::mv(rewriter), physicalProtocol, name,
+            isHttp = sock.which() != config::Socket::TCP, addrStr](
             kj::Promise<kj::Own<kj::ConnectionReceiver>> promise) mutable -> kj::Promise<void> {
-      TRACE_EVENT("workerd", "setup listenHttp");
+      if (isHttp) {
+        TRACE_EVENT("workerd", "setup listenHttp");
+      } else {
+        TRACE_EVENT("workerd", "setup listenTcp");
+      }
+
       auto listener = co_await promise;
       KJ_IF_SOME(stream, controlOverride) {
         auto message = kj::str("{\"event\":\"listen\",\"socket\":\"", name,
@@ -5890,7 +5967,12 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
           KJ_LOG(ERROR, e);
         }
       }
-      co_await listenHttp(kj::mv(listener), kj::mv(service), physicalProtocol, kj::mv(rewriter));
+
+      if (isHttp) {
+        co_await listenHttp(kj::mv(listener), kj::mv(service), physicalProtocol, kj::mv(rewriter));
+      } else {
+        co_await listenTcp(kj::mv(listener), kj::mv(service), addrStr);
+      }
     });
     tasks.add(handle(kj::mv(listener)).exclusiveJoin(forkedDrainWhen.addBranch()));
   }

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -290,6 +290,9 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
       kj::StringPtr physicalProtocol,
       kj::Own<HttpRewriter> rewriter);
 
+  kj::Promise<void> listenTcp(
+      kj::Own<kj::ConnectionReceiver> listener, kj::Own<Service> service, kj::StringPtr addrStr);
+
   kj::Promise<void> listenDebugPort(kj::Own<kj::ConnectionReceiver> listener);
 
   class InvalidConfigService;
@@ -302,6 +305,7 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
   class WorkerEntrypointService;
   class WorkerdBootstrapImpl;
   class HttpListener;
+  class TcpListener;
   class DebugPortListener;
 
   struct ErrorReporter;

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -143,8 +143,11 @@ struct Socket {
       options @3 :HttpOptions;
       tlsOptions @4 :TlsOptions;
     }
+    tcp :group {
+      tlsOptions @6 :TlsOptions;
+    }
 
-    # TODO(someday): TCP, TCP proxy, SMTP, Cap'n Proto, ...
+    # TODO(someday): TCP proxy, SMTP, Cap'n Proto, ...
   }
 
   service @5 :ServiceDesignator;

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -239,6 +239,7 @@ declare namespace CloudflareWorkersModule {
 
     email?(message: ForwardableEmailMessage): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     queue?(batch: MessageBatch<unknown>): void | Promise<void>;
     scheduled?(controller: ScheduledController): void | Promise<void>;
     tail?(events: TraceItem[]): void | Promise<void>;
@@ -260,6 +261,7 @@ declare namespace CloudflareWorkersModule {
 
     alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     webSocketMessage?(
       ws: WebSocket,
       message: string | ArrayBuffer

--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -74,6 +74,10 @@ interface FetchResponseInfo {
   readonly statusCode: number;
 }
 
+interface ConnectEventInfo {
+  readonly type: "connect";
+}
+
 type EventOutcome = "ok" | "canceled" | "exception" | "unknown" | "killSwitch" |
                     "daemonDown" | "exceededCpu" | "exceededMemory" | "loadShed" |
                     "responseStreamDisconnected" | "scriptNotFound";
@@ -95,10 +99,10 @@ interface Onset {
   readonly scriptName?: string;
   readonly scriptTags?: string[];
   readonly scriptVersion?: ScriptVersion;
-  readonly info: FetchEventInfo | JsRpcEventInfo | ScheduledEventInfo |
-                 AlarmEventInfo | QueueEventInfo | EmailEventInfo |
-                 TraceEventInfo | HibernatableWebSocketEventInfo |
-                 CustomEventInfo;
+  readonly info: FetchEventInfo | ConnectEventInfo | JsRpcEventInfo |
+                 ScheduledEventInfo | AlarmEventInfo | QueueEventInfo |
+                 EmailEventInfo | TraceEventInfo |
+                 HibernatableWebSocketEventInfo | CustomEventInfo;
 }
 
 interface Outcome {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -511,6 +511,11 @@ type ExportedHandlerFetchHandler<
   env: Env,
   ctx: ExecutionContext<Props>,
 ) => Response | Promise<Response>;
+type ExportedHandlerConnectHandler<Env = unknown, Props = unknown> = (
+  socket: Socket,
+  env: Env,
+  ctx: ExecutionContext<Props>,
+) => void | Promise<void>;
 type ExportedHandlerTailHandler<Env = unknown, Props = unknown> = (
   events: TraceItem[],
   env: Env,
@@ -552,6 +557,7 @@ interface ExportedHandler<
   Props = unknown,
 > {
   fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata, Props>;
+  connect?: ExportedHandlerConnectHandler<Env, Props>;
   tail?: ExportedHandlerTailHandler<Env, Props>;
   trace?: ExportedHandlerTraceHandler<Env, Props>;
   tailStream?: ExportedHandlerTailStreamHandler<Env, Props>;
@@ -583,6 +589,7 @@ declare abstract class ColoLocalActorNamespace {
 }
 interface DurableObject {
   fetch(request: Request): Response | Promise<Response>;
+  connect?(socket: Socket): void | Promise<void>;
   alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
   webSocketMessage?(
     ws: WebSocket,
@@ -600,7 +607,7 @@ type DurableObjectStub<
   T extends Rpc.DurableObjectBranded | undefined = undefined,
 > = Fetcher<
   T,
-  "alarm" | "webSocketMessage" | "webSocketClose" | "webSocketError"
+  "alarm" | "connect" | "webSocketMessage" | "webSocketClose" | "webSocketError"
 > & {
   readonly id: DurableObjectId;
   readonly name?: string;
@@ -3233,6 +3240,7 @@ interface TraceItem {
     | (
         | TraceItemFetchEventInfo
         | TraceItemJsRpcEventInfo
+        | TraceItemConnectEventInfo
         | TraceItemScheduledEventInfo
         | TraceItemAlarmEventInfo
         | TraceItemQueueEventInfo
@@ -3262,6 +3270,7 @@ interface TraceItem {
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;
 }
+interface TraceItemConnectEventInfo {}
 interface TraceItemCustomEventInfo {}
 interface TraceItemScheduledEventInfo {
   readonly scheduledTime: number;
@@ -13213,6 +13222,7 @@ declare namespace CloudflareWorkersModule {
     constructor(ctx: ExecutionContext, env: Env);
     email?(message: ForwardableEmailMessage): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     queue?(batch: MessageBatch<unknown>): void | Promise<void>;
     scheduled?(controller: ScheduledController): void | Promise<void>;
     tail?(events: TraceItem[]): void | Promise<void>;
@@ -13233,6 +13243,7 @@ declare namespace CloudflareWorkersModule {
     constructor(ctx: DurableObjectState, env: Env);
     alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     webSocketMessage?(
       ws: WebSocket,
       message: string | ArrayBuffer,
@@ -14232,6 +14243,9 @@ declare namespace TailStream {
     readonly type: "fetch";
     readonly statusCode: number;
   }
+  interface ConnectEventInfo {
+    readonly type: "connect";
+  }
   type EventOutcome =
     | "ok"
     | "canceled"
@@ -14262,6 +14276,7 @@ declare namespace TailStream {
     readonly scriptVersion?: ScriptVersion;
     readonly info:
       | FetchEventInfo
+      | ConnectEventInfo
       | JsRpcEventInfo
       | ScheduledEventInfo
       | AlarmEventInfo

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -513,6 +513,11 @@ export type ExportedHandlerFetchHandler<
   env: Env,
   ctx: ExecutionContext<Props>,
 ) => Response | Promise<Response>;
+export type ExportedHandlerConnectHandler<Env = unknown, Props = unknown> = (
+  socket: Socket,
+  env: Env,
+  ctx: ExecutionContext<Props>,
+) => void | Promise<void>;
 export type ExportedHandlerTailHandler<Env = unknown, Props = unknown> = (
   events: TraceItem[],
   env: Env,
@@ -554,6 +559,7 @@ export interface ExportedHandler<
   Props = unknown,
 > {
   fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata, Props>;
+  connect?: ExportedHandlerConnectHandler<Env, Props>;
   tail?: ExportedHandlerTailHandler<Env, Props>;
   trace?: ExportedHandlerTraceHandler<Env, Props>;
   tailStream?: ExportedHandlerTailStreamHandler<Env, Props>;
@@ -585,6 +591,7 @@ export declare abstract class ColoLocalActorNamespace {
 }
 export interface DurableObject {
   fetch(request: Request): Response | Promise<Response>;
+  connect?(socket: Socket): void | Promise<void>;
   alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
   webSocketMessage?(
     ws: WebSocket,
@@ -602,7 +609,7 @@ export type DurableObjectStub<
   T extends Rpc.DurableObjectBranded | undefined = undefined,
 > = Fetcher<
   T,
-  "alarm" | "webSocketMessage" | "webSocketClose" | "webSocketError"
+  "alarm" | "connect" | "webSocketMessage" | "webSocketClose" | "webSocketError"
 > & {
   readonly id: DurableObjectId;
   readonly name?: string;
@@ -3239,6 +3246,7 @@ export interface TraceItem {
     | (
         | TraceItemFetchEventInfo
         | TraceItemJsRpcEventInfo
+        | TraceItemConnectEventInfo
         | TraceItemScheduledEventInfo
         | TraceItemAlarmEventInfo
         | TraceItemQueueEventInfo
@@ -3268,6 +3276,7 @@ export interface TraceItem {
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;
 }
+export interface TraceItemConnectEventInfo {}
 export interface TraceItemCustomEventInfo {}
 export interface TraceItemScheduledEventInfo {
   readonly scheduledTime: number;
@@ -13180,6 +13189,7 @@ export declare namespace CloudflareWorkersModule {
     constructor(ctx: ExecutionContext, env: Env);
     email?(message: ForwardableEmailMessage): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     queue?(batch: MessageBatch<unknown>): void | Promise<void>;
     scheduled?(controller: ScheduledController): void | Promise<void>;
     tail?(events: TraceItem[]): void | Promise<void>;
@@ -13200,6 +13210,7 @@ export declare namespace CloudflareWorkersModule {
     constructor(ctx: DurableObjectState, env: Env);
     alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     webSocketMessage?(
       ws: WebSocket,
       message: string | ArrayBuffer,
@@ -14189,6 +14200,9 @@ export declare namespace TailStream {
     readonly type: "fetch";
     readonly statusCode: number;
   }
+  interface ConnectEventInfo {
+    readonly type: "connect";
+  }
   type EventOutcome =
     | "ok"
     | "canceled"
@@ -14219,6 +14233,7 @@ export declare namespace TailStream {
     readonly scriptVersion?: ScriptVersion;
     readonly info:
       | FetchEventInfo
+      | ConnectEventInfo
       | JsRpcEventInfo
       | ScheduledEventInfo
       | AlarmEventInfo

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -489,6 +489,11 @@ type ExportedHandlerFetchHandler<
   env: Env,
   ctx: ExecutionContext<Props>,
 ) => Response | Promise<Response>;
+type ExportedHandlerConnectHandler<Env = unknown, Props = unknown> = (
+  socket: Socket,
+  env: Env,
+  ctx: ExecutionContext<Props>,
+) => void | Promise<void>;
 type ExportedHandlerTailHandler<Env = unknown, Props = unknown> = (
   events: TraceItem[],
   env: Env,
@@ -530,6 +535,7 @@ interface ExportedHandler<
   Props = unknown,
 > {
   fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata, Props>;
+  connect?: ExportedHandlerConnectHandler<Env, Props>;
   tail?: ExportedHandlerTailHandler<Env, Props>;
   trace?: ExportedHandlerTraceHandler<Env, Props>;
   tailStream?: ExportedHandlerTailStreamHandler<Env, Props>;
@@ -557,6 +563,7 @@ interface Cloudflare {
 }
 interface DurableObject {
   fetch(request: Request): Response | Promise<Response>;
+  connect?(socket: Socket): void | Promise<void>;
   alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
   webSocketMessage?(
     ws: WebSocket,
@@ -574,7 +581,7 @@ type DurableObjectStub<
   T extends Rpc.DurableObjectBranded | undefined = undefined,
 > = Fetcher<
   T,
-  "alarm" | "webSocketMessage" | "webSocketClose" | "webSocketError"
+  "alarm" | "connect" | "webSocketMessage" | "webSocketClose" | "webSocketError"
 > & {
   readonly id: DurableObjectId;
   readonly name?: string;
@@ -3121,6 +3128,7 @@ interface TraceItem {
     | (
         | TraceItemFetchEventInfo
         | TraceItemJsRpcEventInfo
+        | TraceItemConnectEventInfo
         | TraceItemScheduledEventInfo
         | TraceItemAlarmEventInfo
         | TraceItemQueueEventInfo
@@ -3150,6 +3158,7 @@ interface TraceItem {
 interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;
 }
+interface TraceItemConnectEventInfo {}
 interface TraceItemCustomEventInfo {}
 interface TraceItemScheduledEventInfo {
   readonly scheduledTime: number;
@@ -12551,6 +12560,7 @@ declare namespace CloudflareWorkersModule {
     constructor(ctx: ExecutionContext, env: Env);
     email?(message: ForwardableEmailMessage): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     queue?(batch: MessageBatch<unknown>): void | Promise<void>;
     scheduled?(controller: ScheduledController): void | Promise<void>;
     tail?(events: TraceItem[]): void | Promise<void>;
@@ -12571,6 +12581,7 @@ declare namespace CloudflareWorkersModule {
     constructor(ctx: DurableObjectState, env: Env);
     alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     webSocketMessage?(
       ws: WebSocket,
       message: string | ArrayBuffer,
@@ -13570,6 +13581,9 @@ declare namespace TailStream {
     readonly type: "fetch";
     readonly statusCode: number;
   }
+  interface ConnectEventInfo {
+    readonly type: "connect";
+  }
   type EventOutcome =
     | "ok"
     | "canceled"
@@ -13600,6 +13614,7 @@ declare namespace TailStream {
     readonly scriptVersion?: ScriptVersion;
     readonly info:
       | FetchEventInfo
+      | ConnectEventInfo
       | JsRpcEventInfo
       | ScheduledEventInfo
       | AlarmEventInfo

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -491,6 +491,11 @@ export type ExportedHandlerFetchHandler<
   env: Env,
   ctx: ExecutionContext<Props>,
 ) => Response | Promise<Response>;
+export type ExportedHandlerConnectHandler<Env = unknown, Props = unknown> = (
+  socket: Socket,
+  env: Env,
+  ctx: ExecutionContext<Props>,
+) => void | Promise<void>;
 export type ExportedHandlerTailHandler<Env = unknown, Props = unknown> = (
   events: TraceItem[],
   env: Env,
@@ -532,6 +537,7 @@ export interface ExportedHandler<
   Props = unknown,
 > {
   fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata, Props>;
+  connect?: ExportedHandlerConnectHandler<Env, Props>;
   tail?: ExportedHandlerTailHandler<Env, Props>;
   trace?: ExportedHandlerTraceHandler<Env, Props>;
   tailStream?: ExportedHandlerTailStreamHandler<Env, Props>;
@@ -559,6 +565,7 @@ export interface Cloudflare {
 }
 export interface DurableObject {
   fetch(request: Request): Response | Promise<Response>;
+  connect?(socket: Socket): void | Promise<void>;
   alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
   webSocketMessage?(
     ws: WebSocket,
@@ -576,7 +583,7 @@ export type DurableObjectStub<
   T extends Rpc.DurableObjectBranded | undefined = undefined,
 > = Fetcher<
   T,
-  "alarm" | "webSocketMessage" | "webSocketClose" | "webSocketError"
+  "alarm" | "connect" | "webSocketMessage" | "webSocketClose" | "webSocketError"
 > & {
   readonly id: DurableObjectId;
   readonly name?: string;
@@ -3127,6 +3134,7 @@ export interface TraceItem {
     | (
         | TraceItemFetchEventInfo
         | TraceItemJsRpcEventInfo
+        | TraceItemConnectEventInfo
         | TraceItemScheduledEventInfo
         | TraceItemAlarmEventInfo
         | TraceItemQueueEventInfo
@@ -3156,6 +3164,7 @@ export interface TraceItem {
 export interface TraceItemAlarmEventInfo {
   readonly scheduledTime: Date;
 }
+export interface TraceItemConnectEventInfo {}
 export interface TraceItemCustomEventInfo {}
 export interface TraceItemScheduledEventInfo {
   readonly scheduledTime: number;
@@ -12518,6 +12527,7 @@ export declare namespace CloudflareWorkersModule {
     constructor(ctx: ExecutionContext, env: Env);
     email?(message: ForwardableEmailMessage): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     queue?(batch: MessageBatch<unknown>): void | Promise<void>;
     scheduled?(controller: ScheduledController): void | Promise<void>;
     tail?(events: TraceItem[]): void | Promise<void>;
@@ -12538,6 +12548,7 @@ export declare namespace CloudflareWorkersModule {
     constructor(ctx: DurableObjectState, env: Env);
     alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
     fetch?(request: Request): Response | Promise<Response>;
+    connect?(socket: Socket): void | Promise<void>;
     webSocketMessage?(
       ws: WebSocket,
       message: string | ArrayBuffer,
@@ -13527,6 +13538,9 @@ export declare namespace TailStream {
     readonly type: "fetch";
     readonly statusCode: number;
   }
+  interface ConnectEventInfo {
+    readonly type: "connect";
+  }
   type EventOutcome =
     | "ok"
     | "canceled"
@@ -13557,6 +13571,7 @@ export declare namespace TailStream {
     readonly scriptVersion?: ScriptVersion;
     readonly info:
       | FetchEventInfo
+      | ConnectEventInfo
       | JsRpcEventInfo
       | ScheduledEventInfo
       | AlarmEventInfo


### PR DESCRIPTION
This PR implements support for defining a connect() handler, which is behind an experimental compat flag for now. This is largely based on James' previous PR for this (#1429), but includes changes to switch to the socket-based API, drop the deferred proxying code, add more tests, add proper tracing support etc. I don't have a strong background on how workerd/KJ streams work yet – there might be trivial issues in how streams are being used. You'll notice that this PR differs from the internal spec in that it still provides an event to the tail handler and there are several other issues – see the **open questions** below where I'm looking for input on how to best address this.

Open questions:
- ~This still provides a ConnectEvent with a cfJson field to the JS connect handler: Based on the internal discussion, a cfJson field should not be needed, but the parameters set to be provided in server.c++ (clientIp, clientPid, clientUid) feel like they might be useful – should there be a different way to provide such metadata? Otherwise I'll change this to just provide a plain socket as the first parameter to the handler (as discussed on the internal spec)~
- ~[Unchanged from previous PR] The headers provided by the incoming connect() call should be passed through instead of being discarded, right?~
- ~We currently construct a neuterable stream in ServiceWorkerGlobalScope::connect() without really needing to do so – there should be a cleaner way to get an owned AsyncIoStream?~
- ~I assume that HTTP response codes are not needed for TCP? This is relevant for the tail worker return event, which has an optional return code.~
- Is there cleanup potential in WorkerEntrypoint::connect()? A lot of this is adapted from request(), there's likely some logic towards the end that's only needed when doing deferred proxying
- ~Do we need to use HttpRewriter at all for TCP in server.c++? server.c++'s `TcpListener` has remnants of support for this left, but since it's not dealing with HTTP, rewriting might not be needed~
- ~Windows tests are failing – perhaps related to https://github.com/cloudflare/workerd/pull/6059#discussion_r2879817648?~
- ~Miniflare tests are failing – looks like the new code path actually does get enabled for them based on having the "experimental" compat flag. As seen in https://github.com/cloudflare/workerd/actions/runs/22805783114/job/66155261833?pr=6059 (CI run on commit 7713c756e1e2093ddfeb3e26e8b2d07f08a8aace where the wrangler CI jobs were put in a different order), the miniflare tests are the only failing ones~ https://github.com/cloudflare/workers-sdk/pull/12775 has been merged, the next daily miniflare should be sufficient to fix CI and unblock this PR.
- I'll clean up/squash commits before merge. 

The following assumptions were made in implementing this:
- The affected tests have been marked with the Bazel "exclusive" tag and will run one at a time to avoid flakes due to tests trying to use the same TCP port at the same time – I considered using different ports in different tests but we'd still have the issue between regular and @all-autogates variants; the Bazel sandbox might also offer ways to work around this but as long as Bazel does not support sandboxing on Windows we'd still be facing flakes in CI. If there's concerns about a CI slowdown here, I can implement a mechanism to provide a random unused port instead.
- ~I'm assuming that with the socket-based API, neuterable streams are not needed since deferred proxying does not need to be implemented.~
- ~We may want TLS support in the future, but this is not included for now.~
- I'm assuming that connect_handler doesn't need to be a user span for now, just how fetch_handler isn't one.
- Kenton suggested adding a proxyTo() function – I've implemented this but it can land separately, this is available on  the felix/030226-proxyTo branch.
- After factoring out some code shared with the HTTP/fetch code path there's some remaining code duplication – lmk if you can point to any more spots that would be good candidates for deduplication that wouldn't make code harder to maintain.