### PR TITLE
Fix cancellation error propagation through TransformStream.

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -3724,9 +3724,11 @@ void WritableStreamJsController::doError(jsg::Lock& js, v8::Local<v8::Value> rea
   KJ_IF_SOME(locked, lock.state.tryGet<WriterLocked>()) {
     maybeRejectPromise<void>(js, locked.getClosedFulfiller(), reason);
     maybeResolvePromise(js, locked.getReadyFulfiller());
-  } else if (lock.state.tryGet<WritableLockImpl::PipeLocked>() != kj::none) {
-    lock.state.init<Unlocked>();
   }
+  // Note: When pipe-locked, we intentionally do NOT release the pipe lock here.
+  // The pipe loop checks for the Errored state at the start of each iteration and
+  // will handle releasing the pipe lock, canceling the source, and rejecting the
+  // pipe promise with the error reason.
 }
 
 kj::Maybe<int> WritableStreamJsController::getDesiredSize() {


### PR DESCRIPTION
If you cancel the readable side of a TransformStream, writes to the writable side should fail with the cancellation reason.

However, there was a bug such that writes that were initiated _before_ the cancellation would complete successfully. Only writes initiated _after_ the cancellation threw the exception.

I encountered this bug when working on Cap'n Web. I wrote the test.

Claude+Opencode came up with the fix: https://share.opencode.cloudflare.dev/share/bjKKYtel