### PR TITLE
Make node:worker_threads independent of expose_global_message_channel flag

### DIFF
--- a/src/node/internal/messagechannel.d.ts
+++ b/src/node/internal/messagechannel.d.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Type definitions for cloudflare-internal:messagechannel
+// This internal module exposes MessageChannel and MessagePort for use by
+// built-in modules like node:worker_threads, independent of the
+// expose_global_message_channel compatibility flag.
+
+declare namespace _default {
+  const MessageChannel: typeof globalThis.MessageChannel;
+  const MessagePort: typeof globalThis.MessagePort;
+}
+export default _default;

--- a/src/node/tsconfig.json
+++ b/src/node/tsconfig.json
@@ -17,7 +17,8 @@
       "cloudflare-internal:sockets": ["./internal/sockets.d.ts"],
       "cloudflare-internal:workers": ["./internal/workers.d.ts"],
       "cloudflare-internal:tracing": ["./internal/tracing.d.ts"],
-      "cloudflare-internal:filesystem": ["./internal/filesystem.d.ts"]
+      "cloudflare-internal:filesystem": ["./internal/filesystem.d.ts"],
+      "cloudflare-internal:messagechannel": ["./internal/messagechannel.d.ts"]
     }
   }
 }

--- a/src/node/worker_threads.ts
+++ b/src/node/worker_threads.ts
@@ -35,8 +35,12 @@ import type { Readable, Writable } from 'node:stream';
 import type { Transferable, WorkerPerformance } from 'node:worker_threads';
 import type { CPUProfileHandle, HeapInfo, HeapProfileHandle } from 'node:v8';
 
-export const MessageChannel = globalThis.MessageChannel;
-export const MessagePort = globalThis.MessagePort;
+// Import MessageChannel and MessagePort from the internal module to avoid
+// dependency on the expose_global_message_channel compatibility flag.
+import internalMessageChannel from 'cloudflare-internal:messagechannel';
+
+export const MessageChannel = internalMessageChannel.MessageChannel;
+export const MessagePort = internalMessageChannel.MessagePort;
 
 // TODO(soon): Use globalThis.BroadcastChannel once it's available.
 export class BroadcastChannel {

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -6,6 +6,7 @@
 
 #include <workerd/api/base64.h>
 #include <workerd/api/filesystem.h>
+#include <workerd/api/messagechannel.h>
 #include <workerd/api/node/node.h>
 #include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/rtti.h>
@@ -87,6 +88,7 @@ void registerModules(Registry& registry, auto featureFlags) {
   }
   registerSocketsModule(registry, featureFlags);
   registerBase64Module(registry, featureFlags);
+  registerMessageChannelModule(registry, featureFlags);
   registry.addBuiltinBundle(CLOUDFLARE_BUNDLE);
   registerWorkersModule(registry, featureFlags);
   registerTracingModule(registry, featureFlags);
@@ -102,6 +104,7 @@ void registerBuiltinModules(jsg::modules::ModuleRegistry::Builder& builder, auto
   builder.add(node::getExternalNodeJsCompatModuleBundle(featureFlags));
   builder.add(getInternalSocketModuleBundle<TypeWrapper>(featureFlags));
   builder.add(getInternalBase64ModuleBundle<TypeWrapper>(featureFlags));
+  builder.add(getInternalMessageChannelModuleBundle<TypeWrapper>(featureFlags));
   builder.add(getInternalRpcModuleBundle<TypeWrapper>(featureFlags));
 
   builder.add(getInternalUnsafeModuleBundle<TypeWrapper>(featureFlags));

--- a/src/workerd/api/node/tests/worker_threads-nodejs-test.js
+++ b/src/workerd/api/node/tests/worker_threads-nodejs-test.js
@@ -125,8 +125,13 @@ export const testWorkerProperties = {
 
 export const testMessageChannelAndPort = {
   async test() {
-    strictEqual(MessageChannel, globalThis.MessageChannel);
-    strictEqual(MessagePort, globalThis.MessagePort);
+    // Only check reference equality if the global MessageChannel is exposed.
+    // The node:worker_threads module now imports from cloudflare-internal:messagechannel
+    // so it works independently of the expose_global_message_channel compat flag.
+    if (typeof globalThis.MessageChannel !== 'undefined') {
+      strictEqual(MessageChannel, globalThis.MessageChannel);
+      strictEqual(MessagePort, globalThis.MessagePort);
+    }
 
     const channel = new MessageChannel();
     ok(channel instanceof MessageChannel);

--- a/src/workerd/api/node/tests/worker_threads-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/worker_threads-nodejs-test.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "worker_threads-nodejs-test.js")
         ],
-        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "enable_nodejs_worker_threads_module", "experimental", "global_navigator", "expose_global_message_channel"]
+        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "enable_nodejs_worker_threads_module", "experimental", "global_navigator"]
       )
     ),
   ],


### PR DESCRIPTION
## Summary

The `node:worker_threads` module was previously importing `MessageChannel` and `MessagePort` from `globalThis`, which meant it only worked when the `expose_global_message_channel` compatibility flag was enabled.

This change introduces a new internal module (`cloudflare-internal:messagechannel`) that exposes `MessageChannel` and `MessagePort` for use by built-in modules, independent of the global flag.

## Changes

- Add `MessageChannelModule` C++ class in `messagechannel.h`
- Register `cloudflare-internal:messagechannel` as an internal module in `modules.h`
- Update `node:worker_threads` to import from the internal module instead of `globalThis`
- Add TypeScript type definitions for the internal module
- Remove `expose_global_message_channel` from worker_threads tests
- Make the `MessageChannel === globalThis.MessageChannel` test assertion conditional

## Testing

- Ran `bazel test //src/workerd/api/node/tests:worker_threads-nodejs-test@` - all 22 tests pass without the `expose_global_message_channel` flag

## Related

Unblocks https://github.com/cloudflare/workers-sdk/pull/12043 which needs `worker_threads` to work without requiring the global flag.