### PR TITLE
Make "No such Durable Objects class" a user error

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3722,7 +3722,8 @@ Worker::Actor::Actor(const Worker& worker,
       // const_cast OK because we're just storing the pointer and will only use this under lock.
       impl->classInstance = const_cast<ActorClassInfo*>(&cls);
     } else {
-      kj::throwFatalException(KJ_EXCEPTION(FAILED, "broken.ignored; no such actor class", c));
+      kj::throwFatalException(KJ_EXCEPTION(FAILED,
+          "broken.ignored; worker_do_not_log; jsg.Error: No such Durable Objects class", c));
     }
   } else {
     impl->classInstance = Impl::NoClass();

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1889,7 +1889,6 @@ KJ_TEST("Server: configuring a DO namespace with no class export is not an error
   }
 
   // However, a request will still fail at runtime.
-  KJ_EXPECT_LOG(ERROR, "no such actor class");
   KJ_EXPECT_LOG(INFO, "internal error");
   KJ_EXPECT_LOG(INFO, "internal error");
   KJ_EXPECT_LOG(ERROR, "internal error");


### PR DESCRIPTION
Because we lack version locking we can encounter a situation where a Worker can make a request to a Durable Object and the metal chosen to run that Durable Object has no record of the Durable Object class. This is particularly common for high traffic Workers or those using gradual deployments. This will at least let the customer see the error instead of an opaque "Internal error".