### PR TITLE
Add workflow spans for tagging the logs with step name

### DIFF
--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -5,9 +5,9 @@
 // TODO(cleanup): C++ built-in modules do not yet support named exports, so we must define this
 //   wrapper module that simply re-exports the classes from the built-in module.
 
-import entrypoints from 'cloudflare-internal:workers';
 import innerEnv from 'cloudflare-internal:env';
 import innerTracing from 'cloudflare-internal:tracing';
+import entrypoints from 'cloudflare-internal:workers';
 
 export const WorkerEntrypoint = entrypoints.WorkerEntrypoint;
 export const DurableObject = entrypoints.DurableObject;
@@ -16,7 +16,67 @@ export const RpcPromise = entrypoints.RpcPromise;
 export const RpcProperty = entrypoints.RpcProperty;
 export const RpcTarget = entrypoints.RpcTarget;
 export const ServiceStub = entrypoints.ServiceStub;
-export const WorkflowEntrypoint = entrypoints.WorkflowEntrypoint;
+
+type StepCallback = (ctx: unknown, dedupName: string) => unknown;
+
+interface StepRpcStub {
+  do(...args: unknown[]): Promise<unknown>;
+  [method: string]: (...args: unknown[]) => unknown;
+}
+
+function wrapStepForTracing(jsStep: StepRpcStub): StepRpcStub {
+  return new Proxy(jsStep, {
+    get(
+      target: StepRpcStub,
+      prop: string | symbol,
+      receiver: unknown
+    ): unknown {
+      if (prop !== 'do') {
+        return Reflect.get(target, prop, receiver) as unknown;
+      }
+
+      return (name: unknown, ...rest: unknown[]): Promise<unknown> => {
+        const callbackIndex = typeof rest[0] === 'function' ? 0 : 1;
+        const userCb = rest[callbackIndex];
+        if (typeof userCb !== 'function') {
+          throw new Error('No step callback was defined');
+        }
+
+        const callback = userCb as StepCallback;
+        rest[callbackIndex] = (ctx: unknown, dedupName: string): unknown =>
+          innerTracing.enterSpan('workflow_step_do', (span) => {
+            span.setAttribute('cloudflare.workflow.step.name', String(name));
+            span.setAttribute(
+              'cloudflare.workflow.step.unique_name',
+              dedupName
+            );
+            return callback(ctx, dedupName);
+          });
+        return target.do(name, ...rest);
+      };
+    },
+  });
+}
+
+// Wrap WorkflowEntrypoint to intercept internal _run_step() calls for tracing.
+//
+// We use a JS subclass (not a Proxy) because the runtime walks the constructor prototype chain
+// to classify entrypoints (workflowClasses vs actorClasses vs statelessClasses). A Proxy breaks
+// identity comparison: `Proxy !== target`. A JS subclass preserves the chain:
+//   UserWorkflow -> our JS class -> C++ WorkflowEntrypoint (matched by runtime)
+class WorkflowEntrypointImpl extends entrypoints.WorkflowEntrypoint {
+  // @ts-expect-error TS-private but callable via RPC; same convention as pipeline-transform.ts.
+  // eslint-disable-next-line no-restricted-syntax
+  private async _run_step(event: unknown, step: object): Promise<unknown> {
+    const tracedStep = wrapStepForTracing(step as StepRpcStub);
+
+    return (
+      this as unknown as { run: (e: unknown, s: unknown) => Promise<unknown> }
+    ).run(event, tracedStep);
+  }
+}
+
+export const WorkflowEntrypoint = WorkflowEntrypointImpl;
 
 export function withEnv(newEnv: unknown, fn: () => unknown): unknown {
   return innerEnv.withEnv(newEnv, fn);


### PR DESCRIPTION
This is a proposal to add arbitrary step-related tags on console logs emitted from within workflow instances (more specifically, steps).

https://github.com/cloudflare/workerd/pull/6608 got merged, meaning that the tracing api is now using async context to store active spans. This means that user spans can in theory be attributed to the correct span, once the log instrumentation is changed to do so