### PR TITLE
[build] Define ISA extensions for all 1st party code

### DIFF
--- a/build/wd_cc_library.bzl
+++ b/build/wd_cc_library.bzl
@@ -2,13 +2,28 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-def wd_cc_library(strip_include_prefix = "/src", **kwargs):
+def wd_cc_library(strip_include_prefix = "/src", copts = [], **kwargs):
     """Wrapper for cc_library that sets common attributes
     """
     cc_library(
         target_compatible_with = select({
             "@//build/config:no_build": ["@platforms//:incompatible"],
             "//conditions:default": [],
+        }),
+        # global CPU-specific options are inconvenient to specify with bazel – just set the options we
+        # need for CRC32C used in in this target for now.
+        # TODO(cleanup): Come up with a better approach to specify these options for all C/C++
+        # targets - it appears to be impossible to set arch-specific copts without a custom
+        # toolchain or manually setting a config from the CLI interface (which we can do in CI, but
+        # can't easily do for local builds).
+        copts = copts + select({
+            "@platforms//cpu:aarch64": [
+                "-mcrc",
+            ],
+            "@platforms//cpu:x86_64": [
+                # Note that msse4.2 already includes CRC32C and SSSE3 extensions
+                "-msse4.2",
+            ],
         }),
         strip_include_prefix = strip_include_prefix,
         **kwargs

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -59,16 +59,6 @@ wd_cc_library(
         "worker.h",
         "worker-fs.h",
     ] + ["//src/workerd/api:hdrs"],
-    # global CPU-specific options are inconvenient to specify with bazel – just set the options we
-    # need for CRC32C in this target for now.
-    copts = select({
-        "@platforms//cpu:aarch64": [
-            "-mcrc",
-        ],
-        "@platforms//cpu:x86_64": [
-            "-msse4.2",
-        ],
-    }),
     implementation_deps = [
         "//src/workerd/api:crypto-crc-impl",
         "//src/workerd/api:data-url",

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -10,7 +10,13 @@ wd_cc_library(
         "//src/workerd/server:really_use_tcmalloc": ["WD_USE_TCMALLOC"],
         "//conditions:default": [],
     }),
-    tags = ["workerd-benchmark"],
+    # clang-tidy fails on this target when using clang-tidy-21 together with llvm-19 headers due to
+    # changes in how intrinsics are defined - disable clang-tidy here until we start using LLVM 21
+    # everywhere.
+    tags = [
+        "no-clang-tidy",
+        "workerd-benchmark",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "@capnp-cpp//src/kj:kj-test",

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -38,7 +38,13 @@ wd_cc_library(
     # code elimination, but doing so results in a smaller size improvement than enabling
     # optimization here, or no additional improvement when doing combined with enabling
     # optimization.
-    copts = ["-O3"],
+    copts = select({
+        "@platforms//os:windows": [
+            "/O2",
+            "/clang:-O3",
+        ],
+        "//conditions:default": ["-O3"],
+    }),
     defines = select({
         ":really_use_perfetto": ["WORKERD_USE_PERFETTO"],
         "//conditions:default": [],


### PR DESCRIPTION
- Ideally we'd enable this on all C/C++ code, but that's difficult (see TODO comment)
- This should fix cloudflare/workerd#5977 by ensuring both places where we compute SQL-related hashes use hardware acceleration. To address this more generally, we'll need to make changes in capnp (capnproto/capnproto#2564)
- Also fixes a regression where crc-impl.c++ was compiled without CRC extensions enabled, which appears to have caused the software-based CRC32C implementation to be used
- Define -O3 properly for perfetto-tracing target on Windows, for consistency

Notes for reviewers:
- Since we already use the given ISA extensions for parts of the binary, applying them to more code does not affect our existing hardware requirements.
- This should implicitly fix cloudflare/workerd#5977, but it's something we should be doing anyway. Note that we could regress on this again if we were to somehow use the plain cc_library for some targets that end up setting hash values for the affected SQL API, that's why we need to fix the underlying footgun in capnproto.
- Supersedes #6078, which inspired this change. CC @FlorentCollin