### PR TITLE
Drive-by Fix ActorSqlite::armAlarmHandler log

### DIFF
--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -906,9 +906,10 @@ kj::OneOf<ActorSqlite::CancelAlarmHandler, ActorSqlite::RunAlarmHandler> ActorSq
       // blocking alarm execution on the AlarmManager sync when storage is overloaded. The alarm
       // will either delete itself on success or reschedule on failure.
       if ((willFireEarlier(localAlarmState, currentTime))) {
+        auto localAlarmTime = KJ_ASSERT_NONNULL(localAlarmState);
         LOG_WARNING_PERIODICALLY(
             "NOSENTRY SQLite alarm overdue, running despite AlarmManager mismatch", scheduledTime,
-            KJ_ASSERT_NONNULL(localAlarmState), currentTime, actorId);
+            localAlarmTime, currentTime, actorId);
         haveDeferredDelete = true;
         inAlarmHandler = true;
         deferredAlarmSpan = kj::mv(parentSpan);


### PR DESCRIPTION
The `LOG_WARNING_PERIODICALLY` with `KJ_ASSERT_NONNULL(localAlarmState)` is replacing the `KJ_ASSERT_NONNULL(localAlarmState)` or `localAlarmState` with the macro, making it hard to read in the logs. This PR stores the `KJ_ASSERT_NONNULL(localAlarmState)` to a variable before logging, avoiding hard to read logs.