### PR TITLE
fix: Allow internal module resolution to access builtin modules

### DIFF
--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -405,6 +405,11 @@ class ModuleRegistryImpl final: public ModuleRegistry {
       KJ_IF_SOME(entry, entries.find(Key(specifier, Type::INTERNAL))) {
         return entry->module(js, observer, referrer, method);
       }
+      // Also allow BUILTIN modules for internal resolution. This allows
+      // extension modules to import public built-in modules like cloudflare:workers.
+      KJ_IF_SOME(entry, entries.find(Key(specifier, Type::BUILTIN))) {
+        return entry->module(js, observer, referrer, method);
+      }
       return kj::none;
     } else if (option == ResolveOption::BUILTIN_ONLY) {
       KJ_IF_SOME(entry, entries.find(Key(specifier, Type::BUILTIN))) {


### PR DESCRIPTION
When resolving modules with `INTERNAL_ONLY` option, also allow BUILTIN modules to be resolved as a fallback.

This enables extension modules (like miniflare's `dispatch-namespace.worker.ts`, which sparked this PR) to import public built-in modules like `cloudflare:workers`.

Alternative to https://github.com/cloudflare/capnweb/pull/139
