### PR TITLE
avoid emitting unhandled rejections on DecompressionStream

### DIFF
--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -301,6 +301,13 @@ wd_test(
 
 wd_test(
     size = "large",
+    src = "decompression-stream-unhandled-rejection-test.wd-test",
+    args = ["--experimental"],
+    data = ["decompression-stream-unhandled-rejection-test.js"],
+)
+
+wd_test(
+    size = "large",
     src = "htmlrewriter-test.wd-test",
     args = ["--experimental"],
     data = ["htmlrewriter-test.js"],

--- a/src/workerd/api/tests/decompression-stream-unhandled-rejection-test.js
+++ b/src/workerd/api/tests/decompression-stream-unhandled-rejection-test.js
@@ -1,0 +1,49 @@
+// Regression test for https://github.com/cloudflare/workerd/issues/6061
+// DecompressionStream generates unhandled rejections internally when
+// streams are consumed via Array.fromAsync, even when the caller
+// properly handles errors.
+
+import { strictEqual } from 'node:assert';
+import { mock } from 'node:test';
+import { setTimeout } from 'node:timers/promises';
+
+export const decompessionStreamUnhandledRejection = {
+  async test() {
+    const rejectionFn = mock.fn();
+    const unhandledRejectionFn = mock.fn();
+    globalThis.addEventListener('rejectionhandled', rejectionFn);
+    globalThis.addEventListener('unhandledrejection', unhandledRejectionFn);
+
+    const valid = new Uint8Array([120, 156, 75, 4, 0, 0, 98, 0, 98]); // deflate('a')
+    const empty = new Uint8Array(1);
+    const invalid = new Uint8Array([...valid, ...empty]);
+    const double = new Uint8Array([...valid, ...valid]);
+    for (const chunks of [
+      [valid],
+      [invalid],
+      [valid, empty],
+      [valid, valid],
+      [double],
+    ]) {
+      try {
+        const stream = new Blob(chunks)
+          .stream()
+          .pipeThrough(new DecompressionStream('deflate'));
+        await Array.fromAsync(stream);
+      } catch (error) {
+        strictEqual(
+          error.message,
+          'Trailing bytes after end of compressed data'
+        );
+      }
+    }
+
+    await setTimeout(200);
+    globalThis.removeEventListener('rejectionhandled', rejectionFn);
+    globalThis.removeEventListener('unhandledrejection', unhandledRejectionFn);
+    strictEqual(
+      rejectionFn.mock.callCount(),
+      unhandledRejectionFn.mock.callCount()
+    );
+  },
+};

--- a/src/workerd/api/tests/decompression-stream-unhandled-rejection-test.wd-test
+++ b/src/workerd/api/tests/decompression-stream-unhandled-rejection-test.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "decompression-stream-unhandled-rejection-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "decompression-stream-unhandled-rejection-test.js")
+        ],
+        compatibilityFlags = [
+          "nodejs_compat",
+          "strict_compression_checks",
+          "unhandled_rejection_after_microtask_checkpoint",
+        ]
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workerd/issues/6061

DecompressionStream (and more broadly, any pipeThrough + async iteration pattern) generates spurious unhandledrejection events even when the caller properly catches errors. This was caused by three sites creating rejected promises that were never marked as handled: 

(1) the pipeThrough error handler in readable.c++ unnecessarily re-wrapped rejections via js.rejectedPromise(), creating a transient unhandled promise before V8's microtask chain could adopt it — fixed by removing the redundant .then() and marking the pipe promise as handled directly; 
(2) the async iterator's pushCurrent in iterator.h re-rejected in its error handler, orphaning a promise whose error was already propagated through nextImpl — fixed by swallowing the rejection with .catch_() since pushCurrent is purely bookkeeping; 
(3) the async iterator's returnFunction in readable.c++ called reader->cancel() on an already-errored stream without catching the resulting rejection. Fixed by using .catch_() to swallow the expected error during teardown.