### PR TITLE
Fix Windows SQLITE_CANTOPEN by using native path format

### DIFF
--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -508,7 +508,8 @@ void SqliteDatabase::init(kj::Maybe<kj::WriteMode> maybeMode) {
     KJ_IF_SOME(rootedPath, vfs.tryAppend(path)) {
       // If we can get the path rooted in the VFS's directory, use the system's default VFS instead
       // TODO(bug): This doesn't honor vfs.options. (This branch is only used on Windows.)
-      SQLITE_CALL_NODB(sqlite3_open_v2(rootedPath.toString().cStr(), &db, flags, nullptr));
+      SQLITE_CALL_NODB(
+          sqlite3_open_v2(rootedPath.toNativeString(true).cStr(), &db, flags, nullptr));
     } else {
       SQLITE_CALL_NODB(sqlite3_open_v2(path.toString().cStr(), &db, flags, vfs.getName().cStr()));
     }
@@ -516,8 +517,8 @@ void SqliteDatabase::init(kj::Maybe<kj::WriteMode> maybeMode) {
     KJ_IF_SOME(rootedPath, vfs.tryAppend(path)) {
       // If we can get the path rooted in the VFS's directory, use the system's default VFS instead
       // TODO(bug): This doesn't honor vfs.options. (This branch is only used on Windows.)
-      SQLITE_CALL_NODB(
-          sqlite3_open_v2(rootedPath.toString().cStr(), &db, SQLITE_OPEN_READONLY, nullptr));
+      SQLITE_CALL_NODB(sqlite3_open_v2(
+          rootedPath.toNativeString(true).cStr(), &db, SQLITE_OPEN_READONLY, nullptr));
     } else {
       SQLITE_CALL_NODB(
           sqlite3_open_v2(path.toString().cStr(), &db, SQLITE_OPEN_READONLY, vfs.getName().cStr()));


### PR DESCRIPTION
## Summary

On Windows, `SqliteDatabase::init()` in `sqlite.c++` constructs the database file path via `Vfs::tryAppend()`, which returns a `kj::Path`. The path was serialized with `toString()`, which is documented as the **Unix-style serializer** — it always produces forward-slash paths like `D:/a/_temp/.../actor.sqlite`.

This path is then passed to `sqlite3_open_v2()` with `nullptr` VFS, meaning SQLite uses the default `win32` VFS which expects native Windows paths with backslashes.

The fix switches to `toNativeString(true)` which:
- On Windows: produces `D:\a\_temp\...\actor.sqlite` (via `toWin32String`)
- On non-Windows: is equivalent to `toString()` (no-op)

The `tryAppend()` codepath is also Windows-only (returns `kj::none` on other platforms), so this change is fully scoped to Windows.

## Impact

This fixes `SQLITE_CANTOPEN` errors when using SQLite-backed Durable Objects with Miniflare on Windows. The error manifests at `sqlite3_step()` (line 1522) rather than `sqlite3_open_v2()` because the database opens successfully but WAL journal mode (`PRAGMA journal_mode=WAL`) fails when creating the `.sqlite-wal` and `.sqlite-shm` sidecar files.

Discovered while working on vitest-pool-workers v4 support in workers-sdk (cloudflare/workers-sdk#11632).