### PR TITLE
fix: carry request.cf through debug port capnp layer

### DIFF
--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -792,11 +792,11 @@ interface EventDispatcher @0xf20697475ec1752d {
 interface WorkerdBootstrap {
   # Bootstrap interface exposed by workerd when serving Cap'n Proto RPC.
 
-  startEvent @0 () -> (dispatcher :EventDispatcher);
+  startEvent @0 (cfBlobJson :Text) -> (dispatcher :EventDispatcher);
   # Start a new event. Exactly one event should be delivered to the returned EventDispatcher.
   #
-  # TODO(someday): Pass cfBlobJson? Currently doesn't matter since the cf blob is only present for
-  #   HTTP requests which can be delivered over regular HTTP instead of capnp.
+  # If the event is an HTTP request, `cfBlobJson` optionally carries the JSON-encoded `request.cf`
+  # object. The dispatcher will pass it through to the worker via SubrequestMetadata.
 }
 
 interface WorkerdDebugPort {


### PR DESCRIPTION
## Summary

- Fixes `request.cf` being lost when requests go through the debug port (used by Miniflare's native dev registry for cross-worker service bindings)
- The cf blob was already being passed to `startRequest(metadata)` by `Fetcher::getClientWithTracing()` but `WorkerdBootstrapSubrequestChannel` ignored it entirely

## Changes

**Sender side** (`workerd-debug-port-client.c++`):
- `CfInjectingWorkerInterface`: thin `WorkerInterface` wrapper that injects `MF-CF-Blob` header into outgoing HTTP requests when `metadata.cfBlobJson` is present
- `WorkerdBootstrapSubrequestChannel::startRequest()` now wraps the `RpcWorkerInterface` with `CfInjectingWorkerInterface` when cf blob is provided

**Receiver side** (`server.c++`):
- `CfAwareHttpService`: wraps the target service's HTTP interface, extracts `MF-CF-Blob` header from incoming requests, and passes cf to `SubrequestMetadata`
- `EventDispatcherImpl` defers `WorkerInterface` creation until the HTTP request arrives (stores `SubrequestChannel` instead of `WorkerInterface`), enabling cf blob extraction
- `startEvent()` passes `kj::addRef(*service)` instead of `service->startRequest({})`

## Context

Part of cloudflare/workers-sdk#12600 — refactoring the Miniflare dev registry to use native debug port RPC instead of a Node.js HTTP proxy.