### PR TITLE
Use draining read in standard.c++ pumpTo impl

### DIFF
--- a/src/workerd/api/streams/queue.c++
+++ b/src/workerd/api/streams/queue.c++
@@ -232,6 +232,11 @@ jsg::Promise<DrainingReadResult> ValueQueue::Consumer::drainingRead(jsg::Lock& j
       size_t prevChunkCount = chunks.size();
       bool pullCompletedSync = listener.onConsumerWantsData(js);
 
+      // The pull callback may have closed or errored the consumer, which
+      // destroys the Ready state (and its RingBuffer). We must not touch
+      // `ready` after that.
+      if (!impl.state.isActive()) break;
+
       // Drain all buffered data that was added by the pull.
       KJ_IF_SOME(errorPromise, drainBuffer(js, impl, ready, chunks, totalRead, isClosing)) {
         return kj::mv(errorPromise);
@@ -242,6 +247,19 @@ jsg::Promise<DrainingReadResult> ValueQueue::Consumer::drainingRead(jsg::Lock& j
         break;
       }
     }
+  }
+
+  // If the consumer was closed or errored during pumping, the `ready`
+  // reference is dangling. Return what we have or the appropriate error.
+  if (!impl.state.isActive()) {
+    KJ_IF_SOME(errored, impl.state.tryGetErrorUnsafe()) {
+      return js.rejectedPromise<DrainingReadResult>(errored.reason.getHandle(js));
+    }
+    // Closed — all data was already drained. Return collected chunks.
+    return js.resolvedPromise(DrainingReadResult{
+      .chunks = chunks.releaseAsArray(),
+      .done = true,
+    });
   }
 
   // If we collected data, return it immediately.
@@ -656,6 +674,11 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
       size_t prevChunkCount = chunks.size();
       bool pullCompletedSync = listener.onConsumerWantsData(js);
 
+      // The pull callback may have closed or errored the consumer, which
+      // destroys the Ready state (and its RingBuffer). We must not touch
+      // `ready` after that.
+      if (!impl.state.isActive()) break;
+
       // Drain all buffered data that was added by the pull.
       drainBuffer(ready, chunks, totalRead, isClosing);
 
@@ -664,6 +687,19 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
         break;
       }
     }
+  }
+
+  // If the consumer was closed or errored during pumping, the `ready`
+  // reference is dangling. Return what we have or the appropriate error.
+  if (!impl.state.isActive()) {
+    KJ_IF_SOME(errored, impl.state.tryGetErrorUnsafe()) {
+      return js.rejectedPromise<DrainingReadResult>(errored.reason.getHandle(js));
+    }
+    // Closed — all data was already drained. Return collected chunks.
+    return js.resolvedPromise(DrainingReadResult{
+      .chunks = chunks.releaseAsArray(),
+      .done = true,
+    });
   }
 
   // If we collected data, return it immediately.

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -1865,7 +1865,23 @@ struct ValueReadable final: private api::ValueQueue::ConsumerImpl::StateListener
 
   jsg::Promise<DrainingReadResult> drainingRead(jsg::Lock& js, size_t maxRead) {
     KJ_IF_SOME(s, state) {
-      return s.consumer->drainingRead(js, maxRead);
+      // Hold an operation scope on the owner's state machine so that any
+      // deferred close/error transition (triggered by the pull callback inside
+      // drainingRead) does not destroy this ValueReadable — and thus the
+      // Consumer — while consumer->drainingRead() is on the stack.
+      ReadableStreamJsController& owner = s.owner;
+      owner.state.beginOperation();
+      auto result = s.consumer->drainingRead(js, maxRead);
+      if (owner.state.endOperation()) {
+        if (owner.state.template is<StreamStates::Closed>()) {
+          owner.lock.onClose(js);
+        } else if (owner.state.template is<StreamStates::Errored>()) {
+          KJ_IF_SOME(err, owner.state.template tryGetUnsafe<StreamStates::Errored>()) {
+            owner.lock.onError(js, err.getHandle(js));
+          }
+        }
+      }
+      return kj::mv(result);
     }
 
     // We are canceled! Return done with empty chunks.
@@ -2104,7 +2120,23 @@ struct ByteReadable final: private api::ByteQueue::ConsumerImpl::StateListener {
 
   jsg::Promise<DrainingReadResult> drainingRead(jsg::Lock& js, size_t maxRead) {
     KJ_IF_SOME(s, state) {
-      return s.consumer->drainingRead(js, maxRead);
+      // Hold an operation scope on the owner's state machine so that any
+      // deferred close/error transition (triggered by the pull callback inside
+      // drainingRead) does not destroy this ByteReadable — and thus the
+      // Consumer — while consumer->drainingRead() is on the stack.
+      ReadableStreamJsController& owner = s.owner;
+      owner.state.beginOperation();
+      auto result = s.consumer->drainingRead(js, maxRead);
+      if (owner.state.endOperation()) {
+        if (owner.state.template is<StreamStates::Closed>()) {
+          owner.lock.onClose(js);
+        } else if (owner.state.template is<StreamStates::Errored>()) {
+          KJ_IF_SOME(err, owner.state.template tryGetUnsafe<StreamStates::Errored>()) {
+            owner.lock.onError(js, err.getHandle(js));
+          }
+        }
+      }
+      return kj::mv(result);
     }
 
     // We are canceled! Return done with empty chunks.
@@ -3281,281 +3313,69 @@ class AllReader {
   }
 };
 
-class PumpToReader {
- public:
-  PumpToReader(jsg::Ref<ReadableStream> stream, kj::Own<WritableStreamSink> sink, bool end)
-      : ioContext(IoContext::current()),
-        state(State::create<jsg::Ref<ReadableStream>>(kj::mv(stream))),
-        sink(kj::mv(sink)),
-        self(kj::refcounted<WeakRef<PumpToReader>>(kj::Badge<PumpToReader>{}, *this)),
-        end(end) {}
-  KJ_DISALLOW_COPY_AND_MOVE(PumpToReader);
+// pumpToCoroutine uses a DrainingReader to efficiently pull all synchronously available
+// data from the stream in each iteration, then writes it to the sink using vectored
+// I/O. This minimizes isolate lock acquisitions by batching: each time the lock is
+// held, the stream's internal queue is fully drained and the JS pull callback is
+// pumped synchronously as many times as possible.
+//
+// The pump loop is a kj coroutine. Dropping the returned kj::Promise drops the
+// coroutine frame, which destroys the DrainingReader (releasing the stream lock)
+// and the sink. No WeakRef/IoOwn dance is needed because ownership is clear.
+// The coroutine that implements the pump loop takes ownership of the DrainingReader
+// and sink. The jsg::Ref<ReadableStream> is not passed into the coroutine because
+// jsg::Ref is disallowed in coroutine parameters; instead, the DrainingReader holds
+// a reference to the stream internally.
+kj::Promise<void> pumpToImpl(IoContext& ioContext,
+    kj::Own<DrainingReader> reader,
+    kj::Own<WritableStreamSink> sink,
+    bool end) {
 
-  ~PumpToReader() noexcept(false) {
-    self->invalidate();
-    // Ensure that if a write promise is pending it is proactively canceled.
-    canceler.cancel("PumpToReader was destroyed");
-  }
+  bool writeFailed = false;
 
-  kj::Promise<void> pumpTo(jsg::Lock& js) {
-    ioContext.requireCurrentOrThrowJs();
-    KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(stream, jsg::Ref<ReadableStream>) {
-        auto readable = stream.addRef();
-        state.template transitionTo<Pumping>();
-        // Ownership of readable passes into the pump loop...
-        // Ownership of the sink remains with the PumpToReader...
-        // The JS Promise loop uses an IoOwn wrapping a weak ref to the PumpToReader...
-        // The ownership of everything here is a bit complicated. We have a kj::Promise
-        // wrapping a JS Promise that is essentially a loop of JS read promises followed
-        // by kj write promise. If the outer kj Promise is dropped, the PumpToReader attached
-        // to it is dropped. When that happens, there's a chance the JS continuation will still
-        // be scheduled to run. The IoOwn ensures that the PumpToReader, and the sink it owns,
-        // are always accessed from the right IoContext. The WeakRef ensures that if the
-        // PumpToReader is freed while the JS continuation is pending, there won't be a dangling
-        // reference.
-        return ioContext.awaitJs(
-            js, pumpLoop(js, ioContext, kj::mv(readable), ioContext.addObject(self->addRef())));
+  KJ_TRY {
+    while (true) {
+      // Perform a draining read to get all synchronously available data if possible
+      // or fall back to a regular read if not.
+      DrainingReadResult result = co_await ioContext.run([&reader](jsg::Lock& js) mutable {
+        auto& ioContext = IoContext::current();
+        // Use a 256KB limit to allow periodic yielding to the event loop,
+        // preventing a fast producer from monopolizing the thread.
+        constexpr size_t kMaxReadPerCycle = 256 * 1024;
+        return ioContext.awaitJs(js, reader->read(js, kMaxReadPerCycle));
+      });
+
+      // Write all the chunks we received using vectored write for efficiency.
+      if (result.chunks.size() > 0) {
+        KJ_ON_SCOPE_FAILURE(writeFailed = true);
+        auto pieces =
+            KJ_MAP(chunk, result.chunks) -> kj::ArrayPtr<const kj::byte> { return chunk.asPtr(); };
+        co_await sink->write(pieces);
       }
-      KJ_CASE_ONEOF(pumping, Pumping) {
-        return KJ_EXCEPTION(FAILED, "pumping is already in progress");
-      }
-      KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-        return KJ_EXCEPTION(FAILED, "stream has already been consumed");
-      }
-      KJ_CASE_ONEOF(errored, kj::Exception) {
-        return kj::cp(errored);
-      }
-    }
-    KJ_UNREACHABLE;
-  }
 
- private:
-  struct Pumping {
-    static constexpr kj::StringPtr NAME KJ_UNUSED = "pumping"_kj;
-  };
-  IoContext& ioContext;
-
-  // State machine for PumpToReader:
-  // Closed and kj::Exception are terminal states (pump is done).
-  // jsg::Ref<ReadableStream> is the initial state (has stream to pump).
-  // Pumping is the active state (pump is in progress).
-  using State = StateMachine<TerminalStates<StreamStates::Closed>,
-      ErrorState<kj::Exception>,
-      Pumping,
-      StreamStates::Closed,
-      kj::Exception,
-      jsg::Ref<ReadableStream>>;
-  State state;
-  kj::Own<WritableStreamSink> sink;
-  kj::Own<WeakRef<PumpToReader>> self;
-  kj::Canceler canceler;
-  bool end;
-
-  bool isErroredOrClosed() {
-    return state.isTerminal();
-  }
-
-  jsg::Promise<void> pumpLoop(jsg::Lock& js,
-      IoContext& ioContext,
-      jsg::Ref<ReadableStream> readable,
-      IoOwn<WeakRef<PumpToReader>> pumpToReader) {
-    ioContext.requireCurrentOrThrowJs();
-
-    KJ_SWITCH_ONEOF(state) {
-      KJ_CASE_ONEOF(ready, jsg::Ref<ReadableStream>) {
-        KJ_UNREACHABLE;
-      }
-      KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-        return end ? ioContext.awaitIoLegacy(js, sink->end().attach(kj::mv(sink)))
-                   : js.resolvedPromise();
-      }
-      KJ_CASE_ONEOF(errored, kj::Exception) {
+      // If the stream is done, end the output if needed and exit.
+      if (result.done) {
+        KJ_ON_SCOPE_FAILURE(writeFailed = true);
         if (end) {
-          sink->abort(kj::cp(errored));
+          co_await sink->end();
         }
-        return js.rejectedPromise<void>(kj::cp(errored));
-      }
-      KJ_CASE_ONEOF(pumping, Pumping) {
-        using Result = kj::OneOf<Pumping,  // Continue with next read.
-            kj::Array<kj::byte>,           // Bytes to write were returned.
-            StreamStates::Closed,          // Readable indicated done.
-            jsg::Value>;                   // There was an error.
-
-        // The flow here is relatively straightforward but the ownership of
-        // readable/pumpToReader is fairly complicated.
-        //
-        // First, we read from the readable, attaching both a success and fail
-        // continuation. In the success continuation, we check the read result
-        // and determine if the readable is done, if the readable provided bytes,
-        // or if the read failed. This result is passed to another continuation
-        // that processes the result.
-        //
-        // Within that second continuation, we first check to see if the PumpToReader
-        // is still alive. It won't be if the kj::Promise representing the pump has
-        // been dropped. If it is not alive, we clean up by canceling the readable
-        // if necessary and just stopping. If the PumpToReader is alive, our next
-        // step is determined by the result of the read.
-        //
-        // If the read provided bytes, we write those into the sink, which returns
-        // a kj::Promise wrapped with a JS promise. If that write fails, we error
-        // the PumpToReader and cleanup. If the write succeeds, we loop again for
-        // another read.
-        //
-        // If the read indicates that we're done, we close the PumpToReader and
-        // cleanup.
-        //
-        // If the read indicates that we errored, we error the PumpToReader and
-        // cleanup.
-        //
-        // Importantly, at each step, we check the PumpToReader to ensure that
-        // we are accessing it from the correct IoContext (it is wrapped in an
-        // IoOwn), and we check that it's still alive (using the WeakRef).
-        //
-        // This loop owns both the readable and pumpToReader, however, the
-        // pumpToReader is an IoOwn<WeakRef> pointing at the actual PumpToReader
-        // instance, which is a kj heap object attached to the kj::Promise returned
-        // by the pumpTo method. If that promise gets dropped while any of the
-        // JS promises in the loop are still pending, then the PumpToReader will
-        // be freed. When the JS promise resolves, we make sure we detect that
-        // case and handle appropriately (generally by canceling the readable
-        // and exiting the loop).
-        return KJ_ASSERT_NONNULL(readable->getController().read(js, kj::none))
-            .then(js,
-                ioContext.addFunctor([byteStream = readable->getController().isByteOriented()](
-                                         auto& js, ReadResult result) mutable -> Result {
-          if (result.done) {
-            // Indicate to the outer promise that the readable is done.
-            // There's nothing further to do.
-            return StreamStates::Closed();
-          }
-
-          // If we're not done, the result value must be interpretable as
-          // bytes for the read to make any sense.
-          auto handle = KJ_ASSERT_NONNULL(result.value).getHandle(js);
-          if (!handle->IsArrayBufferView() && !handle->IsArrayBuffer()) {
-            return js.v8Ref(js.v8TypeError("This ReadableStream did not return bytes."));
-          }
-
-          jsg::BufferSource bufferSource(js, handle);
-          if (bufferSource.size() == 0) {
-            // Weird, but allowed. We'll skip it.
-            return Pumping{};
-          }
-
-          if (byteStream) {
-            jsg::BackingStore backing = bufferSource.detach(js);
-            return backing.asArrayPtr().attach(kj::mv(backing));
-          }
-          // We do not detach in this case because, as bad as an idea as it is,
-          // the stream spec does allow a single typedarray/arraybuffer instance
-          // to be queued multiple times when using value-oriented streams.
-          return bufferSource.asArrayPtr().attach(kj::mv(bufferSource));
-        }),
-                [](auto& js, jsg::Value exception) mutable -> Result { return kj::mv(exception); })
-            .then(js, ioContext.addFunctor( JSG_VISITABLE_LAMBDA((readable = kj::mv(readable), pumpToReader = kj::mv(pumpToReader)), (readable), (jsg::Lock & js, Result result) mutable {
-              KJ_IF_SOME(reader, pumpToReader->tryGet()) {
-              // Oh good, if we got here it means we're in the right IoContext and
-              // the PumpToReader is still alive. Let's process the result.
-              reader.ioContext.requireCurrentOrThrowJs();
-              auto& ioContext = IoContext::current();
-              KJ_SWITCH_ONEOF(result) {
-              KJ_CASE_ONEOF(bytes, kj::Array<kj::byte>) {
-              // We received bytes to write. Do so...
-              auto promise = reader.sink->write(bytes).attach(kj::mv(bytes));
-              // Wrap the write promise in a canceler that will be triggered when the
-              // PumpToReader is dropped. While the write promise is pending, it is
-              // possible for the promise that is holding the PumpToReader to be
-              // dropped causing the hold on the sink to be released. If that is
-              // released while the write is still pending we can end up with an
-              // error further up the destruct chain.
-              return ioContext.awaitIo(js, reader.canceler.wrap(kj::mv(promise)))
-                  .then(js,
-                      [](jsg::Lock& js) -> kj::Maybe<jsg::Value> {
-                // The write completed successfully.
-                return kj::Maybe<jsg::Value>(kj::none);
-              },
-                      [](jsg::Lock& js, jsg::Value exception) mutable -> kj::Maybe<jsg::Value> {
-                // The write failed.
-                return kj::mv(exception);
-              })
-                  .then(js,
-                      ioContext.addFunctor(JSG_VISITABLE_LAMBDA(
-                          (readable = readable.addRef(), pumpToReader = kj::mv(pumpToReader)),
-                          (readable),
-                          (jsg::Lock & js, kj::Maybe<jsg::Value> maybeException) mutable {
-                            KJ_IF_SOME(reader, pumpToReader->tryGet()) {
-                            auto& ioContext = reader.ioContext;
-                            ioContext.requireCurrentOrThrowJs();
-                            // Oh good, if we got here it means we're in the right IoContext and
-                            // the PumpToReader is still alive.
-                            KJ_IF_SOME(exception, maybeException) {
-                            if (!reader.isErroredOrClosed()) {
-                            reader.state.transitionTo<kj::Exception>(
-                                js.exceptionToKj(kj::mv(exception)));
-                            }
-                            } else {
-                            // Else block to avert dangling else compiler warning.
-                            }
-                            return reader.pumpLoop(
-                                js, ioContext, readable.addRef(), kj::mv(pumpToReader));
-                            } else {
-                            // If we got here, we're in the right IoContext but the PumpToReader
-                            // has been destroyed. Let's cancel the readable as the last step.
-                            return readable->getController().cancel(js,
-                                maybeException.map(
-                                    [&](jsg::Value& ex) { return ex.getHandle(js); }));
-                            }
-                          })));
-              }
-              KJ_CASE_ONEOF(pumping, Pumping) {
-              // If we got here, a zero-length buffer was provided by the read and we're
-              // just going to ignore it and keep going.
-              }
-              KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-              // If we got here, the read signaled that we're done. Close the reader and
-              // pump one more time to shut things down.
-              if (!reader.isErroredOrClosed()) {
-              reader.state.transitionTo<StreamStates::Closed>();
-              }
-              }
-              KJ_CASE_ONEOF(exception, jsg::Value) {
-              // If we got here, the read signaled an exception. Either the read failed or
-              // provided something other than bytes. Error the reader and pump one more
-              // time to shut things down.
-              if (!reader.isErroredOrClosed()) {
-              reader.state.transitionTo<kj::Exception>(js.exceptionToKj(kj::mv(exception)));
-              }
-              }
-              }
-              return reader.pumpLoop(js, ioContext, readable.addRef(), kj::mv(pumpToReader));
-              } else {
-              // If we got here, we're in the right IoContext but the PumpToReader has been
-              // freed. There's nothing we can do except cleanup.
-              KJ_SWITCH_ONEOF(result) {
-              KJ_CASE_ONEOF(bytes, kj::Array<kj::byte>) {
-              return readable->getController().cancel(js, kj::none);
-              }
-              KJ_CASE_ONEOF(pumping, Pumping) {
-              return readable->getController().cancel(js, kj::none);
-              }
-              KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-              // We do not have to cancel the readable in this case because it has already
-              // signaled that it is done. There's nothing to cancel.
-              return js.resolvedPromise();
-              }
-              KJ_CASE_ONEOF(exception, jsg::Value) {
-              return readable->getController().cancel(js, exception.getHandle(js));
-              }
-              }
-              }
-              KJ_UNREACHABLE;
-            })));
+        co_return;
       }
     }
-    KJ_UNREACHABLE;
   }
-};
+  KJ_CATCH(exception) {
+    if (!writeFailed) {
+      sink->abort(kj::cp(exception));
+    }
+
+    co_await ioContext.run([&reader, ex = kj::cp(exception)](jsg::Lock& js) mutable {
+      auto& ioContext = IoContext::current();
+      auto error = js.exceptionToJsValue(kj::mv(ex));
+      return ioContext.awaitJs(js, reader->cancel(js, error.getHandle(js)));
+    });
+    kj::throwFatalException(kj::mv(exception));
+  }
+}
 }  // namespace
 
 template <typename T>
@@ -3698,15 +3518,15 @@ kj::Promise<DeferredProxy<void>> ReadableStreamJsController::pumpTo(
   disturbed = true;
 
   // This operation will leave the ReadableStream locked and disturbed. It will consume
-  // the stream until it either closed or errors. If the deferred proxy promise or its
-  // inner promise is dropped, the PumpToReader (and sink) will be dropped and the stream
-  // will be canceled. If the PumpToReader is dropped while there is a pending write on
-  // the sink, the pending write will be canceled.
+  // the stream until it either closed or errors. If the returned promise (or its inner
+  // promise) is dropped, the coroutine frame is destroyed, which drops the DrainingReader
+  // (releasing the stream lock) and the sink, canceling any in-flight operations.
 
   const auto handlePump = [&] {
-    KJ_ASSERT(lock.lock());
-    auto reader = kj::heap<PumpToReader>(addRef(), kj::mv(sink), end);
-    return addNoopDeferredProxy(reader->pumpTo(js).attach(kj::mv(reader)));
+    auto reader = KJ_ASSERT_NONNULL(DrainingReader::create(js, *this->addRef()),
+        "Failed to create DrainingReader — stream should not be locked");
+    auto& ioContext = IoContext::current();
+    return addNoopDeferredProxy(pumpToImpl(ioContext, kj::mv(reader), kj::mv(sink), end));
   };
 
   KJ_SWITCH_ONEOF(state) {

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -140,6 +140,20 @@ wd_cc_benchmark(
     ],
 )
 
+# Benchmark for PumpToReader (ReadableStream::pumpTo path in standard.c++).
+# Run before and after DrainingReader adoption to measure improvement.
+#   bazel run --config=opt //src/workerd/tests:bench-pumpto
+wd_cc_benchmark(
+    name = "bench-pumpto",
+    srcs = ["bench-pumpto.c++"],
+    tags = ["manual"],
+    deps = [
+        ":test-fixture",
+        "//src/workerd/io",
+        "//src/workerd/jsg",
+    ],
+)
+
 wd_test(
     src = "unknown-import-assertions-test.wd-test",
     args = ["--experimental"],

--- a/src/workerd/tests/bench-pumpto.c++
+++ b/src/workerd/tests/bench-pumpto.c++
@@ -1,0 +1,362 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Benchmark for PumpToReader in standard.c++.
+//
+// Measures the performance of ReadableStream::pumpTo() which routes through
+// ReadableStreamJsController::pumpTo() → PumpToReader::pumpLoop().
+//
+// This benchmark establishes a baseline before the DrainingReader adoption,
+// then the same benchmarks are re-run after the change to quantify improvement.
+//
+// Usage:
+//   # Capture baseline (before changes):
+//   bazel run --config=opt //src/workerd/tests:bench-pumpto \
+//       -- --benchmark_format=json --benchmark_out=baseline.json
+//
+//   # Capture comparison (after changes):
+//   bazel run --config=opt //src/workerd/tests:bench-pumpto \
+//       -- --benchmark_format=json --benchmark_out=after.json
+//
+// Key metrics:
+//   - bytes_per_second: Primary throughput metric.
+//   - WriteOps: Average sink write calls per iteration. Directly measures batching.
+//     Before DrainingReader adoption: WriteOps ≈ numChunks (one write per chunk).
+//     After: WriteOps ≪ numChunks (one vectored write per drain cycle).
+
+#include <workerd/api/streams/standard.h>
+#include <workerd/api/system-streams.h>
+#include <workerd/tests/bench-tools.h>
+#include <workerd/tests/test-fixture.h>
+
+namespace workerd::api::streams {
+namespace {
+
+// =============================================================================
+// Stream configuration
+// =============================================================================
+
+enum class StreamType {
+  VALUE,             // Default ReadableStreamDefaultController
+  BYTE,              // ReadableByteStreamController
+  IO_LATENCY_VALUE,  // Value stream that yields to KJ event loop between chunks
+};
+
+struct StreamConfig {
+  StreamType type = StreamType::VALUE;
+};
+
+// =============================================================================
+// Test utilities
+// =============================================================================
+
+// A discarding sink that counts bytes written and number of write operations.
+struct DiscardingSink final: public kj::AsyncOutputStream {
+  size_t bytesWritten = 0;
+  size_t writeCount = 0;
+
+  kj::Promise<void> write(kj::ArrayPtr<const byte> buffer) override {
+    writeCount++;
+    bytesWritten += buffer.size();
+    co_return;
+  }
+
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override {
+    writeCount++;
+    for (auto piece: pieces) {
+      bytesWritten += piece.size();
+    }
+    co_return;
+  }
+
+  kj::Promise<void> whenWriteDisconnected() override {
+    return kj::NEVER_DONE;
+  }
+
+  void reset() {
+    bytesWritten = 0;
+    writeCount = 0;
+  }
+};
+
+// =============================================================================
+// Stream creation helpers
+// =============================================================================
+
+static size_t benchChunkCounterStatic = 0;
+
+// Creates a JS-backed value ReadableStream that produces data synchronously in pull().
+jsg::Ref<ReadableStream> createValueStream(
+    jsg::Lock& js, size_t chunkSize, size_t numChunks, size_t* counter) {
+  return ReadableStream::constructor(js,
+      UnderlyingSource{
+        .pull =
+            [chunkSize, numChunks, counter](jsg::Lock& js, auto controller) {
+    auto& c =
+        KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableStreamDefaultController>>());
+
+    if ((*counter)++ < numChunks) {
+      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
+      jsg::BufferSource buffer(js, kj::mv(backing));
+      buffer.asArrayPtr().fill(0xAB);
+      c->enqueue(js, buffer.getHandle(js));
+    }
+    if (*counter == numChunks) {
+      c->close(js);
+    }
+    return js.resolvedPromise();
+  },
+        .expectedLength = chunkSize * numChunks,
+      },
+      StreamQueuingStrategy{
+        .highWaterMark = 0,
+      });
+}
+
+// Creates a JS-backed byte ReadableStream that produces data synchronously in pull().
+jsg::Ref<ReadableStream> createByteStream(
+    jsg::Lock& js, size_t chunkSize, size_t numChunks, size_t* counter) {
+  return ReadableStream::constructor(js,
+      UnderlyingSource{
+        .type = kj::str("bytes"),
+        .pull =
+            [chunkSize, numChunks, counter](jsg::Lock& js, auto controller) {
+    auto& c =
+        KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableByteStreamController>>());
+
+    if ((*counter)++ < numChunks) {
+      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
+      jsg::BufferSource buffer(js, kj::mv(backing));
+      buffer.asArrayPtr().fill(0xAB);
+      c->enqueue(js, kj::mv(buffer));
+    }
+    if (*counter == numChunks) {
+      c->close(js);
+    }
+    return js.resolvedPromise();
+  },
+        .expectedLength = chunkSize * numChunks,
+      },
+      StreamQueuingStrategy{
+        .highWaterMark = 0,
+      });
+}
+
+// Creates a value stream that yields to the KJ event loop between chunks.
+// Simulates a network stream where data arrives with real I/O latency.
+// Each chunk requires a KJ event loop iteration, so DrainingReader cannot batch them.
+jsg::Ref<ReadableStream> createIoLatencyValueStream(
+    jsg::Lock& js, size_t chunkSize, size_t numChunks, size_t* counter) {
+  return ReadableStream::constructor(js,
+      UnderlyingSource{
+        .pull =
+            [chunkSize, numChunks, counter](jsg::Lock& js, auto controller) {
+    auto& c =
+        KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableStreamDefaultController>>());
+
+    if (*counter >= numChunks) {
+      c->close(js);
+      return js.resolvedPromise();
+    }
+
+    // Use IoContext.awaitIo() to wait for a KJ event loop yield.
+    // kj::evalLater() schedules on the next KJ event loop iteration.
+    auto& ioContext = IoContext::current();
+    auto cRef = c.addRef();
+    return ioContext.awaitIo(js, kj::evalLater([]() {}),
+        JSG_VISITABLE_LAMBDA(
+            (cRef = kj::mv(cRef), chunkSize, numChunks, counter), (cRef), (jsg::Lock & js) mutable {
+              if ((*counter)++ < numChunks) {
+              auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
+              jsg::BufferSource buffer(js, kj::mv(backing));
+              buffer.asArrayPtr().fill(0xAB);
+              cRef->enqueue(js, buffer.getHandle(js));
+              }
+              if (*counter == numChunks) {
+              cRef->close(js);
+              }
+            }));
+  },
+        .expectedLength = chunkSize * numChunks,
+      },
+      StreamQueuingStrategy{
+        .highWaterMark = 0,
+      });
+}
+
+jsg::Ref<ReadableStream> createConfiguredStream(
+    jsg::Lock& js, size_t chunkSize, size_t numChunks, const StreamConfig& config) {
+  benchChunkCounterStatic = 0;
+  size_t* counter = &benchChunkCounterStatic;
+
+  switch (config.type) {
+    case StreamType::VALUE:
+      return createValueStream(js, chunkSize, numChunks, counter);
+    case StreamType::BYTE:
+      return createByteStream(js, chunkSize, numChunks, counter);
+    case StreamType::IO_LATENCY_VALUE:
+      return createIoLatencyValueStream(js, chunkSize, numChunks, counter);
+  }
+  KJ_UNREACHABLE;
+}
+
+// =============================================================================
+// Core benchmark function
+// =============================================================================
+
+// Exercises: ReadableStream::pumpTo() → ReadableStreamJsController::pumpTo() → PumpToReader
+static void benchPumpTo(
+    benchmark::State& state, size_t chunkSize, size_t numChunks, const StreamConfig& config) {
+  capnp::MallocMessageBuilder message;
+  auto flags = message.initRoot<CompatibilityFlags>();
+  flags.setStreamsJavaScriptControllers(true);
+  TestFixture fixture({.featureFlags = flags.asReader()});
+
+  DiscardingSink sink;
+  size_t expectedBytes = chunkSize * numChunks;
+
+  for (auto _: state) {
+    sink.reset();
+
+    fixture.runInIoContext([&](const TestFixture::Environment& env) {
+      auto stream = createConfiguredStream(env.js, chunkSize, numChunks, config);
+
+      // Wrap DiscardingSink as a WritableStreamSink via newSystemStream.
+      // This is the production path: PumpToReader receives a WritableStreamSink.
+      kj::Own<kj::AsyncOutputStream> fakeOwn(&sink, kj::NullDisposer::instance);
+      auto writableSink = newSystemStream(kj::mv(fakeOwn), StreamEncoding::IDENTITY, env.context);
+
+      return env.context.waitForDeferredProxy(stream->pumpTo(env.js, kj::mv(writableSink), true));
+    });
+
+    KJ_ASSERT(sink.bytesWritten == expectedBytes, "Expected", expectedBytes, "bytes but got",
+        sink.bytesWritten);
+  }
+
+  state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(expectedBytes));
+  state.counters["WriteOps"] =
+      benchmark::Counter(sink.writeCount, benchmark::Counter::kAvgIterations);
+}
+
+// =============================================================================
+// Stream configs
+// =============================================================================
+
+static const StreamConfig VALUE_DEFAULT{.type = StreamType::VALUE};
+static const StreamConfig BYTE_DEFAULT{.type = StreamType::BYTE};
+static const StreamConfig IO_LATENCY_VALUE_DEFAULT{.type = StreamType::IO_LATENCY_VALUE};
+
+// =============================================================================
+// Synchronous streams — 1 MiB total payload
+// =============================================================================
+// These are the primary benchmarks. Data is produced synchronously in the pull
+// callback. DrainingReader (post-change) can drain all chunks in a single lock
+// acquisition, so small-chunk benchmarks should see large improvement.
+
+// Value streams
+static void PumpTo_64B_Value(benchmark::State& state) {
+  benchPumpTo(state, 64, 16384, VALUE_DEFAULT);
+}
+static void PumpTo_256B_Value(benchmark::State& state) {
+  benchPumpTo(state, 256, 4096, VALUE_DEFAULT);
+}
+static void PumpTo_1KB_Value(benchmark::State& state) {
+  benchPumpTo(state, 1024, 1024, VALUE_DEFAULT);
+}
+static void PumpTo_4KB_Value(benchmark::State& state) {
+  benchPumpTo(state, 4096, 256, VALUE_DEFAULT);
+}
+static void PumpTo_16KB_Value(benchmark::State& state) {
+  benchPumpTo(state, 16384, 64, VALUE_DEFAULT);
+}
+static void PumpTo_64KB_Value(benchmark::State& state) {
+  benchPumpTo(state, 65536, 16, VALUE_DEFAULT);
+}
+
+// Byte streams
+static void PumpTo_64B_Byte(benchmark::State& state) {
+  benchPumpTo(state, 64, 16384, BYTE_DEFAULT);
+}
+static void PumpTo_256B_Byte(benchmark::State& state) {
+  benchPumpTo(state, 256, 4096, BYTE_DEFAULT);
+}
+static void PumpTo_1KB_Byte(benchmark::State& state) {
+  benchPumpTo(state, 1024, 1024, BYTE_DEFAULT);
+}
+static void PumpTo_4KB_Byte(benchmark::State& state) {
+  benchPumpTo(state, 4096, 256, BYTE_DEFAULT);
+}
+static void PumpTo_16KB_Byte(benchmark::State& state) {
+  benchPumpTo(state, 16384, 64, BYTE_DEFAULT);
+}
+static void PumpTo_64KB_Byte(benchmark::State& state) {
+  benchPumpTo(state, 65536, 16, BYTE_DEFAULT);
+}
+
+// =============================================================================
+// I/O latency streams — 64 KiB total payload
+// =============================================================================
+// Each chunk requires a KJ event loop yield, simulating real network I/O.
+// DrainingReader cannot batch these (at most 1 chunk per drain cycle).
+// These verify no regression from the PumpToReader change.
+// Smaller total payload because each chunk incurs real event loop overhead.
+
+static void PumpTo_256B_IoLatency(benchmark::State& state) {
+  benchPumpTo(state, 256, 256, IO_LATENCY_VALUE_DEFAULT);
+}
+static void PumpTo_4KB_IoLatency(benchmark::State& state) {
+  benchPumpTo(state, 4096, 16, IO_LATENCY_VALUE_DEFAULT);
+}
+static void PumpTo_64KB_IoLatency(benchmark::State& state) {
+  benchPumpTo(state, 65536, 1, IO_LATENCY_VALUE_DEFAULT);
+}
+
+// =============================================================================
+// Large payload — 10 MiB total, sync value streams
+// =============================================================================
+// Sustained throughput test with small chunks. More data amortizes fixture
+// setup cost, yielding more stable measurements.
+
+static void PumpTo_64B_10MB_Value(benchmark::State& state) {
+  benchPumpTo(state, 64, 163840, VALUE_DEFAULT);
+}
+static void PumpTo_256B_10MB_Value(benchmark::State& state) {
+  benchPumpTo(state, 256, 40960, VALUE_DEFAULT);
+}
+static void PumpTo_1KB_10MB_Value(benchmark::State& state) {
+  benchPumpTo(state, 1024, 10240, VALUE_DEFAULT);
+}
+
+// =============================================================================
+// Register benchmarks
+// =============================================================================
+
+// Sync 1 MiB — value streams
+WD_BENCHMARK(PumpTo_64B_Value);
+WD_BENCHMARK(PumpTo_256B_Value);
+WD_BENCHMARK(PumpTo_1KB_Value);
+WD_BENCHMARK(PumpTo_4KB_Value);
+WD_BENCHMARK(PumpTo_16KB_Value);
+WD_BENCHMARK(PumpTo_64KB_Value);
+
+// Sync 1 MiB — byte streams
+WD_BENCHMARK(PumpTo_64B_Byte);
+WD_BENCHMARK(PumpTo_256B_Byte);
+WD_BENCHMARK(PumpTo_1KB_Byte);
+WD_BENCHMARK(PumpTo_4KB_Byte);
+WD_BENCHMARK(PumpTo_16KB_Byte);
+WD_BENCHMARK(PumpTo_64KB_Byte);
+
+// I/O latency — 64 KiB (no-regression check)
+WD_BENCHMARK(PumpTo_256B_IoLatency);
+WD_BENCHMARK(PumpTo_4KB_IoLatency);
+WD_BENCHMARK(PumpTo_64KB_IoLatency);
+
+// Large payload — 10 MiB value streams
+WD_BENCHMARK(PumpTo_64B_10MB_Value);
+WD_BENCHMARK(PumpTo_256B_10MB_Value);
+WD_BENCHMARK(PumpTo_1KB_10MB_Value);
+
+}  // namespace
+}  // namespace workerd::api::streams


### PR DESCRIPTION
Part of ongoing incremental perf improvements. This updates the standard->to->internal pumpTo loop (consuming a JS readable stream and writing the data to a kj destination) to use the new draining read optimization. 

In a simple local benchmark, we see...

```
| Metric         | Main      | New       | Improvement       |
| -------------- | --------- | --------- | ----------------- |
| Avg Req/Sec    | 777       | 5,026     | 6.5x (+547%)      |
| Avg Latency    | 12.34 ms  | 1.35 ms   | 9.1x lower (-89%) |
| p50 Latency    | 10 ms     | 1 ms      | 10x lower         |
| p99 Latency    | 45 ms     | 8 ms      | 5.6x lower        |
| Max Latency    | 1,771 ms  | 22 ms     | 80x lower         |
| Avg Throughput | 1.49 MB/s | 7.19 MB/s | 4.8x              |
| Total Requests | 9k        | 55k       | 6.1x              |
```

the number vary broadly based on chunk size, write pattern, etc but in general we should see significant improvements across the board. 

The specific scenario that is improved are things like `return new Response(new ReadableStream(...))` in a worker fetch handler. That takes the JS-backed ReadableStream and drains it into the KJ stream at the internal level.

The specific optimization here is that we no longer perform a 1-to-1 read/write loop but instead drain as much data as we can synchronously off the JS-backed ReadableStream every time we are holding the isolate loop the coalescing writes to the kj layer. It means fewer JS->kj iterations, fewer times that we have to take the isolate lock, fewer promise allocations, fewer data copies, etc.