### PR TITLE
fix(node): fix five trivial bugs across crypto and inspect

### DIFF
--- a/src/node/internal/crypto_cipher.ts
+++ b/src/node/internal/crypto_cipher.ts
@@ -618,7 +618,7 @@ export function publicEncrypt(
 ): Buffer {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (key === undefined) {
-    throw new ERR_MISSING_ARGS('privateKey');
+    throw new ERR_MISSING_ARGS('key');
   }
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (buffer === undefined) {
@@ -660,7 +660,7 @@ export function publicDecrypt(
 ): Buffer {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (key === undefined) {
-    throw new ERR_MISSING_ARGS('privateKey');
+    throw new ERR_MISSING_ARGS('key');
   }
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (buffer === undefined) {

--- a/src/node/internal/crypto_random.ts
+++ b/src/node/internal/crypto_random.ts
@@ -87,7 +87,7 @@ export function randomFillSync(
   } else offset = 0;
   if (size !== undefined) {
     validateInteger(size, 'size', 0, maxLength - offset);
-  } else size = maxLength;
+  } else size = maxLength - offset;
   if (isAnyArrayBuffer(buffer)) {
     buffer = Buffer.from(buffer);
   }
@@ -243,8 +243,8 @@ export function randomInt(
     max = minOrMax;
   }
 
-  if (min > max) {
-    throw new ERR_OUT_OF_RANGE('min', 'min <= max', min);
+  if (min >= max) {
+    throw new ERR_OUT_OF_RANGE('min', 'min < max', min);
   }
 
   if (callback != null) {

--- a/src/node/internal/crypto_util.ts
+++ b/src/node/internal/crypto_util.ts
@@ -39,7 +39,7 @@ type ArrayLike = cryptoImpl.ArrayLike;
 
 export const kHandle = Symbol('kHandle');
 export const kFinalized = Symbol('kFinalized');
-export const kState = Symbol('kFinalized');
+export const kState = Symbol('kState');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getStringOption(options: any, key: string): string | undefined {

--- a/src/node/internal/internal_inspect.ts
+++ b/src/node/internal/internal_inspect.ts
@@ -3035,7 +3035,7 @@ function isRpcWildcardType(value: unknown) {
   return (
     value instanceof internalWorkers.RpcStub ||
     value instanceof internalWorkers.RpcPromise ||
-    value instanceof internalWorkers.RpcPromise
+    value instanceof internalWorkers.RpcProperty
   );
 }
 

--- a/src/workerd/api/node/tests/crypto_random-test.js
+++ b/src/workerd/api/node/tests/crypto_random-test.js
@@ -401,6 +401,40 @@ export const timingSafeEqualTest = {
   },
 };
 
+export const randomIntTest = {
+  async test() {
+    const { randomInt } = await import('node:crypto');
+
+    // min === max should throw, not infinite-loop
+    throws(() => randomInt(5, 5), { code: 'ERR_OUT_OF_RANGE' });
+
+    // min > max should throw
+    throws(() => randomInt(10, 5), { code: 'ERR_OUT_OF_RANGE' });
+
+    // Valid range returns value in [min, max)
+    const val = randomInt(0, 10);
+    ok(val >= 0 && val < 10);
+
+    // Single-arg form: randomInt(max) means [0, max)
+    strictEqual(randomInt(1), 0);
+  },
+};
+
+export const randomFillSyncTest = {
+  async test() {
+    const { randomFillSync } = await import('node:crypto');
+
+    // With offset but no size, should fill only buf.length - offset bytes
+    const buf = Buffer.alloc(10, 0);
+    randomFillSync(buf, 4);
+
+    // First 4 bytes must be untouched (all zero)
+    for (let i = 0; i < 4; i++) {
+      strictEqual(buf[i], 0, `byte ${i} should be untouched`);
+    }
+  },
+};
+
 // Ref: https://github.com/cloudflare/workerd/issues/2716
 export const getRandomValuesIllegalInvocation = {
   async test() {


### PR DESCRIPTION
## Summary

Five one-liner bug fixes in the Node.js compatibility layer, plus tests for the two highest-impact ones.

### Fixes

- **`isRpcWildcardType` copy-paste error** (`internal_inspect.ts:3038`): Checked `RpcPromise` twice, never checked `RpcProperty`. Inspecting an `RpcProperty` could trigger proxy traps.

- **`randomInt(n, n)` infinite loop** (`crypto_random.ts:246`): Guard was `min > max` instead of `min >= max`. When `min === max`, `range = 0`, causing `RAND_MAX % 0 = NaN` and an infinite loop.

- **`randomFillSync` default size ignores offset** (`crypto_random.ts:90`): Default size was `maxLength` instead of `maxLength - offset`, writing past buffer bounds when offset is provided without size.

- **`publicEncrypt`/`publicDecrypt` error says "privateKey"** (`crypto_cipher.ts:621,663`): Copy-paste from `privateEncrypt`/`privateDecrypt`. Changed to `'key'`.

- **`kState` Symbol wrong description** (`crypto_util.ts:42`): Was `Symbol('kFinalized')`, now `Symbol('kState')`.

### Tests

- `randomIntTest`: verifies `randomInt(5, 5)` throws `ERR_OUT_OF_RANGE` (without fix: hangs forever)
- `randomFillSyncTest`: verifies `randomFillSync(buf, 4)` leaves first 4 bytes untouched (without fix: writes out of bounds)