### PR TITLE
 Encapsulate Pyodide version compatibility code

### DIFF
--- a/src/pyodide/helpers.bzl
+++ b/src/pyodide/helpers.bzl
@@ -128,6 +128,7 @@ def pyodide_static():
     internal_modules = native.glob(
         [
             "internal/*.ts",
+            "internal/compat/*.ts",
             "internal/topLevelEntropy/*.ts",
             "types/*.ts",
             "types/*/*.ts",
@@ -287,7 +288,9 @@ def _python_bundle(version, *, pyodide_asm_wasm = None, pyodide_asm_js = None, p
             ], exclude = ["internal/pool/emscriptenSetup.ts"]) + [
                 _out_path("pyodide.asm.js", version),
                 "internal/util.ts",
-            ],
+            ] + native.glob([
+                "internal/compat/*.ts",
+            ]),
             config = "internal/pool/esbuild.config.mjs",
             entry_point = "internal/pool/emscriptenSetup.ts",
             external = [

--- a/src/pyodide/internal/compat/compat-api.ts
+++ b/src/pyodide/internal/compat/compat-api.ts
@@ -1,0 +1,112 @@
+/**
+ * PyodideVersionAdapter encapsulates all behavior that differs between Pyodide versions.
+ *
+ * When adding a new Pyodide version:
+ * 1. Create a new file pyodide-X.Y.Z.ts implementing this interface
+ * 2. Register it in index.ts
+ * 3. Existing adapters are frozen — try not to modify them after release unless
+ *    there is a critical bugfix or changes in outer code that require it.
+ */
+export interface PyodideVersionAdapter {
+  readonly version: string;
+
+  // === Dynamic library loading (builtin_wrappers.ts) ===
+
+  /**
+   * Resolve a non-absolute library path to a filesystem path.
+   * 0.26.0a2: searches /usr/lib/ and /session/metadata/python_modules/lib/.
+   * Newer versions: delegates to Module.findLibraryFS(), which respects LD_LIBRARY_PATH and RPATH.
+   */
+  resolveLibraryPath(Module: Module, path: string, rpath: any): string;
+
+  /**
+   * Report undefined symbols after loading dynamic libraries.
+   * 0.26.0a2: no-op. Newer versions: calls Module.reportUndefinedSymbols().
+   * TODO: document why it was needed in 0.26.0a2
+   */
+  reportUndefinedSymbols(Module: Module): void;
+
+  // === Snapshot behavior (snapshot.ts) ===
+
+  /**
+   * Whether dynamic library memory allocation replays addresses from snapshot metadata.
+   * If false, uses simple Module.getMemory(). If true, replays from snapshot.
+   */
+  readonly snapshotAwareDynlibLoading: boolean;
+
+  /**
+   * Whether to always preload all .so files regardless of snapshot state.
+   * 0.26.0a2: true (always preloads). Newer: false (only when restoring snapshot).
+   */
+  readonly alwaysPreloadDynlibs: boolean;
+
+  /**
+   * Whether the version supports serializing hiwire (JS object) state in snapshots.
+   * 0.26.0a2: false. Newer: true.
+   */
+  readonly supportsHiwireSerialization: boolean;
+
+  /**
+   * Assert that dedicated (post-top-level) snapshots are supported.
+   * 0.26.0a2: throws PythonWorkersInternalError. Newer: no-op.
+   */
+  assertDedicatedSnapshotSupported(): void;
+
+  /**
+   * Whether to set _makeSnapshot on pyodide config during snapshot creation.
+   * 0.26.0a2: false. Newer: true.
+   */
+  readonly supportsMakeSnapshotConfig: boolean;
+
+  // === Bootstrap ordering (python.ts) ===
+
+  /**
+   * Whether finalizeBootstrap runs early (in prepareWasmLinearMemory) or late (in loadPyodide).
+   * 0.26.0a2: false (late). Newer: true (early).
+   */
+  readonly earlyFinalizeBootstrap: boolean;
+
+  // === Signal handling (python.ts) ===
+
+  /** Set up CPU limit signal handling for the runtime. */
+  setupSignalHandling(
+    Module: Module,
+    setCpuLimitCallback: (
+      heap: any,
+      clockAddr: number,
+      handlingAddr: number
+    ) => void
+  ): void;
+
+  /** Clear pending signals before processing a new request. */
+  clearSignals(Module: Module): void;
+
+  // === Module import (python-entrypoint-helper.ts) ===
+
+  /**
+   * Import the user's main Python module.
+   * 0.26.0a2: synchronous pyimport. Newer: async callPromising.
+   */
+  pyimportMain(pyodide: Pyodide, moduleName: string): Promise<PyModule>;
+
+  // === Version-specific patches (python-entrypoint-helper.ts) ===
+
+  /**
+   * Return list of package names that require runtime patches for this version.
+   */
+  getRequiredRuntimePatches(transitiveRequirements: Set<string>): string[];
+
+  /**
+   * Inject the legacy cloudflare.workers namespace into site-packages.
+   * 0.26.0a2: creates cloudflare/workers directory and injects __init__ and _workers modules.
+   * Newer: no-op (only the top-level 'workers' package is used).
+   */
+  injectLegacyCloudflareNamespace(
+    pyodide: Pyodide,
+    injectSitePackagesModule: (
+      pyodide: Pyodide,
+      jsModName: string,
+      pyModName: string
+    ) => Promise<void>
+  ): Promise<void>;
+}

--- a/src/pyodide/internal/compat/index.ts
+++ b/src/pyodide/internal/compat/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Version adapter registry.
+ *
+ * Provides getPyodideVersionAdapter() to access the adapter for the current Pyodide version.
+ *
+ * When adding a new Pyodide version:
+ * 1. Create a new file pyodide-X.Y.Z.ts implementing PyodideVersionAdapter
+ * 2. Import and register it in the `adapters` map below
+ * 3. Update the API.version union type in types/emscripten.d.ts
+ */
+import { PythonWorkersInternalError } from 'pyodide-internal:util';
+import { adapter as v026 } from 'pyodide-internal:compat/pyodide-0.26.0a2';
+import { adapter as v028 } from 'pyodide-internal:compat/pyodide-0.28.2';
+import type { PyodideVersionAdapter } from 'pyodide-internal:compat/compat-api';
+
+export type { PyodideVersionAdapter } from 'pyodide-internal:compat/compat-api';
+
+const adapters: Record<string, PyodideVersionAdapter> = {
+  '0.26.0a2': v026,
+  '0.28.2': v028,
+};
+
+let _adapter: PyodideVersionAdapter | undefined;
+
+/**
+ * Get the version adapter for the current Pyodide version.
+ */
+export function getPyodideVersionAdapter(
+  Module?: Module
+): PyodideVersionAdapter {
+  if (!_adapter) {
+    if (!Module) {
+      throw new PythonWorkersInternalError(
+        'Version adapter not initialized. Pass the Module object to getPyodideVersionAdapter() on first call.'
+      );
+    }
+    const version = Module.API.version;
+    const adapter = adapters[version];
+    if (!adapter) {
+      throw new PythonWorkersInternalError(
+        `Unsupported Pyodide version: ${version}. ` +
+          `Supported versions: ${Object.keys(adapters).join(', ')}`
+      );
+    }
+    _adapter = adapter;
+  }
+  return _adapter;
+}

--- a/src/pyodide/internal/compat/pyodide-0.26.0a2.ts
+++ b/src/pyodide/internal/compat/pyodide-0.26.0a2.ts
@@ -1,0 +1,114 @@
+/**
+ * Version adapter for Pyodide 0.26.0a2.
+ */
+import { PythonWorkersInternalError } from 'pyodide-internal:util';
+import type { PyodideVersionAdapter } from 'pyodide-internal:compat/compat-api';
+
+function lookupPath(Module: Module, path: string): string | undefined {
+  try {
+    Module.FS.lookupPath(path);
+  } catch (_e) {
+    return undefined;
+  }
+  return path;
+}
+
+export const adapter: PyodideVersionAdapter = {
+  version: '0.26.0a2',
+
+  // --- Dynamic library loading ---
+
+  resolveLibraryPath(Module: Module, path: string, _rpath: any): string {
+    // In 0.26.0a2 we manually search /usr/lib/ and /session/metadata/python_modules/lib/.
+    // Newer versions use Module.findLibraryFS() and LD_LIBRARY_PATH instead.
+    const result =
+      lookupPath(Module, '/usr/lib/' + path) ??
+      lookupPath(Module, '/session/metadata/python_modules/lib/' + path);
+    if (!result) {
+      console.error('Failed to read ', path);
+      throw new PythonWorkersInternalError('Should not happen');
+    }
+    return result;
+  },
+
+  reportUndefinedSymbols(_Module: Module): void {
+    // No-op in 0.26.0a2.
+  },
+
+  // --- Snapshot behavior ---
+
+  snapshotAwareDynlibLoading: false,
+  alwaysPreloadDynlibs: true,
+  supportsHiwireSerialization: false,
+  assertDedicatedSnapshotSupported(): void {
+    throw new PythonWorkersInternalError(
+      `Dedicated snapshot is not supported for Pyodide version ${this.version}`
+    );
+  },
+  supportsMakeSnapshotConfig: false,
+
+  // --- Bootstrap ordering ---
+
+  earlyFinalizeBootstrap: false,
+
+  // --- Signal handling ---
+
+  setupSignalHandling(
+    _Module: Module,
+    _setCpuLimitCallback: (
+      heap: any,
+      clockAddr: number,
+      handlingAddr: number
+    ) => void
+  ): void {
+    // No signal handling in 0.26.0a2.
+  },
+
+  clearSignals(_Module: Module): void {
+    // No signal handling in 0.26.0a2.
+  },
+
+  // --- Module import ---
+
+  async pyimportMain(pyodide: Pyodide, moduleName: string): Promise<PyModule> {
+    // 0.26.0a2 uses synchronous pyimport.
+    return Promise.resolve(pyodide.pyimport(moduleName));
+  },
+
+  // --- Patching ---
+
+  getRequiredRuntimePatches(transitiveRequirements: Set<string>): string[] {
+    // In 0.26.0a2, httpx and aiohttp patches must be applied at runtime.
+    const patches: string[] = [];
+    if (transitiveRequirements.has('httpx')) {
+      patches.push('httpx');
+    }
+    if (transitiveRequirements.has('aiohttp')) {
+      patches.push('aiohttp');
+    }
+    return patches;
+  },
+
+  async injectLegacyCloudflareNamespace(
+    pyodide: Pyodide,
+    injectSitePackagesModule: (
+      pyodide: Pyodide,
+      jsModName: string,
+      pyModName: string
+    ) => Promise<void>
+  ): Promise<void> {
+    // In 0.26.0a2, the SDK lived under cloudflare.workers.
+    const sitePackages = pyodide.FS.sitePackages;
+    pyodide.FS.mkdirTree(`${sitePackages}/cloudflare/workers`);
+    await injectSitePackagesModule(
+      pyodide,
+      'workers-api/src/workers/__init__',
+      'cloudflare/workers/__init__'
+    );
+    await injectSitePackagesModule(
+      pyodide,
+      'workers-api/src/workers/_workers',
+      'cloudflare/workers/_workers'
+    );
+  },
+};

--- a/src/pyodide/internal/compat/pyodide-0.28.2.ts
+++ b/src/pyodide/internal/compat/pyodide-0.28.2.ts
@@ -1,0 +1,113 @@
+/**
+ * Version adapter for Pyodide 0.28.2.
+ */
+import type { PyodideVersionAdapter } from 'pyodide-internal:compat/compat-api';
+
+const SIGXCPU = 24;
+
+/**
+ * Returns the address of the emscripten signal clock in linear memory.
+ *
+ * This is the address of _Py_emscripten_signal_clock:
+ * https://github.com/python/cpython/blob/main/Python/emscripten_signal.c#L42
+ *
+ * Since the symbol isn't exported, we can't access it directly. Instead, we used wasm-objdump and
+ * searched for the call site to _Py_CheckEmscriptenSignals_Helper(), then read the offset out of
+ * the assembly code.
+ *
+ * TODO: Export this symbol in the next Pyodide release so we can stop using the magic number.
+ */
+function getSignalClockAddr(Module: Module): number {
+  const emscripten_signal_clock_offset = 3171536;
+  return Module.___memory_base.value + emscripten_signal_clock_offset;
+}
+
+export const adapter: PyodideVersionAdapter = {
+  version: '0.28.2',
+
+  // --- Dynamic library loading ---
+
+  resolveLibraryPath(Module: Module, path: string, rpath: any): string {
+    return Module.findLibraryFS(path, rpath);
+  },
+
+  reportUndefinedSymbols(Module: Module): void {
+    Module.reportUndefinedSymbols();
+  },
+
+  // --- Snapshot behavior ---
+
+  snapshotAwareDynlibLoading: true,
+  alwaysPreloadDynlibs: false,
+  supportsHiwireSerialization: true,
+  assertDedicatedSnapshotSupported(): void {
+    // Dedicated snapshots are supported in 0.28.2 — no-op.
+  },
+  supportsMakeSnapshotConfig: true,
+
+  // --- Bootstrap ordering ---
+
+  earlyFinalizeBootstrap: true,
+
+  // --- Signal handling ---
+
+  setupSignalHandling(
+    Module: Module,
+    setCpuLimitCallback: (
+      heap: any,
+      clockAddr: number,
+      handlingAddr: number
+    ) => void
+  ): void {
+    // The callback sets signal_clock to 0 and signal_handling to 1. It has to be in C++ because we
+    // don't hold the isolate lock when we call it.
+    setCpuLimitCallback(
+      Module.HEAP8,
+      getSignalClockAddr(Module),
+      Module._Py_EMSCRIPTEN_SIGNAL_HANDLING
+    );
+  },
+
+  clearSignals(Module: Module): void {
+    // In case the previous request was aborted, make sure that:
+    // 1. a sigint is waiting in the signal buffer
+    // 2. signal handling is off
+    //
+    // We will turn signal handling on as part of triggering the interrupt, having it on otherwise
+    // just wastes cycles.
+    Module.Py_EmscriptenSignalBuffer[0] = SIGXCPU;
+    Module.HEAPU32[getSignalClockAddr(Module) / 4] = 1;
+    Module.HEAPU32[Module._Py_EMSCRIPTEN_SIGNAL_HANDLING / 4] = 0;
+  },
+
+  // --- Module import ---
+
+  async pyimportMain(pyodide: Pyodide, moduleName: string): Promise<PyModule> {
+    // Newer versions use async callPromising for JSPI support.
+    return await pyodide._module.API.pyodide_base.pyimport_impl.callPromising(
+      moduleName
+    ) as PyModule;
+  },
+
+  // --- Patching ---
+
+  getRequiredRuntimePatches(transitiveRequirements: Set<string>): string[] {
+    // In 0.28.2, aiohttp patches must be applied at runtime.
+    const patches: string[] = [];
+    if (transitiveRequirements.has('aiohttp')) {
+      patches.push('aiohttp');
+    }
+    return patches;
+  },
+
+  async injectLegacyCloudflareNamespace(
+    _pyodide: Pyodide,
+    _injectSitePackagesModule: (
+      pyodide: Pyodide,
+      jsModName: string,
+      pyModName: string
+    ) => Promise<void>
+  ): Promise<void> {
+    // No-op in 0.28.2: the legacy cloudflare.workers namespace is no longer needed.
+  },
+};

--- a/src/pyodide/internal/pool/builtin_wrappers.ts
+++ b/src/pyodide/internal/pool/builtin_wrappers.ts
@@ -1,6 +1,7 @@
 import type { getRandomValues as getRandomValuesType } from 'pyodide-internal:topLevelEntropy/lib';
 import type { default as UnsafeEvalType } from 'internal:unsafe-eval';
 import { PythonWorkersInternalError } from 'pyodide-internal:util';
+import { getPyodideVersionAdapter } from 'pyodide-internal:compat/index';
 
 if (typeof FinalizationRegistry === 'undefined') {
   // @ts-expect-error cannot assign to globalThis
@@ -38,56 +39,19 @@ export function setSetTimeout(
 }
 
 export function reportUndefinedSymbolsPatched(Module: Module): void {
-  if (Module.API.version === '0.26.0a2') {
-    return;
-  }
-  Module.reportUndefinedSymbols();
+  getPyodideVersionAdapter(Module).reportUndefinedSymbols(Module);
 }
-
-function dynlibLookup026Helper(
-  Module: Module,
-  path: string
-): string | undefined {
-  try {
-    Module.FS.lookupPath(path);
-  } catch (e) {
-    return undefined;
-  }
-  return path;
-}
-
-function dynlibLookup026(Module: Module, libName: string): string {
-  // This function is for 0.26.0a2 only. In newer versions, we set LD_LIBRARY_PATH instead.
-  if (Module.API.version !== '0.26.0a2') {
-    throw new PythonWorkersInternalError('Should not happen');
-  }
-  // Most libraries are loaded from /usr/lib. For scipy and similar libraries that depend on
-  // Pyodide's dynamic library deps, we may need extra "system libraries". These we'll put in
-  // python_modules/lib. So try loading system libraries from there too.
-  const result =
-    dynlibLookup026Helper(Module, '/usr/lib/' + libName) ??
-    dynlibLookup026Helper(
-      Module,
-      '/session/metadata/python_modules/lib/' + libName
-    );
-  if (!result) {
-    console.error('Failed to read ', libName);
-    throw new PythonWorkersInternalError('Should not happen');
-  }
-  return result;
-}
-
 export function patchedLoadLibData(
   Module: Module,
   path: string,
   rpath: any
 ): WebAssembly.Module {
   if (!path.startsWith('/')) {
-    if (Module.API.version === '0.26.0a2') {
-      path = dynlibLookup026(Module, path);
-    } else {
-      path = Module.findLibraryFS(path, rpath);
-    }
+    path = getPyodideVersionAdapter(Module).resolveLibraryPath(
+      Module,
+      path,
+      rpath
+    );
   }
   return Module.compileModuleFromReadOnlyFS(Module, path);
 }

--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -21,6 +21,7 @@ import {
   LEGACY_VENDOR_PATH,
   setCpuLimitNearlyExceededCallback,
 } from 'pyodide-internal:metadata';
+import { getPyodideVersionAdapter } from 'pyodide-internal:compat/index';
 
 /**
  * SetupEmscripten is an internal module defined in setup-emscripten.h the module instantiates
@@ -34,7 +35,6 @@ import {
   PythonUserError,
   PythonWorkersInternalError,
   reportError,
-  unreachable,
 } from 'pyodide-internal:util';
 import { loadPackages } from 'pyodide-internal:loadPackage';
 import { default as MetadataReader } from 'pyodide-internal:runtime-generated/metadata';
@@ -62,7 +62,7 @@ function prepareWasmLinearMemory(
     // the /session/metadata path is added.
     adjustSysPath(Module);
   }
-  if (Module.API.version !== '0.26.0a2') {
+  if (getPyodideVersionAdapter(Module).earlyFinalizeBootstrap) {
     finalizeBootstrap(Module, customSerializedObjects);
   }
 }
@@ -140,7 +140,7 @@ function makeSetTimeout(Module: Module): typeof setTimeout {
       // In case an Exceeded CPU occurred just as Python was exiting, there may be one waiting that
       // will interrupt the wrong task. Clear signals before entering the task.
       // This is covered by cpu-limit-exceeded.ew-test "async_trip" test.
-      clearSignals(Module);
+      getPyodideVersionAdapter(Module).clearSignals(Module);
       handler();
     }
     if (timeout) {
@@ -151,61 +151,12 @@ function makeSetTimeout(Module: Module): typeof setTimeout {
   } as typeof setTimeout;
 }
 
-function getSignalClockAddr(Module: Module): number {
-  if (Module.API.version !== '0.28.2') {
-    throw new PythonWorkersInternalError(
-      'getSignalClockAddr only supported in 0.28.2'
-    );
-  }
-  // This is the address here:
-  // https://github.com/python/cpython/blob/main/Python/emscripten_signal.c#L42
-  //
-  // Since the symbol isn't exported, we can't access it directly. Instead, we used wasm-objdump and
-  // searched for the call site to _Py_CheckEmscriptenSignals_Helper(), then read the offset out of
-  // the assembly code.
-  //
-  // TODO: Export this symbol in the next Pyodide release so we can stop using the magic number.
-  const emscripten_signal_clock_offset = 3171536;
-  return Module.___memory_base.value + emscripten_signal_clock_offset;
-}
-
 function setupRuntimeSignalHandling(Module: Module): void {
   Module.Py_EmscriptenSignalBuffer = new Uint8Array(1);
-  const version = Module.API.version;
-  if (version === '0.26.0a2') {
-    return;
-  }
-  if (version === '0.28.2') {
-    // The callback sets signal_clock to 0 and signal_handling to 1. It has to be in C++ because we
-    // don't hold the isolate lock when we call it. JS code would be:
-    //
-    // function callback() { Module.HEAP8[getSignalClockAddr(Module)] = 0;
-    //    Module.HEAP8[Module._Py_EMSCRIPTEN_SIGNAL_HANDLING] = 1;
-    // }
-    setCpuLimitNearlyExceededCallback(
-      Module.HEAP8,
-      getSignalClockAddr(Module),
-      Module._Py_EMSCRIPTEN_SIGNAL_HANDLING
-    );
-    return;
-  }
-  unreachable(version);
-}
-
-const SIGXCPU = 24;
-
-export function clearSignals(Module: Module): void {
-  if (Module.API.version === '0.28.2') {
-    // In case the previous request was aborted, make sure that:
-    // 1. a sigint is waiting in the signal buffer
-    // 2. signal handling is off
-    //
-    // We will turn signal handling on as part of triggering the interrupt, having it on otherwise
-    // just wastes cycles.
-    Module.Py_EmscriptenSignalBuffer[0] = SIGXCPU;
-    Module.HEAPU32[getSignalClockAddr(Module) / 4] = 1;
-    Module.HEAPU32[Module._Py_EMSCRIPTEN_SIGNAL_HANDLING / 4] = 0;
-  }
+  getPyodideVersionAdapter(Module).setupSignalHandling(
+    Module,
+    setCpuLimitNearlyExceededCallback
+  );
 }
 
 function compileModuleFromReadOnlyFS(
@@ -239,6 +190,7 @@ export function loadPyodide(
     const Module = enterJaegerSpan('instantiate_emscripten', () =>
       SetupEmscripten.getModule()
     );
+    getPyodideVersionAdapter(Module);
     Module.compileModuleFromReadOnlyFS = compileModuleFromReadOnlyFS;
     Module.API.config.jsglobals = globalThis;
     if (isWorkerd) {
@@ -270,7 +222,7 @@ export function loadPyodide(
     // present in snapshot memory.
     mountWorkerFiles(Module);
 
-    if (Module.API.version === '0.26.0a2') {
+    if (!getPyodideVersionAdapter(Module).earlyFinalizeBootstrap) {
       // Finish setting up Pyodide's ffi so we can use the nice Python interface
       // In newer versions we already did this in prepareWasmLinearMemory.
       finalizeBootstrap(Module, customSerializedObjects);

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -31,6 +31,7 @@ import {
   maybeSerializeJsModule,
   type SerializedJsModule,
 } from 'pyodide-internal:serializeJsModule';
+import { getPyodideVersionAdapter } from 'pyodide-internal:compat/index';
 
 // A handle is the pointer into the linear memory returned by dlopen. Multiple dlopens will return
 // multiple pointers.
@@ -231,7 +232,7 @@ function getMemoryPatched(
   libPath: string,
   size: number
 ): number {
-  if (Module.API.version === '0.26.0a2') {
+  if (!getPyodideVersionAdapter(Module).snapshotAwareDynlibLoading) {
     return Module.getMemory(size);
   }
   // Sometimes the module is loaded once by path and once by name, in either order. I'm not really
@@ -385,8 +386,9 @@ function preloadDynamicLibsMain(Module: Module, loadOrder: string[]): void {
 }
 
 function preloadDynamicLibs(Module: Module): void {
-  if (Module.API.version === '0.26.0a2') {
-    // In 0.26.0a2 we need to preload dynamic libraries even if we aren't restoring a snapshot.
+  if (getPyodideVersionAdapter(Module).alwaysPreloadDynlibs) {
+    // Legacy: preload all dynamic libraries even if we aren't restoring a snapshot.
+    // TODO(later): maybe move this entire function to pyodide-internal:compat?
     preloadDynamicLibs026(Module);
     return;
   }
@@ -640,7 +642,7 @@ function makeLinearMemorySnapshot(
   const dsoHandles = recordDsoHandles(Module);
   let hiwire: SnapshotConfig | undefined;
   const jsModuleNames: Set<string> = new Set();
-  if (Module.API.version !== '0.26.0a2') {
+  if (getPyodideVersionAdapter(Module).supportsHiwireSerialization) {
     hiwire = Module.API.serializeHiwireState(
       getHiwireSerializer(customSerializedObjects, jsModuleNames)
     );
@@ -863,13 +865,7 @@ export function maybeCollectDedicatedSnapshot(
     return;
   }
 
-  if (Module.API.version == '0.26.0a2') {
-    // 0.26.0a2 does not support serialisation of the hiwire state, so it cannot support dedicated
-    // snapshots.
-    throw new PythonWorkersInternalError(
-      'Dedicated snapshot is not supported for Python runtime version 0.26.0a2'
-    );
-  }
+  getPyodideVersionAdapter(Module).assertDedicatedSnapshotSupported();
 
   if (!customSerializedObjects) {
     throw new PythonWorkersInternalError(
@@ -915,7 +911,8 @@ export function finalizeBootstrap(
   customSerializedObjects: CustomSerializedObjects
 ): void {
   Module.API.config._makeSnapshot =
-    IS_CREATING_SNAPSHOT && Module.API.version !== '0.26.0a2';
+    IS_CREATING_SNAPSHOT &&
+    getPyodideVersionAdapter(Module).supportsMakeSnapshotConfig;
   enterJaegerSpan('finalize_bootstrap', () => {
     Module.API.finalizeBootstrap(
       LOADED_SNAPSHOT_META?.hiwire,

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -17,11 +17,7 @@ import {
   WORKERD_INDEX_URL,
   WORKFLOWS_ENABLED,
 } from 'pyodide-internal:metadata';
-import {
-  beforeRequest,
-  clearSignals,
-  loadPyodide,
-} from 'pyodide-internal:python';
+import { beforeRequest, loadPyodide } from 'pyodide-internal:python';
 import { patchLoadPackage } from 'pyodide-internal:setupPackages';
 import {
   LOADED_SNAPSHOT_TYPE,
@@ -33,6 +29,7 @@ import {
   reportError,
 } from 'pyodide-internal:util';
 export { createImportProxy } from 'pyodide-internal:serializeJsModule';
+import { getPyodideVersionAdapter } from 'pyodide-internal:compat/index';
 
 type PyFuture<T> = Promise<T> & { copy(): PyFuture<T>; destroy(): void };
 
@@ -132,13 +129,10 @@ async function pyimportMainModule(pyodide: Pyodide): Promise<PyModule> {
     );
   }
   const mainModuleName = MAIN_MODULE_NAME.slice(0, -3);
-  if (pyodide.version === '0.26.0a2') {
-    return pyodide.pyimport(mainModuleName);
-  } else {
-    return await pyodide._module.API.pyodide_base.pyimport_impl.callPromising(
-      mainModuleName
-    );
-  }
+  return await getPyodideVersionAdapter(pyodide._module).pyimportMain(
+    pyodide,
+    mainModuleName
+  );
 }
 
 let pyodidePromise: Promise<Pyodide> | undefined;
@@ -193,20 +187,9 @@ async function applyPatch(pyodide: Pyodide, patchName: string): Promise<void> {
 
 async function injectWorkersApi(pyodide: Pyodide): Promise<void> {
   const sitePackages = pyodide.FS.sitePackages;
-  if (pyodide.version === '0.26.0a2') {
-    // Inject at cloudflare.workers for backwards compatibility
-    pyodide.FS.mkdirTree(`${sitePackages}/cloudflare/workers`);
-    await injectSitePackagesModule(
-      pyodide,
-      'workers-api/src/workers/__init__',
-      'cloudflare/workers/__init__'
-    );
-    await injectSitePackagesModule(
-      pyodide,
-      'workers-api/src/workers/_workers',
-      'cloudflare/workers/_workers'
-    );
-  }
+  await getPyodideVersionAdapter(
+    pyodide._module
+  ).injectLegacyCloudflareNamespace(pyodide, injectSitePackagesModule);
   // The SDK was moved from `cloudflare.workers` to just `workers`.
   // Create workers package structure with workflows submodule
   pyodide.FS.mkdir(`${sitePackages}/workers`);
@@ -246,16 +229,11 @@ async function setupPatches(pyodide: Pyodide): Promise<void> {
       await injectWorkersApi(pyodide);
     }
 
-    // Install patches as needed
-    if (TRANSITIVE_REQUIREMENTS.has('aiohttp')) {
-      await applyPatch(pyodide, 'aiohttp');
-    }
-    // Other than the oldest version of httpx, we apply the patch at the build step.
-    if (
-      pyodide._module.API.version === '0.26.0a2' &&
-      TRANSITIVE_REQUIREMENTS.has('httpx')
-    ) {
-      await applyPatch(pyodide, 'httpx');
+    // Apply version-specific runtime patches
+    for (const patchName of getPyodideVersionAdapter(
+      pyodide._module
+    ).getRequiredRuntimePatches(TRANSITIVE_REQUIREMENTS)) {
+      await applyPatch(pyodide, patchName);
     }
   });
 }
@@ -302,7 +280,7 @@ async function doPyCallHelper(
   args: any[]
 ): Promise<any> {
   const pyodide = await getPyodide();
-  clearSignals(pyodide._module);
+  getPyodideVersionAdapter(pyodide._module).clearSignals(pyodide._module);
   try {
     if (pyfunc.callWithOptions) {
       return await pyfunc.callWithOptions(


### PR DESCRIPTION
We have a lot of branches such as `if Module.API.version == "0.26.0a2"` in our codebase, while it is unavoidable because of our backward compatibility guarantee, it harms the readability, and is prone to human error when we adds a new Pyodide version.

I extracted the codes that behave differently in Pyodide versions, so we can better manage those updates.