### PR TITLE
Fix AI Search method not being callable

### DIFF
--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -5480,7 +5480,7 @@ export declare abstract class Ai<AiModelList extends AiModelListType = AiModels>
    * });
    * ```
    */
-  aiSearch: AiSearchAccountService;
+  aiSearch(): AiSearchAccountService;
 
   /**
    * @deprecated AutoRAG has been replaced by AI Search.

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -10212,7 +10212,7 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
    * });
    * ```
    */
-  aiSearch: AiSearchAccountService;
+  aiSearch(): AiSearchAccountService;
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
    * Use `env.AI.aiSearch` instead for better API design and new features.

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -10224,7 +10224,7 @@ export declare abstract class Ai<
    * });
    * ```
    */
-  aiSearch: AiSearchAccountService;
+  aiSearch(): AiSearchAccountService;
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
    * Use `env.AI.aiSearch` instead for better API design and new features.

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -9584,7 +9584,7 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
    * });
    * ```
    */
-  aiSearch: AiSearchAccountService;
+  aiSearch(): AiSearchAccountService;
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
    * Use `env.AI.aiSearch` instead for better API design and new features.

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -9596,7 +9596,7 @@ export declare abstract class Ai<
    * });
    * ```
    */
-  aiSearch: AiSearchAccountService;
+  aiSearch(): AiSearchAccountService;
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
    * Use `env.AI.aiSearch` instead for better API design and new features.


### PR DESCRIPTION
This is not a breaking change, since the actual binding usage always used `aiSearch()`, only the types were wrong