### PR TITLE
increase WebSocket attachment size limit from 2KB to 16KB

### DIFF
--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -425,7 +425,7 @@ class WebSocket: public EventTarget {
   inline static const size_t SUGGESTED_MAX_MESSAGE_SIZE = 1u << 20;
 
   // Maximum size of a WebSocket attachment.
-  inline static const size_t MAX_ATTACHMENT_SIZE = 1024 * 2;
+  inline static const size_t MAX_ATTACHMENT_SIZE = 1024 * 16;
 
   struct AwaitingConnection {
     // A canceler associated with the pending websocket connection for `new Websocket()`.


### PR DESCRIPTION
A simple change; as discussed, this kicks up websocket attachment max size from 2kb to 16kb. Couldn't find any existing tests or other references for this value, so sending up just this change. 