### PR TITLE
Revert "Capture strong ref to internal stream in internal.c++"

### DIFF
--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -545,10 +545,9 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
       auto& ioContext = IoContext::current();
       return ioContext.awaitIoLegacy(js, kj::mv(promise))
           .then(js,
-              ioContext.addFunctor(
-                  [this, store = js.v8Ref(store), byteOffset, byteLength,
-                      isByob = maybeByobOptions != kj::none, ref = addRef()](
-                      jsg::Lock& js, size_t amount) mutable -> jsg::Promise<ReadResult> {
+              ioContext.addFunctor([this, store = js.v8Ref(store), byteOffset, byteLength,
+                                       isByob = maybeByobOptions != kj::none](jsg::Lock& js,
+                                       size_t amount) mutable -> jsg::Promise<ReadResult> {
         readPending = false;
         KJ_ASSERT(amount <= byteLength);
         if (amount == 0) {
@@ -690,7 +689,7 @@ kj::Maybe<jsg::Promise<DrainingReadResult>> ReadableStreamInternalController::dr
       auto& ioContext = IoContext::current();
       return ioContext.awaitIoLegacy(js, kj::mv(promise))
           .then(js,
-              ioContext.addFunctor([this, store = kj::mv(store), ref = addRef()](jsg::Lock& js,
+              ioContext.addFunctor([this, store = kj::mv(store)](jsg::Lock& js,
                                        size_t amount) mutable -> jsg::Promise<DrainingReadResult> {
         readPending = false;
         KJ_ASSERT(amount <= store.size());


### PR DESCRIPTION
This reverts commit a6fa6a5714dee8f941a3d366994e1b6e3b51c40b.

Causes a conflict with an internal floated patch. Will need to resolve the conflict before reloading.