### PR TITLE
Correctly handle SharedArrayBuffer with structuredClone

### DIFF
--- a/src/workerd/api/tests/global-scope-test.js
+++ b/src/workerd/api/tests/global-scope-test.js
@@ -326,6 +326,18 @@ export const structuredClone = {
   },
 };
 
+export const SabStructuredCloneTransfer = {
+  async test() {
+    // Can't structureClone a a SharedArrayBuffer with transfer.
+    const sab = new SharedArrayBuffer(64);
+    const view = new Uint8Array(sab);
+
+    throws(() => globalThis.structuredClone(view, { transfer: [view] }), {
+      name: 'DataCloneError',
+    });
+  },
+};
+
 export const base64 = {
   test() {
     function format_value(elem) {

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -360,6 +360,12 @@ void Serializer::transfer(Lock& js, const JsValue& value) {
     JSG_FAIL_REQUIRE(TypeError, "Object is not transferable");
   }
 
+  // SharedArrayBuffers are not transferable. Per the HTML spec, attempting to
+  // transfer a SharedArrayBuffer (or a view backed by one) must throw a
+  // DataCloneError. We must check before calling Detach(), which would trigger
+  // a fatal V8 CHECK failure on non-detachable buffers.
+  JSG_REQUIRE(arrayBuffer->IsDetachable(), DOMDataCloneError, "Object is not transferable.");
+
   uint32_t n;
   for (n = 0; n < arrayBuffers.size(); n++) {
     // If the ArrayBuffer has already been added, we do not want to try adding it again.


### PR DESCRIPTION
Per the spec, SharedArrayBuffer cannot be transfered. There needs to be an error thrown.