### PR TITLE
handle unpaired surrogates on websocket close

### DIFF
--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -607,7 +607,8 @@ void WebSocket::send(jsg::Lock& js, kj::OneOf<kj::Array<byte>, kj::String> messa
   ensurePumping(js);
 }
 
-void WebSocket::close(jsg::Lock& js, jsg::Optional<int> code, jsg::Optional<kj::String> reason) {
+void WebSocket::close(
+    jsg::Lock& js, jsg::Optional<int> code, jsg::Optional<jsg::USVString> reason) {
   auto& native = *farNative;
 
   // Per the spec, close code and reason validation must happen before any readyState checks.
@@ -681,7 +682,7 @@ void WebSocket::close(jsg::Lock& js, jsg::Optional<int> code, jsg::Optional<kj::
     kj::WebSocket::Close{
       // Code 1005 actually translates to sending a close message with no body on the wire.
       static_cast<uint16_t>(code.orDefault(1005)),
-      kj::mv(reason).orDefault(nullptr),
+      kj::mv(reason).orDefault(jsg::USVString(kj::str())),
     },
     pendingAutoResponses});
 

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -42,7 +42,7 @@ class CloseEvent: public Event {
 
   struct Initializer {
     jsg::Optional<int> code;
-    jsg::Optional<kj::String> reason;
+    jsg::Optional<jsg::USVString> reason;
     jsg::Optional<bool> wasClean;
 
     JSG_STRUCT(code, reason, wasClean);
@@ -52,7 +52,7 @@ class CloseEvent: public Event {
       jsg::Lock& js, kj::String type, jsg::Optional<Initializer> initializer) {
     Initializer init = kj::mv(initializer).orDefault({});
     return js.alloc<CloseEvent>(kj::mv(type), init.code.orDefault(0),
-        kj::mv(init.reason).orDefault(nullptr), init.wasClean.orDefault(false));
+        kj::mv(init.reason).orDefault(jsg::USVString(kj::str())), init.wasClean.orDefault(false));
   }
 
   int getCode() {
@@ -303,7 +303,7 @@ class WebSocket: public EventTarget {
   void startReadLoop(jsg::Lock& js, kj::Maybe<kj::Own<InputGate::CriticalSection>> cs);
 
   void send(jsg::Lock& js, kj::OneOf<kj::Array<byte>, kj::String> message);
-  void close(jsg::Lock& js, jsg::Optional<int> code, jsg::Optional<kj::String> reason);
+  void close(jsg::Lock& js, jsg::Optional<int> code, jsg::Optional<jsg::USVString> reason);
 
   // Used to get/set the attachment for hibernation.
   // If the object isn't serialized, it will not survive hibernation.

--- a/src/wpt/websockets-test.ts
+++ b/src/wpt/websockets-test.ts
@@ -70,9 +70,16 @@ export default {
     replace: removeUseCapture,
   },
   'Close-onlyReason.any.js': {
-    comment:
-      'workerd throws TypeError instead of INVALID_ACCESS_ERR for close(undefined, reason), test hangs',
-    disabledTests: true,
+    replace: (code: string): string => {
+      code = removeUseCapture(code);
+      // The test expects close("reason") to throw, leaving the WebSocket open.
+      // Add a cleanup to close the WebSocket when the test completes so the
+      // connection is properly shut down.
+      return code.replace(
+        'var wsocket = CreateWebSocket(false, false);',
+        'var wsocket = CreateWebSocket(false, false);\ntest.add_cleanup(function() { wsocket.close(); });'
+      );
+    },
   },
   'Close-readyState-Closed.any.js': {
     replace: removeUseCapture,
@@ -81,10 +88,6 @@ export default {
     replace: removeUseCapture,
   },
   'Close-reason-unpaired-surrogates.any.js': {
-    comment: 'workerd handles unpaired surrogates differently',
-    expectedFailures: [
-      'Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed',
-    ],
     replace: removeUseCapture,
   },
   'Close-server-initiated-close.any.js': {


### PR DESCRIPTION
I don't think this change substitutes for a compat flag but I'm open to be convinced.