### PR TITLE
Make WorkerdDebugPort binding synchronous via Cap'n Proto pipelining

### DIFF
--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -5700,7 +5700,7 @@ KJ_TEST("Server: workerdDebugPort binding loopback test") {
                 `    const client = await env.debugPort.connect("debug-addr");
                 `
                 `    // Test 1: Access the default entrypoint
-                `    const defaultFetcher = await client.getEntrypoint("target-service");
+                `    const defaultFetcher = client.getEntrypoint("target-service");
                 `    const defaultResp = await defaultFetcher.fetch("http://fake-host/");
                 `    const defaultText = await defaultResp.text();
                 `    if (defaultText !== "Hello from target!") {
@@ -5708,7 +5708,7 @@ KJ_TEST("Server: workerdDebugPort binding loopback test") {
                 `    }
                 `
                 `    // Test 2: Access a named entrypoint
-                `    const namedFetcher = await client.getEntrypoint("target-service", "namedHandler");
+                `    const namedFetcher = client.getEntrypoint("target-service", "namedHandler");
                 `    const namedResp = await namedFetcher.fetch("http://fake-host/");
                 `    const namedText = await namedResp.text();
                 `    if (namedText !== "Hello from named entrypoint!") {
@@ -5779,7 +5779,7 @@ KJ_TEST("Server: workerdDebugPort binding with props") {
                 `    const client = await env.debugPort.connect("debug-addr");
                 `
                 `    // Test passing props to the entrypoint
-                `    const fetcher = await client.getEntrypoint(
+                `    const fetcher = client.getEntrypoint(
                 `        "target-service", "PropsHandler", {foo: "bar", num: 42});
                 `    const resp = await fetcher.fetch("http://fake-host/");
                 `    const props = await resp.json();
@@ -5867,7 +5867,7 @@ KJ_TEST("Server: workerdDebugPort binding getActor") {
                 `    // Get the same actor twice using a fixed ID
                 `    const actorId = "0".repeat(64);
                 `
-                `    const actor1 = await client.getActor("do-service", "Counter", actorId);
+                `    const actor1 = client.getActor("do-service", "Counter", actorId);
                 `    const resp1 = await actor1.fetch("http://fake-host/");
                 `    const text1 = await resp1.text();
                 `    if (text1 !== "Counter: 1") {
@@ -5875,7 +5875,7 @@ KJ_TEST("Server: workerdDebugPort binding getActor") {
                 `    }
                 `
                 `    // Second request to same actor should increment counter
-                `    const actor2 = await client.getActor("do-service", "Counter", actorId);
+                `    const actor2 = client.getActor("do-service", "Counter", actorId);
                 `    const resp2 = await actor2.fetch("http://fake-host/");
                 `    const text2 = await resp2.text();
                 `    if (text2 !== "Counter: 2") {
@@ -5884,7 +5884,7 @@ KJ_TEST("Server: workerdDebugPort binding getActor") {
                 `
                 `    // Different actor ID should have independent state (counter starts at 1)
                 `    const differentActorId = "1".repeat(64);
-                `    const actor3 = await client.getActor("do-service", "Counter", differentActorId);
+                `    const actor3 = client.getActor("do-service", "Counter", differentActorId);
                 `    const resp3 = await actor3.fetch("http://fake-host/");
                 `    const text3 = await resp3.text();
                 `    if (text3 !== "Counter: 1") {
@@ -5962,7 +5962,7 @@ KJ_TEST("Server: workerdDebugPort WebSocket passthrough via WorkerEntrypoint") {
                 `export class Proxy extends WorkerEntrypoint {
                 `  async fetch(request) {
                 `    const client = await this.env.debugPort.connect("debug-addr");
-                `    const fetcher = await client.getEntrypoint("target-service");
+                `    const fetcher = client.getEntrypoint("target-service");
                 `    const response = await fetcher.fetch(request);
                 `    if (response.webSocket) {
                 `      // Pass through the WebSocket from the debug port


### PR DESCRIPTION
`connect()`, `getEntrypoint()`, and `getActor()` on the `WorkerdDebugPort` binding now return synchronously instead of returning Promises.

## Changes

- **`WorkerdDebugPortConnector::connect()`** — uses `kj::newPromisedStream()` to wrap the pending TCP connection into an immediate `AsyncIoStream`. The `TwoPartyClient` and bootstrap capability are created synchronously on this promised stream.
- **`WorkerdDebugPortClient::getEntrypoint()` / `getActor()`** — use Cap'n Proto pipelining to extract the entrypoint/actor capability from the in-flight RPC response without awaiting it. The capability is a lazy proxy that only triggers the actual network round-trip when first used (e.g. `fetch()`).
- **Tests** — removed `await` from `client.getEntrypoint()` and `client.getActor()` calls in `server-test.c++`. `connect()` still uses `await` (identity on non-Promise).

This enables miniflare's dev registry proxy worker to resolve cross-process service bindings in constructors (where `await` isn't available), which is needed for the simplified Proxy-based forwarding pattern.