### PR TITLE
Add logger to the Python ASGI module

### DIFF
--- a/src/pyodide/internal/workers-api/src/asgi.py
+++ b/src/pyodide/internal/workers-api/src/asgi.py
@@ -1,3 +1,4 @@
+import logging
 from asyncio import Event, Future, Queue, create_task, ensure_future, sleep
 from collections.abc import Awaitable
 from contextlib import contextmanager
@@ -8,15 +9,21 @@ import js
 from workers import Context, Request
 
 ASGI = {"spec_version": "2.0", "version": "3.0"}
-
-
+logger = logging.getLogger("asgi")
 background_tasks = set()
 
 
 def run_in_background(coro: Awaitable[Any]) -> None:
     fut = ensure_future(coro)
     background_tasks.add(fut)
-    fut.add_done_callback(background_tasks.discard)
+
+    def _on_done(f):
+        background_tasks.discard(f)
+        exc = f.exception() if not f.cancelled() else None
+        if exc is not None:
+            logger.error("Unhandled exception in background task", exc_info=exc)
+
+    fut.add_done_callback(_on_done)
 
 
 @contextmanager
@@ -203,11 +210,14 @@ async def process_request(
             if not result.done():
                 raise RuntimeError("The application did not generate a response")  # noqa: TRY301
         except Exception as e:
-            # Handle any errors in the application
             if not result.done():
                 result.set_exception(e)
                 await writer.close()  # Close the writer
                 finished_response.set()
+            else:
+                # Response already sent — exception can't be propagated to the
+                # client, so log it to avoid silently swallowing errors.
+                logger.exception("Exception in ASGI application after response started")
 
     # Create task to run the application in the background
     app_task = create_task(run_app())
@@ -268,7 +278,7 @@ async def process_websocket(app: Any, req: "Request | js.Request") -> js.Respons
                 server.send(s)
 
         else:
-            print(" == Not implemented", got["type"])
+            logger.warning(" == Not implemented %s", got["type"])
 
     async def ws_receive():
         received = await queue.get()
@@ -283,8 +293,13 @@ async def process_websocket(app: Any, req: "Request | js.Request") -> js.Respons
 async def fetch(
     app: Any, req: "Request | js.Request", env: Any, ctx: Context | None = None
 ) -> js.Response:
+    logger.debug("ASGI request: %s %s", req.method, req.url)
     shutdown = await start_application(app)
-    result = await process_request(app, req, env, ctx)
+    try:
+        result = await process_request(app, req, env, ctx)
+    except Exception:
+        logger.exception("ASGI request failed")
+        raise
     await shutdown()
     return result
 

--- a/src/workerd/server/tests/python/asgi/worker.py
+++ b/src/workerd/server/tests/python/asgi/worker.py
@@ -1,3 +1,6 @@
+import asyncio
+import logging
+
 import asgi
 import js
 from workers import Request, WorkerEntrypoint
@@ -73,6 +76,9 @@ class Default(WorkerEntrypoint):
 
     async def test(self, ctrl):
         await header_test(self.env)
+        await test_error_after_response_is_logged(self.env)
+        await test_background_task_error_is_logged()
+        await test_app_exception_before_response_is_logged()
 
 
 app = Server()
@@ -85,3 +91,172 @@ async def header_test(env):
         expected_hdr = {k.lower(): v.lower() for k, v in example_hdr.items()}
         assert header[0] in expected_hdr.keys()
         assert expected_hdr[header[0]] == header[1].lower()
+
+
+# ---------------------------------------------------------------------------
+# Logging tests
+# ---------------------------------------------------------------------------
+
+
+class _ListHandler(logging.Handler):
+    """A logging handler that captures records into a list for assertions."""
+
+    def __init__(self):
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def clear(self):
+        self.records.clear()
+
+
+def _install_handler():
+    """Install a ListHandler on the 'asgi' logger and return it."""
+    handler = _ListHandler()
+    logger = logging.getLogger("asgi")
+    logger.addHandler(handler)
+    # Ensure the logger level is low enough to capture everything.
+    logger.setLevel(logging.DEBUG)
+    return handler
+
+
+def _remove_handler(handler):
+    logging.getLogger("asgi").removeHandler(handler)
+
+
+class _ErrorAfterResponseApp:
+    """ASGI app that sends a valid response, then raises an exception."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            return
+
+        if scope["type"] == "http":
+            await receive()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/plain")],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"ok",
+                }
+            )
+            # Response is already sent — now raise an error.
+            raise RuntimeError("post-response error for testing")
+
+
+async def test_error_after_response_is_logged(env):
+    handler = _install_handler()
+    try:
+        req = js.Request.new("http://example.com/log-test")
+        # The response should still succeed — the error happens after it's sent.
+        response = await asgi.fetch(_ErrorAfterResponseApp(), req, env)
+        assert response.status == 200, f"Expected 200, got {response.status}"
+
+        # Let the event loop run
+        await asyncio.sleep(20)
+
+        # The error should have been logged, not swallowed.
+        error_records = [r for r in handler.records if r.levelno >= logging.ERROR]
+        assert len(error_records) > 0, (
+            "Expected at least one ERROR log record for post-response exception, "
+            f"got {len(error_records)}. All records: {[r.getMessage() for r in handler.records]}"
+        )
+        matched = any(
+            "post-response error for testing" in str(r.exc_info[1])
+            if r.exc_info
+            else False
+            for r in error_records
+        )
+        assert matched, (
+            "Expected log message containing 'post-response error for testing', "
+            f"got: {[r.getMessage() for r in error_records]}"
+        )
+    finally:
+        _remove_handler(handler)
+
+
+async def test_background_task_error_is_logged():
+    handler = _install_handler()
+    try:
+
+        async def failing_task():
+            raise ValueError("background task failure for testing")
+
+        asgi.run_in_background(failing_task())
+
+        # Let the event loop run
+        await asyncio.sleep(20)
+
+        error_records = [r for r in handler.records if r.levelno >= logging.ERROR]
+        assert len(error_records) > 0, (
+            "Expected at least one ERROR log for background task failure, "
+            f"got {len(error_records)}. All records: {[r.getMessage() for r in handler.records]}"
+        )
+        matched = any(
+            "background task failure for testing" in str(r.exc_info[1])
+            if r.exc_info
+            else False
+            for r in error_records
+        )
+        assert matched, (
+            "Expected log message containing 'background task failure for testing', "
+            f"got: {[r.getMessage() for r in error_records]}"
+        )
+    finally:
+        _remove_handler(handler)
+
+
+class _ErrorBeforeResponseApp:
+    """ASGI app that raises before sending any response."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            return
+
+        if scope["type"] == "http":
+            await receive()
+            raise RuntimeError("app crash before response for testing")
+
+
+async def test_app_exception_before_response_is_logged():
+    handler = _install_handler()
+    try:
+        req = js.Request.new("http://example.com/crash-test")
+        threw = False
+        try:
+            await asgi.fetch(_ErrorBeforeResponseApp(), req, {})
+        except RuntimeError as e:
+            threw = True
+            assert "app crash before response for testing" in str(e), (
+                f"Expected original exception message, got: {e}"
+            )
+
+        assert threw, "Expected RuntimeError to be raised from asgi.fetch"
+
+        # fetch() should have logged the error before re-raising.
+        error_records = [r for r in handler.records if r.levelno >= logging.ERROR]
+        assert len(error_records) > 0, (
+            "Expected at least one ERROR log for request failure, "
+            f"got {len(error_records)}. All records: {[r.getMessage() for r in handler.records]}"
+        )
+        matched = any("ASGI request failed" in r.getMessage() for r in error_records)
+        assert matched, (
+            "Expected log message containing 'ASGI request failed', "
+            f"got: {[r.getMessage() for r in error_records]}"
+        )
+    finally:
+        _remove_handler(handler)


### PR DESCRIPTION
Adds logger to the Python ASGI module, users can overwrite the logger behavior by

```py
logger = logging.getLogger("asgi")
do_something_with_logger(logger)
```

before this change, all the errors were not showed to the user at all, while after this change, errors are caught and showed to stderr.

For example, the bug reported in https://discord.com/channels/595317990191398933/1224715939581530112/1473759889582194758 which showed nothing now shows

```
⎔ Starting local server...
[wrangler:info] Ready on http://0.0.0.0:8787
[wrangler:info] - http://127.0.0.1:8787
[wrangler:info] - http://172.17.0.2:8787
✘ [ERROR] Exception in ASGI application after response started
✘ [ERROR] Traceback (most recent call last):
✘ [ERROR]   File "/lib/python3.13/site-packages/asgi.py", line 208, in run_app
✘ [ERROR]     await app(request_to_scope(req, env), receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/fastapi/applications.py", line 1160, in __call__
✘ [ERROR]     await super().__call__(scope, receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/starlette/applications.py", line 107, in __call__
✘ [ERROR]     await self.middleware_stack(scope, receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/starlette/middleware/errors.py", line 186, in __call__
✘ [ERROR]     raise exc
✘ [ERROR]   File "/session/metadata/python_modules/starlette/middleware/errors.py", line 164, in __call__
✘ [ERROR]     await self.app(scope, receive, _send)
✘ [ERROR]   File "/session/metadata/python_modules/starlette/middleware/exceptions.py", line 63, in __call__
✘ [ERROR]     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/starlette/_exception_handler.py", line 53, in wrapped_app
✘ [ERROR]     raise exc
✘ [ERROR]   File "/session/metadata/python_modules/starlette/_exception_handler.py", line 42, in wrapped_app
✘ [ERROR]     await app(scope, receive, sender)
✘ [ERROR]   File "/session/metadata/python_modules/fastapi/middleware/asyncexitstack.py", line 18, in __call__
✘ [ERROR]     await self.app(scope, receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/starlette/routing.py", line 716, in __call__
✘ [ERROR]     await self.middleware_stack(scope, receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/starlette/routing.py", line 736, in app
✘ [ERROR]     await route.handle(scope, receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/starlette/routing.py", line 290, in handle
✘ [ERROR]     await self.app(scope, receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/fastapi/routing.py", line 119, in app
✘ [ERROR]     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
✘ [ERROR]   File "/session/metadata/python_modules/starlette/_exception_handler.py", line 53, in wrapped_app
✘ [ERROR]     raise exc
✘ [ERROR]   File "/session/metadata/python_modules/starlette/_exception_handler.py", line 42, in wrapped_app
✘ [ERROR]     await app(scope, receive, sender)
✘ [ERROR]   File "/session/metadata/python_modules/fastapi/routing.py", line 105, in app
✘ [ERROR]     response = await f(request)
✘ [ERROR]                ^^^^^^^^^^^^^^^^
✘ [ERROR]   File "/session/metadata/python_modules/fastapi/routing.py", line 431, in app
✘ [ERROR]     raw_response = await run_endpoint_function(
✘ [ERROR]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
✘ [ERROR]     ...<3 lines>...
✘ [ERROR]     )
✘ [ERROR]     ^
✘ [ERROR]   File "/session/metadata/python_modules/fastapi/routing.py", line 315, in run_endpoint_function
✘ [ERROR]     return await run_in_threadpool(dependant.call, **values)
✘ [ERROR]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
✘ [ERROR]   File "/session/metadata/python_modules/starlette/concurrency.py", line 32, in run_in_threadpool
✘ [ERROR]     return await anyio.to_thread.run_sync(func)
✘ [ERROR]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
✘ [ERROR]   File "/session/metadata/python_modules/anyio/to_thread.py", line 63, in run_sync
✘ [ERROR]     return await get_async_backend().run_sync_in_worker_thread(
✘ [ERROR]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
✘ [ERROR]         func, args, abandon_on_cancel=abandon_on_cancel, limiter=limiter
✘ [ERROR]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
✘ [ERROR]     )
✘ [ERROR]     ^
✘ [ERROR]   File "/session/metadata/python_modules/anyio/_backends/_asyncio.py", line 2470, in run_sync_in_worker_thread
✘ [ERROR]     worker.start()
✘ [ERROR]     ~~~~~~~~~~~~^^
✘ [ERROR]   File "/lib/python313.zip/threading.py", line 973, in start
✘ [ERROR]     _start_joinable_thread(self._bootstrap, handle=self._handle,
✘ [ERROR]     ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
✘ [ERROR]                            daemon=self.daemon)
✘ [ERROR]                            ^^^^^^^^^^^^^^^^^^^
✘ [ERROR] RuntimeError: can't start new thread
[wrangler:info] GET / 500 Internal Server Error (4678ms)
```

which helps us to debug the issue.
