### PR TITLE
containers: Make sure req.url in the worker has format 'http://...' and egress listener should be backed by an atomic boolean to not start it twice

### DIFF
--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -146,6 +146,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
 
   std::atomic_bool containerStarted = false;
   std::atomic_bool containerSidecarStarted = false;
+  std::atomic_bool egressListenerStarted = false;
 
   kj::Maybe<kj::Own<kj::HttpServer>> egressHttpServer;
   kj::Maybe<kj::Promise<void>> egressListenerTask;
@@ -160,6 +161,9 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   // Start the egress listener on the given address with an OS-chosen port.
   kj::Promise<uint16_t> startEgressListener(kj::String listenAddress);
   void stopEgressListener();
+  // Ensure the egress listener is started exactly once.
+  // Uses egressListenerStarted as a guard. Called from setEgressHttp().
+  kj::Promise<void> ensureEgressListenerStarted();
   // Ensure the egress listener and sidecar container are started exactly once.
   // Uses containerSidecarStarted as a guard. Called from both start() and setEgressHttp().
   kj::Promise<void> ensureSidecarStarted();

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -394,7 +394,10 @@ export class DurableObjectExample extends DurableObject {
           headers: { 'x-host': '1.2.3.4:80' },
         });
       assert.equal(response.status, 200);
-      assert.equal(await response.text(), 'hello binding: 1234');
+      assert.equal(
+        await response.text(),
+        'hello binding: 1234 http://1.2.3.4/'
+      );
     }
 
     {
@@ -404,7 +407,10 @@ export class DurableObjectExample extends DurableObject {
           headers: { 'x-host': '11.0.0.1:9999' },
         });
       assert.equal(response.status, 200);
-      assert.equal(await response.text(), 'hello binding: 1');
+      assert.equal(
+        await response.text(),
+        'hello binding: 1 http://11.0.0.1:9999/'
+      );
     }
 
     {
@@ -414,7 +420,10 @@ export class DurableObjectExample extends DurableObject {
           headers: { 'x-host': '11.0.0.2:9999' },
         });
       assert.equal(response.status, 200);
-      assert.equal(await response.text(), 'hello binding: 2');
+      assert.equal(
+        await response.text(),
+        'hello binding: 2 http://11.0.0.2:9999/'
+      );
     }
 
     {
@@ -424,7 +433,7 @@ export class DurableObjectExample extends DurableObject {
           headers: { 'x-host': '15.0.0.2:80' },
         });
       assert.equal(response.status, 200);
-      assert.equal(await response.text(), 'hello binding: 3');
+      assert.equal(await response.text(), 'hello binding: 3 http://15.0.0.2/');
     }
 
     {
@@ -434,7 +443,20 @@ export class DurableObjectExample extends DurableObject {
           headers: { 'x-host': '[111::]:80' },
         });
       assert.equal(response.status, 200);
-      assert.equal(await response.text(), 'hello binding: 3');
+      assert.equal(await response.text(), 'hello binding: 3 http://[111::]/');
+    }
+
+    {
+      const response = await container
+        .getTcpPort(8080)
+        .fetch('http://foo/intercept', {
+          headers: { 'x-host': 'google.com/hello/world' },
+        });
+      assert.equal(response.status, 200);
+      assert.equal(
+        await response.text(),
+        'hello binding: 3 http://google.com/hello/world'
+      );
     }
   }
 
@@ -531,7 +553,9 @@ export class TestService extends WorkerEntrypoint {
     }
 
     // Regular HTTP request
-    return new Response('hello binding: ' + this.ctx.props.id);
+    return new Response(
+      'hello binding: ' + this.ctx.props.id + ' ' + request.url
+    );
   }
 }
 


### PR DESCRIPTION
Should make it less flakey