### PR TITLE
Add MySQL port to Hyperdrive binding

### DIFF
--- a/src/workerd/api/hyperdrive.c++
+++ b/src/workerd/api/hyperdrive.c++
@@ -80,14 +80,22 @@ kj::StringPtr Hyperdrive::getHost() {
   return randomHost;
 }
 
-// Always returns the default postgres port
+// We currently only support Postgres and MySQL
 uint16_t Hyperdrive::getPort() {
+  if (scheme == "mysql") {
+    return 3306;
+  }
+
+  // We default to postgres if the scheme is not mysql
   return 5432;
 }
 
 kj::String Hyperdrive::getConnectionString() {
+  // MySQL: `?ssl-mode=disabled`
+  // PostgreSQL: `?sslmode=disable`
+  auto sslParameter = scheme == "mysql" ? "?ssl-mode=disabled" : "?sslmode=disable";
   return kj::str(getScheme(), "://", getUser(), ":", getPassword(), "@", getHost(), ":", getPort(),
-      "/", getDatabase(), "?sslmode=disable");
+      "/", getDatabase(), sslParameter);
 }
 
 kj::Promise<kj::Own<kj::AsyncIoStream>> Hyperdrive::connectToDb() {


### PR DESCRIPTION
This change makes Hyperdrive's magic connection string port match the database the user is using. This does not and should not change functionality, it just changes the user visible port to avoid confusion. 