### PR TITLE
Add further support for DO cohorts

### DIFF
--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -676,6 +676,8 @@ class DurableObjectState: public jsg::Object {
     if (flags.getWorkerdExperimental()) {
       // Experimental new API, details may change!
       JSG_LAZY_INSTANCE_PROPERTY(facets, getFacets);
+    }
+    if (flags.getEnableVersionApi()) {
       JSG_LAZY_INSTANCE_PROPERTY(version, getVersion);
     }
     JSG_METHOD(blockConcurrencyWhile);

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -158,7 +158,7 @@ jsg::Ref<DurableObject> DurableObjectNamespace::getImpl(jsg::Lock& js,
   kj::Maybe<ActorVersion> version;
   KJ_IF_SOME(o, options) {
     locationHint = kj::mv(o.locationHint);
-    if (FeatureFlags::get(js).getWorkerdExperimental()) {
+    if (FeatureFlags::get(js).getEnableVersionApi()) {
       KJ_IF_SOME(v, o.version) {
         version = ActorVersion{.cohort = kj::mv(v.cohort)};
       }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3610,6 +3610,7 @@ struct Worker::Actor::Impl {
 
   kj::Maybe<rpc::Container::Client> container;
   kj::Maybe<FacetManager&> facetManager;
+  kj::Maybe<ActorVersion> version;
 
   struct NoClass {};
   struct Initializing {};
@@ -3824,12 +3825,14 @@ Worker::Actor::Actor(const Worker& worker,
     kj::Maybe<kj::Own<HibernationManager>> manager,
     kj::Maybe<uint16_t> hibernationEventType,
     kj::Maybe<rpc::Container::Client> container,
-    kj::Maybe<FacetManager&> facetManager)
+    kj::Maybe<FacetManager&> facetManager,
+    kj::Maybe<ActorVersion> version)
     : worker(kj::atomicAddRef(worker)),
       tracker(tracker.map([](RequestTracker& tracker) { return tracker.addRef(); })) {
   impl = kj::heap<Impl>(*this, kj::mv(actorId), hasTransient, kj::mv(makeActorCache), kj::mv(props),
       kj::mv(makeStorage), kj::mv(loopback), timerChannel, kj::mv(metrics), kj::mv(manager),
       hibernationEventType, kj::mv(container), facetManager);
+  impl->version = kj::mv(version);
 
   KJ_IF_SOME(c, className) {
     KJ_IF_SOME(cls, worker.impl->actorClasses.find(c)) {
@@ -3889,7 +3892,9 @@ kj::Promise<void> Worker::Actor::ensureConstructedImpl(IoContext& context, Actor
       auto ctx = js.alloc<api::DurableObjectState>(js, cloneId(),
           jsg::JsValue(KJ_ASSERT_NONNULL(lock.getWorker().impl->ctxExports).getHandle(js)),
           impl->props.toJs(js), kj::mv(storage), kj::mv(impl->container), containerRunning,
-          impl->facetManager);
+          impl->facetManager, impl->version.map([](ActorVersion& v) {
+        return ActorVersion{.cohort = v.cohort.map([](kj::String& s) { return kj::str(s); })};
+      }));
 
       auto handler =
           info.cls(lock, ctx.addRef(), KJ_ASSERT_NONNULL(lock.getWorker().impl->env).addRef(js));

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -920,7 +920,8 @@ class Worker::Actor final: public kj::Refcounted {
       kj::Maybe<kj::Own<HibernationManager>> manager,
       kj::Maybe<uint16_t> hibernationEventType,
       kj::Maybe<rpc::Container::Client> container = kj::none,
-      kj::Maybe<FacetManager&> facetManager = kj::none);
+      kj::Maybe<FacetManager&> facetManager = kj::none,
+      kj::Maybe<ActorVersion> version = kj::none);
 
   ~Actor() noexcept(false);
 


### PR DESCRIPTION
Uses the more specific `getEnableVersionApi` flag and adds some missing interface additions. 