### PR TITLE
containers: Fix workerd reloads with egress interception

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -417,14 +417,15 @@ static kj::Maybe<kj::String> gatewayForPlatform(kj::String gateway) {
 #endif
 }
 
-kj::Promise<uint16_t> ContainerClient::startEgressListener(kj::String listenAddress) {
+kj::Promise<uint16_t> ContainerClient::startEgressListener(
+    kj::String listenAddress, uint16_t port) {
   auto service = kj::heap<EgressHttpService>(*this, headerTable);
   auto httpServer = kj::heap<kj::HttpServer>(timer, headerTable, *service);
   auto& httpServerRef = *httpServer;
 
   egressHttpServer = httpServer.attach(kj::mv(service));
 
-  auto addr = co_await network.parseAddress(kj::str(listenAddress, ":0"));
+  auto addr = co_await network.parseAddress(kj::str(listenAddress, ":", port));
   auto listener = addr->listen();
 
   uint16_t chosenPort = listener->getPort();
@@ -532,6 +533,43 @@ kj::Promise<ContainerClient::InspectResponse> ContainerClient::inspectContainer(
   // so that start() correctly refuses to start a duplicate and destroy() can clean it up.
   bool running = status == "running" || status == "restarting";
   co_return InspectResponse{.isRunning = running, .ports = kj::mv(portMappings)};
+}
+
+kj::Promise<kj::Maybe<uint16_t>> ContainerClient::inspectSidecarEgressPort() {
+  auto endpoint = kj::str("/containers/", sidecarContainerName, "/json");
+  auto response = co_await dockerApiRequest(
+      network, kj::str(dockerPath), kj::HttpMethod::GET, kj::mv(endpoint));
+
+  if (response.statusCode == 404) {
+    co_return kj::Maybe<uint16_t>(kj::none);
+  }
+
+  JSG_REQUIRE(response.statusCode == 200, Error, "Sidecar container inspect failed");
+
+  auto jsonRoot = decodeJsonResponse<docker_api::Docker::ContainerInspectResponse>(response.body);
+
+  // Check if sidecar is actually running
+  if (jsonRoot.hasState()) {
+    auto state = jsonRoot.getState();
+    if (state.hasStatus()) {
+      auto status = state.getStatus();
+      if (status != "running" && status != "restarting") {
+        co_return kj::Maybe<uint16_t>(kj::none);
+      }
+    }
+  }
+
+  // Parse args to find --http-egress-port value
+  if (jsonRoot.hasArgs()) {
+    auto args = jsonRoot.getArgs();
+    for (auto i = 0u; i < args.size(); i++) {
+      if (args[i] == "--http-egress-port" && i + 1 < args.size()) {
+        co_return kj::str(args[i + 1]).parseAs<uint16_t>();
+      }
+    }
+  }
+
+  co_return kj::Maybe<uint16_t>(kj::none);
 }
 
 kj::Promise<void> ContainerClient::createContainer(
@@ -757,6 +795,23 @@ ContainerClient::RpcTurn ContainerClient::getRpcTurn() {
 kj::Promise<void> ContainerClient::status(StatusContext context) {
   const auto [isRunning, _ports] = co_await inspectContainer();
   containerStarted.store(isRunning, std::memory_order_release);
+
+  if (isRunning && containerEgressInterceptorImage != kj::none) {
+    // If the sidecar container is already running (e.g. workerd restarted while
+    // containers stayed up), recover the egress port it was started with and
+    // start the host-side egress listener on that same port so the sidecar can
+    // reconnect.
+    KJ_IF_SOME(port, co_await inspectSidecarEgressPort()) {
+      containerSidecarStarted.store(true, std::memory_order_release);
+      co_await ensureEgressListenerStarted(port);
+    } else {
+      // We could not really recover, set it to false and ensure it's up and running
+      containerSidecarStarted.store(false, std::memory_order_release);
+      co_await ensureEgressListenerStarted();
+      co_await ensureSidecarStarted();
+    }
+  }
+
   context.getResults().setRunning(isRunning);
 }
 
@@ -788,8 +843,7 @@ kj::Promise<void> ContainerClient::start(StartContext context) {
   // for now. In the future, it will always run when a user container is running
   if (!egressMappings.empty()) {
     // The user container will be blocked on network connectivity until this finishes.
-    // When workerd-network is more battle-tested and goes out of experimental so it's non-optional,
-    // we should make the sidecar start first and _then_ make the user container join the sidecar network.
+    containerSidecarStarted = false;
     co_await ensureSidecarStarted();
   }
 
@@ -898,7 +952,7 @@ kj::Promise<void> ContainerClient::ensureSidecarStarted() {
   co_await startSidecarContainer();
 }
 
-kj::Promise<void> ContainerClient::ensureEgressListenerStarted() {
+kj::Promise<void> ContainerClient::ensureEgressListenerStarted(uint16_t port) {
   if (egressListenerStarted.exchange(true, std::memory_order_acquire)) {
     co_return;
   }
@@ -910,7 +964,7 @@ kj::Promise<void> ContainerClient::ensureEgressListenerStarted() {
   // routes host-gateway to host loopback through the VM).
   auto ipamConfig = co_await getDockerBridgeIPAMConfig();
   egressListenerPort = co_await startEgressListener(
-      gatewayForPlatform(kj::mv(ipamConfig.gateway)).orDefault(kj::str("127.0.0.1")));
+      gatewayForPlatform(kj::mv(ipamConfig.gateway)).orDefault(kj::str("127.0.0.1")), port);
 }
 
 kj::Promise<void> ContainerClient::setEgressHttp(SetEgressHttpContext context) {

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -108,6 +108,9 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
       kj::String endpoint,
       kj::Maybe<kj::String> body = kj::none);
   kj::Promise<InspectResponse> inspectContainer();
+  // Inspect the sidecar container and extract the --http-egress-port from its args.
+  // Returns kj::none if the sidecar doesn't exist or is not running.
+  kj::Promise<kj::Maybe<uint16_t>> inspectSidecarEgressPort();
   kj::Promise<void> createContainer(kj::Maybe<capnp::List<capnp::Text>::Reader> entrypoint,
       kj::Maybe<capnp::List<capnp::Text>::Reader> environment,
       rpc::Container::StartParams::Reader params);
@@ -172,12 +175,13 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   // Check if the Docker daemon has IPv6 enabled by inspecting the default bridge network's
   // IPAM config for IPv6 subnets.
   kj::Promise<bool> isDaemonIpv6Enabled();
-  // Start the egress listener on the given address with an OS-chosen port.
-  kj::Promise<uint16_t> startEgressListener(kj::String listenAddress);
+  // Start the egress listener on the given address. If port is 0, an OS-chosen port is used.
+  kj::Promise<uint16_t> startEgressListener(kj::String listenAddress, uint16_t port = 0);
   void stopEgressListener();
   // Ensure the egress listener is started exactly once.
-  // Uses egressListenerStarted as a guard. Called from setEgressHttp().
-  kj::Promise<void> ensureEgressListenerStarted();
+  // Uses egressListenerStarted as a guard. Called from setEgressHttp() and status().
+  // If port is non-zero, binds to that specific port (for reconnecting to an existing sidecar).
+  kj::Promise<void> ensureEgressListenerStarted(uint16_t port = 0);
   // Ensure the egress listener and sidecar container are started exactly once.
   // Uses containerSidecarStarted as a guard. Called from both start() and setEgressHttp().
   kj::Promise<void> ensureSidecarStarted();

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -303,11 +303,6 @@ export class DurableObjectExample extends DurableObject {
   async testSetEgressHttp() {
     const container = this.ctx.container;
 
-    if (container.running) {
-      await this.ctx.container.destroy();
-      await this.ctx.container.monitor().catch(() => {});
-    }
-
     // Set up egress TCP mapping to route requests to the binding
     // We can configure this even before the container starts.
     await container.interceptOutboundHttp(
@@ -315,7 +310,11 @@ export class DurableObjectExample extends DurableObject {
       this.ctx.exports.TestService({ props: { id: 1234 } })
     );
 
-    container.start();
+    if (!container.running) container.start();
+
+    // Keep container alive after abort();
+    await container.setInactivityTimeout(60_000 + Date.now());
+
     container.monitor().catch((err) => {
       console.error('Container exited with an error:', err.message);
     });
@@ -429,10 +428,17 @@ export class DurableObjectExample extends DurableObject {
 
     assert.strictEqual(container.running, false);
 
+    // Set up egress mapping to route WebSocket requests to the binding
+    await container.interceptOutboundHttp(
+      '11.0.0.1:9999',
+      this.ctx.exports.TestService({ props: { id: 42 } })
+    );
+
     // Start container with WebSocket proxy mode enabled
     container.start({
       env: { WS_ENABLED: 'true', WS_PROXY_TARGET: '11.0.0.1:9999' },
     });
+
     container.monitor().finally(() => {
       console.log('Container exited');
     });
@@ -441,12 +447,6 @@ export class DurableObjectExample extends DurableObject {
     await this.waitUntilContainerIsHealthy();
 
     assert.strictEqual(container.running, true);
-
-    // Set up egress mapping to route WebSocket requests to the binding
-    await container.interceptOutboundHttp(
-      '11.0.0.1:9999',
-      this.ctx.exports.TestService({ props: { id: 42 } })
-    );
 
     // Connect to container's /ws endpoint which proxies to the intercepted address
     // Flow: DO -> container:8080/ws -> container connects to 11.0.0.1:9999/ws


### PR DESCRIPTION
When workerd reloads, and the container is still running, there might be a chance that the container loses connectivity.

This changes make sure that we can recover the proxy sidecar we were running, and listen in the same port we were before in Workerd.