### PR TITLE
containers: Cancel async destruction from ContainerClient if a new ContainerClient takes over, and be able to recover container sidecar proxies

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -180,7 +180,8 @@ ContainerClient::ContainerClient(capnp::ByteStreamFactory& byteStreamFactory,
     kj::String imageName,
     kj::Maybe<kj::String> containerEgressInterceptorImage,
     kj::TaskSet& waitUntilTasks,
-    kj::Function<void()> cleanupCallback,
+    kj::Promise<void> pendingCleanup,
+    kj::Function<void(kj::Promise<void>)> cleanupCallback,
     ChannelTokenHandler& channelTokenHandler)
     : byteStreamFactory(byteStreamFactory),
       timer(timer),
@@ -191,23 +192,29 @@ ContainerClient::ContainerClient(capnp::ByteStreamFactory& byteStreamFactory,
       imageName(kj::mv(imageName)),
       containerEgressInterceptorImage(kj::mv(containerEgressInterceptorImage)),
       waitUntilTasks(waitUntilTasks),
+      pendingCleanup(kj::mv(pendingCleanup).fork()),
       cleanupCallback(kj::mv(cleanupCallback)),
       channelTokenHandler(channelTokenHandler) {}
 
 ContainerClient::~ContainerClient() noexcept(false) {
   stopEgressListener();
 
-  // Call the cleanup callback to remove this client from the ActorNamespace map
-  cleanupCallback();
-
-  // Sidecar shares main container's network namespace, so must be destroyed first
-  waitUntilTasks.add(dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::DELETE,
+  // Sidecar shares main container's network namespace, so must be destroyed first.
+  auto sidecarCleanup = dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::DELETE,
       kj::str("/containers/", sidecarContainerName, "?force=true"))
-                         .ignoreResult());
+                            .ignoreResult()
+                            .catch_([](kj::Exception&&) {});
 
-  waitUntilTasks.add(dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::DELETE,
+  auto mainCleanup = dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::DELETE,
       kj::str("/containers/", containerName, "?force=true"))
-                         .ignoreResult());
+                         .ignoreResult()
+                         .catch_([](kj::Exception&&) {});
+
+  // Pass the joined cleanup promise to the callback. The callback wraps it with the
+  // canceler (so a future client creation can cancel it), stores it so the next
+  // ContainerClient can await it, and adds a branch to waitUntilTasks to keep the
+  // underlying I/O alive.
+  cleanupCallback(kj::joinPromises(kj::arr(kj::mv(sidecarCleanup), kj::mv(mainCleanup))));
 }
 
 // Docker-specific Port implementation that implements rpc::Container::Port::Server
@@ -739,7 +746,6 @@ kj::Promise<void> ContainerClient::createSidecarContainer(
   // Sidecar needs NET_ADMIN capability for iptables/TPROXY
   auto capAdd = hostConfig.initCapAdd(1);
   capAdd.set(0, "NET_ADMIN");
-  hostConfig.setAutoRemove(true);
 
   auto response = co_await dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::POST,
       kj::str("/containers/create?name=", sidecarContainerName), codec.encode(jsonRoot));
@@ -793,6 +799,15 @@ ContainerClient::RpcTurn ContainerClient::getRpcTurn() {
 }
 
 kj::Promise<void> ContainerClient::status(StatusContext context) {
+  // Wait for any pending cleanup from a previous ContainerClient (Docker DELETE).
+  // If the cleanup was already cancelled via containerCleanupCanceler the .catch_()
+  // in the destructor resolves it immediately, so this is a no-op in that case.
+  co_await pendingCleanup.addBranch();
+
+  auto [ready, done] = getRpcTurn();
+  co_await ready;
+  KJ_DEFER(done->fulfill());
+
   const auto [isRunning, _ports] = co_await inspectContainer();
   containerStarted.store(isRunning, std::memory_order_release);
 
@@ -804,11 +819,6 @@ kj::Promise<void> ContainerClient::status(StatusContext context) {
     KJ_IF_SOME(port, co_await inspectSidecarEgressPort()) {
       containerSidecarStarted.store(true, std::memory_order_release);
       co_await ensureEgressListenerStarted(port);
-    } else {
-      // We could not really recover, set it to false and ensure it's up and running
-      containerSidecarStarted.store(false, std::memory_order_release);
-      co_await ensureEgressListenerStarted();
-      co_await ensureSidecarStarted();
     }
   }
 

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -23,6 +23,19 @@
 
 namespace workerd::server {
 
+// Tracks the canceler and cleanup promise for a Docker container's lifecycle cleanup.
+// Useful to await on async calls of a ContainerClient destructor when the new
+// one appears before they've been resolved.
+struct ContainerCleanupState {
+  // Canceler that wraps the promise fired in ~ContainerClient. Replacing
+  // it cancels any pending cleanup, which resolves the promise immediately.
+  kj::Own<kj::Canceler> canceler;
+
+  // Forked cleanup promise. A branch is added to waitUntilTasks to keep the I/O alive,
+  // and another branch is passed to the next ContainerClient so its status() can await.
+  kj::ForkedPromise<void> promise = kj::Promise<void>(kj::READY_NOW).fork();
+};
+
 // Docker-based implementation that implements the rpc::Container::Server interface
 // so it can be used as a rpc::Container::Client via kj::heap<ContainerClient>().
 // This allows the Container JSG class to use Docker directly without knowing
@@ -41,7 +54,8 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
       kj::String imageName,
       kj::Maybe<kj::String> containerEgressInterceptorImage,
       kj::TaskSet& waitUntilTasks,
-      kj::Function<void()> cleanupCallback,
+      kj::Promise<void> pendingCleanup,
+      kj::Function<void(kj::Promise<void>)> cleanupCallback,
       ChannelTokenHandler& channelTokenHandler);
 
   ~ContainerClient() noexcept(false);
@@ -73,6 +87,12 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   kj::Maybe<kj::String> containerEgressInterceptorImage;
 
   kj::TaskSet& waitUntilTasks;
+
+  // Forked promise representing pending cleanup from a previous ContainerClient for the same
+  // container ID. status() co_awaits a branch so that Docker inspect only runs after any
+  // in-flight DELETE from the previous client has settled (either completed or been cancelled
+  // via containerCleanupCanceler, in which case the .catch_() resolves it immediately).
+  kj::ForkedPromise<void> pendingCleanup;
 
   static constexpr kj::StringPtr defaultEnv[] = {"CLOUDFLARE_COUNTRY_A2=XX"_kj,
     "CLOUDFLARE_DEPLOYMENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"_kj,
@@ -125,8 +145,10 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   kj::Promise<void> destroySidecarContainer();
   kj::Promise<void> monitorSidecarContainer();
 
-  // Cleanup callback to remove from ActorNamespace map when destroyed
-  kj::Function<void()> cleanupCallback;
+  // Cleanup callback invoked from the destructor. Receives the joined cleanup promise so
+  // ActorNamespace can wrap it with the canceler, store it for the next ContainerClient
+  // to await, and add a branch to waitUntilTasks to keep the cleanup tasks alive.
+  kj::Function<void(kj::Promise<void>)> cleanupCallback;
 
   // For redeeming channel tokens received via setEgressHttp
   ChannelTokenHandler& channelTokenHandler;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2855,15 +2855,52 @@ class Server::WorkerService final: public Service,
       auto& dockerPathRef = KJ_ASSERT_NONNULL(
           dockerPath, "dockerPath must be defined to enable containers on this Durable Object.");
 
-      // Remove from the map when the container is destroyed
-      kj::Function<void()> cleanupCallback = [this, containerId = kj::str(containerId)]() {
-        containerClients.erase(containerId);
+      // Grab a branch of any pending cleanup from a previous ContainerClient for this
+      // container. If it exists, pass it to the container client so it knows that it has to sync.
+      kj::Promise<void> previousCleanup = kj::READY_NOW;
+      KJ_IF_SOME(state, containerCleanupState.find(containerId)) {
+        previousCleanup = state.promise.addBranch();
+      }
+
+      // Upsert the cleanup state for this container ID. Replacing the
+      // canceler auto-cancels any in-flight cleanup tasks from the previous
+      // client's destructor.
+      auto canceler = kj::heap<kj::Canceler>();
+      auto* cancelerPtr = canceler.get();
+      containerCleanupState.upsert(kj::str(containerId),
+          ContainerCleanupState{.canceler = kj::mv(canceler)},
+          [](ContainerCleanupState& existing, ContainerCleanupState&& incoming) {
+        existing.canceler = kj::mv(incoming.canceler);
+      });
+
+      // Cleanup callback: invoked from the ContainerClient destructor with the joined
+      // with a cleanup promise
+      kj::Function<void(kj::Promise<void>)> cleanupCallback =
+          [this, containerId = kj::str(containerId), cancelerPtr](
+              kj::Promise<void> cleanupPromise) mutable {
+        KJ_IF_SOME(state, containerCleanupState.find(containerId)) {
+          if (state.canceler.get() != cancelerPtr) {
+            // A newer ContainerClient has replaced us already with another destructor.
+            // drop the promise.
+            return;
+          }
+
+          containerClients.erase(containerId);
+          // Wrap with the canceler so a future client creation can cancel these
+          // tasks
+          auto cancellable =
+              state.canceler->wrap(kj::mv(cleanupPromise)).catch_([](kj::Exception&&) {});
+
+          auto forked = kj::mv(cancellable).fork();
+          waitUntilTasks.add(forked.addBranch());
+          state.promise = kj::mv(forked);
+        }
       };
 
       auto client = kj::refcounted<ContainerClient>(byteStreamFactory, timer, dockerNetwork,
           kj::str(dockerPathRef), kj::str(containerId), kj::str(imageName),
           containerEgressInterceptorImage.map([](kj::StringPtr s) { return kj::str(s); }),
-          waitUntilTasks, kj::mv(cleanupCallback), channelTokenHandler);
+          waitUntilTasks, kj::mv(previousCleanup), kj::mv(cleanupCallback), channelTokenHandler);
 
       // Store raw pointer in map (does not own)
       containerClients.insert(kj::str(containerId), client.get());
@@ -2895,15 +2932,18 @@ class Server::WorkerService final: public Service,
     //   declare `actorStorage` before `actors`.
     kj::Maybe<ActorStorage> actorStorage;
 
-    // If the actor is broken, we remove it from the map. However, if it's just evicted due to
-    // inactivity, we keep the ActorContainer in the map but drop the Own<Worker::Actor>. When a new
-    // request comes in, we recreate the Own<Worker::Actor>.
-    ActorMap actors;
+    // Per-container cleanup state: canceler + forked cleanup promise.
+    kj::HashMap<kj::String, ContainerCleanupState> containerCleanupState;
 
     // Map of container IDs to ContainerClients (for reconnection support with inactivity timeouts).
     // The map holds raw pointers (not ownership) - ContainerClients are owned by actors and timers.
     // When the last reference is dropped, the destructor removes the entry from this map.
     kj::HashMap<kj::String, ContainerClient*> containerClients;
+
+    // If the actor is broken, we remove it from the map. However, if it's just evicted due to
+    // inactivity, we keep the ActorContainer in the map but drop the Own<Worker::Actor>. When a new
+    // request comes in, we recreate the Own<Worker::Actor>.
+    ActorMap actors;
 
     kj::Maybe<kj::Promise<void>> cleanupTask;
     kj::Timer& timer;

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -313,8 +313,6 @@ export class DurableObjectExample extends DurableObject {
     if (!container.running) container.start();
 
     // Keep container alive after abort();
-    await container.setInactivityTimeout(60_000 + Date.now());
-
     container.monitor().catch((err) => {
       console.error('Container exited with an error:', err.message);
     });
@@ -584,8 +582,7 @@ export const testAlarm = {
       retries++;
     }
 
-    // Wait for container to start
-    await scheduler.wait(500);
+    await scheduler.wait(50);
 
     // Set alarm for future and abort
     await stub.startAlarm(false, 1000);
@@ -596,14 +593,9 @@ export const testAlarm = {
       // Expected to throw
     }
 
-    // Poll for the alarm to run after abort. The DO must be re-created and the
-    // alarm handler must fire, which can take variable time on CI.
-    // 50 iterations * 200ms = 10s max wait, which gives plenty of headroom for
-    // slow CI environments where Docker and DO reconstruction add latency.
     stub = env.MY_CONTAINER.get(id);
     let confirmed = false;
     for (let i = 0; i < 50 && !confirmed; i++) {
-      await scheduler.wait(200);
       try {
         await stub.checkAlarmAbortConfirmation();
         confirmed = true;
@@ -613,6 +605,8 @@ export const testAlarm = {
           /Abort confirmation did not get inserted/,
           `Unexpected error while polling for alarm: ${e.message}`
         );
+
+        await scheduler.wait(100);
       }
     }
     if (!confirmed) {


### PR DESCRIPTION
 containers: Fix workerd reloads with egress interception

    When workerd reloads, and the container is still running, there might be
    a chance that the container loses connectivity.

    This changes make sure that we can recover the proxy sidecar we were
    running, and listen in the same port we were before in Workerd.

containers: Cancel async destruction from ContainerClient if a new ContainerClient takes over

    The new system makes it so we have a containerCleanupCanceler reference
    that a container destructor uses to wrap async calls that should be
    cancelled if a new ContainerClient of the same id takes over.

    This fixes issues where we abort a DO container, but then we call it
    again, racing the old destructor tasks against the new ContainerClient.