### PR TITLE
Restore default container PID namespace isolation (remove host PID mode)

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -577,11 +577,8 @@ kj::Promise<void> ContainerClient::createContainer(
 
   hostConfig.setNetworkMode("bridge");
 
-  // When containersPidNamespace is NOT enabled, use host PID namespace for backwards compatibility.
-  // This allows the container to see processes on the host.
-  if (!params.getCompatibilityFlags().getContainersPidNamespace()) {
-    hostConfig.setPidMode("host");
-  }
+  // Do not set pidMode. Docker defaults to an isolated PID namespace, which prevents
+  // containers from enumerating or signaling host processes.
 
   auto response = co_await dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::POST,
       kj::str("/containers/create?name=", containerName), codec.encode(jsonRoot));


### PR DESCRIPTION
### Motivation
- A recent change set `HostConfig.PidMode` to `"host"` when the `containers_pid_namespace` compatibility flag was not enabled, causing containers to share the host PID namespace by default and weakening container/host isolation.

### Description
- Remove the explicit `PidMode = "host"` assignment in `ContainerClient::createContainer()` so Docker's default (an isolated PID namespace) is used instead; the change modifies `src/workerd/server/container-client.c++` and leaves other hostConfig settings (network, restart policy, extra hosts) unchanged.

### Testing
- Verified the source no longer contains `setPidMode("host")` via a repository search (`rg`) and inspected the modified code region to confirm the `PidMode` assignment was removed; the search returned no matches.
- Attempted to run the container-client test target (`bazel test //src/workerd/server/tests/container-client:container-client-test@`) but the test run could not complete in this environment because downloading the Bazel binary failed with an HTTP 403, so a full test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a203967320832399a3ff2b24618759)