### PR TITLE
server: restrict container egress CONNECT listener to the managed container

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -20,6 +20,9 @@
 #include <kj/encoding.h>
 #include <kj/exception.h>
 #include <kj/string.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 
 namespace workerd::server {
 
@@ -225,7 +228,7 @@ class ContainerClient::DockerPort final: public rpc::Container::Port::Server {
     // Port mappings might have outdated mappings, we can't know if a connect request
     // fails because the app hasn't finished starting up or because the mapping is outdated.
     // To be safe we should inspect the container to get up to date mappings.
-    const auto [_running, portMappings] = co_await containerClient.inspectContainer();
+    const auto [_running, portMappings, _ipAddress] = co_await containerClient.inspectContainer();
     auto maybeMappedPort = portMappings.find(containerPort);
     if (maybeMappedPort == kj::none) {
       throw JSG_KJ_EXCEPTION(DISCONNECTED, Error,
@@ -322,6 +325,14 @@ class EgressHttpService final: public kj::HttpService {
       kj::AsyncIoStream& connection,
       ConnectResponse& response,
       kj::HttpConnectSettings settings) override {
+    auto isAuthorized = co_await containerClient.isEgressPeerAuthorized(connection);
+    if (!isAuthorized) {
+      kj::HttpHeaders responseHeaders(headerTable);
+      response.accept(403, "Forbidden", responseHeaders);
+      connection.shutdownWrite();
+      co_return;
+    }
+
     auto destAddr = kj::str(host);
 
     kj::HttpHeaders responseHeaders(headerTable);
@@ -486,7 +497,7 @@ kj::Promise<ContainerClient::InspectResponse> ContainerClient::inspectContainer(
   // We check if the container with the given name exist, and if it's not,
   // we simply return false while avoiding an unnecessary error.
   if (response.statusCode == 404) {
-    co_return InspectResponse{.isRunning = false, .ports = {}};
+    co_return InspectResponse{.isRunning = false, .ports = {}, .ipAddress = kj::none};
   }
 
   JSG_REQUIRE(response.statusCode == 200, Error, "Container inspect failed");
@@ -531,7 +542,22 @@ kj::Promise<ContainerClient::InspectResponse> ContainerClient::inspectContainer(
   // perspective, a restarting container is still "alive" and should be treated as running
   // so that start() correctly refuses to start a duplicate and destroy() can clean it up.
   bool running = status == "running" || status == "restarting";
-  co_return InspectResponse{.isRunning = running, .ports = kj::mv(portMappings)};
+  auto ipAddress = kj::Maybe<kj::String>(kj::none);
+  if (jsonRoot.hasNetworkSettings()) {
+    auto networkSettings = jsonRoot.getNetworkSettings();
+    if (networkSettings.hasIpAddress()) {
+      auto ip = networkSettings.getIpAddress();
+      if (!ip.isEmpty()) {
+        ipAddress = kj::str(ip);
+      }
+    }
+  }
+
+  co_return InspectResponse{
+    .isRunning = running,
+    .ports = kj::mv(portMappings),
+    .ipAddress = kj::mv(ipAddress),
+  };
 }
 
 kj::Promise<void> ContainerClient::createContainer(
@@ -606,6 +632,46 @@ kj::Promise<void> ContainerClient::createContainer(
     JSG_FAIL_REQUIRE(
         Error, "Create container failed with [", response.statusCode, "] ", response.body);
   }
+}
+
+
+kj::Promise<bool> ContainerClient::isEgressPeerAuthorized(kj::AsyncIoStream& connection) {
+  auto [isRunning, _ports, maybeIpAddress] = co_await inspectContainer();
+  if (!isRunning || maybeIpAddress == kj::none) {
+    co_return false;
+  }
+
+  sockaddr_storage peerAddrStorage;
+  auto peerAddr = reinterpret_cast<sockaddr*>(&peerAddrStorage);
+  kj::uint peerAddrLen = sizeof(peerAddrStorage);
+  connection.getpeername(peerAddr, &peerAddrLen);
+
+  KJ_IF_SOME(containerIp, maybeIpAddress) {
+    switch (peerAddr->sa_family) {
+      case AF_INET: {
+        char addrBuf[INET_ADDRSTRLEN] = {0};
+        auto* sin = reinterpret_cast<sockaddr_in*>(peerAddr);
+        if (inet_ntop(AF_INET, &sin->sin_addr, addrBuf, INET_ADDRSTRLEN) != nullptr &&
+            containerIp == kj::str(addrBuf)) {
+          co_return true;
+        }
+        break;
+      }
+      case AF_INET6: {
+        char addrBuf[INET6_ADDRSTRLEN] = {0};
+        auto* sin6 = reinterpret_cast<sockaddr_in6*>(peerAddr);
+        if (inet_ntop(AF_INET6, &sin6->sin6_addr, addrBuf, INET6_ADDRSTRLEN) != nullptr &&
+            containerIp == kj::str(addrBuf)) {
+          co_return true;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  co_return false;
 }
 
 kj::Promise<void> ContainerClient::startContainer() {
@@ -755,7 +821,7 @@ ContainerClient::RpcTurn ContainerClient::getRpcTurn() {
 }
 
 kj::Promise<void> ContainerClient::status(StatusContext context) {
-  const auto [isRunning, _ports] = co_await inspectContainer();
+  const auto [isRunning, _ports, _ipAddress] = co_await inspectContainer();
   containerStarted.store(isRunning, std::memory_order_release);
   context.getResults().setRunning(isRunning);
 }

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -94,6 +94,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   struct InspectResponse {
     bool isRunning;
     kj::HashMap<uint16_t, uint16_t> ports;
+    kj::Maybe<kj::String> ipAddress;
   };
 
   struct IPAMConfigResult {
@@ -140,6 +141,9 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   // Find a matching egress mapping for the given destination address (host:port format)
   kj::Maybe<workerd::IoChannelFactory::SubrequestChannel*> findEgressMapping(
       kj::StringPtr destAddr, uint16_t defaultPort);
+
+  // Validates that an incoming egress proxy connection comes from the managed container.
+  kj::Promise<bool> isEgressPeerAuthorized(kj::AsyncIoStream& connection);
 
   // Whether general internet access is enabled for this container
   bool internetEnabled = false;


### PR DESCRIPTION
### Motivation
- The egress CONNECT listener accepted tunnels from any peer on the Docker bridge, enabling other containers to use it as an open proxy or access per-container subrequest channels.
- The change aims to restore per-container egress isolation by ensuring only the managed container (sidecar peer) can establish CONNECT tunnels.

### Description
- Added `ipAddress` to `InspectResponse` returned by `ContainerClient::inspectContainer()` so the container's IP is available for authorization (`src/workerd/server/container-client.h`, `src/workerd/server/container-client.c++`).
- Implemented `ContainerClient::isEgressPeerAuthorized(kj::AsyncIoStream&)` which calls `inspectContainer()`, obtains the container IP, retrieves the peer socket address via `getpeername()`, and compares addresses for IPv4/IPv6; it returns `true` only when the peer matches the managed container IP (`src/workerd/server/container-client.c++`).
- Gate the CONNECT handler in `EgressHttpService::connect()` to call `isEgressPeerAuthorized()` and reject unauthorized peers with `403 Forbidden` and immediately close the connection before accepting/forwarding (`src/workerd/server/container-client.c++`).
- Updated callsites that destructured `inspectContainer()` results to match the extended result tuple (`src/workerd/server/container-client.c++`).

### Testing
- Ran `bazel test //src/workerd/server/tests/container-client:container-client@`, which failed in this environment due to inability to download the Bazel binary (HTTP 403), so automated tests could not complete.
- Performed repository-local static edits and quick code inspection to ensure the new `InspectResponse` shape is handled at modified callsites and that the CONNECT path now performs authorization; no runtime test harness could be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ffb2b19c8323aed47f6538369b19)