### PR TITLE
Enable global Performance classes when perf_hooks module is enabled

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -772,7 +772,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
     JSG_NESTED_TYPE(HTMLRewriter);
 
     // Performance API
-    if (flags.getEnableGlobalPerformanceClasses()) {
+    if (flags.getEnableGlobalPerformanceClasses() || flags.getEnableNodeJsPerfHooksModule()) {
       JSG_NESTED_TYPE(Performance);
       JSG_NESTED_TYPE(PerformanceEntry);
       JSG_NESTED_TYPE(PerformanceMark);

--- a/src/workerd/api/node/tests/perf-hooks-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/perf-hooks-nodejs-test.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "perf-hooks-nodejs-test.js")
         ],
-        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "enable_nodejs_perf_hooks_module", "enable_global_performance_classes"],
+        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "enable_nodejs_perf_hooks_module"],
       )
     ),
   ],

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1067,7 +1067,8 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
      $experimental;
      # $impliedByAfterDate(name = "nodeJsCompat", date = "2025-10-01");
    # Enables the Node.js perf_hooks module. It is required to use this flag with
-   # nodejs_compat (or nodejs_compat_v2).
+   # nodejs_compat (or nodejs_compat_v2). This flag also implicitly enables the
+   # global Performance classes (PerformanceEntry, PerformanceMark, etc.).
 
   enableGlobalPerformanceClasses @123 :Bool
      $compatEnableFlag("enable_global_performance_classes")
@@ -1075,6 +1076,7 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
      $experimental;
    # Enables PerformanceEntry, PerformanceMark, PerformanceMeasure, PerformanceResourceTiming,
    # PerformanceObserver and PerformanceObserverEntryList global classes.
+   # These are also implicitly enabled by enableNodeJsPerfHooksModule.
 
   enableNodeJsDomainModule @124 :Bool
     $compatEnableFlag("enable_nodejs_domain_module")


### PR DESCRIPTION
## Summary

- The `enableNodeJsPerfHooksModule` compat flag now implicitly enables the global Performance constructor classes (`Performance`, `PerformanceEntry`, `PerformanceMark`, `PerformanceMeasure`, `PerformanceResourceTiming`, `PerformanceObserver`, `PerformanceObserverEntryList`), removing the need to separately specify `enable_global_performance_classes`.
- Updated the `perf_hooks` test to no longer require the `enable_global_performance_classes` flag.
- Documented the implicit relationship in `compatibility-date.capnp` on both flags.