### PR TITLE
Harden bigbonk workflow trigger authorization

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -14,7 +14,13 @@ concurrency:
 
 jobs:
   bonk:
-    if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bigbonk')
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      contains(github.event.comment.body, '/bigbonk') &&
+      contains(
+        fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.comment.author_association || github.event.review.author_association
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
### Motivation
- The `bigbonk` workflow could be triggered by any non-bot commenter while running with `id-token: write`, repo write permissions, and injected Cloudflare secrets, creating a CI privilege-escalation and secret-exfiltration risk.

### Description
- Tighten the job-level `if` expression in `.github/workflows/bigbonk.yml` to require that the comment/review author association is one of `OWNER`, `MEMBER`, or `COLLABORATOR` in addition to the existing non-bot and `/bigbonk` mention checks.
- The new condition uses `fromJSON('["OWNER","MEMBER","COLLABORATOR"]')` and tests `github.event.comment.author_association || github.event.review.author_association` to block untrusted external commenters.

### Testing
- Verified the updated YAML contents with `sed -n '1,220p' .github/workflows/bigbonk.yml` and `nl -ba .github/workflows/bigbonk.yml`, which showed the new `if` expression as intended (succeeded).
- Confirmed the change via `git diff -- .github/workflows/bigbonk.yml` to inspect the patch (succeeded).
- Attempted to verify the third-party action reference via `git ls-remote` but the network check failed due to environment/proxy restrictions (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fdc05a9c832399e34e337a9860c3)