### PR TITLE
Restore isolated Docker network for managed containers

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -25,6 +25,10 @@ namespace workerd::server {
 
 namespace {
 
+// The name of the docker network managed by workerd. Containers spawned by workerd are
+// attached to this network to avoid joining Docker's shared default bridge.
+constexpr kj::StringPtr WORKERD_NETWORK_NAME = "workerd-network"_kj;
+
 struct ParsedAddress {
   kj::CidrRange cidr;
   kj::Maybe<uint16_t> port;
@@ -366,8 +370,16 @@ class EgressHttpService final: public kj::HttpService {
 };
 
 kj::Promise<ContainerClient::IPAMConfigResult> ContainerClient::getDockerBridgeIPAMConfig() {
-  auto response = co_await dockerApiRequest(
-      network, kj::str(dockerPath), kj::HttpMethod::GET, kj::str("/networks/bridge"));
+  auto response = co_await dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::GET,
+      kj::str("/networks/", WORKERD_NETWORK_NAME));
+
+  if (response.statusCode == 404) {
+    // Network doesn't exist, create it and fetch it again.
+    co_await createWorkerdNetwork();
+    response = co_await dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::GET,
+        kj::str("/networks/", WORKERD_NETWORK_NAME));
+  }
+
   if (response.statusCode == 200) {
     auto jsonRoot = decodeJsonResponse<docker_api::Docker::NetworkInspectResponse>(response.body);
     auto ipamConfig = jsonRoot.getIpam().getConfig();
@@ -381,7 +393,7 @@ kj::Promise<ContainerClient::IPAMConfigResult> ContainerClient::getDockerBridgeI
   }
 
   JSG_FAIL_REQUIRE(Error,
-      "Failed to get bridge. "
+      "Failed to get workerd-network. "
       "Status: ",
       response.statusCode, ", Body: ", response.body);
 }
@@ -405,6 +417,39 @@ kj::Promise<bool> ContainerClient::isDaemonIpv6Enabled() {
   }
 
   co_return false;
+}
+
+kj::Promise<void> ContainerClient::createWorkerdNetwork() {
+  if (workerdNetworkCreated.exchange(true, std::memory_order_acquire)) {
+    co_return;
+  }
+
+  KJ_ON_SCOPE_FAILURE(workerdNetworkCreated.store(false, std::memory_order_release));
+
+  auto ipv6Enabled = co_await isDaemonIpv6Enabled();
+
+  // Equivalent to: docker network create -d bridge [--ipv6] workerd-network
+  capnp::JsonCodec codec;
+  codec.handleByAnnotation<docker_api::Docker::NetworkCreateRequest>();
+  capnp::MallocMessageBuilder message;
+  auto jsonRoot = message.initRoot<docker_api::Docker::NetworkCreateRequest>();
+  jsonRoot.setName(WORKERD_NETWORK_NAME);
+  jsonRoot.setDriver("bridge");
+  jsonRoot.setEnableIpv6(ipv6Enabled);
+  if (!ipv6Enabled) {
+    KJ_LOG(WARNING,
+        "Docker has IPv6 disabled. Connections to Workers via IPv6 won't work. If you want to enable IPv6, remove the workerd-network after re-enabling.");
+  }
+
+  auto response = co_await dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::POST,
+      kj::str("/networks/create"), codec.encode(jsonRoot));
+
+  if (response.statusCode != 201 && response.statusCode != 409) {
+    JSG_FAIL_REQUIRE(Error,
+        "Failed to create workerd-network."
+        "Status: ",
+        response.statusCode, ", Body: ", response.body);
+  }
 }
 
 // Returns the gateway IP on Linux for direct container access.
@@ -564,6 +609,8 @@ kj::Promise<void> ContainerClient::createContainer(
     jsonEnv.set(envSize + i, defaultEnv[i]);
   }
 
+  co_await createWorkerdNetwork();
+
   auto hostConfig = jsonRoot.initHostConfig();
   // We need to publish all ports to properly get the mapped port number locally
   hostConfig.setPublishAllPorts(true);
@@ -575,7 +622,7 @@ kj::Promise<void> ContainerClient::createContainer(
   auto extraHosts = hostConfig.initExtraHosts(1);
   extraHosts.set(0, "host.docker.internal:host-gateway"_kj);
 
-  hostConfig.setNetworkMode("bridge");
+  hostConfig.setNetworkMode(WORKERD_NETWORK_NAME);
 
   // When containersPidNamespace is NOT enabled, use host PID namespace for backwards compatibility.
   // This allows the container to see processes on the host.

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -146,6 +146,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
 
   std::atomic_bool containerStarted = false;
   std::atomic_bool containerSidecarStarted = false;
+  std::atomic_bool workerdNetworkCreated = false;
   std::atomic_bool egressListenerStarted = false;
 
   kj::Maybe<kj::Own<kj::HttpServer>> egressHttpServer;
@@ -169,6 +170,8 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
 
   // Get the Docker bridge network gateway IP and subnet.
   kj::Promise<IPAMConfigResult> getDockerBridgeIPAMConfig();
+  // Create the dedicated workerd Docker bridge network when missing.
+  kj::Promise<void> createWorkerdNetwork();
   // Check if the Docker daemon has IPv6 enabled by inspecting the default bridge network's
   // IPAM config for IPv6 subnets.
   kj::Promise<bool> isDaemonIpv6Enabled();


### PR DESCRIPTION
### Motivation

- A recent change attached workerd-managed containers to Docker’s default `bridge`, removing the isolation boundary and allowing lateral access to other containers on the host.
- The intent of this PR is to restore the prior isolation by ensuring workerd-managed containers join a dedicated `workerd-network` bridge instead of the shared default.

### Description

- Reintroduced `WORKERD_NETWORK_NAME` and `createWorkerdNetwork()` to create a dedicated `workerd-network` bridge (with IPv6 enabled according to daemon capability) when missing.
- Changed `getDockerBridgeIPAMConfig()` to inspect `/networks/workerd-network` and create it on-demand if it does not exist, returning gateway and subnet from that network.
- Call `createWorkerdNetwork()` before container creation and set `HostConfig.NetworkMode` to `WORKERD_NETWORK_NAME` so managed containers are attached to the dedicated network.
- Added an atomic guard `workerdNetworkCreated` and corresponding header declarations to avoid races when creating the network.

### Testing

- Attempted to build the modified target with `bazel build //src/workerd/server:container-client`, but the Bazel bootstrap download was blocked in this environment (`Forbidden`), so the build could not be completed.
- No automated tests were executed here due to the environment bootstrap/network restrictions; the change is intentionally minimal to preserve existing behavior while restoring network isolation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f99e1d6083238414cdd286592eb0)