### PR TITLE
node:zlib: account Zstd native allocations against external memory

### DIFF
--- a/src/workerd/api/node/zlib-util.c++
+++ b/src/workerd/api/node/zlib-util.c++
@@ -812,10 +812,19 @@ void zstdFreeDCtx(ZSTD_DCtx* dctx) {
 }  // namespace
 
 ZstdEncoderContext::ZstdEncoderContext(ZlibMode _mode)
-    : ZstdContext(_mode),
-      cctx_(kj::disposeWith<zstdFreeCCtx>(ZSTD_createCCtx())) {}
+    : ZstdContext(_mode) {}
 
 kj::Maybe<CompressionError> ZstdEncoderContext::initialize(uint64_t pledgedSrcSize) {
+  KJ_DASSERT(allocator_ != nullptr, "Zstd encoder allocator should not be null");
+  if (cctx_.get() == nullptr) {
+    ZSTD_customMem customMem = {
+      .customAlloc = CompressionAllocator::AllocForBrotli,
+      .customFree = CompressionAllocator::FreeForZlib,
+      .opaque = allocator_,
+    };
+    cctx_ = kj::disposeWith<zstdFreeCCtx>(ZSTD_createCCtx_advanced(customMem));
+  }
+
   if (cctx_.get() == nullptr) {
     return CompressionError(
         "Could not initialize Zstd instance"_kj, "ERR_ZLIB_INITIALIZATION_FAILED"_kj, -1);
@@ -878,12 +887,19 @@ kj::Maybe<CompressionError> ZstdEncoderContext::getError() const {
 }
 
 ZstdDecoderContext::ZstdDecoderContext(ZlibMode _mode)
-    : ZstdContext(_mode),
-      dctx_(kj::disposeWith<zstdFreeDCtx>(ZSTD_createDCtx())) {}
+    : ZstdContext(_mode) {}
 
 kj::Maybe<CompressionError> ZstdDecoderContext::initialize() {
-  // dctx_ is created in the constructor. It can only be nullptr if ZSTD_createDCtx()
-  // failed due to memory allocation failure.
+  KJ_DASSERT(allocator_ != nullptr, "Zstd decoder allocator should not be null");
+  if (dctx_.get() == nullptr) {
+    ZSTD_customMem customMem = {
+      .customAlloc = CompressionAllocator::AllocForBrotli,
+      .customFree = CompressionAllocator::FreeForZlib,
+      .opaque = allocator_,
+    };
+    dctx_ = kj::disposeWith<zstdFreeDCtx>(ZSTD_createDCtx_advanced(customMem));
+  }
+
   if (dctx_.get() == nullptr) {
     return CompressionError(
         "Could not initialize Zstd instance"_kj, "ERR_ZLIB_INITIALIZATION_FAILED"_kj, -1);
@@ -957,6 +973,7 @@ bool ZlibUtil::ZstdCompressionStream<CompressionContext>::initialize(jsg::Lock& 
     jsg::Function<void()> writeCallback,
     jsg::Optional<uint64_t> pledgedSrcSize) {
   this->initializeStream(kj::mv(writeResult), kj::mv(writeCallback));
+  this->context()->setAllocator(&this->allocator);
 
   uint64_t srcSize = pledgedSrcSize.orDefault(ZSTD_CONTENTSIZE_UNKNOWN);
 
@@ -1168,7 +1185,9 @@ void ZlibUtil::brotliWithCallback(
 
 template <typename Context>
 kj::Array<kj::byte> ZlibUtil::zstdSync(jsg::Lock& js, InputSource data, ZstdContext::Options opts) {
+  CompressionAllocator allocator(js.getExternalMemoryTarget());
   Context ctx(Context::Mode);
+  ctx.setAllocator(&allocator);
 
   auto chunkSize = opts.chunkSize.orDefault(ZLIB_PERFORMANT_CHUNK_SIZE);
   auto maxOutputLength = opts.maxOutputLength.orDefault(Z_MAX_CHUNK);

--- a/src/workerd/api/node/zlib-util.h
+++ b/src/workerd/api/node/zlib-util.h
@@ -292,6 +292,10 @@ class ZstdContext {
   explicit ZstdContext(ZlibMode _mode): mode(_mode) {}
   KJ_DISALLOW_COPY(ZstdContext);
 
+  void setAllocator(CompressionAllocator* allocator) {
+    allocator_ = allocator;
+  }
+
   void setBuffers(kj::ArrayPtr<kj::byte> input, kj::ArrayPtr<kj::byte> output);
   void setInputBuffer(kj::ArrayPtr<const kj::byte> input);
   void setOutputBuffer(kj::ArrayPtr<kj::byte> output);
@@ -313,6 +317,7 @@ class ZstdContext {
   };
 
  protected:
+  CompressionAllocator* allocator_ = nullptr;
   ZlibMode mode;
   ZSTD_inBuffer input_{nullptr, 0, 0};
   ZSTD_outBuffer output_{nullptr, 0, 0};


### PR DESCRIPTION
### Motivation
- Zstd encoder/decoder contexts were being created with the library defaults, causing native allocations that were not tracked by the isolate external-memory accounting and enabling untrusted Workers to exhaust process memory.

### Description
- Add allocator plumbing to `ZstdContext` via `void setAllocator(CompressionAllocator*)` and a `CompressionAllocator* allocator_` field so Zstd code can use the existing external-memory accounting.
- Create Zstd contexts with `ZSTD_createCCtx_advanced()` / `ZSTD_createDCtx_advanced()` using a `ZSTD_customMem` that forwards to `CompressionAllocator::AllocForBrotli` / `CompressionAllocator::FreeForZlib` so native allocations are tracked.
- Wire the allocator into both streaming and synchronous Zstd entry points by calling `context()->setAllocator(&this->allocator)` in `ZstdCompressionStream::initialize()` and creating a temporary `CompressionAllocator` for `zstdSync()` and calling `ctx.setAllocator(&allocator)` before initialization.
- Changes affect `src/workerd/api/node/zlib-util.h` and `src/workerd/api/node/zlib-util.c++` and preserve the original lifetime/behavior of Zstd contexts while enabling external-memory accounting.

### Testing
- Attempted to run `bazel test //src/workerd/api/node/tests:zlib-zstd-nodejs-test@`, but the test run failed in this environment because Bazel could not be downloaded from `releases.bazel.build` (HTTP 403), so no build/test artifacts were produced.
- No other automated tests were executed in this environment; the diff was inspected and local compile/run was not possible here due to environment/network restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2058cedf48323b206051e7d705997)