### PR TITLE
Start egress-interception sidecar before user container to prevent startup egress bypass

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -782,16 +782,16 @@ kj::Promise<void> ContainerClient::start(StartContext context) {
   internetEnabled = params.getEnableInternet();
 
   co_await createContainer(entrypoint, environment, params);
-  co_await startContainer();
 
   // Opt in to the proxy sidecar container only if the user has configured egressMappings
   // for now. In the future, it will always run when a user container is running
   if (!egressMappings.empty()) {
-    // The user container will be blocked on network connectivity until this finishes.
-    // When workerd-network is more battle-tested and goes out of experimental so it's non-optional,
-    // we should make the sidecar start first and _then_ make the user container join the sidecar network.
+    // Start the sidecar before the user container starts, so interception is active before any
+    // workload code can issue outbound traffic.
     co_await ensureSidecarStarted();
   }
+
+  co_await startContainer();
 
   containerStarted.store(true, std::memory_order_release);
 }


### PR DESCRIPTION
### Motivation
- The previous startup order in `ContainerClient::start()` started the user container before the egress-interception sidecar, creating a TOCTOU window where a malicious container could open outbound connections before interception rules were active.

### Description
- Reordered startup in `src/workerd/server/container-client.c++` so that `ensureSidecarStarted()` is awaited before `startContainer()` when `egressMappings` are configured, and updated the inline comment to document the guarantee that interception is active before the workload starts.

### Testing
- Ran `git diff --check` which passed; attempted `bazel test //src/workerd/server/tests/container-client:container-client-test@` but it failed in this environment due to a Bazel binary download error (HTTP 403), so the repository-level tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a202181c5883238a94e6a3d63fbd8f)