### PR TITLE
fix TextDecoder streaming to ignore empty chunks

### DIFF
--- a/src/workerd/api/encoding-legacy.c++
+++ b/src/workerd/api/encoding-legacy.c++
@@ -53,6 +53,11 @@ void LegacyDecoder::reset() {
 
 kj::Maybe<jsg::JsString> LegacyDecoder::decode(
     jsg::Lock& js, kj::ArrayPtr<const kj::byte> buffer, bool flush) {
+  if (!flush && buffer.size() == 0) {
+    // Avoid encoding_rs empty-chunk streaming bug:
+    // https://github.com/hsivonen/encoding_rs/issues/126#issuecomment-3677642122
+    return js.str();
+  }
   // Reset decoder state after flush, matching IcuDecoder's KJ_DEFER contract.
   // This ensures decodePtr() (used by TextDecoderStream) resets correctly on flush.
   KJ_DEFER({

--- a/src/workerd/api/tests/encoding-test.js
+++ b/src/workerd/api/tests/encoding-test.js
@@ -154,6 +154,23 @@ export const decodeStreamingTest = {
       decodeStreaming(fatalIgnoreBomDecoder, bomBom) === '\ufeff\ufeff',
       'first BOM not to be stripped by TextDecoder with ignoreBOM set'
     );
+
+    const shiftJisDecoder = new TextDecoder('shift_jis');
+    let shiftJisResult = '';
+    shiftJisResult += shiftJisDecoder.decode(new Uint8Array([0x82]), {
+      stream: true,
+    });
+    shiftJisResult += shiftJisDecoder.decode(new Uint8Array(), {
+      stream: true,
+    });
+    shiftJisResult += shiftJisDecoder.decode(new Uint8Array([0xa0]), {
+      stream: true,
+    });
+    shiftJisResult += shiftJisDecoder.decode();
+    ok(
+      shiftJisResult === 'あ',
+      'streaming Shift_JIS should tolerate empty chunks without flushing state'
+    );
   },
 };
 


### PR DESCRIPTION
If I understood correctly, this should fix https://github.com/cloudflare/workerd/issues/6193

Fixes https://github.com/cloudflare/workerd/issues/6193

cc @ChALkeR