### PR TITLE
Remove periodic log statements about calling deleteAll in a DO with an alarm still set

### DIFF
--- a/src/workerd/io/actor-cache.c++
+++ b/src/workerd/io/actor-cache.c++
@@ -2073,12 +2073,6 @@ ActorCache::DeleteAllResults ActorCache::deleteAll(
     evictOrOomIfNeeded(lock);
   }
 
-  KJ_IF_SOME(t, currentAlarmTime.tryGet<KnownAlarmTime>()) {
-    if (t.time != kj::none) {
-      LOG_WARNING_PERIODICALLY("NOSENTRY deleteAll() called on ActorCache with an alarm still set");
-    }
-  }
-
   return DeleteAllResults{.backpressure = getBackpressure(), .count = kj::mv(result)};
 }
 

--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -770,9 +770,6 @@ ActorCacheInterface::DeleteAllResults ActorSqlite::deleteAll(
   // kv.deleteAll() clears the database, so we need to save and possibly restore alarm state in
   // the metadata table to maintain behavior from before the deleteAllDeletesAlarm compat flag.
   auto localAlarmState = metadata.getAlarm();
-  if (localAlarmState != kj::none) {
-    LOG_WARNING_PERIODICALLY("NOSENTRY deleteAll() called on ActorSqlite with an alarm still set");
-  }
 
   // deleteAll() cannot be part of a transaction because it deletes the database altogether. So,
   // we have to close our transactions or fail.


### PR DESCRIPTION
Revert "Log periodically when deleteAll is called with an alarm still set

This reverts commit d3d6c560aede245e9faedb894268a3d0cd3774d1.

I'm just cleaning this log statement from #6056 up because it's no longer needed. The new deleteAll behavior from #6044 is live behind a compatibility flag, but I don't plan to change the legacy behavior.