### PR TITLE
Fix AI Search filter type to re-use vectorize types

### DIFF
--- a/types/defines/ai-search.d.ts
+++ b/types/defines/ai-search.d.ts
@@ -3,18 +3,6 @@ export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}
 export interface AiSearchNameNotSetError extends Error {}
 
-// Filter types (shared with AutoRAG for compatibility)
-export type ComparisonFilter = {
-  key: string;
-  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
-  value: string | number | boolean;
-};
-
-export type CompoundFilter = {
-  type: 'and' | 'or';
-  filters: ComparisonFilter[];
-};
-
 // AI Search V2 Request Types
 export type AiSearchSearchRequest = {
   messages: Array<{
@@ -28,7 +16,7 @@ export type AiSearchSearchRequest = {
       match_threshold?: number;
       /** Maximum number of results (1-50, default 10) */
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       /** Context expansion (0-3, default 0) */
       context_expansion?: number;
       [key: string]: unknown;
@@ -63,7 +51,7 @@ export type AiSearchChatCompletionsRequest = {
       retrieval_type?: 'vector' | 'keyword' | 'hybrid';
       match_threshold?: number;
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       context_expansion?: number;
       [key: string]: unknown;
     };

--- a/types/defines/autorag.d.ts
+++ b/types/defines/autorag.d.ts
@@ -21,6 +21,17 @@ export interface AutoRAGUnauthorizedError extends Error {}
  */
 export interface AutoRAGNameNotSetError extends Error {}
 
+export type ComparisonFilter = {
+  key: string;
+  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
+  value: string | number | boolean;
+};
+
+export type CompoundFilter = {
+  type: 'and' | 'or';
+  filters: ComparisonFilter[];
+};
+
 /**
  * @deprecated AutoRAG has been replaced by AI Search.
  * Use AiSearchSearchRequest with the new API instead.

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4546,16 +4546,6 @@ interface EventCounts {
 interface AiSearchInternalError extends Error {}
 interface AiSearchNotFoundError extends Error {}
 interface AiSearchNameNotSetError extends Error {}
-// Filter types (shared with AutoRAG for compatibility)
-type ComparisonFilter = {
-  key: string;
-  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
-  value: string | number | boolean;
-};
-type CompoundFilter = {
-  type: "and" | "or";
-  filters: ComparisonFilter[];
-};
 // AI Search V2 Request Types
 type AiSearchSearchRequest = {
   messages: Array<{
@@ -4569,7 +4559,7 @@ type AiSearchSearchRequest = {
       match_threshold?: number;
       /** Maximum number of results (1-50, default 10) */
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       /** Context expansion (0-3, default 0) */
       context_expansion?: number;
       [key: string]: unknown;
@@ -4603,7 +4593,7 @@ type AiSearchChatCompletionsRequest = {
       retrieval_type?: "vector" | "keyword" | "hybrid";
       match_threshold?: number;
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       context_expansion?: number;
       [key: string]: unknown;
     };
@@ -10434,6 +10424,15 @@ interface AutoRAGUnauthorizedError extends Error {}
  * @see AiSearchNameNotSetError
  */
 interface AutoRAGNameNotSetError extends Error {}
+type ComparisonFilter = {
+  key: string;
+  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+  value: string | number | boolean;
+};
+type CompoundFilter = {
+  type: "and" | "or";
+  filters: ComparisonFilter[];
+};
 /**
  * @deprecated AutoRAG has been replaced by AI Search.
  * Use AiSearchSearchRequest with the new API instead.

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4555,16 +4555,6 @@ export interface EventCounts {
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}
 export interface AiSearchNameNotSetError extends Error {}
-// Filter types (shared with AutoRAG for compatibility)
-export type ComparisonFilter = {
-  key: string;
-  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
-  value: string | number | boolean;
-};
-export type CompoundFilter = {
-  type: "and" | "or";
-  filters: ComparisonFilter[];
-};
 // AI Search V2 Request Types
 export type AiSearchSearchRequest = {
   messages: Array<{
@@ -4578,7 +4568,7 @@ export type AiSearchSearchRequest = {
       match_threshold?: number;
       /** Maximum number of results (1-50, default 10) */
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       /** Context expansion (0-3, default 0) */
       context_expansion?: number;
       [key: string]: unknown;
@@ -4612,7 +4602,7 @@ export type AiSearchChatCompletionsRequest = {
       retrieval_type?: "vector" | "keyword" | "hybrid";
       match_threshold?: number;
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       context_expansion?: number;
       [key: string]: unknown;
     };
@@ -10446,6 +10436,15 @@ export interface AutoRAGUnauthorizedError extends Error {}
  * @see AiSearchNameNotSetError
  */
 export interface AutoRAGNameNotSetError extends Error {}
+export type ComparisonFilter = {
+  key: string;
+  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+  value: string | number | boolean;
+};
+export type CompoundFilter = {
+  type: "and" | "or";
+  filters: ComparisonFilter[];
+};
 /**
  * @deprecated AutoRAG has been replaced by AI Search.
  * Use AiSearchSearchRequest with the new API instead.

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -3898,16 +3898,6 @@ declare abstract class Performance {
 interface AiSearchInternalError extends Error {}
 interface AiSearchNotFoundError extends Error {}
 interface AiSearchNameNotSetError extends Error {}
-// Filter types (shared with AutoRAG for compatibility)
-type ComparisonFilter = {
-  key: string;
-  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
-  value: string | number | boolean;
-};
-type CompoundFilter = {
-  type: "and" | "or";
-  filters: ComparisonFilter[];
-};
 // AI Search V2 Request Types
 type AiSearchSearchRequest = {
   messages: Array<{
@@ -3921,7 +3911,7 @@ type AiSearchSearchRequest = {
       match_threshold?: number;
       /** Maximum number of results (1-50, default 10) */
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       /** Context expansion (0-3, default 0) */
       context_expansion?: number;
       [key: string]: unknown;
@@ -3955,7 +3945,7 @@ type AiSearchChatCompletionsRequest = {
       retrieval_type?: "vector" | "keyword" | "hybrid";
       match_threshold?: number;
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       context_expansion?: number;
       [key: string]: unknown;
     };
@@ -9786,6 +9776,15 @@ interface AutoRAGUnauthorizedError extends Error {}
  * @see AiSearchNameNotSetError
  */
 interface AutoRAGNameNotSetError extends Error {}
+type ComparisonFilter = {
+  key: string;
+  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+  value: string | number | boolean;
+};
+type CompoundFilter = {
+  type: "and" | "or";
+  filters: ComparisonFilter[];
+};
 /**
  * @deprecated AutoRAG has been replaced by AI Search.
  * Use AiSearchSearchRequest with the new API instead.

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -3907,16 +3907,6 @@ export declare abstract class Performance {
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}
 export interface AiSearchNameNotSetError extends Error {}
-// Filter types (shared with AutoRAG for compatibility)
-export type ComparisonFilter = {
-  key: string;
-  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
-  value: string | number | boolean;
-};
-export type CompoundFilter = {
-  type: "and" | "or";
-  filters: ComparisonFilter[];
-};
 // AI Search V2 Request Types
 export type AiSearchSearchRequest = {
   messages: Array<{
@@ -3930,7 +3920,7 @@ export type AiSearchSearchRequest = {
       match_threshold?: number;
       /** Maximum number of results (1-50, default 10) */
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       /** Context expansion (0-3, default 0) */
       context_expansion?: number;
       [key: string]: unknown;
@@ -3964,7 +3954,7 @@ export type AiSearchChatCompletionsRequest = {
       retrieval_type?: "vector" | "keyword" | "hybrid";
       match_threshold?: number;
       max_num_results?: number;
-      filters?: CompoundFilter | ComparisonFilter;
+      filters?: VectorizeVectorMetadataFilter;
       context_expansion?: number;
       [key: string]: unknown;
     };
@@ -9798,6 +9788,15 @@ export interface AutoRAGUnauthorizedError extends Error {}
  * @see AiSearchNameNotSetError
  */
 export interface AutoRAGNameNotSetError extends Error {}
+export type ComparisonFilter = {
+  key: string;
+  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+  value: string | number | boolean;
+};
+export type CompoundFilter = {
+  type: "and" | "or";
+  filters: ComparisonFilter[];
+};
 /**
  * @deprecated AutoRAG has been replaced by AI Search.
  * Use AiSearchSearchRequest with the new API instead.


### PR DESCRIPTION
This is not a breaking change, the types just were wrong before
This methods are also not announced yet