### PR TITLE
Add external memory accounting to JsRpcStub deserialization

### DIFF
--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -731,13 +731,6 @@ kj::Maybe<jsg::Ref<JsRpcProperty>> JsRpcPromise::getProperty(jsg::Lock& js, kj::
   return js.alloc<JsRpcProperty>(JSG_THIS, kj::mv(name));
 }
 
-JsRpcStub::JsRpcStub(
-    IoOwn<rpc::JsRpcTarget::Client> capnpClient, RpcStubDisposalGroup& disposalGroup)
-    : capnpClient(kj::mv(capnpClient)),
-      disposalGroup(disposalGroup) {
-  disposalGroup.list.add(*this);
-}
-
 JsRpcStub::JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient,
     RpcStubDisposalGroup& disposalGroup,
     jsg::ExternalMemoryAdjustment externalMemoryAdjustment)

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -370,8 +370,10 @@ class JsRpcProperty: public JsRpcClientProvider {
 // `JsRpcStub::sendJsRpc()`.
 class JsRpcStub: public JsRpcClientProvider {
  public:
+  // Only deserialize() needs ExternalMemoryAdjustment — it extracts a new capability from an RPC
+  // response, creating MembraneHook + forked promise allocations. The other callers (dup() and
+  // constructor()) just refcount existing capabilities or create local loopbacks.
   JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient): capnpClient(kj::mv(capnpClient)) {}
-  JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient, RpcStubDisposalGroup& disposalGroup);
   JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient,
       RpcStubDisposalGroup& disposalGroup,
       jsg::ExternalMemoryAdjustment externalMemoryAdjustment);


### PR DESCRIPTION
_Written using Claude._

When a worker receives RPC capabilities (JsRpcStub instances), each stub creates:

- A Cap'n Proto membrane wrapper for capability security
- A forked promise branch for revocation tracking

These allocations live in the native heap but are not reported to V8's external memory.