### PR TITLE
Change dependency update time to match on-call schedules

### DIFF
--- a/.github/workflows/deps-updater.yml
+++ b/.github/workflows/deps-updater.yml
@@ -2,8 +2,8 @@ name: Dependency updater
 
 on:
   schedule:
-    # Run at 00:00 UTC every Sunday
-    - cron: '0 0 * * 0'
+    # Run at 18:30 UTC every Monday
+    - cron: '30 18 * * 1'
   # Allow manual triggering for testing
   workflow_dispatch:
 


### PR DESCRIPTION
Each week, our team has an engineer assigned, who is responsible for tasks like dependency updates. This changes the schedule for this task to better match our schedule.