### PR TITLE
Implement runScheduled and queue in EventDispatcherImpl

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -11,6 +11,7 @@
 
 #include <workerd/api/actor-state.h>
 #include <workerd/api/analytics-engine.capnp.h>
+#include <workerd/api/queue.h>
 #include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/trace.h>
 #include <workerd/api/worker-rpc.h>
@@ -5200,7 +5201,14 @@ class Server::WorkerdBootstrapImpl final: public rpc::WorkerdBootstrap::Server {
     }
 
     kj::Promise<void> runScheduled(RunScheduledContext context) override {
-      throwUnsupported();
+      auto params = context.getParams();
+      auto scheduledTime = kj::UNIX_EPOCH + params.getScheduledTime() * kj::SECONDS;
+      auto cron = params.getCron();
+      auto worker = getWorker();
+      auto result = co_await worker->runScheduled(scheduledTime, cron);
+      auto resp = context.getResults().initResult();
+      resp.setOutcome(result.outcome);
+      resp.setRetry(result.retry);
     }
 
     kj::Promise<void> runAlarm(RunAlarmContext context) override {
@@ -5208,7 +5216,36 @@ class Server::WorkerdBootstrapImpl final: public rpc::WorkerdBootstrap::Server {
     }
 
     kj::Promise<void> queue(QueueContext context) override {
-      throwUnsupported();
+      auto event = kj::refcounted<api::QueueCustomEvent>(context.getParams());
+      auto eventRef = kj::addRef(*event);
+      auto worker = getWorker();
+      auto result = co_await worker->customEvent(kj::mv(event));
+
+      auto resp = context.getResults().initResult();
+      resp.setOutcome(result.outcome);
+      resp.setAckAll(eventRef->getAckAll());
+
+      auto retryBatch = eventRef->getRetryBatch();
+      auto rb = resp.initRetryBatch();
+      rb.setRetry(retryBatch.retry);
+      KJ_IF_SOME(delay, retryBatch.delaySeconds) {
+        rb.setDelaySeconds(delay);
+      }
+
+      auto explicitAcks = eventRef->getExplicitAcks();
+      auto acks = resp.initExplicitAcks(explicitAcks.size());
+      for (auto i: kj::indices(explicitAcks)) {
+        acks.set(i, explicitAcks[i]);
+      }
+
+      auto retryMessages = eventRef->getRetryMessages();
+      auto retries = resp.initRetryMessages(retryMessages.size());
+      for (auto i: kj::indices(retryMessages)) {
+        retries[i].setMsgId(retryMessages[i].msgId);
+        KJ_IF_SOME(delay, retryMessages[i].delaySeconds) {
+          retries[i].setDelaySeconds(delay);
+        }
+      }
     }
 
     kj::Promise<void> jsRpcSession(JsRpcSessionContext context) override {


### PR DESCRIPTION
`WorkerdBootstrapImpl::EventDispatcherImpl` currently throws `"RPC connections don't yet support this event type"` for `runScheduled` and `queue` — this implements both.

## Changes

- **`runScheduled`** — reads `scheduledTime` and `cron` from params, calls `worker->runScheduled()`, writes outcome and retry to the response
- **`queue`** — creates a `QueueCustomEvent` from the capnp params, dispatches via `worker->customEvent()`, then marshals the full response (outcome, ackAll, retryBatch with optional delay, explicitAcks, retryMessages with optional per-message delay)
- Adds `#include <workerd/api/queue.h>` for `QueueCustomEvent`

## Motivation

The debug port / inspector connection exposes `EventDispatcher` via cap'n proto pipelining. `getHttpService` (fetch), `jsRpcSession` (RPC), `sendTraces` (tail), and `tailStreamSession` already work — but `runScheduled` and `queue` throw. This forces callers (e.g. Miniflare's dev registry proxy) to use HTTP workarounds through `core:entry` for scheduled events instead of calling `fetcher.scheduled()` directly.

## Notes

- `runAlarm` is still unsupported — left as-is since it needs alarm storage state that isn't available in this context
- `queue` uses `kj::refcounted` + `kj::addRef` to keep a reference to the event after `customEvent()` takes ownership, so we can read the result fields (ackAll, retryBatch, etc.) after execution
