### PR TITLE
[build] Enable ISA extensions globally in release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -382,6 +382,18 @@ build:opt --@capnp-cpp//src/kj:debug_memory=False
 build:release --config=opt
 build:release --@rules_rust//:extra_rustc_flag=-Ccodegen-units=1
 
+# Enable architecture-specific flags for building with advanced ISA extensions. Not enabled by
+# default since bazel offers no good way to tell the architecture from within .bazelrc. Intended for
+# release builds, but also safe to enable elsewhere as long as we know which architecture we're on.
+# This also allows us to enable the CRC32 hash for capnproto.
+build:arm64-release --@capnp-cpp//src/kj:kj_crc32_hash=True
+build:arm64-release --copt=-mcrc --host_copt=-mcrc
+build:x64-release --@capnp-cpp//src/kj:kj_crc32_hash=True
+# Note that msse4.2 already includes CRC32C and SSSE3 extensions
+build:x64-release --copt=-msse4.2 --host_copt=-msse4.2
+build:x64-cross-release --@capnp-cpp//src/kj:kj_crc32_hash=True
+build:x64-cross-release --copt=-msse4.2 --host_copt=-mcrc
+
 # enable -O3 for the release configuration. Based on benchmarking there is little difference in
 # performance, but -O3 should generally be expected to be faster for at least parts of the workerd API.
 build:release_unix --copt='-O3'
@@ -389,6 +401,8 @@ build:release_unix --config=release
 
 build:release_linux --config=release_unix
 build:release_linux --linkopt="-Wl,-O2"
+build:release_linux_arm64 --config=release_linux --config=arm64-release
+build:release_linux_x64 --config=release_linux --config=x64-release
 
 build:release_macos --config=release_unix
 # Disable generating LC_DATA_IN_CODE and LC_FUNCTION_STARTS binary sections, two rarely used types
@@ -397,9 +411,11 @@ build:release_macos --config=release_unix
 # data in releases.
 build:release_macos --linkopt="-Wl,-no_data_in_code_info"
 build:release_macos --linkopt="-Wl,-no_function_starts"
+build:release_macos_arm64 --config=release_macos --config=arm64-release
+build:release_macos_x64 --config=release_macos --config=x64-release
 
 # Cross-compiled release build for x86_64.
-build:release_macos_cross_x86_64 --config=release_macos
+build:release_macos_cross_x86_64 --config=release_macos --config=x64-cross-release
 build:release_macos_cross_x86_64 --config=macos-cross-x86_64
 
 # On macOS, optionally compile using LLD (19 or higher is compatible with the default flags added by
@@ -425,6 +441,8 @@ build:release_windows --copt="-fstrict-aliasing"
 # This file breaks our CI windows release builds when compiled using O2/O3
 # Ref: https://github.com/llvm/llvm-project/issues/136481
 build:release_windows --per_file_copt=.*capnp/rpc\.c++@/clang:-O1
+# We assume that all Windows builds are for x64.
+build:release_windows --config=x64-release
 
 build:windows --cxxopt='/std:c++23preview' --host_cxxopt='/std:c++23preview'
 build:windows --copt='/D_CRT_USE_BUILTIN_OFFSETOF' --host_copt='/D_CRT_USE_BUILTIN_OFFSETOF'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,12 @@ jobs:
           - title: linux
             os-name: Linux
             image: ubuntu-22.04-16core
-            bazel-config: release_linux
+            bazel-config: release_linux_x64
             target-arch: X64
           - title: linux-arm64
             os-name: Linux
             image: ubuntu-22.04-arm-16core
-            bazel-config: release_linux
+            bazel-config: release_linux_arm64
             target-arch: ARM64
           # Based on runner availability, we build both Apple Silicon and (cross-compiled) x86
           # release binaries on the macos-15-xlarge runner.
@@ -97,7 +97,7 @@ jobs:
           - title: macOS-arm64
             os-name: macOS
             image: macos-15-xlarge
-            bazel-config: release_macos
+            bazel-config: release_macos_arm64
             target-arch: ARM64
           - title: windows
             os-name: Windows
@@ -259,7 +259,7 @@ jobs:
         uses: ./.github/actions/setup-runner
       - name: Build type generating Worker
         run: |
-          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types:types_worker
+          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux_x64 //types:types_worker
 
       - name: Modify package.json version
         run: node npm/scripts/bump-version.mjs npm/workerd/package.json
@@ -314,7 +314,7 @@ jobs:
         uses: ./.github/actions/setup-runner
       - name: build types
         run: |
-          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types
+          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux_x64 //types
       - name: Build package
         run: node npm/scripts/build-types-package.mjs
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,7 +148,7 @@ jobs:
         uses: ./.github/actions/setup-runner
       - name: build types
         run: |
-          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux //types
+          bazel build --strip=always --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci --config=release_linux_x64 //types
       - name: Check snapshot diff
         run: |
           diff -r types/generated-snapshot/latest bazel-bin/types/definitions/latest > types.diff

--- a/build/deps/deps.jsonc
+++ b/build/deps/deps.jsonc
@@ -37,7 +37,8 @@
       "owner": "capnproto",
       "repo": "capnproto",
       "branch": "v2",
-      "extra_strip_prefix": "/c++"
+      "extra_strip_prefix": "/c++",
+      "freeze_commit": "22c4d06f04216a42753dc3fe12556f9ed0e619df"
     },
     // We want to avoid version skew with v8, so we use identical versions.
     {

--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -27,10 +27,10 @@ bazel_dep(name = "brotli", version = "1.2.0")
 # capnp-cpp
 http.archive(
     name = "capnp-cpp",
-    sha256 = "f502ac3ada732800929706f3d6dacb9bcf3639d3bffde6387f4dd5e0e11984f5",
-    strip_prefix = "capnproto-capnproto-a7654b2/c++",
+    sha256 = "2cf7c0d18e3e7710a150b91bcaa018138f5f76f8b044dae5eb1379dadcb25142",
+    strip_prefix = "capnproto-capnproto-22c4d06/c++",
     type = "tgz",
-    url = "https://github.com/capnproto/capnproto/tarball/a7654b2041731d0ee323aa2bdb7975c7ab903f5e",
+    url = "https://github.com/capnproto/capnproto/tarball/22c4d06f04216a42753dc3fe12556f9ed0e619df",
 )
 use_repo(http, "capnp-cpp")
 


### PR DESCRIPTION
As a long-term solution for which hardware flags to enable, we enable the flags we need on all of workerd in release builds. Alongside capnproto/capnproto#2582, this should fix the footgun responsible for #5977 for good as the CRC-based hash is only used when all of workerd is built with the given CPU flags.

Also see #2582.