### PR TITLE
[build] Update perfetto, enable proto toolchain resolution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,10 @@ common --incompatible_autoload_externally="+ProtoInfo,+cc_binary,+cc_import,+cc_
 # TODO(cleanup): Bazel 9 sets this by default, which breaks the macOS-cross build. Fix and re-enable.
 common --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False
 
+# Enable proto toolchain resolution to use prebuilt protoc (starting with protobuf v34.0). Will be
+# the default starting with Bazel 10.
+common --incompatible_enable_proto_toolchain_resolution
+
 # bazel7 enables Build without the Bytes (BwoB) by default. This significantly speeds up builds
 # using the remote cache since less data needs to be fetched.
 # Note that we use remote_download_minimal for test builds, which avoids fetching build outputs

--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -113,10 +113,10 @@ archive_override(
         "//:patches/perfetto/0001-Don-t-attempt-to-use-rules_android.patch",
         "//:patches/perfetto/0002-disable-info-level-logging.patch",
     ],
-    sha256 = "feae4e379ef39e12f6f18b1e62e132ed411b5369750a23e18cae76cb42ef7192",
-    strip_prefix = "google-perfetto-095212b",
+    sha256 = "90aea67f5ac88ae7bb56bc24574beb5cd924a5ae9d861826a6fd151c13b4767b",
+    strip_prefix = "google-perfetto-b34c975",
     type = "tgz",
-    url = "https://api.github.com/repos/google/perfetto/tarball/v53.0",
+    url = "https://api.github.com/repos/google/perfetto/tarball/v54.0",
 )
 
 # simdutf

--- a/build/perfetto/MODULE.bazel
+++ b/build/perfetto/MODULE.bazel
@@ -2,4 +2,4 @@ module(name = "perfetto_cfg")
 
 bazel_dep(name = "rules_python", version = "1.6.3")
 bazel_dep(name = "rules_cc", version = "0.2.11")
-bazel_dep(name = "protobuf", version = "33.1")
+bazel_dep(name = "protobuf", version = "33.4")

--- a/patches/perfetto/0001-Don-t-attempt-to-use-rules_android.patch
+++ b/patches/perfetto/0001-Don-t-attempt-to-use-rules_android.patch
@@ -1,18 +1,37 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 418089631def5cb0cb92b550f2500bcff1230980 Mon Sep 17 00:00:00 2001
 From: Felix Hanau <felix@cloudflare.com>
 Date: Sat, 15 Nov 2025 16:55:07 -0500
 Subject: Don't attempt to use rules_android
 
 
 diff --git a/MODULE.bazel b/MODULE.bazel
-index a321128ae62530e160b6d2ef7c99a98f7071396d..237cac531da071da049eaa3c35c84be7fbcc5a9f 100644
+index 47f7f25cfd..dc006ebba8 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -12,35 +12,7 @@
- # See the License for the specific language governing permissions and
- # limitations under the License.
+@@ -14,102 +14,10 @@
  
--bazel_dep(name = "rules_android", version = "0.6.0")
+ """Perfetto Bazel module configuration for bzlmod."""
+ 
+-module(
+-    name = "perfetto",
+-    version = "0.0.0",
+-)
++module(name = "perfetto")
++bazel_dep(name = "perfetto_cfg", version = "0.0.0")
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.7.1")
+-bazel_dep(name = "platforms", version = "0.0.10")
+-bazel_dep(name = "protobuf", version = "31.1", repo_name = "com_google_protobuf")
++bazel_dep(name = "platforms", version = "1.0.0")
++bazel_dep(name = "protobuf", version = "33.4")
+ bazel_dep(name = "rules_python", version = "1.0.0")
+-bazel_dep(name = "rules_android", version = "0.6.6")
+-
+-remote_android_extensions = use_extension(
+-    "@rules_android//bzlmod_extensions:android_extensions.bzl",
+-    "remote_android_tools_extensions",
+-)
+-use_repo(remote_android_extensions, "android_tools")
 -
 -android_sdk_repository_extension = use_extension(
 -    "@rules_android//rules/android_sdk_repository:rule.bzl",
@@ -26,9 +45,12 @@ index a321128ae62530e160b6d2ef7c99a98f7071396d..237cac531da071da049eaa3c35c84be7
 -    api_level = 35,
 -    build_tools_version = "35.0.1",
 -)
+-use_repo(android_sdk_repository_extension, "androidsdk")
 -
--bazel_dep(name = "rules_jvm_external", version = "6.6")
--bazel_dep(name = "rules_android_ndk", version = "0.1.2")
+-register_toolchains("@androidsdk//:sdk-toolchain", "@androidsdk//:all")
+-
+-bazel_dep(name = "rules_jvm_external", version = "6.9")
+-bazel_dep(name = "rules_android_ndk", version = "0.1.3")
 -
 -android_ndk_repository_extension = use_extension(
 -    "@rules_android_ndk//:extension.bzl",
@@ -44,12 +66,57 @@ index a321128ae62530e160b6d2ef7c99a98f7071396d..237cac531da071da049eaa3c35c84be7
 -use_repo(android_ndk_repository_extension, "androidndk")
 -
 -register_toolchains("@androidndk//:all")
-+module(name = "perfetto")
-+bazel_dep(name = "perfetto_cfg", version = "0.0.0")
-+bazel_dep(name = "platforms", version = "1.0.0")
-+bazel_dep(name = "protobuf", version = "33.1")
+-
+-# Perfetto configuration repository extension.
+-# This creates @perfetto_cfg which provides PERFETTO_CONFIG struct.
+-perfetto_cfg_ext = use_extension(
+-    "//bazel:perfetto_cfg_ext.bzl",
+-    "perfetto_cfg_ext",
+-)
+-use_repo(perfetto_cfg_ext, "perfetto_cfg")
+-
+-# Perfetto third-party dependencies extension.
+-# These are the same deps defined in //bazel:deps.bzl for WORKSPACE users.
+-perfetto_deps = use_extension(
+-    "//bazel:perfetto_deps.bzl",
+-    "perfetto_deps",
+-)
+-use_repo(
+-    perfetto_deps,
+-    "perfetto_dep_expat",
+-    "perfetto_dep_linenoise",
+-    "perfetto_dep_llvm_demangle",
+-    "perfetto_dep_open_csd",
+-    "perfetto_dep_sqlite",
+-    "perfetto_dep_sqlite_src",
+-    "perfetto_dep_zlib",
+-)
+-
+-# Maven dependencies for Android instrumentation tests.
+-# Use a unique name to avoid conflicts with other modules (e.g., bazel_worker_java).
+-maven = use_extension(
+-    "@rules_jvm_external//:extensions.bzl",
+-    "maven",
+-)
+-maven.install(
+-    name = "perfetto_maven",
+-    artifacts = [
+-        "androidx.test:runner:1.6.2",
+-        "androidx.test:monitor:1.7.2",
+-        "com.google.truth:truth:1.4.4",
+-        "junit:junit:4.13.2",
+-        "androidx.test.ext:junit:1.2.1",
+-    ],
+-    repositories = [
+-        "https://maven.google.com",
+-        "https://repo1.maven.org/maven2",
+-    ],
+-    # Use rules_android's aar_import to avoid toolchain type mismatch.
+-    aar_import_bzl_label = "@rules_android//rules:rules.bzl",
+-)
+-use_repo(maven, "perfetto_maven")
 diff --git a/bazel/rules.bzl b/bazel/rules.bzl
-index 563382a18bfde2506f613f274304387dace9f2dd..d7e77cf21416588a3a55e0bb6d67099a148d1de1 100644
+index 563382a18b..d7e77cf214 100644
 --- a/bazel/rules.bzl
 +++ b/bazel/rules.bzl
 @@ -13,9 +13,7 @@

--- a/patches/perfetto/0002-disable-info-level-logging.patch
+++ b/patches/perfetto/0002-disable-info-level-logging.patch
@@ -1,20 +1,17 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From cf26a646ce050b734771bfc212e6c9f1cc9f7f14 Mon Sep 17 00:00:00 2001
 From: Dan Carney <dcarney@cloudflare.com>
 Date: Wed, 17 Dec 2025 10:59:18 +0000
 Subject: disable info level logging
 
----
- .../perfetto/base/build_configs/bazel/perfetto_build_flags.h    | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/perfetto/base/build_configs/bazel/perfetto_build_flags.h b/include/perfetto/base/build_configs/bazel/perfetto_build_flags.h
-index 5298f8c6..d409d690 100644
+index a9bfdbc2aa..278785fb7b 100644
 --- a/include/perfetto/base/build_configs/bazel/perfetto_build_flags.h
 +++ b/include/perfetto/base/build_configs/bazel/perfetto_build_flags.h
-@@ -35,7 +35,7 @@
- #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_FORCE_DLOG_OFF() (0)
+@@ -36,7 +36,7 @@
  #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_FORCE_DCHECK_ON() (0)
  #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_FORCE_DCHECK_OFF() (1)
+ #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_HTTP_ADDITIONAL_CORS_ORIGINS() ("")
 -#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_VERBOSE_LOGS() (1)
 +#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_VERBOSE_LOGS() (0)
  #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_VERSION_GEN() (1)


### PR DESCRIPTION
This matches what we have downstream, will allow us to use pre-compiled protoc instead of having to compile it ourselves on builds that use perfetto.