### PR TITLE
Remove increase-external-memory-adjustment-for-fetch autogate

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -19,7 +19,6 @@
 #include <workerd/jsg/ser.h>
 #include <workerd/jsg/url.h>
 #include <workerd/util/abortable.h>
-#include <workerd/util/autogate.h>
 #include <workerd/util/entropy.h>
 #include <workerd/util/http-util.h>
 #include <workerd/util/mimetype.h>
@@ -1464,13 +1463,6 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
   // TODO(cleanup): Don't convert to HttpClient. Use the HttpService interface instead. This
   //   requires a significant rewrite of the code below. It'll probably get simpler, though?
   kj::Own<kj::HttpClient> client = asHttpClient(kj::mv(clientWithTracing.client));
-
-  // fetch() requests use a lot of unaccounted C++ memory, so we adjust memory usage to pressure
-  // the GC and protect against OOMs. When the autogate is enabled, this adjustment is applied
-  // centrally to all subrequests in IoContext::getSubrequestNoChecks() instead.
-  if (!util::Autogate::isEnabled(util::AutogateKey::INCREASE_EXTERNAL_MEMORY_ADJUSTMENT_FOR_FETCH)) {
-    client = client.attach(js.getExternalMemoryAdjustment(3 * 1024));
-  }
 
   kj::HttpHeaders headers(ioContext.getHeaderTable());
   jsRequest->shallowCopyHeadersTo(headers);

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -9,7 +9,6 @@
 #include <workerd/io/worker.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/setup.h>
-#include <workerd/util/autogate.h>
 #include <workerd/util/own-util.h>
 #include <workerd/util/sentry.h>
 #include <workerd/util/uncaught-exception-source.h>
@@ -942,15 +941,12 @@ kj::Own<WorkerInterface> IoContext::getSubrequestNoChecks(
   }
 
   // Subrequests use a lot of unaccounted C++ memory, so we adjust V8's external memory counter to
-  // pressure the GC and protect against OOMs. When the autogate is enabled, we apply this
-  // adjustment to ALL subrequests (not just fetch). We only apply this when the JS lock is held
-  // (i.e., when JS code initiated the subrequest); infrastructure paths that bypass JS don't need
-  // it.
-  if (util::Autogate::isEnabled(util::AutogateKey::INCREASE_EXTERNAL_MEMORY_ADJUSTMENT_FOR_FETCH)) {
-    KJ_IF_SOME(lock, currentLock) {
-      jsg::Lock& js = lock;
-      ret = ret.attach(js.getExternalMemoryAdjustment(8 * 1024));
-    }
+  // pressure the GC and protect against OOMs. We apply this adjustment to ALL subrequests (not
+  // just fetch). We only apply this when the JS lock is held (i.e., when JS code initiated the
+  // subrequest); infrastructure paths that bypass JS don't need it.
+  KJ_IF_SOME(lock, currentLock) {
+    jsg::Lock& js = lock;
+    ret = ret.attach(js.getExternalMemoryAdjustment(8 * 1024));
   }
 
   return kj::mv(ret);
@@ -1042,13 +1038,11 @@ kj::Own<CacheClient> IoContext::getCacheClient() {
   limitEnforcer->newSubrequest(false);
   auto ret = getIoChannelFactory().getCache();
 
-  // Apply external memory adjustment for Cache API subrequests when autogate is enabled (same as
-  // other subrequests in getSubrequestNoChecks).
-  if (util::Autogate::isEnabled(util::AutogateKey::INCREASE_EXTERNAL_MEMORY_ADJUSTMENT_FOR_FETCH)) {
-    KJ_IF_SOME(lock, currentLock) {
-      jsg::Lock& js = lock;
-      ret = ret.attach(js.getExternalMemoryAdjustment(8 * 1024));
-    }
+  // Apply external memory adjustment for Cache API subrequests (same as other subrequests in
+  // getSubrequestNoChecks).
+  KJ_IF_SOME(lock, currentLock) {
+    jsg::Lock& js = lock;
+    ret = ret.attach(js.getExternalMemoryAdjustment(8 * 1024));
   }
 
   return kj::mv(ret);

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -25,8 +25,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "streaming-tail-worker"_kj;
     case AutogateKey::TAIL_STREAM_REFACTOR:
       return "tail-stream-refactor"_kj;
-    case AutogateKey::INCREASE_EXTERNAL_MEMORY_ADJUSTMENT_FOR_FETCH:
-      return "increase-external-memory-adjustment-for-fetch"_kj;
     case AutogateKey::RUST_BACKED_NODE_DNS:
       return "rust-backed-node-dns"_kj;
     case AutogateKey::RPC_USE_EXTERNAL_PUSHER:

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -20,9 +20,6 @@ enum class AutogateKey {
   STREAMING_TAIL_WORKER,
   // Enable refactor used to consolidate the different tail worker stream implementations.
   TAIL_STREAM_REFACTOR,
-  // When enabled, increases the external memory adjustment for fetch() from 3 KiB to 8 KiB. This
-  // brings it closer to the actual C++ memory overhead.
-  INCREASE_EXTERNAL_MEMORY_ADJUSTMENT_FOR_FETCH,
   // Enable Rust-backed Node.js DNS implementation
   RUST_BACKED_NODE_DNS,
   // Use ExternalPusher instead of StreamSink to handle streams in RPC.


### PR DESCRIPTION
The autogate is fully deployed. Collapse all conditional checks to the always-on behavior: 8 KiB external memory adjustments applied to all subrequests (fetch, Cache API, etc.) in IoContext, with the old 3 KiB fetch-only fallback in http.c++ removed.