### PR TITLE
Move the coverage-linux workflow to separate group

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: coverage.yml-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  # Read repo
+  contents: read
+  # Read/write artifacts
+  actions: write
+
+jobs:
+  coverage-linux:
+    uses: ./.github/workflows/_bazel.yml
+    with:
+      image: ubuntu-22.04-16core
+      os_name: linux
+      arch_name: 'X64'
+      suffix: 'coverage'
+      # Don't use ci-test here because it enables --remote_download_minimal which prevents
+      # coverage data from being fetched from cache. The coverage config already sets
+      # --test_env=CI=true and --config=wpt-test which are the relevant parts of ci-test.
+      # Use ci-linux-common instead of ci-linux to avoid overriding coverage test_tag_filters
+      # (ci-linux sets test_tag_filters that would include container tests which require docker)
+      extra_bazel_args: '--config=ci-linux-common --config=ci-limit-storage --config=coverage --test_env=CI=true --config=wpt-test'
+      upload_test_logs: true
+      upload_binary: false
+      build_container_images: false
+      run_coverage: true
+      run_tests: false
+    secrets:
+      BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
+      WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,29 +97,6 @@ jobs:
       BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
       WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}
 
-  coverage-linux:
-    uses: ./.github/workflows/_bazel.yml
-    with:
-      image: ubuntu-22.04-16core
-      os_name: linux
-      arch_name: 'X64'
-      suffix: 'coverage'
-      # Don't use ci-test here because it enables --remote_download_minimal which prevents
-      # coverage data from being fetched from cache. The coverage config already sets
-      # --test_env=CI=true and --config=wpt-test which are the relevant parts of ci-test.
-      # Use ci-linux-common instead of ci-linux to avoid overriding coverage test_tag_filters
-      # (ci-linux sets test_tag_filters that would include container tests which require docker)
-      extra_bazel_args: '--config=ci-linux-common --config=ci-limit-storage --config=coverage --test_env=CI=true --config=wpt-test'
-      upload_test_logs: true
-      upload_binary: false
-      build_container_images: false
-      run_coverage: true
-      run_tests: false
-    secrets:
-      BAZEL_CACHE_KEY: ${{ secrets.BAZEL_CACHE_KEY }}
-      WORKERS_MIRROR_URL: ${{ secrets.WORKERS_MIRROR_URL }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
   lint:
     uses: ./.github/workflows/_bazel.yml
     with:


### PR DESCRIPTION
Moves it to a separate group to avoid it making the main test workflow take much longer to complete.