### PR TITLE
Add CSS Selector option

### DIFF
--- a/src/cloudflare/internal/to-markdown-api.ts
+++ b/src/cloudflare/internal/to-markdown-api.ts
@@ -41,6 +41,7 @@ export type ConversionOptions = {
   html?: {
     images?: EmbeddedImageConversionOptions & { convertOGImage?: boolean };
     hostname?: string;
+    cssSelector?: string;
   };
   docx?: {
     images?: EmbeddedImageConversionOptions;

--- a/types/defines/to-markdown.d.ts
+++ b/types/defines/to-markdown.d.ts
@@ -31,6 +31,7 @@ export type ConversionOptions = {
   html?: {
     images?: EmbeddedImageConversionOptions & { convertOGImage?: boolean };
     hostname?: string;
+    cssSelector?: string;
   },
   docx?: {
     images?: EmbeddedImageConversionOptions;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -12759,6 +12759,7 @@ type ConversionOptions = {
       convertOGImage?: boolean;
     };
     hostname?: string;
+    cssSelector?: string;
   };
   docx?: {
     images?: EmbeddedImageConversionOptions;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -12717,6 +12717,7 @@ export type ConversionOptions = {
       convertOGImage?: boolean;
     };
     hostname?: string;
+    cssSelector?: string;
   };
   docx?: {
     images?: EmbeddedImageConversionOptions;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12111,6 +12111,7 @@ type ConversionOptions = {
       convertOGImage?: boolean;
     };
     hostname?: string;
+    cssSelector?: string;
   };
   docx?: {
     images?: EmbeddedImageConversionOptions;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12069,6 +12069,7 @@ export type ConversionOptions = {
       convertOGImage?: boolean;
     };
     hostname?: string;
+    cssSelector?: string;
   };
   docx?: {
     images?: EmbeddedImageConversionOptions;


### PR DESCRIPTION
Adds new `cssSelector` option to the Markdown Conversion API Types