### PR TITLE
properly set function length for spec compliance

### DIFF
--- a/build/wpt_test.bzl
+++ b/build/wpt_test.bzl
@@ -66,7 +66,7 @@ def wpt_test(name, wpt_directory, config, compat_date = "", compat_flags = [], a
         wpt_common = wpt_common,
         wpt_resources = wpt_resources,
         wpt_interfaces = wpt_interfaces,
-        compat_flags = compat_flags + ["immutable_api_prototypes", "pedantic_wpt", "experimental", "nodejs_compat", "unsupported_process_actual_platform"],
+        compat_flags = compat_flags + ["immutable_api_prototypes", "spec_compliant_property_attributes", "pedantic_wpt", "experimental", "nodejs_compat", "unsupported_process_actual_platform"],
     )
 
     data = [

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1458,4 +1458,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # With HWM=0 the readable side starts with backpressure, so writes correctly
   # block until a reader pulls. Previously HWM defaulted to 1, which caused
   # pull() to fire at startup, clearing backpressure before any write.
+
+  specCompliantPropertyAttributes @169 :Bool
+      $compatEnableFlag("spec_compliant_property_attributes")
+      $compatDisableFlag("no_spec_compliant_property_attributes")
+      $experimental;
+  # Fixes several Web IDL compliance issues on constructor, method, getter,
+  # setter, and constant property attributes:
+  #  - Constructor .length reflects the number of required arguments instead
+  #    of always being 0.
 }

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -1114,6 +1114,9 @@ Worker::Isolate::Isolate(kj::Own<Api> apiParam,
     if (features.getShouldSetImmutablePrototype() || features.getPythonWorkers()) {
       lock->setImmutablePrototype();
     }
+    if (features.getSpecCompliantPropertyAttributes()) {
+      lock->setSpecCompliantPropertyAttributes();
+    }
     if (features.getNodeJsCompatV2()) {
       lock->setNodeJsCompatEnabled();
     }

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -243,6 +243,10 @@ void Lock::setImmutablePrototype() {
   IsolateBase::from(v8Isolate).enableSetImmutablePrototype();
 }
 
+void Lock::setSpecCompliantPropertyAttributes() {
+  IsolateBase::from(v8Isolate).enableSpecCompliantPropertyAttributes();
+}
+
 void Lock::setLoggerCallback(kj::Function<Logger>&& logger) {
   IsolateBase::from(v8Isolate).setLoggerCallback({}, kj::mv(logger));
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2652,6 +2652,7 @@ class Lock {
   bool getThrowOnUnrecognizedImportAssertion() const;
   void setToStringTag();
   void setImmutablePrototype();
+  void setSpecCompliantPropertyAttributes();
   void disableTopLevelAwait();
 
   using Logger = void(Lock&, kj::StringPtr);

--- a/src/workerd/jsg/meta.h
+++ b/src/workerd/jsg/meta.h
@@ -57,4 +57,62 @@ using ArgumentIndexes = ArgumentIndexes_<T>::Indexes;
 // number of arguments to the method, not counting the magic Lock or FunctionCallbackInfo parameter
 // (if any).
 
+// =======================================================================================
+// requiredArgumentCount<T> — counts leading required JS-visible arguments.
+//
+// Used by resource.h to set the Web IDL .length property on functions.
+
+// Lightweight type list; kj::Tuple is an alias template and cannot be partially specialized.
+template <typename... Ts>
+struct TypeList {};
+
+namespace detail {
+
+// Phase 1: Normalize member-function-pointer or free-function type to Ret(Args...).
+template <typename T>
+struct NormalizeFunc_;
+template <typename C, typename R, typename... A>
+struct NormalizeFunc_<R (C::*)(A...)> {
+  using type = R(A...);
+};
+template <typename C, typename R, typename... A>
+struct NormalizeFunc_<R (C::*)(A...) const> {
+  using type = R(A...);
+};
+template <typename R, typename... A>
+struct NormalizeFunc_<R(A...)> {
+  using type = R(A...);
+};
+
+// Phase 2: Strip leading Lock& / FunctionCallbackInfo& and yield the JS-visible args.
+template <typename T>
+struct StripMagicParam_;
+template <typename R, typename... A>
+struct StripMagicParam_<R(A...)> {
+  using Args = TypeList<A...>;
+};
+template <typename R, typename... A>
+struct StripMagicParam_<R(Lock&, A...)> {
+  using Args = TypeList<A...>;
+};
+template <typename R, typename... A>
+struct StripMagicParam_<R(const v8::FunctionCallbackInfo<v8::Value>&, A...)> {
+  using Args = TypeList<A...>;
+};
+
+template <typename T>
+using MethodArgs = StripMagicParam_<typename NormalizeFunc_<T>::type>;
+
+// Forward declaration — specialized in web-idl.h where the full JSG type system is visible.
+template <typename ArgsList>
+struct RequiredArgCount_;
+
+}  // namespace detail
+
+// Per Web IDL, the .length of a function is the number of leading required arguments.
+// The actual counting logic lives in web-idl.h.
+template <typename T>
+inline constexpr int requiredArgumentCount =
+    detail::RequiredArgCount_<typename detail::MethodArgs<T>::Args>::value;
+
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -1317,6 +1317,10 @@ struct ResourceTypeBuilder {
 
   template <const char* name, auto method>
   inline void registerMethod() {
+    // Per Web IDL, function .length = number of required arguments.
+    constexpr int specLength = requiredArgumentCount<decltype(method)>;
+    const int length = getSpecCompliantPropertyAttributes(isolate) ? specLength : 0;
+
     if constexpr (isFastApiCompatible<decltype(method)>) {
       if (typeWrapper.isFastApiEnabled()) {
         auto cFunction = v8::CFunction::Make(MethodCallback<TypeWrapper, name, isContext, Self,
@@ -1324,7 +1328,7 @@ struct ResourceTypeBuilder {
         auto functionTemplate = v8::FunctionTemplate::NewWithCFunctionOverloads(isolate,
             &MethodCallback<TypeWrapper, name, isContext, Self, decltype(method), method,
                 ArgumentIndexes<decltype(method)>>::callback,
-            v8::Local<v8::Value>(), signature, 0, v8::ConstructorBehavior::kThrow,
+            v8::Local<v8::Value>(), signature, length, v8::ConstructorBehavior::kThrow,
             v8::SideEffectType::kHasSideEffect, {&cFunction, 1});
 
         prototype->Set(isolate, name, functionTemplate);
@@ -1336,11 +1340,15 @@ struct ResourceTypeBuilder {
         v8::FunctionTemplate::New(isolate,
             &MethodCallback<TypeWrapper, name, isContext, Self, decltype(method), method,
                 ArgumentIndexes<decltype(method)>>::callback,
-            v8::Local<v8::Value>(), signature, 0, v8::ConstructorBehavior::kThrow));
+            v8::Local<v8::Value>(), signature, length, v8::ConstructorBehavior::kThrow));
   }
 
   template <const char* name, typename Method, Method method>
   inline void registerStaticMethod() {
+    // Per Web IDL, function .length = number of required arguments.
+    constexpr int specLength = requiredArgumentCount<Method>;
+    const int length = getSpecCompliantPropertyAttributes(isolate) ? specLength : 0;
+
     if constexpr (isFastApiCompatible<Method>) {
       if (typeWrapper.isFastApiEnabled()) {
         auto cFunction = v8::CFunction::Make(StaticMethodCallback<TypeWrapper, name, Self, Method,
@@ -1352,8 +1360,8 @@ struct ResourceTypeBuilder {
         auto functionTemplate = v8::FunctionTemplate::NewWithCFunctionOverloads(isolate,
             &StaticMethodCallback<TypeWrapper, name, Self, Method, method,
                 ArgumentIndexes<Method>>::callback,
-            v8::Local<v8::Value>(), v8::Local<v8::Signature>(), 0, v8::ConstructorBehavior::kThrow,
-            v8::SideEffectType::kHasSideEffect, {&cFunction, 1});
+            v8::Local<v8::Value>(), v8::Local<v8::Signature>(), length,
+            v8::ConstructorBehavior::kThrow, v8::SideEffectType::kHasSideEffect, {&cFunction, 1});
         functionTemplate->RemovePrototype();
         constructor->Set(v8StrIntern(isolate, name), functionTemplate);
         return;
@@ -1365,7 +1373,8 @@ struct ResourceTypeBuilder {
     auto functionTemplate = v8::FunctionTemplate::New(isolate,
         &StaticMethodCallback<TypeWrapper, name, Self, Method, method,
             ArgumentIndexes<Method>>::callback,
-        v8::Local<v8::Value>(), v8::Local<v8::Signature>(), 0, v8::ConstructorBehavior::kThrow);
+        v8::Local<v8::Value>(), v8::Local<v8::Signature>(), length,
+        v8::ConstructorBehavior::kThrow);
     functionTemplate->RemovePrototype();
     constructor->Set(v8StrIntern(isolate, name), functionTemplate);
   }
@@ -1399,6 +1408,8 @@ struct ResourceTypeBuilder {
       inspectProperties->Set(v8Name, v8::False(isolate), v8::PropertyAttribute::ReadOnly);
     }
 
+    const bool specCompliant = getSpecCompliantPropertyAttributes(isolate);
+
     bool useSlowApi = true;
     if constexpr (isFastApiCompatible<Getter> && isFastApiCompatible<Setter>) {
       if (typeWrapper.isFastApiEnabled()) {
@@ -1409,8 +1420,9 @@ struct ResourceTypeBuilder {
 
         auto setterCFunction = v8::CFunction::Make(Scb::template fastCallback<>);
         setterFn = v8::FunctionTemplate::NewWithCFunctionOverloads(isolate, &Scb::callback,
-            v8::Local<v8::Value>(), signature, 0, v8::ConstructorBehavior::kThrow,
-            v8::SideEffectType::kHasSideEffect, {&setterCFunction, 1});
+            v8::Local<v8::Value>(), signature, specCompliant ? 1 : 0,
+            v8::ConstructorBehavior::kThrow, v8::SideEffectType::kHasSideEffect,
+            {&setterCFunction, 1});
 
         useSlowApi = false;
       }
@@ -1421,8 +1433,16 @@ struct ResourceTypeBuilder {
       // properties because it will not properly handle the prototype chain when it comes
       // to using setters... which is annoying. It means we end up having to use FunctionTemplates
       // instead of the more convenient property callbacks.
-      getterFn = v8::FunctionTemplate::New(isolate, Gcb::callback);
-      setterFn = v8::FunctionTemplate::New(isolate, &Scb::callback);
+      if (specCompliant) {
+        // Per Web IDL, getter .length = 0; setter .length = 1.
+        getterFn = v8::FunctionTemplate::New(
+            isolate, Gcb::callback, v8::Local<v8::Value>(), v8::Local<v8::Signature>(), 0);
+        setterFn = v8::FunctionTemplate::New(
+            isolate, &Scb::callback, v8::Local<v8::Value>(), v8::Local<v8::Signature>(), 1);
+      } else {
+        getterFn = v8::FunctionTemplate::New(isolate, Gcb::callback);
+        setterFn = v8::FunctionTemplate::New(isolate, &Scb::callback);
+      }
     }
 
     prototype->SetAccessorProperty(v8Name, getterFn, setterFn,
@@ -1459,7 +1479,14 @@ struct ResourceTypeBuilder {
     if (!Gcb::enumerable) {
       inspectProperties->Set(v8Name, v8::False(isolate), v8::PropertyAttribute::ReadOnly);
     }
-    auto getterFn = v8::FunctionTemplate::New(isolate, Gcb::callback);
+    v8::Local<v8::FunctionTemplate> getterFn;
+    if (getSpecCompliantPropertyAttributes(isolate)) {
+      // Per Web IDL, getter .length = 0.
+      getterFn = v8::FunctionTemplate::New(
+          isolate, Gcb::callback, v8::Local<v8::Value>(), v8::Local<v8::Signature>(), 0);
+    } else {
+      getterFn = v8::FunctionTemplate::New(isolate, Gcb::callback);
+    }
 
     prototype->SetAccessorProperty(v8Name, getterFn, {},
         Gcb::enumerable ? v8::PropertyAttribute::ReadOnly
@@ -1913,8 +1940,12 @@ class ResourceWrapper {
 
       v8::Local<v8::FunctionTemplate> constructor;
       if constexpr (!isContext && HasConstructorMethod<T>) {
+        // Per Web IDL, constructor .length = number of required arguments.
+        constexpr int specCtorLength = requiredArgumentCount<decltype(T::constructor)>;
+        const int ctorLength = getSpecCompliantPropertyAttributes(isolate) ? specCtorLength : 0;
         constructor =
-            v8::FunctionTemplate::New(isolate, &ConstructorCallback<TypeWrapper, T>::callback);
+            v8::FunctionTemplate::New(isolate, &ConstructorCallback<TypeWrapper, T>::callback,
+                v8::Local<v8::Value>(), v8::Local<v8::Signature>(), ctorLength);
       } else {
         constructor = v8::FunctionTemplate::New(isolate, &throwIllegalConstructor);
       }

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -207,6 +207,14 @@ class IsolateBase {
     shouldSetImmutablePrototypeFlag = true;
   }
 
+  inline bool shouldUseSpecCompliantPropertyAttributes() const {
+    return specCompliantPropertyAttributesFlag;
+  }
+
+  void enableSpecCompliantPropertyAttributes() {
+    specCompliantPropertyAttributesFlag = true;
+  }
+
   inline void disableTopLevelAwait() {
     allowTopLevelAwait = false;
   }
@@ -363,6 +371,7 @@ class IsolateBase {
   bool requireReturnsDefaultExportEnabled = false;
   bool setToStringTag = false;
   bool shouldSetImmutablePrototypeFlag = false;
+  bool specCompliantPropertyAttributesFlag = false;
   bool allowTopLevelAwait = true;
   bool usingNewModuleRegistry = false;
   bool usingEnhancedErrorSerialization = false;

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -38,6 +38,11 @@ bool getShouldSetImmutablePrototype(v8::Isolate* isolate) {
   return jsgIsolate.shouldSetImmutablePrototype();
 }
 
+bool getSpecCompliantPropertyAttributes(v8::Isolate* isolate) {
+  auto& jsgIsolate = *reinterpret_cast<IsolateBase*>(isolate->GetData(SET_DATA_ISOLATE_BASE));
+  return jsgIsolate.shouldUseSpecCompliantPropertyAttributes();
+}
+
 #if _WIN32
 kj::String fullyQualifiedTypeName(const std::type_info& type) {
   // type.name() returns a human-readable name on Windows:

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -67,6 +67,7 @@ class JsExceptionThrown: public std::exception {
 bool getCaptureThrowsAsRejections(v8::Isolate* isolate);
 bool getShouldSetToStringTag(v8::Isolate* isolate);
 bool getShouldSetImmutablePrototype(v8::Isolate* isolate);
+bool getSpecCompliantPropertyAttributes(v8::Isolate* isolate);
 
 kj::String fullyQualifiedTypeName(const std::type_info& type);
 kj::String typeName(const std::type_info& type);

--- a/src/workerd/jsg/web-idl.h
+++ b/src/workerd/jsg/web-idl.h
@@ -8,6 +8,7 @@
 // Type traits and concepts to help us map between C++ and Web IDL types.
 
 #include <workerd/jsg/jsg.h>
+#include <workerd/jsg/meta.h>
 
 #include <kj/array.h>
 #include <kj/common.h>
@@ -332,3 +333,37 @@ struct UnionTypeValidator {
 };
 
 }  // namespace workerd::jsg::webidl
+
+// =======================================================================================
+// RequiredArgCount_ specialization — counts leading required (non-optional, non-valueless)
+// arguments in a tuple of JS-visible parameter types.
+//
+// This completes the definition of requiredArgumentCount<T> declared in meta.h.  We place
+// it here (rather than meta.h) because we need the full JSG type system: isOptional,
+// Optional<T>, LenientOptional<T>, TypeHandler<T>, Arguments<T>.
+
+namespace workerd::jsg::detail {
+
+// True for parameter types that do not consume a JS argument at all.
+template <typename T>
+constexpr bool isValuelessArg = false;
+template <typename T>
+constexpr bool isValuelessArg<TypeHandler<T>> = true;
+template <typename T>
+constexpr bool isValuelessArg<Arguments<T>> = true;
+
+template <>
+struct RequiredArgCount_<TypeList<>> {
+  static constexpr int value = 0;
+};
+
+template <typename Head, typename... Tail>
+struct RequiredArgCount_<TypeList<Head, Tail...>> {
+  using D = kj::Decay<Head>;
+  static constexpr int value = isValuelessArg<D>
+      ? RequiredArgCount_<TypeList<Tail...>>::value  // skip invisible args, continue
+      : (webidl::isOptional<D> ? 0                   // optional arg — stop counting required
+                               : 1 + RequiredArgCount_<TypeList<Tail...>>::value);
+};
+
+}  // namespace workerd::jsg::detail

--- a/src/wpt/url-test.ts
+++ b/src/wpt/url-test.ts
@@ -12,9 +12,6 @@ export default {
     comment: 'TODO: Investigate this',
     expectedFailures: [
       'URL interface: existence and properties of interface object',
-      'URL interface object length',
-      'URL interface: operation parse(USVString, optional USVString)',
-      'URL interface: operation canParse(USVString, optional USVString)',
       'URL interface: attribute href',
       'URL interface: attribute origin',
       'URL interface: attribute protocol',


### PR DESCRIPTION
Splitted from https://github.com/cloudflare/workerd/pull/6229

Kept the new compat flag as experimental. Will split the original PR more and make sure all changes rely on the same compat flag.