### PR TITLE
Add package.json for .opencode plugin dependency

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opencode-ai/plugin": "^1"
+  }
+}


### PR DESCRIPTION
The .opencode tools import from @opencode-ai/plugin but had no package.json declaring the dependency, causing module resolution failures (see https://github.com/ask-bonk/ask-bonk/issues/143).