### PR TITLE
Fixup `@all-autogates` bug

### DIFF
--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -261,6 +261,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":sentry",
+        ":strong-bool",
         "@capnp-cpp//src/capnp",
         "@capnp-cpp//src/kj",
     ],

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -67,7 +67,19 @@ bool Autogate::isEnabled(AutogateKey key) {
   return defaultResult;
 }
 
-void Autogate::initAutogate(capnp::List<capnp::Text>::Reader gates) {
+void Autogate::initAutogate(
+    capnp::List<capnp::Text>::Reader gates, IgnoreAllAutogatesEnv ignoreEnv) {
+  // If the WORKERD_ALL_AUTOGATES env var is set, enable all gates regardless of what
+  // was passed in. This ensures the @all-autogates test variant works even when
+  // initAutogate({}) is called early (e.g. by TestFixture), which would otherwise
+  // set globalAutogate to all-false and prevent isEnabled() from reaching its env var
+  // fallback.
+  //
+  // Callers (e.g. the production server) that manage the all-autogates behavior themselves and
+  // build selective gate configs can pass IgnoreAllAutogatesEnv::YES to skip this override.
+  if (!ignoreEnv && getenv("WORKERD_ALL_AUTOGATES") != nullptr) {
+    return initAllAutogates();
+  }
   globalAutogate = Autogate(gates);
 }
 

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -3,6 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
+#include <workerd/util/strong-bool.h>
+
 #include <capnp/blob.h>
 #include <capnp/list.h>
 #include <kj/string.h>
@@ -10,6 +12,12 @@
 #include <initializer_list>
 
 namespace workerd::util {
+
+// When YES, initAutogate() ignores the WORKERD_ALL_AUTOGATES environment variable and uses only
+// the gates list that was explicitly passed in. This is used by the production server, which has
+// its own autogate test infrastructure that manages the all-autogates behavior and builds
+// selective gate configs (with forceOff / toggle support).
+WD_STRONG_BOOL(IgnoreAllAutogatesEnv);
 
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
@@ -53,7 +61,8 @@ class Autogate {
   //
   // This function is not thread safe, it should be called exactly once close to the start of the
   // process before any threads are created.
-  static void initAutogate(capnp::List<capnp::Text>::Reader autogates);
+  static void initAutogate(capnp::List<capnp::Text>::Reader autogates,
+      IgnoreAllAutogatesEnv ignoreEnv = IgnoreAllAutogatesEnv::NO);
 
   // Convenience method for bin-tests to invoke initAutogate() with an appropriate config.
   static void initAutogateNamesForTest(std::initializer_list<kj::StringPtr> gateNames);


### PR DESCRIPTION
There was a bug when running the @all-autogates
test variants with KJ_TESTs using `TestFixture`.
The test fixture was overriding and switching off
the autogates ignoring the environment variable.