### PR TITLE
Decouple AbortSignal from IOContext

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -622,12 +622,8 @@ class AbortTriggerRpcServer final: public rpc::AbortTrigger::Server {
 };
 }  // namespace
 
-AbortSignal::AbortSignal(kj::Maybe<kj::Exception> exception,
-    jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason,
-    Flag flag)
-    : canceler(
-          IoContext::current().addObject(kj::refcounted<RefcountedCanceler>(kj::cp(exception)))),
-      flag(flag),
+AbortSignal::AbortSignal(jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason, Flag flag)
+    : flag(flag),
       reason(kj::mv(maybeReason)) {}
 
 kj::Maybe<jsg::JsValue> AbortSignal::getOnAbort(jsg::Lock& js) {
@@ -659,7 +655,7 @@ void AbortSignal::addEventListener(jsg::Lock& js,
 }
 
 bool AbortSignal::getAborted(jsg::Lock& js) {
-  return canceler->isCanceled() || hasPendingReason();
+  return reason != kj::none || hasPendingReason();
 }
 
 jsg::JsValue AbortSignal::getReason(jsg::Lock& js) {
@@ -691,15 +687,14 @@ kj::Exception AbortSignal::abortException(
 }
 
 jsg::Ref<AbortSignal> AbortSignal::abort(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
-  auto exception = abortException(js, maybeReason);
   KJ_IF_SOME(reason, maybeReason) {
-    return js.alloc<AbortSignal>(kj::mv(exception), reason.addRef(js));
+    return js.alloc<AbortSignal>(reason.addRef(js));
   }
-  return js.alloc<AbortSignal>(kj::cp(exception), js.exceptionToJsValue(kj::mv(exception)));
+  return js.alloc<AbortSignal>(js.exceptionToJsValue(abortException(js, maybeReason)));
 }
 
 void AbortSignal::throwIfAborted(jsg::Lock& js) {
-  if (canceler->isCanceled()) {
+  if (getAborted(js)) {
     KJ_IF_SOME(r, reason) {
       js.throwException(r.getHandle(js));
     } else {
@@ -739,7 +734,7 @@ jsg::Ref<AbortSignal> AbortSignal::any(jsg::Lock& js,
     const jsg::TypeHandler<jsg::Ref<EventTarget>>& eventTargetHandler) {
   // If nothing was passed in, we can just return a signal that never aborts.
   if (signals.size() == 0) {
-    return js.alloc<AbortSignal>(kj::none, kj::none, AbortSignal::Flag::NEVER_ABORTS);
+    return js.alloc<AbortSignal>(kj::none, AbortSignal::Flag::NEVER_ABORTS);
   }
 
   // Let's check to see if any of the signals are already aborted. If it is, we can
@@ -787,17 +782,11 @@ void AbortSignal::visitForGc(jsg::GcVisitor& visitor) {
   visitor.visit(reason, onAbortHandler);
 }
 
-RefcountedCanceler& AbortSignal::getCanceler() {
-  return *canceler;
-}
-
 void AbortSignal::triggerAbort(
     jsg::Lock& js, jsg::Optional<kj::OneOf<kj::Exception, jsg::JsValue>> maybeReason) {
-  KJ_ASSERT(flag != Flag::NEVER_ABORTS);
-  if (canceler->isCanceled()) {
+  if (reason != kj::none || flag == Flag::NEVER_ABORTS) {
     return;
   }
-  auto exception = AbortSignal::abortException(js, maybeReason);
   KJ_IF_SOME(r, maybeReason) {
     KJ_SWITCH_ONEOF(r) {
       KJ_CASE_ONEOF(value, jsg::JsValue) {
@@ -808,13 +797,13 @@ void AbortSignal::triggerAbort(
       }
     }
   } else {
-    reason = js.exceptionToJsValue(kj::cp(exception));
+    reason = js.exceptionToJsValue(AbortSignal::abortException(js, kj::none));
   }
-
-  canceler->cancel(kj::mv(exception));
 
   // 1. Dispatch to RPC clients
   if (!rpcClients.empty()) {
+    // Let's make sure we're triggering from the correct IoContext.
+    auto _ = *rpcClients.front();
     IoContext& ioContext = IoContext::current();
     jsg::Serializer ser(js);
     KJ_IF_SOME(r, reason) {
@@ -849,7 +838,7 @@ void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   JSG_REQUIRE(
       externalHandler != nullptr, DOMDataCloneError, "AbortSignal can only be serialized for RPC.");
 
-  serializer.writeRawUint32(static_cast<uint>(canceler->isCanceled()));
+  serializer.writeRawUint32(static_cast<uint>(getAborted(js)));
   serializer.writeRawUint32(static_cast<uint>(flag));
   KJ_IF_SOME(r, reason) {
     serializer.write(js, r.getHandle(js));
@@ -904,12 +893,12 @@ jsg::Ref<AbortSignal> AbortSignal::deserialize(
 
   if (flag == Flag::NEVER_ABORTS) {
     // The signal can't be aborted. We don't need to setup RPC
-    return js.alloc<AbortSignal>(/* exception */ kj::none, /* maybeReason */ kj::none, flag);
+    return js.alloc<AbortSignal>(/* maybeReason */ kj::none, flag);
   }
 
   // The AbortSignalImpl will receive any remote triggerAbort requests and fulfill the promise with the reason for abort
 
-  auto signal = js.alloc<AbortSignal>(/* exception */ kj::none, /* maybeReason */ kj::none, flag);
+  auto signal = js.alloc<AbortSignal>(/* maybeReason */ kj::none, flag);
 
   auto& ioctx = IoContext::current();
 
@@ -1078,18 +1067,72 @@ kj::Promise<void> Scheduler::wait(
   auto promise = kj::mv(paf.promise);
 
   KJ_IF_SOME(options, maybeOptions) {
-    KJ_IF_SOME(s, options.signal) {
-      promise = s->wrap(js, kj::mv(promise));
-      // When the signal aborts and the canceler drops the promise, clear the underlying
-      // timeout to free the quota slot. clearTimeoutImpl is a no-op if the timeout has
-      // already fired, so this is safe on the normal completion path as well.
-      promise = promise.attach(kj::defer([timeoutId, &ioContext = IoContext::current()]() {
-        ioContext.clearTimeoutImpl(TimeoutId::fromNumber(timeoutId));
-      }));
-    }
+    // When the signal aborts and the canceler drops the promise, clear the underlying
+    // timeout to free the quota slot. clearTimeoutImpl is a no-op if the timeout has
+    // already fired, so this is safe on the normal completion path as well.
+    auto& ioContext = IoContext::current();
+    promise = AbortSignal::maybeCancelWrap(js, options.signal, kj::mv(promise))
+                  .attach(kj::defer([timeoutId, &ioContext]() {
+      ioContext.clearTimeoutImpl(TimeoutId::fromNumber(timeoutId));
+    }));
   }
 
   return kj::mv(promise);
+}
+
+AbortSignal::CancelerAndHandler AbortSignal::newMaybeCrossContextCancelHandler(
+    jsg::Lock& js, jsg::Ref<AbortSignal> signal) {
+  signal->subscribeToRpcAbort(js);
+
+  if (signal->getAborted(js)) {
+    // The signal is already aborted! So we can just trigger the canceler immediately and
+    // return a dummy handler that doesn't actually do anything since we don't need it to.
+    auto exception = js.exceptionToKj(signal->getReason(js));
+    auto canceler = kj::rc<RefcountedCanceler>(kj::mv(exception));
+    return {
+      .canceler = kj::mv(canceler),
+      .handler = kj::Own<void>(nullptr, kj::NullDisposer::instance),
+    };
+  }
+
+  auto& ioContext = IoContext::current();
+  auto executor = ioContext.getCrossContextExecutor();
+  auto canceler = kj::rc<RefcountedCanceler>();
+
+  // Note that the handler here wraps an IoContext-attached kj::Canceler.
+  // We are not, however, using an ioContext.addFunctor here because we
+  // need to be able to handle the case where this is invoked from the
+  // wrong IoContext. Be extremely careful here! Pay close attention to
+  // how the IoContext checks are handled within the handler lambda.
+  auto handler = signal->newNativeHandler(js, kj::str("abort"),
+      [signal = signal.addRef(), canceler = ioContext.addObject(canceler.addRef().toOwn()),
+          ioContext = ioContext.getWeakRef(),
+          executor = kj::mv(executor)](jsg::Lock& js, jsg::Ref<Event>) mutable {
+    // First, let's check that the original context even still exists.
+    KJ_IF_SOME(originalContext, ioContext->tryGet()) {
+      if (!originalContext.isCurrent()) {
+        // Doh! the abort signal fired from a different IoContext that the one that
+        // created this handler. We need to arrange to have the canceler triggered
+        // in the correct IoContext.
+        return executor->execute(
+            js, [canceler = kj::mv(canceler), signal = signal.addRef()](jsg::Lock& js) mutable {
+          canceler->cancel(js.exceptionToKj(signal->getReason(js)));
+        });
+      }
+
+      // We are in the right context so we can just trigger the canceler directly.
+      auto exception = js.exceptionToKj(signal->getReason(js));
+      canceler->cancel(kj::mv(exception));
+    } else {
+      // IoContext that was used to create this handler no longer exists.
+      // This becomes a non-op
+    }
+  },
+      true /* once */);
+  return {
+    .canceler = kj::mv(canceler),
+    .handler = kj::mv(handler),
+  };
 }
 
 void ExtendableEvent::waitUntil(kj::Promise<void> promise) {

--- a/src/workerd/api/basics.h
+++ b/src/workerd/api/basics.h
@@ -9,6 +9,7 @@
 
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/external-pusher.h>
+#include <workerd/io/io-context.h>
 #include <workerd/io/io-own.h>
 #include <workerd/io/worker-interface.capnp.h>
 #include <workerd/jsg/jsg.h>
@@ -568,9 +569,8 @@ class AbortSignal final: public EventTarget {
  public:
   enum class Flag { NONE, NEVER_ABORTS, IGNORE_FOR_SUBREQUESTS };
 
-  AbortSignal(kj::Maybe<kj::Exception> exception = kj::none,
-      jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason = kj::none,
-      Flag flag = Flag::NONE);
+  AbortSignal(
+      jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason = kj::none, Flag flag = Flag::NONE);
 
   using PendingReason = ExternalPusherImpl::PendingAbortReason;
 
@@ -640,31 +640,28 @@ class AbortSignal final: public EventTarget {
     }
   }
 
-  // Allows this AbortSignal to also serve as a kj::Canceler
-  template <typename T>
-  kj::Promise<T> wrap(jsg::Lock& js, kj::Promise<T> promise) {
-    subscribeToRpcAbort(js);
+  struct CancelerAndHandler {
+    kj::Rc<RefcountedCanceler> canceler;
+    kj::Own<void> handler;
+  };
 
-    JSG_REQUIRE(!canceler->isCanceled(), TypeError, "The AbortSignal has already been triggered");
-    return canceler->wrap(kj::mv(promise));
-  }
+  static CancelerAndHandler newMaybeCrossContextCancelHandler(
+      jsg::Lock& js, jsg::Ref<AbortSignal> signal);
 
   template <typename T>
   static kj::Promise<T> maybeCancelWrap(
-      jsg::Lock& js, kj::Maybe<jsg::Ref<AbortSignal>>& signal, kj::Promise<T> promise) {
-    KJ_IF_SOME(s, signal) {
-      return s->wrap(js, kj::mv(promise));
+      jsg::Lock& js, kj::Maybe<jsg::Ref<AbortSignal>>& maybeSignal, kj::Promise<T> promise) {
+    KJ_IF_SOME(signal, maybeSignal) {
+      auto cancelerAndHandler = newMaybeCrossContextCancelHandler(js, signal.addRef());
+      promise = cancelerAndHandler.canceler->wrap(kj::mv(promise));
+      return promise.attach(kj::mv(cancelerAndHandler));
     } else {
       return kj::mv(promise);
     }
   }
 
-  RefcountedCanceler& getCanceler();
-
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
     EventTarget::visitForMemoryInfo(tracker);
-    tracker.trackInlineFieldWithSize(
-        "IoOwn<RefcountedCanceler>", sizeof(IoOwn<RefcountedCanceler>));
     tracker.trackField("reason", reason);
   }
 
@@ -686,7 +683,6 @@ class AbortSignal final: public EventTarget {
   bool isIgnoredForSubrequests(jsg::Lock& js) const;
 
  private:
-  IoOwn<RefcountedCanceler> canceler;
   Flag flag;
 
   kj::Maybe<jsg::JsRef<jsg::JsValue>> reason;
@@ -735,8 +731,7 @@ class AbortController final: public jsg::Object {
  public:
   explicit AbortController(
       jsg::Lock& js, AbortSignal::Flag abortSignalFlag = AbortSignal::Flag::NONE)
-      : signal(js.alloc<AbortSignal>(
-            kj::none /* exception */, kj::none /* maybeReason */, abortSignalFlag)) {}
+      : signal(js.alloc<AbortSignal>(kj::none /* maybeReason */, abortSignalFlag)) {}
 
   static jsg::Ref<AbortController> constructor(jsg::Lock& js) {
     return js.alloc<AbortController>(js);

--- a/src/workerd/api/eventsource.c++
+++ b/src/workerd/api/eventsource.c++
@@ -323,8 +323,12 @@ void EventSource::reconnect(jsg::Lock& js) {
   KJ_ASSERT(impl != kj::none);
   readyState = State::CONNECTING;
   abortController = js.alloc<AbortController>(js);
-  auto signal = abortController->getSignal();
-  context.awaitIo(js, signal->wrap(js, context.afterLimitTimeout(reconnectionTime)))
+  kj::Maybe<jsg::Ref<AbortSignal>> signal = abortController->getSignal();
+
+  auto promise =
+      AbortSignal::maybeCancelWrap(js, signal, context.afterLimitTimeout(reconnectionTime));
+
+  context.awaitIo(js, kj::mv(promise))
       .then(js,
           JSG_VISITABLE_LAMBDA(
               (self = JSG_THIS), (self), (jsg::Lock & js) mutable { self->start(js); }),

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -645,7 +645,7 @@ jsg::Ref<AbortSignal> Request::getThisSignal(jsg::Lock& js) {
   KJ_IF_SOME(s, thisSignal) {
     return s.addRef();
   }
-  auto newSignal = js.alloc<AbortSignal>(kj::none, kj::none, AbortSignal::Flag::NEVER_ABORTS);
+  auto newSignal = js.alloc<AbortSignal>(kj::none, AbortSignal::Flag::NEVER_ABORTS);
   thisSignal = newSignal.addRef();
   return newSignal;
 }
@@ -1530,7 +1530,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
     return ioContext.awaitIo(js,
         AbortSignal::maybeCancelWrap(js, signal, kj::mv(webSocketResponse)),
         [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest), urlList = kj::mv(urlList),
-            client = kj::mv(client), signal = kj::mv(signal)](
+            client = kj::mv(client), maybeSignal = kj::mv(signal)](
             jsg::Lock& js, kj::HttpClient::WebSocketResponse&& response) mutable
         -> jsg::Promise<jsg::Ref<Response>> {
       KJ_SWITCH_ONEOF(response.webSocketOrBody) {
@@ -1542,17 +1542,24 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
         KJ_CASE_ONEOF(webSocket, kj::Own<kj::WebSocket>) {
           KJ_ASSERT(response.statusCode == 101);
           webSocket = webSocket.attach(kj::mv(client));
-          KJ_IF_SOME(s, signal) {
+          KJ_IF_SOME(signal, maybeSignal) {
             // If the AbortSignal has already been triggered, then we need to stop here.
-            if (s->getAborted(js)) {
-              return js.rejectedPromise<jsg::Ref<Response>>(s->getReason(js));
+            if (signal->getAborted(js)) {
+              return js.rejectedPromise<jsg::Ref<Response>>(signal->getReason(js));
             }
-            webSocket = kj::refcounted<AbortableWebSocket>(kj::mv(webSocket), s->getCanceler());
+
+            auto cancelerAndHandler = AbortSignal::newMaybeCrossContextCancelHandler(
+                js, signal.addRef());
+
+            webSocket = kj::refcounted<AbortableWebSocket>(
+                kj::mv(webSocket),
+                kj::mv(cancelerAndHandler.canceler),
+                kj::mv(cancelerAndHandler.handler));
           }
           return js.resolvedPromise(makeHttpResponse(js, jsRequest->getMethodEnum(),
               kj::mv(urlList), response.statusCode, response.statusText, *response.headers,
               newNullInputStream(), js.alloc<WebSocket>(js, kj::mv(webSocket)),
-              jsRequest->getResponseBodyEncoding(), kj::mv(signal)));
+              jsRequest->getResponseBodyEncoding(), kj::mv(maybeSignal)));
         }
       }
       KJ_UNREACHABLE;
@@ -1603,7 +1610,8 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
           co_await promise;
         } catch (...) {
           auto exception = kj::getCaughtExceptionAsKj();
-          if (exception.getType() != kj::Exception::Type::DISCONNECTED) {
+          if (exception.getType() != kj::Exception::Type::DISCONNECTED &&
+              !exception.getDescription().startsWith("jsg.DOMException(AbortError): ")) {
             kj::throwFatalException(kj::mv(exception));
           }
           // Ignore DISCONNECTED exceptions thrown by the writePromise, so that we always
@@ -1669,14 +1677,21 @@ jsg::Promise<jsg::Ref<Response>> handleHttpResponse(jsg::Lock& js,
     jsg::Ref<Request> jsRequest,
     kj::Vector<kj::Url> urlList,
     kj::HttpClient::Response&& response) {
-  auto signal = jsRequest->getSignal();
+  auto maybeSignal = jsRequest->getSignal();
 
-  KJ_IF_SOME(s, signal) {
+  KJ_IF_SOME(signal, maybeSignal) {
     // If the AbortSignal has already been triggered, then we need to stop here.
-    if (s->getAborted(js)) {
-      return js.rejectedPromise<jsg::Ref<Response>>(s->getReason(js));
+    if (signal->getAborted(js)) {
+      return js.rejectedPromise<jsg::Ref<Response>>(signal->getReason(js));
     }
-    response.body = kj::refcounted<AbortableInputStream>(kj::mv(response.body), s->getCanceler());
+
+    auto cancelerAndHandler = AbortSignal::newMaybeCrossContextCancelHandler(
+        js, signal.addRef());
+
+    response.body = kj::refcounted<AbortableInputStream>(
+        kj::mv(response.body),
+        kj::mv(cancelerAndHandler.canceler),
+        kj::mv(cancelerAndHandler.handler));
   }
 
   if (isRedirectStatusCode(response.statusCode) &&
@@ -1700,7 +1715,7 @@ jsg::Promise<jsg::Ref<Response>> handleHttpResponse(jsg::Lock& js,
 
   auto result = makeHttpResponse(js, jsRequest->getMethodEnum(), kj::mv(urlList),
       response.statusCode, response.statusText, *response.headers, kj::mv(response.body), kj::none,
-      jsRequest->getResponseBodyEncoding(), kj::mv(signal));
+      jsRequest->getResponseBodyEncoding(), kj::mv(maybeSignal));
 
   return js.resolvedPromise(kj::mv(result));
 }

--- a/src/workerd/api/tests/abortsignal-test.js
+++ b/src/workerd/api/tests/abortsignal-test.js
@@ -525,7 +525,7 @@ export const rpcCrossRequestSignal = {
       {
         name: 'Error',
         message:
-          "Cannot perform I/O on behalf of a different request. I/O objects (such as streams, request/response bodies, and others) created in the context of one request handler cannot be accessed from a different request's handler. This is a limitation of Cloudflare Workers which allows us to improve overall performance. (I/O type: RefcountedCanceler)",
+          "Cannot perform I/O on behalf of a different request. I/O objects (such as streams, request/response bodies, and others) created in the context of one request handler cannot be accessed from a different request's handler. This is a limitation of Cloudflare Workers which allows us to improve overall performance. (I/O type: AbortTriggerRpcClient)",
       }
     );
   },
@@ -590,5 +590,37 @@ export const rpcDestroySignalClean = {
     // A release message was sent, the signal will remain in an unaborted state
     ok(!signal.aborted);
     strictEqual(signal.reason, undefined);
+  },
+};
+
+const ac = new AbortController();
+let isFirstRequest = false;
+
+export const topLevelAbortController = {
+  async test(ctrl, env) {
+    const results = await Promise.allSettled([
+      env.subrequest.fetch('http://example.com'),
+      env.subrequest.fetch('http://example.com'),
+    ]);
+    ok(results[0].status === 'fulfilled');
+    ok(results[1].status === 'fulfilled');
+    strictEqual(await results[0].value.text(), 'Hello World\n');
+    strictEqual(await results[1].value.text(), 'Hello World\n');
+  },
+};
+
+export default {
+  async fetch(req, env) {
+    if (!isFirstRequest) {
+      isFirstRequest = true;
+      await rejects(scheduler.wait(5_000, { signal: ac.signal }), {
+        message: 'boomdiggity',
+      });
+    } else {
+      ac.abort(new Error('boomdiggity'));
+      isFirstRequest = false;
+    }
+
+    return new Response('Hello World\n');
   },
 };

--- a/src/workerd/api/tests/abortsignal-test.wd-test
+++ b/src/workerd/api/tests/abortsignal-test.wd-test
@@ -10,6 +10,7 @@ const unitTests :Workerd.Config = (
         compatibilityFlags = ["nodejs_compat", "enable_abortsignal_rpc", "experimental"],
         bindings = [
           (name = "RpcRemoteEnd", service = (name = "abortsignal-test", entrypoint = "RpcRemoteEnd")),
+          (name = "subrequest", service = "abortsignal-test"),
         ]
       )
     ),

--- a/src/workerd/api/tests/cross-context-promise-test.js
+++ b/src/workerd/api/tests/cross-context-promise-test.js
@@ -174,19 +174,14 @@ async function resolveTest(req, env, ctx) {
     setupWaiter(ctx);
     const { promise, resolve } = Promise.withResolvers();
     globalThis.request1 = { promise, resolve };
-    const ab = AbortSignal.abort();
-    strictEqual(ab.aborted, true);
+    const immediate = setImmediate(() => {});
     await als.run(123, async () => {
       await promise;
       strictEqual(als.getStore(), 123);
     });
     // This part is the main test. It will not run until after the promise
     // is resolved in the second request.
-    // We use an AbortSignal because it is bound to the IoContext and will
-    // throw an error if ab.aborted is checked from the wrong IoContext.
-    // If this line runes, it is proof that the promise continuation is
-    // running in the correct IoContext.
-    strictEqual(ab.aborted, true);
+    clearImmediate(immediate);
     return new Response('ok');
   }
 
@@ -219,8 +214,7 @@ async function rejectTest(req, env, ctx) {
     setupWaiter(ctx);
     const { promise, reject } = Promise.withResolvers();
     globalThis.request2 = { reject };
-    const ab = AbortSignal.abort();
-    strictEqual(ab.aborted, true);
+    const immediate = setImmediate(() => {});
     try {
       // The promise will be rejected from the other request.
       await promise;
@@ -231,7 +225,7 @@ async function rejectTest(req, env, ctx) {
       // is running in the wrong IoContext, which is the main thing we are
       // testing for here.
       strictEqual(err, reason);
-      strictEqual(ab.aborted, true);
+      clearImmediate(immediate);
     }
     return new Response('ok');
   }
@@ -257,10 +251,9 @@ async function crossRequestStream(req, env, ctx) {
     });
     globalThis.stream = { controller };
     const reader = readable.getReader();
-    const ab = AbortSignal.abort();
-    strictEqual(ab.aborted, true);
-    const read = await reader.read();
-    strictEqual(ab.aborted, true);
+    const immediate = setImmediate(() => {});
+    await reader.read();
+    clearImmediate(immediate);
     return new Response('ok');
   }
 
@@ -280,8 +273,7 @@ async function customThenable(req, env, ctx) {
     setupWaiter(ctx);
     const { promise, resolve } = Promise.withResolvers();
     globalThis.thenable = { resolve };
-    const ab = AbortSignal.abort();
-    strictEqual(ab.aborted, true);
+    const immediate = setImmediate(() => {});
 
     // We check to make sure the value provided by the custom thenable is
     // property passed through to the promise resolution.
@@ -289,22 +281,17 @@ async function customThenable(req, env, ctx) {
     strictEqual(await promise, 1);
     // This part is the main test. It will not run until after the promise
     // is resolved in the second request.
-    // We use an AbortSignal because it is bound to the IoContext and will
-    // throw an error if ab.aborted is checked from the wrong IoContext.
-    // If this line runes, it is proof that the promise continuation is
-    // running in the correct IoContext.
-    strictEqual(ab.aborted, true);
+    clearImmediate(immediate);
     return new Response('ok');
   }
 
   // This is our second request. Here, all we do is resolve the promise.
-  const ab = AbortSignal.abort();
-  strictEqual(ab.aborted, true);
+  const immediate = setImmediate(() => {});
 
   const then = mock.fn((resolve) => {
     // The thenable should be invoked in the second request's IoContext.
     // If it is not, then the ab.aborted check below will fail.
-    strictEqual(ab.aborted, true);
+    clearImmediate(immediate);
     resolve(1);
   });
 
@@ -326,8 +313,7 @@ async function unhandledRejection(req, env, ctx) {
     setupWaiter(ctx);
     const { promise, reject } = Promise.withResolvers();
     globalThis.unhandled = { reject };
-    const ab = AbortSignal.abort();
-    strictEqual(ab.aborted, true);
+    const immediate = setImmediate(() => {});
 
     const rejectPromise = Promise.withResolvers();
     globalThis.addEventListener(
@@ -337,8 +323,8 @@ async function unhandledRejection(req, env, ctx) {
         // synchronously when the promise is rejected. It does not get deferred.
         // so the IoContext here will be the second request's IoContext! This
         // means that our ab.aborted check will fail!
-        throws(() => ab.aborted, {
-          message: /I\/O type: RefcountedCanceler/,
+        throws(() => clearImmediate(immediate), {
+          message: /I\/O type: IoContext/,
         });
         strictEqual(event.reason, reason);
         rejectPromise.resolve();
@@ -384,20 +370,21 @@ async function expiredContext(req, env, ctx) {
   return new Response('ok');
 }
 
-async function* gen(ab) {
+async function* gen(immediate) {
   let c = 0;
   for (;;) {
     await scheduler.wait(10);
-    strictEqual(ab.aborted, true);
+    clearImmediate(immediate);
     yield c++;
   }
 }
 
 async function asyncIterator(req, env, ctx) {
   if (globalThis.asynciter === undefined) {
-    const ab = AbortSignal.abort();
-    globalThis.asynciter = gen(ab);
-    globalThis.asyncIter2 = gen(ab);
+    const immediate1 = setImmediate(() => {});
+    const immediate2 = setImmediate(() => {});
+    globalThis.asynciter = gen(immediate1);
+    globalThis.asyncIter2 = gen(immediate2);
     return new Response('ok');
   }
 
@@ -432,8 +419,7 @@ async function cyclicPromise(req, env, ctx) {
     setupWaiter(ctx);
     const { promise, resolve } = Promise.withResolvers();
     globalThis.cyclic = { promise, resolve };
-    const ab = AbortSignal.abort();
-    strictEqual(ab.aborted, true);
+    const immediate = setImmediate(() => {});
     await promise;
     throw new Error('should never get here');
   }

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1492,9 +1492,13 @@ void IoContext::throwNotCurrentJsError(kj::Maybe<const std::type_info&> maybeTyp
   }
 }
 
+kj::Own<IoCrossContextExecutor> IoContext::getCrossContextExecutor() {
+  return kj::heap<IoCrossContextExecutor>(deleteQueue.queue.addRef());
+}
+
 jsg::JsObject IoContext::getPromiseContextTag(jsg::Lock& js) {
   if (promiseContextTag == kj::none) {
-    auto deferral = kj::heap<IoCrossContextExecutor>(deleteQueue.queue.addRef());
+    auto deferral = getCrossContextExecutor();
     promiseContextTag = jsg::JsRef(js, js.opaque(kj::mv(deferral)));
   }
   return KJ_REQUIRE_NONNULL(promiseContextTag).getHandle(js);

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -902,6 +902,7 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
 
   void writeLogfwdr(uint channel, kj::FunctionParam<void(capnp::AnyPointer::Builder)> buildMessage);
 
+  kj::Own<IoCrossContextExecutor> getCrossContextExecutor();
   jsg::JsObject getPromiseContextTag(jsg::Lock& js);
 
   // The IoChannelFactory must be accessed through the

--- a/src/workerd/util/abortable.h
+++ b/src/workerd/util/abortable.h
@@ -12,10 +12,11 @@ namespace workerd {
 template <typename T>
 class AbortableImpl final {
  public:
-  AbortableImpl(kj::Own<T> inner, RefcountedCanceler& canceler)
-      : canceler(kj::addRef(canceler)),
+  AbortableImpl(kj::Own<T> inner, kj::Rc<RefcountedCanceler> canceler, kj::Own<void> opaqueHandle)
+      : canceler(canceler.addRef()),
+        opaqueHandle(kj::mv(opaqueHandle)),
         inner(kj::mv(inner)),
-        onCancel(*(this->canceler), [this]() { this->inner = kj::none; }) {}
+        onCancel(canceler.addRef(), [this]() { this->inner = kj::none; }) {}
 
   template <typename V, typename... Args, typename... ArgsT>
   kj::Promise<V> wrap(kj::Promise<V> (T::*fn)(ArgsT...), Args&&... args) {
@@ -42,7 +43,8 @@ class AbortableImpl final {
   }
 
  private:
-  kj::Own<RefcountedCanceler> canceler;
+  kj::Rc<RefcountedCanceler> canceler;
+  kj::Own<void> opaqueHandle;
   kj::Maybe<kj::Own<T>> inner;
   RefcountedCanceler::Listener onCancel;
 };
@@ -57,8 +59,10 @@ class AbortableImpl final {
 // could be combined into a single utility.
 class AbortableInputStream final: public kj::AsyncInputStream, public kj::Refcounted {
  public:
-  AbortableInputStream(kj::Own<kj::AsyncInputStream> inner, RefcountedCanceler& canceler)
-      : impl(kj::mv(inner), canceler) {}
+  AbortableInputStream(kj::Own<kj::AsyncInputStream> inner,
+      kj::Rc<RefcountedCanceler> canceler,
+      kj::Own<void> opaqueHandle)
+      : impl(kj::mv(inner), kj::mv(canceler), kj::mv(opaqueHandle)) {}
 
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
     kj::Promise<size_t> (kj::AsyncInputStream::*tryRead)(void*, size_t, size_t) =
@@ -84,8 +88,9 @@ class AbortableInputStream final: public kj::AsyncInputStream, public kj::Refcou
 // RefcountedCanceler, which will be triggered when the AbortSignal is triggered.
 class AbortableWebSocket final: public kj::WebSocket, public kj::Refcounted {
  public:
-  AbortableWebSocket(kj::Own<kj::WebSocket> inner, RefcountedCanceler& canceler)
-      : impl(kj::mv(inner), canceler) {}
+  AbortableWebSocket(
+      kj::Own<kj::WebSocket> inner, kj::Rc<RefcountedCanceler> canceler, kj::Own<void> opaqueHandle)
+      : impl(kj::mv(inner), kj::mv(canceler), kj::mv(opaqueHandle)) {}
 
   kj::Promise<void> send(kj::ArrayPtr<const kj::byte> message) override {
     return impl.wrap(

--- a/src/workerd/util/canceler.h
+++ b/src/workerd/util/canceler.h
@@ -23,19 +23,19 @@ class RefcountedCanceler: public kj::Refcounted {
  public:
   class Listener {
    public:
-    explicit Listener(RefcountedCanceler& canceler, kj::Function<void()> fn)
+    explicit Listener(kj::Rc<RefcountedCanceler> canceler, kj::Function<void()> fn)
         : fn(kj::mv(fn)),
-          canceler(canceler) {
-      canceler.addListener(*this);
+          canceler(kj::mv(canceler)) {
+      this->canceler->addListener(*this);
     }
 
     ~Listener() {
-      canceler.removeListener(*this);
+      canceler->removeListener(*this);
     }
 
    private:
     kj::Function<void()> fn;
-    RefcountedCanceler& canceler;
+    kj::Rc<RefcountedCanceler> canceler;
     kj::ListLink<Listener> link;
 
     friend class RefcountedCanceler;


### PR DESCRIPTION
Allow a AbortController/AbortSignal to be created outside of a request context, and allow cross-context aborts to work.

In some ways this is a bit of a hack. When a native abort handler is added from one IoContext, and the abort is triggered from another IoContext, the, we have to arrange for the handler to trigger the actual kj::Canceler from the right IoContext. We do this using the same approach we use for cross-context promises: we abuse...er, use.. the DeleteQueue to schedule the canceler to trigger the next time the correct IoContext is entered.

This needs to be reviewed very carefully!

I'm not likely to land this as is, I'll probably restore the original impl and add an autogate to switch between two different AbortSignal impls but I want to get an initial review on the approach before making those changes.