### PR TITLE
SECENG-13376: Add getMulti() type to SecretsStoreSecret interface

### DIFF
--- a/types/defines/secrets-store.d.ts
+++ b/types/defines/secrets-store.d.ts
@@ -4,4 +4,12 @@ interface SecretsStoreSecret {
    * if it exists, or throws an error if it does not exist
    */
   get(): Promise<string>;
+
+  /**
+   * Get multiple secrets from the same Secrets Store in a single request.
+   * Returns a record mapping secret names to their values.
+   * Only secrets that are found are included in the result.
+   * Throws an error if the request fails.
+   */
+  getMulti(secretNames: string[]): Promise<Record<string, string>>;
 }


### PR DESCRIPTION
## Summary
Adds a `getMulti()` method to the `SecretsStoreSecret` type definition, allowing workers to fetch multiple secrets from the same store in a single request.
## Motivation
Workers that need multiple secrets currently call `get()` sequentially for each one. Each call traverses the full JSRPC → service binding → edge service → QuickSilver path, with P99 latency of 200–500ms per call. For workers fetching 2–3 secrets, this compounds to 1–3s+ at the tail.
The secrets store edge service already supports a batch endpoint (`store_secrets_multi`), and the proxy worker now exposes it as `getMulti()` via [SECENG-13376](https://gitlab.cfdata.org/cloudflare/https/secrets-store-worker/-/merge_requests/12). This PR adds the corresponding TypeScript type so users get autocomplete and type checking without `@ts-expect-error`.
## Usage
```typescript
// Before: sequential, 2-3 round trips
const apiKey = await env.MY_SECRET.get();
const dbPass = await env.DB_SECRET.get();
// After: single round trip from any binding in the same store
const secrets = await env.MY_SECRET.getMulti(["API_KEY", "DB_PASSWORD", "AUTH_TOKEN"]);
// secrets = { API_KEY: "...", DB_PASSWORD: "...", AUTH_TOKEN: "..." }
Only found secrets are included in the returned record.
Changes
- types/defines/secrets-store.d.ts: Added getMulti(secretNames: string[]): Promise<Record<string, string>>