### PR TITLE
IMAGES-2139: switch images binding to a chainable handle

### DIFF
--- a/src/cloudflare/internal/images-api.ts
+++ b/src/cloudflare/internal/images-api.ts
@@ -245,14 +245,11 @@ function isDrawTransformer(input: unknown): input is DrawTransformer {
 }
 
 interface ServiceEntrypointStub {
-  details(imageId: string): Promise<ImageMetadata | null>;
-  image(imageId: string): Promise<ReadableStream<Uint8Array> | null>;
+  image(imageId: string): ImageHandle;
   upload(
     image: ReadableStream<Uint8Array> | ArrayBuffer,
     options?: ImageUploadOptions
   ): Promise<ImageMetadata>;
-  update(imageId: string, options: ImageUpdateOptions): Promise<ImageMetadata>;
-  delete(imageId: string): Promise<boolean>;
   list(options?: ImageListOptions): Promise<ImageList>;
 }
 
@@ -263,11 +260,7 @@ class HostedImagesBindingImpl implements HostedImagesBinding {
     this.#fetcher = fetcher;
   }
 
-  async details(imageId: string): Promise<ImageMetadata | null> {
-    return this.#fetcher.details(imageId);
-  }
-
-  async image(imageId: string): Promise<ReadableStream<Uint8Array> | null> {
+  image(imageId: string): ImageHandle {
     return this.#fetcher.image(imageId);
   }
 
@@ -276,17 +269,6 @@ class HostedImagesBindingImpl implements HostedImagesBinding {
     options?: ImageUploadOptions
   ): Promise<ImageMetadata> {
     return this.#fetcher.upload(image, options);
-  }
-
-  async update(
-    imageId: string,
-    options: ImageUpdateOptions
-  ): Promise<ImageMetadata> {
-    return this.#fetcher.update(imageId, options);
-  }
-
-  async delete(imageId: string): Promise<boolean> {
-    return this.#fetcher.delete(imageId);
   }
 
   async list(options?: ImageListOptions): Promise<ImageList> {

--- a/src/cloudflare/internal/images.d.ts
+++ b/src/cloudflare/internal/images.d.ts
@@ -138,20 +138,41 @@ interface ImageList {
   listComplete: boolean;
 }
 
-interface HostedImagesBinding {
+interface ImageHandle {
   /**
    * Get metadata for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
    * @returns Image metadata, or null if not found
    */
-  details(imageId: string): Promise<ImageMetadata | null>;
+  details(): Promise<ImageMetadata | null>;
 
   /**
    * Get the raw image data for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
    * @returns ReadableStream of image bytes, or null if not found
    */
-  image(imageId: string): Promise<ReadableStream<Uint8Array> | null>;
+  bytes(): Promise<ReadableStream<Uint8Array> | null>;
+
+  /**
+   * Update hosted image metadata
+   * @param options Properties to update
+   * @returns Updated image metadata
+   * @throws {@link ImagesError} if update fails
+   */
+  update(options: ImageUpdateOptions): Promise<ImageMetadata>;
+
+  /**
+   * Delete a hosted image
+   * @returns True if deleted, false if not found
+   */
+  delete(): Promise<boolean>;
+}
+
+interface HostedImagesBinding {
+  /**
+   * Get a handle for a hosted image
+   * @param imageId The ID of the image (UUID or custom ID)
+   * @returns A handle for per-image operations
+   */
+  image(imageId: string): ImageHandle;
 
   /**
    * Upload a new hosted image
@@ -164,22 +185,6 @@ interface HostedImagesBinding {
     image: ReadableStream<Uint8Array> | ArrayBuffer,
     options?: ImageUploadOptions
   ): Promise<ImageMetadata>;
-
-  /**
-   * Update hosted image metadata
-   * @param imageId The ID of the image
-   * @param options Properties to update
-   * @returns Updated image metadata
-   * @throws {@link ImagesError} if update fails
-   */
-  update(imageId: string, options: ImageUpdateOptions): Promise<ImageMetadata>;
-
-  /**
-   * Delete a hosted image
-   * @param imageId The ID of the image
-   * @returns True if deleted, false if not found
-   */
-  delete(imageId: string): Promise<boolean>;
 
   /**
    * List hosted images with pagination

--- a/src/cloudflare/internal/test/images/images-api-test.js
+++ b/src/cloudflare/internal/test/images/images-api-test.js
@@ -458,7 +458,7 @@ export const test_images_get_success = {
    * @param {Env} env
    */
   async test(_, env) {
-    const metadata = await env.images.hosted.details('test-image-id');
+    const metadata = await env.images.hosted.image('test-image-id').details();
     assert.notEqual(metadata, null);
     assert.equal(metadata.id, 'test-image-id');
     assert.equal(metadata.filename, 'test.jpg');
@@ -473,7 +473,7 @@ export const test_images_get_not_found = {
    * @param {Env} env
    */
   async test(_, env) {
-    const metadata = await env.images.hosted.details('not-found');
+    const metadata = await env.images.hosted.image('not-found').details();
     assert.equal(metadata, null);
   },
 };
@@ -485,7 +485,7 @@ export const test_images_getImage_success = {
    * @param {Env} env
    */
   async test(_, env) {
-    const stream = await env.images.hosted.image('test-image-id');
+    const stream = await env.images.hosted.image('test-image-id').bytes();
     assert.notEqual(stream, null);
 
     const reader = stream.getReader();
@@ -506,7 +506,7 @@ export const test_images_getImage_not_found = {
    * @param {Env} env
    */
   async test(_, env) {
-    const stream = await env.images.hosted.image('not-found');
+    const stream = await env.images.hosted.image('not-found').bytes();
     assert.equal(stream, null);
   },
 };
@@ -556,7 +556,7 @@ export const test_images_update_success = {
    * @param {Env} env
    */
   async test(_, env) {
-    const metadata = await env.images.hosted.update('test-image-id', {
+    const metadata = await env.images.hosted.image('test-image-id').update({
       requireSignedURLs: true,
       metadata: { updated: true },
       creator: 'update-creator',
@@ -580,7 +580,9 @@ export const test_images_update_not_found = {
      */
     let e;
     try {
-      await env.images.hosted.update('not-found', { requireSignedURLs: true });
+      await env.images.hosted
+        .image('not-found')
+        .update({ requireSignedURLs: true });
     } catch (err) {
       e = err;
     }
@@ -596,7 +598,7 @@ export const test_images_delete_success = {
    * @param {Env} env
    */
   async test(_, env) {
-    const result = await env.images.hosted.delete('test-image-id');
+    const result = await env.images.hosted.image('test-image-id').delete();
     assert.equal(result, true);
   },
 };
@@ -607,7 +609,7 @@ export const test_images_delete_not_found = {
    * @param {Env} env
    */
   async test(_, env) {
-    const result = await env.images.hosted.delete('not-found');
+    const result = await env.images.hosted.image('not-found').delete();
     assert.equal(result, false);
   },
 };

--- a/src/cloudflare/internal/test/images/images-upstream-mock.js
+++ b/src/cloudflare/internal/test/images/images-upstream-mock.js
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { WorkerEntrypoint } from 'cloudflare:workers';
+import { WorkerEntrypoint, RpcTarget } from 'cloudflare:workers';
 
 /**
  * @param {FormDataEntryValue | null} blob
@@ -20,18 +20,23 @@ async function imageAsString(blob) {
   return blob.text();
 }
 
-export class ServiceEntrypoint extends WorkerEntrypoint {
-  /**
-   * @param {string} imageId
-   * @returns {Promise<ImageMetadata | null>}
-   */
-  async details(imageId) {
-    if (imageId === 'not-found') {
+class ImageHandleMock extends RpcTarget {
+  /** @type {string} */
+  #imageId;
+
+  /** @param {string} imageId */
+  constructor(imageId) {
+    super();
+    this.#imageId = imageId;
+  }
+
+  async details() {
+    if (this.#imageId === 'not-found') {
       return null;
     }
 
     return {
-      id: imageId,
+      id: this.#imageId,
       filename: 'test.jpg',
       uploaded: '2024-01-01T00:00:00Z',
       requireSignedURLs: false,
@@ -42,13 +47,52 @@ export class ServiceEntrypoint extends WorkerEntrypoint {
     };
   }
 
-  async image(imageId) {
-    if (imageId === 'not-found') {
+  async bytes() {
+    if (this.#imageId === 'not-found') {
       return null;
     }
 
-    const mockData = `MOCK_IMAGE_DATA_${imageId}`;
+    const mockData = `MOCK_IMAGE_DATA_${this.#imageId}`;
     return new Blob([mockData]).stream();
+  }
+
+  /**
+   * @param {ImageUpdateOptions} body
+   * @returns {Promise<ImageMetadata>}
+   */
+  async update(body) {
+    if (this.#imageId === 'not-found') {
+      throw new Error('Image not found');
+    }
+
+    return {
+      id: this.#imageId,
+      filename: 'updated.jpg',
+      uploaded: '2024-01-01T00:00:00Z',
+      requireSignedURLs:
+        body.requireSignedURLs !== undefined ? body.requireSignedURLs : false,
+      variants: ['public'],
+      meta: body.metadata || {},
+      draft: false,
+      creator: body.creator,
+    };
+  }
+
+  /**
+   * @returns {Promise<boolean>}
+   */
+  async delete() {
+    return this.#imageId !== 'not-found';
+  }
+}
+
+export class ServiceEntrypoint extends WorkerEntrypoint {
+  /**
+   * @param {string} imageId
+   * @returns {ImageHandleMock}
+   */
+  image(imageId) {
+    return new ImageHandleMock(imageId);
   }
 
   async upload(image, options) {
@@ -75,37 +119,6 @@ export class ServiceEntrypoint extends WorkerEntrypoint {
       draft: false,
       creator: options?.creator,
     };
-  }
-
-  /**
-   * @param {string} imageId
-   * @param {ImageUpdateOptions} body
-   * @returns {Promise<ImageMetadata>}
-   */
-  async update(imageId, body) {
-    if (imageId === 'not-found') {
-      throw new Error('Image not found');
-    }
-
-    return {
-      id: imageId,
-      filename: 'updated.jpg',
-      uploaded: '2024-01-01T00:00:00Z',
-      requireSignedURLs:
-        body.requireSignedURLs !== undefined ? body.requireSignedURLs : false,
-      variants: ['public'],
-      meta: body.metadata || {},
-      draft: false,
-      creator: body.creator,
-    };
-  }
-
-  /**
-   * @param {string} imageId
-   * @returns {Promise<boolean>}
-   */
-  async delete(imageId) {
-    return imageId !== 'not-found';
   }
 
   /**

--- a/types/defines/images.d.ts
+++ b/types/defines/images.d.ts
@@ -135,20 +135,41 @@ interface ImageList {
   listComplete: boolean;
 }
 
-interface HostedImagesBinding {
+interface ImageHandle {
   /**
-   * Get detailed metadata for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
+   * Get metadata for a hosted image
    * @returns Image metadata, or null if not found
    */
-  details(imageId: string): Promise<ImageMetadata | null>;
+  details(): Promise<ImageMetadata | null>;
 
   /**
    * Get the raw image data for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
    * @returns ReadableStream of image bytes, or null if not found
    */
-  image(imageId: string): Promise<ReadableStream<Uint8Array> | null>;
+  bytes(): Promise<ReadableStream<Uint8Array> | null>;
+
+  /**
+   * Update hosted image metadata
+   * @param options Properties to update
+   * @returns Updated image metadata
+   * @throws {@link ImagesError} if update fails
+   */
+  update(options: ImageUpdateOptions): Promise<ImageMetadata>;
+
+  /**
+   * Delete a hosted image
+   * @returns True if deleted, false if not found
+   */
+  delete(): Promise<boolean>;
+}
+
+interface HostedImagesBinding {
+  /**
+   * Get a handle for a hosted image
+   * @param imageId The ID of the image (UUID or custom ID)
+   * @returns A handle for per-image operations
+   */
+  image(imageId: string): ImageHandle;
 
   /**
    * Upload a new hosted image
@@ -161,22 +182,6 @@ interface HostedImagesBinding {
     image: ReadableStream<Uint8Array> | ArrayBuffer,
     options?: ImageUploadOptions
   ): Promise<ImageMetadata>;
-
-  /**
-   * Update hosted image metadata
-   * @param imageId The ID of the image
-   * @param options Properties to update
-   * @returns Updated image metadata
-   * @throws {@link ImagesError} if update fails
-   */
-  update(imageId: string, options: ImageUpdateOptions): Promise<ImageMetadata>;
-
-  /**
-   * Delete a hosted image
-   * @param imageId The ID of the image
-   * @returns True if deleted, false if not found
-   */
-  delete(imageId: string): Promise<boolean>;
 
   /**
    * List hosted images with pagination

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -12905,19 +12905,37 @@ interface ImageList {
   cursor?: string;
   listComplete: boolean;
 }
-interface HostedImagesBinding {
+interface ImageHandle {
   /**
-   * Get detailed metadata for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
+   * Get metadata for a hosted image
    * @returns Image metadata, or null if not found
    */
-  details(imageId: string): Promise<ImageMetadata | null>;
+  details(): Promise<ImageMetadata | null>;
   /**
    * Get the raw image data for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
    * @returns ReadableStream of image bytes, or null if not found
    */
-  image(imageId: string): Promise<ReadableStream<Uint8Array> | null>;
+  bytes(): Promise<ReadableStream<Uint8Array> | null>;
+  /**
+   * Update hosted image metadata
+   * @param options Properties to update
+   * @returns Updated image metadata
+   * @throws {@link ImagesError} if update fails
+   */
+  update(options: ImageUpdateOptions): Promise<ImageMetadata>;
+  /**
+   * Delete a hosted image
+   * @returns True if deleted, false if not found
+   */
+  delete(): Promise<boolean>;
+}
+interface HostedImagesBinding {
+  /**
+   * Get a handle for a hosted image
+   * @param imageId The ID of the image (UUID or custom ID)
+   * @returns A handle for per-image operations
+   */
+  image(imageId: string): ImageHandle;
   /**
    * Upload a new hosted image
    * @param image The image file to upload
@@ -12929,20 +12947,6 @@ interface HostedImagesBinding {
     image: ReadableStream<Uint8Array> | ArrayBuffer,
     options?: ImageUploadOptions,
   ): Promise<ImageMetadata>;
-  /**
-   * Update hosted image metadata
-   * @param imageId The ID of the image
-   * @param options Properties to update
-   * @returns Updated image metadata
-   * @throws {@link ImagesError} if update fails
-   */
-  update(imageId: string, options: ImageUpdateOptions): Promise<ImageMetadata>;
-  /**
-   * Delete a hosted image
-   * @param imageId The ID of the image
-   * @returns True if deleted, false if not found
-   */
-  delete(imageId: string): Promise<boolean>;
   /**
    * List hosted images with pagination
    * @param options List configuration

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -12921,19 +12921,37 @@ export interface ImageList {
   cursor?: string;
   listComplete: boolean;
 }
-export interface HostedImagesBinding {
+export interface ImageHandle {
   /**
-   * Get detailed metadata for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
+   * Get metadata for a hosted image
    * @returns Image metadata, or null if not found
    */
-  details(imageId: string): Promise<ImageMetadata | null>;
+  details(): Promise<ImageMetadata | null>;
   /**
    * Get the raw image data for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
    * @returns ReadableStream of image bytes, or null if not found
    */
-  image(imageId: string): Promise<ReadableStream<Uint8Array> | null>;
+  bytes(): Promise<ReadableStream<Uint8Array> | null>;
+  /**
+   * Update hosted image metadata
+   * @param options Properties to update
+   * @returns Updated image metadata
+   * @throws {@link ImagesError} if update fails
+   */
+  update(options: ImageUpdateOptions): Promise<ImageMetadata>;
+  /**
+   * Delete a hosted image
+   * @returns True if deleted, false if not found
+   */
+  delete(): Promise<boolean>;
+}
+export interface HostedImagesBinding {
+  /**
+   * Get a handle for a hosted image
+   * @param imageId The ID of the image (UUID or custom ID)
+   * @returns A handle for per-image operations
+   */
+  image(imageId: string): ImageHandle;
   /**
    * Upload a new hosted image
    * @param image The image file to upload
@@ -12945,20 +12963,6 @@ export interface HostedImagesBinding {
     image: ReadableStream<Uint8Array> | ArrayBuffer,
     options?: ImageUploadOptions,
   ): Promise<ImageMetadata>;
-  /**
-   * Update hosted image metadata
-   * @param imageId The ID of the image
-   * @param options Properties to update
-   * @returns Updated image metadata
-   * @throws {@link ImagesError} if update fails
-   */
-  update(imageId: string, options: ImageUpdateOptions): Promise<ImageMetadata>;
-  /**
-   * Delete a hosted image
-   * @param imageId The ID of the image
-   * @returns True if deleted, false if not found
-   */
-  delete(imageId: string): Promise<boolean>;
   /**
    * List hosted images with pagination
    * @param options List configuration

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12192,19 +12192,37 @@ interface ImageList {
   cursor?: string;
   listComplete: boolean;
 }
-interface HostedImagesBinding {
+interface ImageHandle {
   /**
-   * Get detailed metadata for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
+   * Get metadata for a hosted image
    * @returns Image metadata, or null if not found
    */
-  details(imageId: string): Promise<ImageMetadata | null>;
+  details(): Promise<ImageMetadata | null>;
   /**
    * Get the raw image data for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
    * @returns ReadableStream of image bytes, or null if not found
    */
-  image(imageId: string): Promise<ReadableStream<Uint8Array> | null>;
+  bytes(): Promise<ReadableStream<Uint8Array> | null>;
+  /**
+   * Update hosted image metadata
+   * @param options Properties to update
+   * @returns Updated image metadata
+   * @throws {@link ImagesError} if update fails
+   */
+  update(options: ImageUpdateOptions): Promise<ImageMetadata>;
+  /**
+   * Delete a hosted image
+   * @returns True if deleted, false if not found
+   */
+  delete(): Promise<boolean>;
+}
+interface HostedImagesBinding {
+  /**
+   * Get a handle for a hosted image
+   * @param imageId The ID of the image (UUID or custom ID)
+   * @returns A handle for per-image operations
+   */
+  image(imageId: string): ImageHandle;
   /**
    * Upload a new hosted image
    * @param image The image file to upload
@@ -12216,20 +12234,6 @@ interface HostedImagesBinding {
     image: ReadableStream<Uint8Array> | ArrayBuffer,
     options?: ImageUploadOptions,
   ): Promise<ImageMetadata>;
-  /**
-   * Update hosted image metadata
-   * @param imageId The ID of the image
-   * @param options Properties to update
-   * @returns Updated image metadata
-   * @throws {@link ImagesError} if update fails
-   */
-  update(imageId: string, options: ImageUpdateOptions): Promise<ImageMetadata>;
-  /**
-   * Delete a hosted image
-   * @param imageId The ID of the image
-   * @returns True if deleted, false if not found
-   */
-  delete(imageId: string): Promise<boolean>;
   /**
    * List hosted images with pagination
    * @param options List configuration

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12208,19 +12208,37 @@ export interface ImageList {
   cursor?: string;
   listComplete: boolean;
 }
-export interface HostedImagesBinding {
+export interface ImageHandle {
   /**
-   * Get detailed metadata for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
+   * Get metadata for a hosted image
    * @returns Image metadata, or null if not found
    */
-  details(imageId: string): Promise<ImageMetadata | null>;
+  details(): Promise<ImageMetadata | null>;
   /**
    * Get the raw image data for a hosted image
-   * @param imageId The ID of the image (UUID or custom ID)
    * @returns ReadableStream of image bytes, or null if not found
    */
-  image(imageId: string): Promise<ReadableStream<Uint8Array> | null>;
+  bytes(): Promise<ReadableStream<Uint8Array> | null>;
+  /**
+   * Update hosted image metadata
+   * @param options Properties to update
+   * @returns Updated image metadata
+   * @throws {@link ImagesError} if update fails
+   */
+  update(options: ImageUpdateOptions): Promise<ImageMetadata>;
+  /**
+   * Delete a hosted image
+   * @returns True if deleted, false if not found
+   */
+  delete(): Promise<boolean>;
+}
+export interface HostedImagesBinding {
+  /**
+   * Get a handle for a hosted image
+   * @param imageId The ID of the image (UUID or custom ID)
+   * @returns A handle for per-image operations
+   */
+  image(imageId: string): ImageHandle;
   /**
    * Upload a new hosted image
    * @param image The image file to upload
@@ -12232,20 +12250,6 @@ export interface HostedImagesBinding {
     image: ReadableStream<Uint8Array> | ArrayBuffer,
     options?: ImageUploadOptions,
   ): Promise<ImageMetadata>;
-  /**
-   * Update hosted image metadata
-   * @param imageId The ID of the image
-   * @param options Properties to update
-   * @returns Updated image metadata
-   * @throws {@link ImagesError} if update fails
-   */
-  update(imageId: string, options: ImageUpdateOptions): Promise<ImageMetadata>;
-  /**
-   * Delete a hosted image
-   * @param imageId The ID of the image
-   * @returns True if deleted, false if not found
-   */
-  delete(imageId: string): Promise<boolean>;
   /**
    * List hosted images with pagination
    * @param options List configuration


### PR DESCRIPTION
This PR updates the Images Binding interface to adopt a chainable handle pattern for per-image operations, bringing it more in line with the upcoming Stream Binding. 

CRUD support was originally added in #5912 but has yet to be made generally available - at present it is gated to my developer account. This is technically a breaking change to the interface, but is safe as no external users will be impacted.

## Changes

Previously, per-image operations were flat methods on the hosted namespace:

```
await env.IMAGES.hosted.details(id);
await env.IMAGES.hosted.update(id, { requireSignedURLs: true });
await env.IMAGES.hosted.delete(id);
const stream = await env.IMAGES.hosted.image(id); // raw bytes
```

These operations now go via an intermediate handle, returned synchronously from hosted.image(id):

```
const handle = env.IMAGES.hosted.image(id);
await handle.details();
await handle.update({ requireSignedURLs: true });
await handle.delete();
const stream = await handle.bytes(); // renamed from image()
```

Note that `upload()` and `list()` are unchanged.

### Reviewer considerations
- The breaking change to image() — which previously returned a Promise<ReadableStream> and now returns a synchronous handle — is the most significant thing to be aware of. Given the gating situation this should be fine, but worth a look.
- The rename from `image()` to `bytes()` on the handle is deliberate, to avoid confusion now that `image()` is the handle factory.
- The corresponding upstream service change is [here](https://gitlab.cfdata.org/cloudflare/images/images-edge-api/-/merge_requests/159)

### Testing
Unit tests. Will verify E2E against gated developer account before releasing more widely