### PR TITLE
Do not shadow JS RPC methods in Python

### DIFF
--- a/src/pyodide/internal/workers-api/src/workers/_workers.py
+++ b/src/pyodide/internal/workers-api/src/workers/_workers.py
@@ -1018,6 +1018,8 @@ class _FetcherWrapper:
     def _getattr_helper(self, name):
         attr = getattr(self._binding, name)
 
+        # TODO: check if this is actually needed. Can the attribute be
+        # non-callable regarding the fetcher is an RPC object?
         if not callable(attr):
             return attr
 
@@ -1025,7 +1027,9 @@ class _FetcherWrapper:
         async def wrapper(*args, **kwargs):
             js_args = [python_to_rpc(arg) for arg in args]
             js_kwargs = {k: python_to_rpc(v) for k, v in kwargs.items()}
-            result = attr(*js_args, **js_kwargs)
+            result = _pyodide_entrypoint_helper.callRpcMethod(
+                self._binding, name, *js_args, **js_kwargs
+            )
             if hasattr(result, "then") and callable(result.then):
                 return python_from_rpc(await result)
             else:

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -84,7 +84,17 @@ export type PyodideEntrypointHelper = {
   workerEntrypoint: any;
   patchWaitUntil: typeof patchWaitUntil;
   patch_env_helper: (patch: unknown) => Generator<void>;
+  callRpcMethod: (binding: any, method: string, ...args: any[]) => any;
 };
+
+// Calls an RPC method on a JS binding entirely from the JS side, bypassing
+// Pyodide's JsProxy attribute resolution. Pyodide misidentifies bindings with
+// JSG_WILDCARD_PROPERTY (like Fetcher) as iterators because the wildcard makes
+// hasMethod("next") return true. This causes Python generator protocol methods
+// (send/next/throw/close) to shadow the JS RPC methods of the same name.
+function callRpcMethod(binding: any, method: string, ...args: any[]): any {
+  return binding[method](...args);
+}
 
 // Function to import JavaScript modules from Python
 let _pyodide_entrypoint_helper: PyodideEntrypointHelper | null = null;
@@ -109,6 +119,7 @@ export async function setDoAnImport(
     workerEntrypoint,
     patchWaitUntil,
     patch_env_helper,
+    callRpcMethod,
   };
 }
 

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -62,6 +62,8 @@ py_wd_test(
 
 py_wd_test("python-rpc")
 
+py_wd_test("fetcher-rpc-method-names")
+
 py_wd_test("workflow-entrypoint")
 
 py_wd_test("vendor_dir_compat_flag")

--- a/src/workerd/server/tests/python/fetcher-rpc-method-names/fetcher-rpc-method-names.wd-test
+++ b/src/workerd/server/tests/python/fetcher-rpc-method-names/fetcher-rpc-method-names.wd-test
@@ -1,0 +1,30 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "py", worker = .pyWorker),
+    (name = "js", worker = .jsWorker),
+  ],
+);
+
+const pyWorker :Workerd.Worker = (
+
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "rpc", "python_no_global_handlers"],
+
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py"),
+  ],
+
+  bindings = [
+    (name = "SERVICE", service = (name = "js", entrypoint = "JsService")),
+  ],
+);
+
+const jsWorker :Workerd.Worker = (
+
+  compatibilityFlags = ["nodejs_compat", "rpc"],
+
+  modules = [
+    (name = "worker", esModule = embed "worker.js"),
+  ],
+);

--- a/src/workerd/server/tests/python/fetcher-rpc-method-names/worker.js
+++ b/src/workerd/server/tests/python/fetcher-rpc-method-names/worker.js
@@ -1,0 +1,27 @@
+import { WorkerEntrypoint } from 'cloudflare:workers';
+
+// Exposes RPC methods whose names collide with Python's iterator/generator
+// protocol. Pyodide's JsProxy detects objects with a callable "next" property
+// as iterators and installs C-level descriptors for send/next/throw/close that
+// shadow JS property access via __getattr__.
+export class JsService extends WorkerEntrypoint {
+  async send(msg) {
+    return `sent:${msg}`;
+  }
+
+  async next(val) {
+    return `next:${val}`;
+  }
+
+  async throw(err) {
+    return `throw:${err}`;
+  }
+
+  async close() {
+    return 'closed';
+  }
+
+  async normalMethod(x) {
+    return `normal:${x}`;
+  }
+}

--- a/src/workerd/server/tests/python/fetcher-rpc-method-names/worker.py
+++ b/src/workerd/server/tests/python/fetcher-rpc-method-names/worker.py
@@ -1,0 +1,21 @@
+from workers import WorkerEntrypoint
+
+
+class Default(WorkerEntrypoint):
+    async def test(self, request, env):
+        # Verify RPC methods whose names collide with Python's iterator/generator
+        # protocol (send, next, throw, close) work through _FetcherWrapper.
+        result = await self.env.SERVICE.send("hello")
+        assert result == "sent:hello", f"send failed: {result!r}"
+
+        result = await self.env.SERVICE.next("val")
+        assert result == "next:val", f"next failed: {result!r}"
+
+        result = await self.env.SERVICE.throw("err")
+        assert result == "throw:err", f"throw failed: {result!r}"
+
+        result = await self.env.SERVICE.close()
+        assert result == "closed", f"close failed: {result!r}"
+
+        result = await self.env.SERVICE.normalMethod("test")
+        assert result == "normal:test", f"normalMethod failed: {result!r}"


### PR DESCRIPTION
Related thread: https://discord.com/channels/595317990191398933/1224715939581530112/1479918643268550667

When Pyodide handles JSProxy of RPC objects, it adds additional methods such as `send`, `throw` to make the object behave like a Python generator.

However, this shadows the actual JS methods such as the `send` method in SendEmail client. This PR fixes that behavior.