### PR TITLE
Add Socket::proxyTo() API

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -519,6 +519,23 @@ jsg::Promise<void> Socket::close(jsg::Lock& js) {
   });
 }
 
+void Socket::proxyTo(jsg::Lock& js, jsg::Ref<Socket> sock, jsg::Optional<PipeToOptions> options) {
+  jsg::Optional<PipeToOptions> optionsCopy = kj::none;
+  KJ_IF_SOME(o, options) {
+    optionsCopy = PipeToOptions{
+      .preventAbort = o.preventAbort,
+      .preventCancel = o.preventCancel,
+      .preventClose = o.preventClose,
+      .signal = kj::none,
+    };
+    KJ_IF_SOME(s, o.signal) {
+      KJ_ASSERT_NONNULL(optionsCopy).signal = s.addRef();
+    }
+  }
+  sock->readable.pipeTo(js, writable, kj::mv(options).orDefault({}));
+  readable.pipeTo(js, sock->writable, kj::mv(optionsCopy).orDefault({}));
+}
+
 jsg::Ref<Socket> Socket::startTls(jsg::Lock& js, jsg::Optional<TlsOptions> tlsOptions) {
   JSG_REQUIRE(
       secureTransport != SecureTransportKind::ON, TypeError, "Cannot startTls on a TLS socket.");

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -131,6 +131,10 @@ class Socket: public jsg::Object {
   // closing.
   jsg::Promise<void> close(jsg::Lock& js);
 
+  // Proxies to the other socket. Equivalent to:
+  // a.readable.pipeTo(b.writable); b.readable.pipeTo(a.writable);
+  void proxyTo(jsg::Lock& js, jsg::Ref<Socket> sock, jsg::Optional<PipeToOptions> options);
+
   // Flushes write buffers then performs a TLS handshake on the current Socket connection.
   // The current `Socket` instance is closed and its readable/writable instances are also closed.
   // All new operations should be performed on the new `Socket` instance.
@@ -176,6 +180,7 @@ class Socket: public jsg::Object {
     JSG_READONLY_PROTOTYPE_PROPERTY(secureTransport, getSecureTransport);
     JSG_METHOD(close);
     JSG_METHOD(startTls);
+    JSG_METHOD(proxyTo);
 
     JSG_TS_OVERRIDE({
       get secureTransport(): 'on' | 'off' | 'starttls';

--- a/src/workerd/api/tests/connect-handler-test-proxy.js
+++ b/src/workerd/api/tests/connect-handler-test-proxy.js
@@ -8,10 +8,10 @@ export class ConnectProxy extends WorkerEntrypoint {
   async connect(socket) {
     // proxy for ConnectEndpoint instance on port 8083.
     let upstream = connect('localhost:8083');
-    await Promise.all([
-      socket.readable.pipeTo(upstream.writable),
-      upstream.readable.pipeTo(socket.writable),
-    ]);
+    socket.proxyTo(upstream);
+    // proxyTo() can't be awaited – wait briefly so that we can be sure the data has been sent by
+    // the time we return so that the calling worker can read it right away.
+    await scheduler.wait(10);
   }
 }
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3910,6 +3910,7 @@ interface Socket {
   get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
+  proxyTo(sock: Socket, options?: StreamPipeOptions): void;
 }
 interface SocketOptions {
   secureTransport?: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3920,6 +3920,7 @@ export interface Socket {
   get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
+  proxyTo(sock: Socket, options?: StreamPipeOptions): void;
 }
 export interface SocketOptions {
   secureTransport?: string;

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -3822,6 +3822,7 @@ interface Socket {
   get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
+  proxyTo(sock: Socket, options?: StreamPipeOptions): void;
 }
 interface SocketOptions {
   secureTransport?: string;

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -3832,6 +3832,7 @@ export interface Socket {
   get secureTransport(): "on" | "off" | "starttls";
   close(): Promise<void>;
   startTls(options?: TlsOptions): Socket;
+  proxyTo(sock: Socket, options?: StreamPipeOptions): void;
 }
 export interface SocketOptions {
   secureTransport?: string;


### PR DESCRIPTION
This makes proxying sockets more convenient, should be especially useful for the connect handler.

Follow-up to https://github.com/cloudflare/workerd/pull/6059.