### PR TITLE
Fix asgi.py when workers is in old memory snapshot and not asgi

### DIFF
--- a/src/pyodide/internal/workers-api/src/asgi.py
+++ b/src/pyodide/internal/workers-api/src/asgi.py
@@ -6,7 +6,8 @@ from inspect import isawaitable
 from typing import Any
 
 import js
-from workers import Context, Request, wait_until
+from workers import Context, Request
+from workers import waitUntil as wait_until
 
 ASGI = {"spec_version": "2.0", "version": "3.0"}
 logger = logging.getLogger("asgi")


### PR DESCRIPTION
If a worker was deployed before we released #6173 and imported workers at top level and asgi in a function:
```py
import workers

class Default(WorkerEntrypoint)
   def fetch(...):
      import asgi
      ...
```
then workers went into the memory snapshot but not asgi. As a result, such workers would get the updated asgi but the old version of workers. The old version of workers does not define `wait_until` but the new version of asgi.py expects it.

To fix this sort of problem in the future, we need to finish the plan to move the workers sdk into the workers-py repo and switch to bundling it into the worker from there. The version in workerd can then never change again to keep existing workers happy.

This resolves https://github.com/cloudflare/workers-py/issues/70