### PR TITLE
containers: Add experimental support for interceptOutboundHttps

### DIFF
--- a/build/deps/oci.MODULE.bazel
+++ b/build/deps/oci.MODULE.bazel
@@ -14,7 +14,7 @@ oci.pull(
 )
 oci.pull(
     name = "proxy_everything",
-    digest = "sha256:f159d9e1b0f28bc01bd106f38d62479c018d050e3f95b365c5f9b5f83f60df82",
+    digest = "sha256:90f89ffbb09605d6d2152ecc8a1b3d45418023bbcbd0103188a06095d8d2dfa1",
     image = "docker.io/cloudflare/proxy-everything",
     platforms = [
         "linux/amd64",

--- a/images/container-client-test/app.js
+++ b/images/container-client-test/app.js
@@ -2,6 +2,7 @@ const { createServer } = require('http');
 
 const webSocketEnabled = process.env.WS_ENABLED === 'true';
 const wsProxyTarget = process.env.WS_PROXY_TARGET || null;
+const wsProxySecure = process.env.WS_PROXY_SECURE === 'true';
 
 const server = createServer(function (req, res) {
   if (req.url === '/ws') {
@@ -55,6 +56,24 @@ const server = createServer(function (req, res) {
     return;
   }
 
+  if (req.url === '/intercept-https') {
+    const targetHost = req.headers['x-host'] || 'example.com';
+    fetch(`https://${targetHost}`)
+      .then((result) => result.text())
+      .then((body) => {
+        res.writeHead(200);
+        res.write(body);
+        res.end();
+      })
+      .catch((err) => {
+        res.writeHead(500);
+        res.write(`${targetHost} ${err.message}`);
+        res.end();
+      });
+
+    return;
+  }
+
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('Hello World!');
   res.end();
@@ -66,7 +85,8 @@ if (webSocketEnabled) {
 
   wss.on('connection', function (clientWs) {
     if (wsProxyTarget) {
-      const targetWs = new WebSocket(`ws://${wsProxyTarget}/ws`);
+      const protocol = wsProxySecure ? 'wss' : 'ws';
+      const targetWs = new WebSocket(`${protocol}://${wsProxyTarget}/ws`);
       const ready = new Promise(function (resolve) {
         targetWs.on('open', resolve);
       });

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -106,6 +106,19 @@ jsg::Promise<void> Container::interceptAllOutboundHttp(jsg::Lock& js, jsg::Ref<F
       kj::joinPromisesFailFast(kj::arr(reqV4.sendIgnoringResult(), reqV6.sendIgnoringResult())));
 }
 
+jsg::Promise<void> Container::interceptOutboundHttps(
+    jsg::Lock& js, kj::String sniGlob, jsg::Ref<Fetcher> binding) {
+  auto& ioctx = IoContext::current();
+  auto channel = binding->getSubrequestChannel(ioctx);
+  auto token = channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+
+  auto req = rpcClient->setEgressHttpsRequest();
+  req.setSniGlob(sniGlob);
+  req.setChannelToken(token);
+
+  return ioctx.awaitIo(js, req.sendIgnoringResult());
+}
+
 jsg::Promise<void> Container::monitor(jsg::Lock& js) {
   JSG_REQUIRE(running, Error, "monitor() cannot be called on a container that is not running.");
 

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -65,6 +65,8 @@ class Container: public jsg::Object {
   jsg::Promise<void> interceptOutboundHttp(
       jsg::Lock& js, kj::String addr, jsg::Ref<Fetcher> binding);
   jsg::Promise<void> interceptAllOutboundHttp(jsg::Lock& js, jsg::Ref<Fetcher> binding);
+  jsg::Promise<void> interceptOutboundHttps(
+      jsg::Lock& js, kj::String sniGlob, jsg::Ref<Fetcher> binding);
 
   // TODO(containers): listenTcp()
 
@@ -79,6 +81,9 @@ class Container: public jsg::Object {
 
     JSG_METHOD(interceptOutboundHttp);
     JSG_METHOD(interceptAllOutboundHttp);
+    if (flags.getWorkerdExperimental()) {
+      JSG_METHOD(interceptOutboundHttps);
+    }
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -119,8 +119,19 @@ interface Container @0x9aaceefc06523bca {
   # Configures egress HTTP routing for the container. When the container attempts to connect to the
   # specified host:port, the connection should be routed back to the Workers runtime using the channel token.
   # The format of hostPort can be '<ip|cidr>[':'<port>]'. If port is omitted, it's assumed to only cover port 80.
-  # This method does not support HTTPs yet.
 
+  setEgressHttps @9 (sniGlob :Text, channelToken :Data);
+  # Intercepts outbound TLS connections whose SNI matches `sniGlob`, routing decrypted
+  # HTTP to the worker binding identified by `channelToken`. The runtime must ensure
+  # the container trusts the interception CA.
+  #
+  # sniGlob: glob pattern for TLS SNI hostnames (e.g. "*.example.com", "*").
+  #   "*.example.com" matches any subdomain including nested ones like "a.b.example.com".
+  # channelToken: opaque token identifying the worker binding to route requests to.
+  #
+  # This method does not support specifying ports as it's designed for traffic firewall
+  # of internet access of the container through Workers. To hit a Worker in another
+  # port that is not 443, use setEgressHttp.
 
   # TODO: setEgressTcp
 }

--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -162,6 +162,98 @@ kj::StringPtr signalToString(uint32_t signal) {
       return "SIGKILL"_kj;
   }
 }
+
+// ASCII-only case-insensitive equality for DNS hostnames / SNI.
+bool asciiCaseInsensitiveEquals(kj::ArrayPtr<const char> a, kj::ArrayPtr<const char> b) {
+  if (a.size() != b.size()) return false;
+  for (size_t i = 0; i < a.size(); ++i) {
+    char ca = (a[i] >= 'A' && a[i] <= 'Z') ? (a[i] | 0x20) : a[i];
+    char cb = (b[i] >= 'A' && b[i] <= 'Z') ? (b[i] | 0x20) : b[i];
+    if (ca != cb) return false;
+  }
+  return true;
+}
+
+// Matches a hostname against a glob pattern (only leading '*' supported).
+// "*.example.com" also matches "a.b.example.com" because RFC 6125 single-label
+// restriction doesn't apply to interception config (not a TLS certificate).
+// Case-insensitive per RFC 6066 §3.
+bool matchSniGlob(kj::StringPtr glob, kj::StringPtr hostname) {
+  if (glob == "*") return true;
+  if (glob.startsWith("*.")) {
+    // "*.example.com" should match "foo.example.com" but not "example.com"
+    auto suffix = glob.slice(1);  // ".example.com"
+    if (hostname.size() <= suffix.size()) return false;
+    return asciiCaseInsensitiveEquals(hostname.slice(hostname.size() - suffix.size()), suffix);
+  }
+  return asciiCaseInsensitiveEquals(glob, hostname);
+}
+
+void writeTarField(kj::ArrayPtr<kj::byte> field, kj::StringPtr value) {
+  auto len = kj::min(value.size(), field.size());
+  auto src = value.asBytes().first(len);
+  field.first(len).copyFrom(src);
+}
+
+// Creates a minimal POSIX (ustar) tar archive containing a single file.
+// Used to upload CA certs via PUT /containers/{id}/archive.
+// Only handles small files with short known filenames. Replace with a
+// proper tar library if requirements grow.
+kj::Array<kj::byte> createTarWithFile(
+    kj::StringPtr filename, kj::ArrayPtr<const kj::byte> content) {
+  KJ_REQUIRE(filename.size() < 100, "tar filename must be < 100 bytes");
+  KJ_REQUIRE(
+      content.size() < 8ull * 1024 * 1024 * 1024, "tar content too large for 11-digit octal");
+  // Tar: 512-byte header + content padded to 512 + two 512-byte EOF blocks.
+  size_t paddedSize = (content.size() + 511) & ~511;
+  size_t totalSize = 512 + paddedSize + 1024;
+  auto tar = kj::heapArray<kj::byte>(totalSize);
+  tar.asPtr().fill(0);
+
+  auto header = tar.first(512);
+
+  // Name (offset 0, 100 bytes)
+  writeTarField(header.slice(0, 100), filename);
+
+  // Mode (offset 100, 8 bytes)
+  writeTarField(header.slice(100, 108), "0000644"_kj);
+
+  // UID/GID (offset 108/116, 8 bytes each)
+  writeTarField(header.slice(108, 116), "0000000"_kj);
+  writeTarField(header.slice(116, 124), "0000000"_kj);
+
+  // Size (offset 124, 12 bytes), octal
+  {
+    char sizeBuf[12];
+    snprintf(sizeBuf, sizeof(sizeBuf), "%011lo", static_cast<unsigned long>(content.size()));
+    writeTarField(header.slice(124, 136), kj::StringPtr(sizeBuf));
+  }
+
+  // Mtime (offset 136, 12 bytes)
+  writeTarField(header.slice(136, 148), "00000000000"_kj);
+
+  // Typeflag (offset 156), '0' = regular file
+  header[156] = '0';
+
+  // Magic (offset 257, 6 bytes) + version (offset 263, 2 bytes)
+  writeTarField(header.slice(257, 263), "ustar"_kj);
+  writeTarField(header.slice(263, 265), "00"_kj);
+
+  // Checksum (offset 148, 8 bytes): sum of all header bytes with checksum field as spaces.
+  header.slice(148, 156).fill(' ');
+  uint32_t checksum = 0;
+  for (auto b: header) checksum += b;
+  {
+    char csumBuf[8];
+    snprintf(csumBuf, sizeof(csumBuf), "%06o ", checksum);
+    writeTarField(header.slice(148, 155), kj::StringPtr(csumBuf));
+  }
+
+  tar.slice(512, 512 + content.size()).copyFrom(content);
+
+  return tar;
+}
+
 }  // namespace
 
 ContainerClient::ContainerClient(capnp::ByteStreamFactory& byteStreamFactory,
@@ -286,9 +378,10 @@ class InnerEgressService final: public kj::HttpService {
  public:
   using ChannelLookup = kj::Function<kj::Maybe<kj::Own<IoChannelFactory::SubrequestChannel>>()>;
 
-  InnerEgressService(ChannelLookup lookupChannel, kj::StringPtr destAddr)
+  InnerEgressService(ChannelLookup lookupChannel, kj::StringPtr destAddr, bool isTls = false)
       : lookupChannel(kj::mv(lookupChannel)),
-        destAddr(kj::str(destAddr)) {}
+        destAddr(kj::str(destAddr)),
+        isTls(isTls) {}
 
   kj::Promise<void> request(kj::HttpMethod method,
       kj::StringPtr requestUri,
@@ -305,10 +398,11 @@ class InnerEgressService final: public kj::HttpService {
     auto urlForWorker = kj::str(requestUri);
     // Probably only a path, try to get it from Host:
     if (requestUri.startsWith("/")) {
-      auto baseUrl = kj::str("http://", destAddr);
+      auto scheme = isTls ? "https://"_kj : "http://"_kj;
+      auto baseUrl = kj::str(scheme, destAddr);
       // Use Host: when possible
       KJ_IF_SOME(host, headers.get(kj::HttpHeaderId::HOST)) {
-        baseUrl = kj::str("http://", host);
+        baseUrl = kj::str(scheme, host);
       }
 
       // Parse url, if invalid, try to use the original requestUri (http://<ip>/<path>
@@ -325,7 +419,14 @@ class InnerEgressService final: public kj::HttpService {
  private:
   ChannelLookup lookupChannel;
   kj::String destAddr;
+  bool isTls;
 };
+
+kj::Promise<void> pumpBidirectional(kj::AsyncIoStream& a, kj::AsyncIoStream& b) {
+  auto aToB = a.pumpTo(b).then([&b](uint64_t) { b.shutdownWrite(); });
+  auto bToA = b.pumpTo(a).then([&a](uint64_t) { a.shutdownWrite(); });
+  co_await kj::joinPromisesFailFast(kj::arr(kj::mv(aToB), kj::mv(bToA)));
+}
 
 // Outer HTTP service that handles CONNECT requests from the sidecar.
 class EgressHttpService final: public kj::HttpService {
@@ -343,6 +444,18 @@ class EgressHttpService final: public kj::HttpService {
     co_return co_await response.sendError(405, "Method Not Allowed", headerTable);
   }
 
+  // CONNECT protocol between the sidecar and workerd:
+  //
+  // The sidecar sends an HTTP CONNECT for every outbound connection from the container.
+  // If it detected a TLS ClientHello, it includes an "X-Tls-Sni" header with the SNI.
+  //
+  // Response status codes signal the sidecar what to do:
+  //   200: Workerd will handle this connection (intercepted HTTP/HTTPS or plaintext
+  //        passthrough). For TLS with a mapping the sidecar MITMs and sends decrypted
+  //        HTTP through the tunnel; for plaintext it sends raw bytes.
+  //   202: TLS with no matching HTTPS mapping. Sidecar passes raw TLS bytes through
+  //        the tunnel without decryption (workerd forwards to destination or drops
+  //        if internet is disabled).
   kj::Promise<void> connect(kj::StringPtr host,
       const kj::HttpHeaders& headers,
       kj::AsyncIoStream& connection,
@@ -350,6 +463,46 @@ class EgressHttpService final: public kj::HttpService {
       kj::HttpConnectSettings settings) override {
     auto destAddr = kj::str(host);
 
+    auto tlsSni = headers.get(containerClient.egressHeaderTable.tlsSniId);
+
+    KJ_IF_SOME(sni, tlsSni) {
+      auto httpsMapping = containerClient.findEgressHttpsMapping(sni);
+
+      if (httpsMapping != kj::none) {
+        // Mapping matched; tell sidecar to MITM and send us decrypted HTTP.
+        kj::HttpHeaders responseHeaders(headerTable);
+        response.accept(200, "OK", responseHeaders);
+
+        // Looks up the mapping on each request so channel replacements are
+        // picked up on existing tunnels.
+        auto innerService = kj::heap<InnerEgressService>(
+            [&client = containerClient, sniStr = kj::str(sni)]()
+                -> kj::Maybe<kj::Own<IoChannelFactory::SubrequestChannel>> {
+          return client.findEgressHttpsMapping(sniStr);
+        },
+            destAddr, /*isTls=*/true);
+        auto innerServer =
+            kj::heap<kj::HttpServer>(containerClient.timer, headerTable, *innerService);
+        co_await innerServer->listenHttpCleanDrain(connection);
+        co_return;
+      }
+
+      // No HTTPS mapping, pass raw TLS through (202).
+      kj::HttpHeaders responseHeaders(headerTable);
+      response.accept(202, "Accepted", responseHeaders);
+
+      if (!containerClient.internetEnabled) {
+        connection.shutdownWrite();
+        co_return;
+      }
+
+      auto addr = co_await containerClient.network.parseAddress(destAddr);
+      auto destConn = co_await addr->connect();
+      co_await pumpBidirectional(connection, *destConn);
+      co_return;
+    }
+
+    // No TLS, plain HTTP proxying.
     kj::HttpHeaders responseHeaders(headerTable);
     response.accept(200, "OK", responseHeaders);
 
@@ -367,9 +520,7 @@ class EgressHttpService final: public kj::HttpService {
           destAddr);
       auto innerServer =
           kj::heap<kj::HttpServer>(containerClient.timer, headerTable, *innerService);
-
       co_await innerServer->listenHttpCleanDrain(connection);
-
       co_return;
     }
 
@@ -381,15 +532,7 @@ class EgressHttpService final: public kj::HttpService {
     // No egress mapping and internet enabled, so forward via raw TCP
     auto addr = co_await containerClient.network.parseAddress(destAddr);
     auto destConn = co_await addr->connect();
-
-    auto connToDestination = connection.pumpTo(*destConn).then(
-        [&destConn = *destConn](uint64_t) { destConn.shutdownWrite(); });
-
-    auto destinationToConn =
-        destConn->pumpTo(connection).then([&connection](uint64_t) { connection.shutdownWrite(); });
-
-    co_await kj::joinPromisesFailFast(
-        kj::arr(kj::mv(connToDestination), kj::mv(destinationToConn)));
+    co_await pumpBidirectional(connection, *destConn);
     co_return;
   }
 
@@ -539,6 +682,68 @@ kj::Promise<ContainerClient::Response> ContainerClient::dockerApiRequest(kj::Net
     auto result = co_await response.body->readAllText();
     co_return Response{.statusCode = response.statusCode, .body = kj::mv(result)};
   }
+}
+
+kj::Promise<void> ContainerClient::writeFileToContainer(kj::StringPtr container,
+    kj::StringPtr dir,
+    kj::StringPtr filename,
+    kj::ArrayPtr<const kj::byte> content) {
+  kj::HttpHeaderTable table;
+  auto address = co_await network.parseAddress(kj::str(dockerPath));
+  auto connection = co_await address->connect();
+  auto httpClient = kj::newHttpClient(table, *connection).attach(kj::mv(connection));
+
+  auto tar = createTarWithFile(filename, content);
+
+  kj::HttpHeaders headers(table);
+  headers.setPtr(kj::HttpHeaderId::HOST, "localhost");
+  headers.setPtr(kj::HttpHeaderId::CONTENT_TYPE, "application/x-tar");
+  headers.set(kj::HttpHeaderId::CONTENT_LENGTH, kj::str(tar.size()));
+
+  auto endpoint = kj::str("/containers/", container, "/archive?path=", kj::encodeUriComponent(dir));
+  auto req = httpClient->request(kj::HttpMethod::PUT, endpoint, headers, tar.size());
+  {
+    auto body = kj::mv(req.body);
+    co_await body->write(tar.asBytes());
+  }
+  auto response = co_await req.response;
+  auto result = co_await response.body->readAllText();
+  JSG_REQUIRE(response.statusCode == 200, Error, "Failed to write file", dir, filename,
+      "to container [", response.statusCode, "] ", result);
+}
+
+// Distro-independent path for the Cloudflare CA cert inside the user container.
+// Written relative to /etc; Docker's tar extraction creates intermediate dirs.
+static constexpr kj::StringPtr cloudflareCaDir = "/etc"_kj;
+static constexpr kj::StringPtr cloudflareCaFilename =
+    "cloudflare/certs/cloudflare-containers-ca.crt"_kj;
+
+kj::Promise<void> ContainerClient::readCACert() {
+  auto ingressPort = KJ_REQUIRE_NONNULL(
+      sidecarIngressHostPort, "Cannot read CA cert: sidecar ingress port not known");
+
+  auto response = co_await dockerApiRequest(
+      network, kj::str("127.0.0.1:", ingressPort), kj::HttpMethod::GET, kj::str("/ca"));
+
+  JSG_REQUIRE(response.statusCode == 200, Error,
+      "Failed to read CA cert from sidecar: ", response.statusCode, " ", response.body);
+
+  caBytes = kj::heapArray<kj::byte>(response.body.asBytes());
+}
+
+kj::Promise<void> ContainerClient::injectCACert() {
+  if (caCertInjected.exchange(true, std::memory_order_acquire)) {
+    co_return;
+  }
+
+  bool succeeded = false;
+  KJ_DEFER(if (!succeeded) caCertInjected.store(false, std::memory_order_release));
+
+  auto& bytes = KJ_REQUIRE_NONNULL(caBytes, "CA cert not read from sidecar yet");
+  co_await writeFileToContainer(containerName, cloudflareCaDir, cloudflareCaFilename, bytes);
+
+  succeeded = true;
+  co_return;
 }
 
 kj::Promise<ContainerClient::InspectResponse> ContainerClient::inspectContainer() {
@@ -771,7 +976,7 @@ kj::Promise<void> ContainerClient::createSidecarContainer(
   auto ipv6Enabled = co_await isDaemonIpv6Enabled();
 
   uint32_t cmdSize =
-      6;  // --http-egress-port <port> --http-ingress-address 0.0.0.0:<port> --docker-gateway-cidr <cidr>
+      7;  // --http-egress-port <port> --http-ingress-address 0.0.0.0:<port> --docker-gateway-cidr <cidr> --tls-intercept
   if (!ipv6Enabled) cmdSize += 1;  // --disable-ipv6
 
   auto cmd = jsonRoot.initCmd(cmdSize);
@@ -785,6 +990,10 @@ kj::Promise<void> ContainerClient::createSidecarContainer(
   if (!ipv6Enabled) {
     cmd.set(idx++, "--disable-ipv6");
   }
+
+  // Enabling tls-intercept is OK because it adds minimal overhead,
+  // we won't attempt to intercept in workerd unless the SNI glob matches.
+  cmd.set(idx++, "--tls-intercept");
 
   jsonRoot.initExposedPorts().setRaw(kj::str("{\"", SIDECAR_INGRESS_PORT, "/tcp\":{}}"));
 
@@ -876,6 +1085,7 @@ kj::Promise<void> ContainerClient::status(StatusContext context) {
     this->sidecarIngressHostPort = sidecar.ingressHostPort;
     co_await ensureEgressListenerStarted();
     co_await updateSidecarEgressPort(sidecar.ingressHostPort, egressListenerPort);
+    co_await readCACert();
   }
 
   context.getResults().setRunning(isRunning);
@@ -907,8 +1117,13 @@ kj::Promise<void> ContainerClient::start(StartContext context) {
   co_await ensureSidecarStarted();
 
   co_await createContainer(entrypoint, environment, params);
-  co_await startContainer();
 
+  if (!egressHttpsMappings.empty()) {
+    caCertInjected = false;
+    co_await injectCACert();
+  }
+
+  co_await startContainer();
   containerStarted.store(true, std::memory_order_release);
 }
 
@@ -1017,6 +1232,28 @@ kj::Maybe<kj::Own<workerd::IoChannelFactory::SubrequestChannel>> ContainerClient
   return kj::none;
 }
 
+void ContainerClient::upsertEgressHttpsMapping(EgressHttpsMapping mapping) {
+  for (auto& m: egressHttpsMappings) {
+    if (m.sniGlob == mapping.sniGlob) {
+      m.channel = kj::mv(mapping.channel);
+      return;
+    }
+  }
+
+  egressHttpsMappings.add(kj::mv(mapping));
+}
+
+kj::Maybe<kj::Own<workerd::IoChannelFactory::SubrequestChannel>> ContainerClient::
+    findEgressHttpsMapping(kj::StringPtr sni) {
+  for (auto& mapping: egressHttpsMappings) {
+    if (matchSniGlob(mapping.sniGlob, sni)) {
+      return kj::addRef(*mapping.channel);
+    }
+  }
+
+  return kj::none;
+}
+
 kj::Promise<void> ContainerClient::ensureSidecarStarted() {
   if (containerSidecarStarted.exchange(true, std::memory_order_acquire)) {
     co_return;
@@ -1049,11 +1286,14 @@ kj::Promise<void> ContainerClient::ensureSidecarStarted() {
       maybeError = kj::getCaughtExceptionAsKj();
     }
 
-    if (maybeError == kj::none) co_return;
+    if (maybeError == kj::none) break;
     if (attempt >= MAX_READY_RETRIES - 1)
       kj::throwFatalException(kj::mv(KJ_REQUIRE_NONNULL(maybeError)));
     co_await timer.afterDelay(READY_RETRY_DELAY);
   }
+
+  // Read the CA cert now so injection into user containers is instant.
+  co_await readCACert();
 }
 
 kj::Promise<void> ContainerClient::ensureEgressListenerStarted(uint16_t port) {
@@ -1098,6 +1338,43 @@ kj::Promise<void> ContainerClient::setEgressHttp(SetEgressHttpContext context) {
   upsertEgressMapping(EgressMapping{
     .cidr = kj::mv(cidr),
     .port = port,
+    .channel = kj::mv(subrequestChannel),
+  });
+
+  co_return;
+}
+
+kj::Promise<void> ContainerClient::setEgressHttps(SetEgressHttpsContext context) {
+  auto [ready, done] = getRpcTurn();
+  co_await ready;
+  KJ_DEFER(done->fulfill());
+
+  auto params = context.getParams();
+  auto sniGlob = kj::str(params.getSniGlob());
+  auto tokenBytes = params.getChannelToken();
+
+  KJ_REQUIRE(sniGlob.size() > 0, "sniGlob must not be empty");
+  if (sniGlob[0] == '*') {
+    KJ_REQUIRE(sniGlob.size() == 1 || (sniGlob[1] == '.' && sniGlob.size() > 2),
+        "wildcard glob must be \"*\" or \"*.hostname\", got: ", sniGlob);
+  }
+  for (size_t i = 1; i < sniGlob.size(); ++i) {
+    KJ_REQUIRE(sniGlob[i] != '*', "sniGlob may only contain a leading '*', got: ", sniGlob);
+  }
+
+  co_await ensureEgressListenerStarted();
+
+  if (containerStarted.load(std::memory_order_acquire)) {
+    // Sidecar is always started before the container, so caBytes is already
+    // populated. We just need to push the cert into the user container.
+    co_await injectCACert();
+  }
+
+  auto subrequestChannel = channelTokenHandler.decodeSubrequestChannelToken(
+      workerd::IoChannelFactory::ChannelTokenUsage::RPC, tokenBytes);
+
+  upsertEgressHttpsMapping(EgressHttpsMapping{
+    .sniGlob = kj::mv(sniGlob),
     .channel = kj::mv(subrequestChannel),
   });
 

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -75,12 +75,20 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   kj::Promise<void> listenTcp(ListenTcpContext context) override;
   kj::Promise<void> setInactivityTimeout(SetInactivityTimeoutContext context) override;
   kj::Promise<void> setEgressHttp(SetEgressHttpContext context) override;
+  kj::Promise<void> setEgressHttps(SetEgressHttpsContext context) override;
 
   kj::Own<ContainerClient> addRef();
 
  private:
   capnp::ByteStreamFactory& byteStreamFactory;
-  kj::HttpHeaderTable headerTable;
+
+  struct EgressHeaderTable {
+    kj::HttpHeaderTable::Builder builder;
+    kj::HttpHeaderId tlsSniId = builder.add("X-Tls-Sni");
+    kj::Own<kj::HttpHeaderTable> table = builder.build();
+  };
+  EgressHeaderTable egressHeaderTable;
+  kj::HttpHeaderTable& headerTable = *egressHeaderTable.table;
   kj::Timer& timer;
   kj::Network& network;
   kj::String dockerPath;
@@ -180,12 +188,43 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   kj::Maybe<kj::Own<workerd::IoChannelFactory::SubrequestChannel>> findEgressMapping(
       kj::StringPtr destAddr, uint16_t defaultPort);
 
+  // Routes on SNI hostname only (no CIDR or port matching unlike HTTP egress).
+  struct EgressHttpsMapping {
+    kj::String sniGlob;
+    kj::Own<workerd::IoChannelFactory::SubrequestChannel> channel;
+  };
+
+  kj::Vector<EgressHttpsMapping> egressHttpsMappings;
+
+  void upsertEgressHttpsMapping(EgressHttpsMapping mapping);
+
+  // Returns addRef'd so the channel outlives mapping replacement.
+  kj::Maybe<kj::Own<workerd::IoChannelFactory::SubrequestChannel>> findEgressHttpsMapping(
+      kj::StringPtr sni);
+
+  // Uses Docker archive API (PUT /archive).
+  kj::Promise<void> writeFileToContainer(kj::StringPtr container,
+      kj::StringPtr dir,
+      kj::StringPtr filename,
+      kj::ArrayPtr<const kj::byte> content);
+
+  // Reads the sidecar CA cert from the running sidecar container into caBytes.
+  // Called once after the sidecar is confirmed ready.
+  kj::Promise<void> readCACert();
+
+  // Injects the sidecar CA cert into the user container's system CA bundle.
+  kj::Promise<void> injectCACert();
+
   // Whether general internet access is enabled for this container
   bool internetEnabled = false;
 
   std::atomic_bool containerStarted = false;
   std::atomic_bool containerSidecarStarted = false;
   std::atomic_bool egressListenerStarted = false;
+  std::atomic_bool caCertInjected = false;
+
+  // CA cert bytes read from the sidecar after it starts.
+  kj::Maybe<kj::Array<kj::byte>> caBytes;
 
   kj::Maybe<kj::Own<kj::HttpServer>> egressHttpServer;
   kj::Maybe<kj::Promise<void>> egressListenerTask;

--- a/src/workerd/server/docker-api.capnp
+++ b/src/workerd/server/docker-api.capnp
@@ -313,6 +313,7 @@ struct Docker {
     id @0 :Text $Json.name("Id");
     warning @1 :Text $Json.name("Warning");
   }
+
 }
 
 struct ProxyEverything {

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -495,6 +495,124 @@ export class DurableObjectExample extends DurableObject {
     }
   }
 
+  async testSetEgressHttps() {
+    const container = this.ctx.container;
+
+    await container.interceptOutboundHttps(
+      'example.com',
+      this.ctx.exports.TestService({ props: { id: 1000 } })
+    );
+
+    if (!container.running) {
+      container.start({
+        // Trust the sidecar's MITM CA cert.
+        env: {
+          NODE_EXTRA_CA_CERTS:
+            '/etc/cloudflare/certs/cloudflare-containers-ca.crt',
+        },
+      });
+    }
+
+    // Keep container alive after abort().
+    container.monitor().catch((err) => {
+      console.error('Container exited with an error:', err.message);
+    });
+
+    await this.waitUntilContainerIsHealthy();
+
+    // Register after container is running.
+    await container.interceptOutboundHttps(
+      '*.cloudflare.com',
+      this.ctx.exports.TestService({ props: { id: 2000 } })
+    );
+
+    await container.interceptOutboundHttps(
+      '*',
+      this.ctx.exports.TestService({ props: { id: 3000 } })
+    );
+
+    // Exact hostname match (registered before start).
+    {
+      const response = await container
+        .getTcpPort(8080)
+        .fetch('http://foo/intercept-https', {
+          headers: { 'x-host': 'example.com' },
+          abort: AbortSignal.timeout(DEFAULT_TIMEOUT_DURATION),
+        });
+      assert.equal(response.status, 200);
+      assert.equal(
+        await response.text(),
+        'hello binding: 1000 https://example.com/'
+      );
+    }
+
+    // Wildcard subdomain match.
+    {
+      const response = await container
+        .getTcpPort(8080)
+        .fetch('http://foo/intercept-https', {
+          headers: { 'x-host': 'www.cloudflare.com' },
+          abort: AbortSignal.timeout(DEFAULT_TIMEOUT_DURATION),
+        });
+      assert.equal(response.status, 200);
+      assert.equal(
+        await response.text(),
+        'hello binding: 2000 https://www.cloudflare.com/'
+      );
+    }
+
+    // Catch-all match.
+    {
+      const response = await container
+        .getTcpPort(8080)
+        .fetch('http://foo/intercept-https', {
+          headers: { 'x-host': 'google.com' },
+          abort: AbortSignal.timeout(DEFAULT_TIMEOUT_DURATION),
+        });
+      assert.equal(response.status, 200);
+      assert.equal(
+        await response.text(),
+        'hello binding: 3000 https://google.com/'
+      );
+    }
+
+    // Replace catch-all binding.
+    await container.interceptOutboundHttps(
+      '*',
+      this.ctx.exports.TestService({ props: { id: 4000 } })
+    );
+
+    // Exact match still takes precedence.
+    {
+      const response = await container
+        .getTcpPort(8080)
+        .fetch('http://foo/intercept-https', {
+          headers: { 'x-host': 'example.com' },
+          abort: AbortSignal.timeout(DEFAULT_TIMEOUT_DURATION),
+        });
+      assert.equal(response.status, 200);
+      assert.equal(
+        await response.text(),
+        'hello binding: 1000 https://example.com/'
+      );
+    }
+
+    // Catch-all was replaced.
+    {
+      const response = await container
+        .getTcpPort(8080)
+        .fetch('http://foo/intercept-https', {
+          headers: { 'x-host': 'github.com' },
+          abort: AbortSignal.timeout(DEFAULT_TIMEOUT_DURATION),
+        });
+      assert.equal(response.status, 200);
+      assert.equal(
+        await response.text(),
+        'hello binding: 4000 https://github.com/'
+      );
+    }
+  }
+
   async testInterceptWebSocket() {
     const container = this.ctx.container;
     if (container.running) {
@@ -566,6 +684,83 @@ export class DurableObjectExample extends DurableObject {
     const response = new TextDecoder().decode(await promise);
     clearTimeout(timeout);
     assert.strictEqual(response, 'Binding 42: Hello through intercept!');
+
+    ws.close();
+    await container.destroy();
+  }
+
+  async testInterceptWebSocketHttps() {
+    const container = this.ctx.container;
+    if (container.running) {
+      const monitor = container.monitor().catch((_err) => {});
+      await container.destroy();
+      await monitor;
+    }
+
+    assert.strictEqual(container.running, false);
+
+    await container.interceptOutboundHttps(
+      'example.com',
+      this.ctx.exports.TestService({ props: { id: 99 } })
+    );
+
+    // NODE_EXTRA_CA_CERTS: trust the sidecar's MITM CA cert.
+    container.start({
+      env: {
+        WS_ENABLED: 'true',
+        WS_PROXY_TARGET: 'example.com',
+        WS_PROXY_SECURE: 'true',
+        NODE_EXTRA_CA_CERTS:
+          '/etc/cloudflare/certs/cloudflare-containers-ca.crt',
+      },
+    });
+
+    container.monitor().finally(() => {
+      console.log('Container exited');
+    });
+
+    await this.waitUntilContainerIsHealthy();
+
+    assert.strictEqual(container.running, true);
+
+    // DO -> container:8080/ws -> wss://example.com/ws -> sidecar MITM -> TestService
+    const res = await container.getTcpPort(8080).fetch('http://foo/ws', {
+      headers: {
+        Upgrade: 'websocket',
+        Connection: 'Upgrade',
+        'Sec-WebSocket-Key': 'x3JJHMbDL1EzLkh9GBhXDw==',
+        'Sec-WebSocket-Version': '13',
+      },
+      abort: AbortSignal.timeout(DEFAULT_TIMEOUT_DURATION),
+    });
+
+    assert.strictEqual(res.status, 101);
+    assert.strictEqual(res.headers.get('upgrade'), 'websocket');
+    assert.strictEqual(!!res.webSocket, true);
+
+    const ws = res.webSocket;
+    ws.binaryType = 'arraybuffer';
+    ws.accept();
+
+    const { promise, resolve, reject } = Promise.withResolvers();
+
+    ws.addEventListener(
+      'message',
+      (event) => {
+        resolve(event.data);
+      },
+      { once: true }
+    );
+
+    const timeout = setTimeout(() => {
+      reject(new Error('Websocket message not received within 5 seconds'));
+    }, 5_000);
+
+    ws.send('Hello through WSS intercept!');
+
+    const response = new TextDecoder().decode(await promise);
+    clearTimeout(timeout);
+    assert.strictEqual(response, 'Binding 99: Hello through WSS intercept!');
 
     ws.close();
     await container.destroy();
@@ -810,6 +1005,23 @@ export const testSetEgressHttp = {
   },
 };
 
+export const testSetEgressHttps = {
+  async test(_ctrl, env) {
+    const name = getRandomDurableObjectName('testSetEgressHttps');
+    const id = env.MY_CONTAINER.idFromName(name);
+    let stub = env.MY_CONTAINER.get(id);
+    await stub.testSetEgressHttps();
+    try {
+      // test we recover from aborts
+      await stub.abort();
+    } catch {}
+
+    stub = env.MY_CONTAINER.get(id);
+    // should work idempotent
+    await stub.testSetEgressHttps();
+  },
+};
+
 // Test WebSocket through interceptOutboundHttp - DO -> container -> worker binding via WebSocket
 export const testInterceptWebSocket = {
   async test(_ctrl, env) {
@@ -819,5 +1031,15 @@ export const testInterceptWebSocket = {
 
     const stub = env.MY_CONTAINER.get(id);
     await stub.testInterceptWebSocket();
+  },
+};
+
+export const testInterceptWebSocketHttps = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testInterceptWebSocketHttps')
+    );
+    const stub = env.MY_CONTAINER.get(id);
+    await stub.testInterceptWebSocketHttps();
   },
 };

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3887,6 +3887,7 @@ interface Container {
   setInactivityTimeout(durationMs: number | bigint): Promise<void>;
   interceptOutboundHttp(addr: string, binding: Fetcher): Promise<void>;
   interceptAllOutboundHttp(binding: Fetcher): Promise<void>;
+  interceptOutboundHttps(sniGlob: string, binding: Fetcher): Promise<void>;
 }
 interface ContainerStartupOptions {
   entrypoint?: string[];

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3893,6 +3893,7 @@ export interface Container {
   setInactivityTimeout(durationMs: number | bigint): Promise<void>;
   interceptOutboundHttp(addr: string, binding: Fetcher): Promise<void>;
   interceptAllOutboundHttp(binding: Fetcher): Promise<void>;
+  interceptOutboundHttps(sniGlob: string, binding: Fetcher): Promise<void>;
 }
 export interface ContainerStartupOptions {
   entrypoint?: string[];


### PR DESCRIPTION
`interceptOutboundHttps` is a way for users to intercept their own TLS traffic.

The way this works is different from interceptOutboundHttp. In the first one, we can decide which IP and port combinations should intercept HTTP traffic, but HTTPS is more idiomatic to handle at the SNI level.

The reasoning behind this is that customers that want to intercept TLS might want to only be triggering on certain SNIs being intercepted.

We do support currently other ports than 443 but that might change in the future by extending the method to accept a port with the SNI. It's just the use-case is clear to be SNI based only.

The glob format of the SNI that we accept is really simple, only '*' and the domain (to support cases like *google.com and all its subdomains). No plans on supporting regex here whatsoever.

The way local dev works is we generate the certificates in the networking sidecar, we read it via a HTTP request to the sidecar, and write them to the container to a known path (/etc/cloudflare/certs/cloudflare-containers-ca.crt).

We could try to append the certificate to
known distro paths, but that might be a more controversial move, we can discuss in the MR if it's worth doing.

The flow of the connection is:

```
[container] --> [proxy-everything] (tls) -->
[workerd container-client.c++] (processes configured egress policies) ->
[workerd subrequest channel]
```

The only way to make files being written consistently across distros is by using the Docker /archive API. It can only accept a tar right now, so we had to add a method that creates a simple tar file that contains a single file that we want to add to the container (the CA).