### PR TITLE
use ValueLessParameter concept for requiredArgumentCount

### DIFF
--- a/src/workerd/jsg/meta.h
+++ b/src/workerd/jsg/meta.h
@@ -58,7 +58,7 @@ using ArgumentIndexes = ArgumentIndexes_<T>::Indexes;
 // (if any).
 
 // =======================================================================================
-// requiredArgumentCount<T> — counts leading required JS-visible arguments.
+// requiredArgumentCount<TypeWrapper, T> — counts leading required JS-visible arguments.
 //
 // Used by resource.h to set the Web IDL .length property on functions.
 //
@@ -69,11 +69,13 @@ using ArgumentIndexes = ArgumentIndexes_<T>::Indexes;
 //     appear first and are never JS-visible.  meta.h can handle them because
 //     it only needs the v8 forward declarations it already includes.
 //
-//  2. RequiredArgCount_ (in web-idl.h) skips TypeHandler<T> and Arguments<T>
-//     when counting.  These types can appear at any position in the parameter
-//     list and are "invisible" to JS callers, but they are JSG-specific types
-//     that are not available in meta.h's include graph.  web-idl.h has the
-//     full JSG type system visible, so the counting logic lives there.
+//  2. RequiredArgCount_ (in type-wrapper.h) skips all "injected" parameter
+//     types that don't consume a JS argument.  It uses the ValueLessParameter
+//     concept to automatically detect types like TypeHandler<T> and
+//     InjectConfiguration types (e.g. CompatibilityFlags::Reader), plus
+//     isArguments<>() for variadic Arguments<T>.  The TypeWrapper template
+//     parameter is required because ValueLessParameter checks whether the
+//     wrapper has a 3-arg unwrap(js, context, T*) overload for the type.
 
 // Lightweight type list; kj::Tuple is an alias template and cannot be partially specialized.
 template <typename... Ts>
@@ -117,16 +119,16 @@ struct StripMagicParam_<R(const v8::FunctionCallbackInfo<v8::Value>&, A...)> {
 template <typename T>
 using MethodArgs = StripMagicParam_<typename NormalizeFunc_<T>::type>;
 
-// Forward declaration — specialized in web-idl.h where the full JSG type system is visible.
-template <typename ArgsList>
+// Forward declaration — specialized in type-wrapper.h where ValueLessParameter is visible.
+template <typename TypeWrapper, typename ArgsList>
 struct RequiredArgCount_;
 
 }  // namespace detail
 
 // Per Web IDL, the .length of a function is the number of leading required arguments.
-// The actual counting logic lives in web-idl.h.
-template <typename T>
+// The actual counting logic lives in type-wrapper.h (needs the ValueLessParameter concept).
+template <typename TypeWrapper, typename T>
 inline constexpr int requiredArgumentCount =
-    detail::RequiredArgCount_<typename detail::MethodArgs<T>::Args>::value;
+    detail::RequiredArgCount_<TypeWrapper, typename detail::MethodArgs<T>::Args>::value;
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -1318,7 +1318,7 @@ struct ResourceTypeBuilder {
   template <const char* name, auto method>
   inline void registerMethod() {
     // Per Web IDL, function .length = number of required arguments.
-    constexpr int specLength = requiredArgumentCount<decltype(method)>;
+    constexpr int specLength = requiredArgumentCount<TypeWrapper, decltype(method)>;
     const int length = getSpecCompliantPropertyAttributes(isolate) ? specLength : 0;
 
     if constexpr (isFastApiCompatible<decltype(method)>) {
@@ -1346,7 +1346,7 @@ struct ResourceTypeBuilder {
   template <const char* name, typename Method, Method method>
   inline void registerStaticMethod() {
     // Per Web IDL, function .length = number of required arguments.
-    constexpr int specLength = requiredArgumentCount<Method>;
+    constexpr int specLength = requiredArgumentCount<TypeWrapper, Method>;
     const int length = getSpecCompliantPropertyAttributes(isolate) ? specLength : 0;
 
     if constexpr (isFastApiCompatible<Method>) {
@@ -1974,7 +1974,7 @@ class ResourceWrapper {
       v8::Local<v8::FunctionTemplate> constructor;
       if constexpr (!isContext && HasConstructorMethod<T>) {
         // Per Web IDL, constructor .length = number of required arguments.
-        constexpr int specCtorLength = requiredArgumentCount<decltype(T::constructor)>;
+        constexpr int specCtorLength = requiredArgumentCount<TypeWrapper, decltype(T::constructor)>;
         const int ctorLength = getSpecCompliantPropertyAttributes(isolate) ? specCtorLength : 0;
         constructor =
             v8::FunctionTemplate::New(isolate, &ConstructorCallback<TypeWrapper, T>::callback,

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -35,6 +35,39 @@ concept ValueLessParameter =
       wrapper.unwrap(js, context, ptr);
     };
 
+// =======================================================================================
+// RequiredArgCount_ specialization — counts leading required JS-visible arguments.
+//
+// This completes the definition of requiredArgumentCount<TypeWrapper, T> declared in meta.h.
+// It lives here (rather than meta.h or web-idl.h) because it needs the ValueLessParameter
+// concept above to automatically detect ALL injected parameter types — TypeHandler<T>,
+// InjectConfiguration<T> (e.g. CompatibilityFlags::Reader), and any future valueless types.
+//
+// Arguments<T> (variadic rest args) is detected separately via isArguments<>() because it
+// does not satisfy ValueLessParameter — it consumes remaining JS arguments rather than being
+// injected by the runtime.
+//
+// Template instantiation of requiredArgumentCount happens from resource.h templates, which
+// are only instantiated after this header is fully parsed, so these specializations are
+// guaranteed to be visible at the point of use.
+namespace detail {
+
+template <typename TypeWrapper>
+struct RequiredArgCount_<TypeWrapper, TypeList<>> {
+  static constexpr int value = 0;
+};
+
+template <typename TypeWrapper, typename Head, typename... Tail>
+struct RequiredArgCount_<TypeWrapper, TypeList<Head, Tail...>> {
+  using D = kj::Decay<Head>;
+  static constexpr int value = (isArguments<D>() || ValueLessParameter<TypeWrapper, D>)
+      ? RequiredArgCount_<TypeWrapper, TypeList<Tail...>>::value  // skip injected args
+      : (webidl::isOptional<D> ? 0  // optional arg — stop counting required
+                               : 1 + RequiredArgCount_<TypeWrapper, TypeList<Tail...>>::value);
+};
+
+}  // namespace detail
+
 // TypeWrapper mixin for V8 handles.
 //
 // This is just a trivial pass-through.

--- a/src/workerd/jsg/web-idl-test.c++
+++ b/src/workerd/jsg/web-idl-test.c++
@@ -100,51 +100,76 @@ static_assert(kj::isSameType<ArgumentIndexes<void(Lock&, int)>, kj::_::Indexes<0
 static_assert(kj::isSameType<ArgumentIndexes<void()>, kj::_::Indexes<>>());
 
 // =====================================================================================
-// requiredArgumentCount tests (meta.h + web-idl.h)
+// requiredArgumentCount tests (meta.h + type-wrapper.h)
+//
+// requiredArgumentCount<TypeWrapper, FuncType> uses the ValueLessParameter concept to detect
+// injected parameter types. We use a minimal mock wrapper that provides the right unwrap()
+// overloads so the concept checks succeed for TypeHandler<T> and a fake injected config type.
+
+struct FakeConfig {};  // Simulates an InjectConfiguration<T> injected type.
+
+struct MockTypeWrapper {
+  // Makes ValueLessParameter<MockTypeWrapper, TypeHandler<T>> true.
+  template <typename U>
+  const TypeHandler<U>& unwrap(Lock&, v8::Local<v8::Context>, TypeHandler<U>*);
+  // Makes ValueLessParameter<MockTypeWrapper, FakeConfig> true (simulates InjectConfiguration).
+  FakeConfig unwrap(Lock&, v8::Local<v8::Context>, FakeConfig*);
+};
+
+// Shorthand for the tests below.
+template <typename T>
+constexpr int rac = requiredArgumentCount<MockTypeWrapper, T>;
 
 // All required - count equals total visible args.
-static_assert(requiredArgumentCount<int(int, double, bool)> == 3);
-static_assert(requiredArgumentCount<int(Lock&, int, double, bool)> == 3);
+static_assert(rac<int(int, double, bool)> == 3);
+static_assert(rac<int(Lock&, int, double, bool)> == 3);
 
-// No args �� length is 0.
-static_assert(requiredArgumentCount<void()> == 0);
-static_assert(requiredArgumentCount<void(Lock&)> == 0);
+// No args — length is 0.
+static_assert(rac<void()> == 0);
+static_assert(rac<void(Lock&)> == 0);
 
 // Optional args stop the count.
-static_assert(requiredArgumentCount<void(int, Optional<int>)> == 1);
-static_assert(requiredArgumentCount<void(int, double, Optional<int>)> == 2);
-static_assert(requiredArgumentCount<void(Optional<int>)> == 0);
-static_assert(requiredArgumentCount<void(Lock&, int, Optional<int>)> == 1);
+static_assert(rac<void(int, Optional<int>)> == 1);
+static_assert(rac<void(int, double, Optional<int>)> == 2);
+static_assert(rac<void(Optional<int>)> == 0);
+static_assert(rac<void(Lock&, int, Optional<int>)> == 1);
 
 // LenientOptional also stops the count.
-static_assert(requiredArgumentCount<void(int, LenientOptional<int>)> == 1);
+static_assert(rac<void(int, LenientOptional<int>)> == 1);
 
 // TypeHandler<T> is invisible - does not count and does not stop.
-static_assert(requiredArgumentCount<void(TypeHandler<int>&, int, double)> == 2);
-static_assert(requiredArgumentCount<void(int, TypeHandler<int>&, double)> == 2);
-static_assert(requiredArgumentCount<void(int, TypeHandler<int>&, Optional<double>)> == 1);
-// Arguments following optionals are not counted
-static_assert(requiredArgumentCount<void(int, TypeHandler<int>&, Optional<double>, int)> == 1);
+static_assert(rac<void(TypeHandler<int>&, int, double)> == 2);
+static_assert(rac<void(int, TypeHandler<int>&, double)> == 2);
+static_assert(rac<void(int, TypeHandler<int>&, Optional<double>)> == 1);
+// Arguments following optionals are not counted.
+static_assert(rac<void(int, TypeHandler<int>&, Optional<double>, int)> == 1);
 
 // Arguments<T> is invisible - does not count and does not stop.
-static_assert(requiredArgumentCount<void(int, Arguments<int>)> == 1);
+static_assert(rac<void(int, Arguments<int>)> == 1);
+
+// InjectConfiguration types (e.g. CompatibilityFlags::Reader) are invisible.
+static_assert(rac<void(FakeConfig, int, double)> == 2);
+static_assert(rac<void(int, FakeConfig, double)> == 2);
+static_assert(rac<void(int, FakeConfig, Optional<double>)> == 1);
 
 // Member functions.
-static_assert(requiredArgumentCount<decltype(&Dummy::noMagic)> == 3);
-static_assert(requiredArgumentCount<decltype(&Dummy::withLock)> == 2);
-static_assert(requiredArgumentCount<decltype(&Dummy::withInfo)> == 1);
-static_assert(requiredArgumentCount<decltype(&Dummy::constNoMagic)> == 1);
-static_assert(requiredArgumentCount<decltype(&Dummy::constWithLock)> == 2);
-static_assert(requiredArgumentCount<decltype(&Dummy::constWithInfo)> == 0);
+static_assert(rac<decltype(&Dummy::noMagic)> == 3);
+static_assert(rac<decltype(&Dummy::withLock)> == 2);
+static_assert(rac<decltype(&Dummy::withInfo)> == 1);
+static_assert(rac<decltype(&Dummy::constNoMagic)> == 1);
+static_assert(rac<decltype(&Dummy::constWithLock)> == 2);
+static_assert(rac<decltype(&Dummy::constWithInfo)> == 0);
 
 // =====================================================================================
-// isValuelessArg tests (web-idl.h)
+// ValueLessParameter concept tests (type-wrapper.h)
 
-static_assert(detail::isValuelessArg<TypeHandler<int>> == true);
-static_assert(detail::isValuelessArg<Arguments<int>> == true);
-static_assert(detail::isValuelessArg<int> == false);
-static_assert(detail::isValuelessArg<Optional<int>> == false);
-static_assert(detail::isValuelessArg<kj::String> == false);
+static_assert(ValueLessParameter<MockTypeWrapper, TypeHandler<int>> == true);
+static_assert(ValueLessParameter<MockTypeWrapper, FakeConfig> == true);
+static_assert(ValueLessParameter<MockTypeWrapper, int> == false);
+static_assert(ValueLessParameter<MockTypeWrapper, Optional<int>> == false);
+static_assert(ValueLessParameter<MockTypeWrapper, kj::String> == false);
+// Arguments<T> is NOT a ValueLessParameter — it has its own handling via isArguments<>().
+static_assert(ValueLessParameter<MockTypeWrapper, Arguments<int>> == false);
 
 KJ_TEST("web-idl meta") {
   // Nothing to actually do here; tests are compile-time

--- a/src/workerd/jsg/web-idl.h
+++ b/src/workerd/jsg/web-idl.h
@@ -333,37 +333,3 @@ struct UnionTypeValidator {
 };
 
 }  // namespace workerd::jsg::webidl
-
-// =======================================================================================
-// RequiredArgCount_ specialization — counts leading required (non-optional, non-valueless)
-// arguments in a tuple of JS-visible parameter types.
-//
-// This completes the definition of requiredArgumentCount<T> declared in meta.h.  We place
-// it here (rather than meta.h) because we need the full JSG type system: isOptional,
-// Optional<T>, LenientOptional<T>, TypeHandler<T>, Arguments<T>.
-
-namespace workerd::jsg::detail {
-
-// True for parameter types that do not consume a JS argument at all.
-template <typename T>
-constexpr bool isValuelessArg = false;
-template <typename T>
-constexpr bool isValuelessArg<TypeHandler<T>> = true;
-template <typename T>
-constexpr bool isValuelessArg<Arguments<T>> = true;
-
-template <>
-struct RequiredArgCount_<TypeList<>> {
-  static constexpr int value = 0;
-};
-
-template <typename Head, typename... Tail>
-struct RequiredArgCount_<TypeList<Head, Tail...>> {
-  using D = kj::Decay<Head>;
-  static constexpr int value = isValuelessArg<D>
-      ? RequiredArgCount_<TypeList<Tail...>>::value  // skip invisible args, continue
-      : (webidl::isOptional<D> ? 0                   // optional arg — stop counting required
-                               : 1 + RequiredArgCount_<TypeList<Tail...>>::value);
-};
-
-}  // namespace workerd::jsg::detail


### PR DESCRIPTION
The previous isValuelessArg trait in web-idl.h only handled TypeHandler<T> and Arguments<T>, missing InjectConfiguration types like CompatibilityFlags::Reader. Instead of maintaining a manual list, thread TypeWrapper through requiredArgumentCount and use the ValueLessParameter
concept to automatically detect all injected parameter types.