### PR TITLE
use v8 copy constructor for v8 global

### DIFF
--- a/src/rust/jsg/ffi.c++
+++ b/src/rust/jsg/ffi.c++
@@ -386,8 +386,9 @@ void global_drop(Global value) {
   global_from_ffi<v8::Value>(kj::mv(value));
 }
 
-Global global_clone(const Global& value) {
-  return Global{.ptr = value.ptr};
+Global global_clone(Isolate* isolate, const Global& value) {
+  auto& original = global_as_ref_from_ffi<v8::Value>(value);
+  return to_ffi(v8::Global<v8::Value>(isolate, original));
 }
 
 Local global_to_local(Isolate* isolate, const Global& value) {

--- a/src/rust/jsg/ffi.h
+++ b/src/rust/jsg/ffi.h
@@ -103,7 +103,7 @@ uint64_t local_biguint64_array_get(Isolate* isolate, const Local& array, size_t 
 
 // Global<T>
 void global_drop(Global value);
-Global global_clone(const Global& value);
+Global global_clone(Isolate* isolate, const Global& value);
 Local global_to_local(Isolate* isolate, const Global& value);
 void global_make_weak(
     Isolate* isolate, Global* value, size_t /* void* */ data, WeakCallback callback);

--- a/src/rust/jsg/v8.rs
+++ b/src/rust/jsg/v8.rs
@@ -239,7 +239,7 @@ pub mod ffi {
 
         // Global<T>
         pub unsafe fn global_drop(value: Global);
-        pub unsafe fn global_clone(value: &Global) -> Global;
+        pub unsafe fn global_clone(isolate: *mut Isolate, value: &Global) -> Global;
         pub unsafe fn global_to_local(isolate: *mut Isolate, value: &Global) -> Local;
         pub unsafe fn global_make_weak(
             isolate: *mut Isolate,
@@ -1168,9 +1168,18 @@ impl<T> Drop for Global<T> {
     }
 }
 
-impl<T> Clone for Global<T> {
-    fn clone(&self) -> Self {
-        unsafe { ffi::global_clone(&self.handle).into() }
+// Note: Global<T> intentionally does NOT implement the std Clone trait.
+// Cloning a V8 persistent handle requires an isolate pointer to create an
+// independent handle via v8::Global::New(isolate, original). The Clone trait
+// cannot provide this. Use the `clone()` method directly instead.
+impl<T> Global<T> {
+    /// Creates an independent copy of this persistent handle.
+    ///
+    /// This properly creates a new V8 persistent handle that references the same
+    /// JS object. Both the original and clone can be independently dropped.
+    #[must_use]
+    pub fn clone(&self, lock: &mut Lock) -> Self {
+        unsafe { ffi::global_clone(lock.isolate().as_ffi(), &self.handle).into() }
     }
 }
 


### PR DESCRIPTION
Create a proper independent persistent handle via V8's copy constructor. The previous implementation would cause a double-free when both the original and clone were dropped.