### PR TITLE
handle RSA_R_INTERNAL_ERROR as a user-facing error

### DIFF
--- a/src/workerd/api/crypto/impl-test.c++
+++ b/src/workerd/api/crypto/impl-test.c++
@@ -44,5 +44,15 @@ KJ_TEST("RSA_R_KEY_SIZE_TOO_SMALL is a user-facing error") {
       "jsg.DOMException(OperationError): RSA key size is too small.", OSSLCALL(0));
 }
 
+KJ_TEST("RSA_R_INTERNAL_ERROR is a user-facing error") {
+  ClearErrorOnReturn clearErrorOnReturn;
+
+  // RSA_R_INTERNAL_ERROR should be converted to a DOMException(OperationError) rather than
+  // an internal error. This error occurs during RSA signing when the private key computation
+  // or post-sign verification fails (e.g. due to corrupted key material).
+  OPENSSL_PUT_ERROR(RSA, RSA_R_INTERNAL_ERROR);
+  KJ_EXPECT_THROW_MESSAGE("jsg.DOMException(OperationError): RSA operation failed.", OSSLCALL(0));
+}
+
 }  // namespace
 }  // namespace workerd::api

--- a/src/workerd/api/crypto/impl.c++
+++ b/src/workerd/api/crypto/impl.c++
@@ -103,6 +103,7 @@ void throwOpensslError(const char* file, int line, kj::StringPtr code) {
       switch (ERR_GET_REASON(ERR_peek_last_error())) {
         MAP_ERROR(RSA_R_DATA_LEN_NOT_EQUAL_TO_MOD_LEN, "Invalid RSA signature.");
         MAP_ERROR(RSA_R_KEY_SIZE_TOO_SMALL, "RSA key size is too small.");
+        MAP_ERROR(RSA_R_INTERNAL_ERROR, "RSA operation failed.");
 #undef MAP_ERROR
 
         default:
@@ -140,6 +141,8 @@ kj::Vector<kj::OneOf<kj::StringPtr, OpensslUntranslatedError>> consumeAllOpenssl
               return "Invalid RSA signature."_kj;
             case RSA_R_KEY_SIZE_TOO_SMALL:
               return "RSA key size is too small."_kj;
+            case RSA_R_INTERNAL_ERROR:
+              return "RSA operation failed."_kj;
           }
           break;
         case ERR_LIB_EC:


### PR DESCRIPTION
Fixes a sentry issue