### PR TITLE
Add WORKER_LOADER.load() for one-off workers. 

### DIFF
--- a/src/workerd/api/tests/worker-loader-test.js
+++ b/src/workerd/api/tests/worker-loader-test.js
@@ -864,3 +864,52 @@ export let startupException = {
     }
   },
 };
+
+export let justLoad = {
+  async test(ctrl, env, ctx) {
+    let worker = env.loader.load({
+      compatibilityDate: '2025-01-01',
+      mainModule: 'foo.js',
+      modules: {
+        'foo.js': `
+          import {WorkerEntrypoint} from "cloudflare:workers";
+          export default {
+            greet(name) { return "Hello, " + name; }
+          }
+          export let alternate = {
+            greet(name, env, ctx) { return \`\${ctx.props.greeting}, \${name}\`; }
+          }
+          export class FancyPropsEntrypoint extends WorkerEntrypoint {
+            async run() {
+              let greet1 = await this.ctx.props.greeter.greet("Dave");
+              let greet2 = await this.ctx.props.greeter2.greet("Eve");
+              return [greet1, greet2].join("\\n");
+            }
+          }
+        `,
+      },
+    });
+
+    {
+      let result = await worker.getEntrypoint().greet('Alice');
+      assert.strictEqual(result, 'Hello, Alice');
+    }
+
+    let greeter = worker.getEntrypoint('alternate', {
+      props: { greeting: 'Welcome' },
+    });
+    let greeter2 = worker.getEntrypoint('alternate', {
+      props: { greeting: 'Howdy' },
+    });
+
+    {
+      let result = await greeter.greet('Bob');
+      assert.strictEqual(result, 'Welcome, Bob');
+    }
+
+    {
+      let result = await greeter2.greet('Carol');
+      assert.strictEqual(result, 'Howdy, Carol');
+    }
+  },
+};

--- a/src/workerd/api/worker-loader.c++
+++ b/src/workerd/api/worker-loader.c++
@@ -77,8 +77,33 @@ jsg::Ref<WorkerStub> WorkerLoader::get(
   return js.alloc<WorkerStub>(ioctx.addObject(kj::mv(isolateChannel)));
 }
 
-DynamicWorkerSource WorkerLoader::toDynamicWorkerSource(
-    jsg::Lock& js, IoContext& ioctx, CompatibilityDateValidation compatDateValidation,
+jsg::Ref<WorkerStub> WorkerLoader::load(jsg::Lock& js, WorkerCode code) {
+  auto& ioctx = IoContext::current();
+
+  auto source = toDynamicWorkerSource(js, ioctx, compatDateValidation, kj::mv(code));
+
+  // Annoyingly, the callback we pass to `loadIsolate()` technically may be called any number of
+  // times. Yes, even though we aren't providing an ID. The runtime can actually evict the isolate
+  // while a stub still exists, as long as there is no active request on the stub, and then
+  // recreate the isolate on the next request. Moreover, it may ultimately destroy the `ownContent`
+  // in another thread, so we need to use atomic refcounting on it. Ugh!
+  struct OwnContentWrapper: public kj::AtomicRefcounted {
+    kj::Own<void> content;
+    OwnContentWrapper(kj::Own<void> content): content(kj::mv(content)) {}
+  };
+  auto ownContentWrapper = kj::atomicRefcounted<OwnContentWrapper>(kj::mv(source.ownContent));
+
+  auto isolateChannel = ioctx.getIoChannelFactory().loadIsolate(channel, kj::none,
+      [source = kj::mv(source), ownContentWrapper = kj::mv(ownContentWrapper)]() mutable {
+    return source.clone(kj::atomicAddRef(*ownContentWrapper));
+  });
+
+  return js.alloc<WorkerStub>(ioctx.addObject(kj::mv(isolateChannel)));
+}
+
+DynamicWorkerSource WorkerLoader::toDynamicWorkerSource(jsg::Lock& js,
+    IoContext& ioctx,
+    CompatibilityDateValidation compatDateValidation,
     WorkerCode code) {
   auto extractedSource = extractSource(js, code);
   auto ownCompatFlags = extractCompatFlags(js, code, compatDateValidation);

--- a/src/workerd/api/worker-loader.h
+++ b/src/workerd/api/worker-loader.h
@@ -127,8 +127,12 @@ class WorkerLoader: public jsg::Object {
   jsg::Ref<WorkerStub> get(
       jsg::Lock& js, kj::Maybe<kj::String> name, jsg::Function<jsg::Promise<WorkerCode>()> getCode);
 
+  // Shortcut for `get(null, () => code)`.
+  jsg::Ref<WorkerStub> load(jsg::Lock& js, WorkerCode code);
+
   JSG_RESOURCE_TYPE(WorkerLoader) {
     JSG_METHOD(get);
+    JSG_METHOD(load);
 
     JSG_TS_ROOT();
   }
@@ -137,8 +141,8 @@ class WorkerLoader: public jsg::Object {
   uint channel;
   CompatibilityDateValidation compatDateValidation;
 
-  static DynamicWorkerSource toDynamicWorkerSource(
-      jsg::Lock& js, IoContext& ioctx,
+  static DynamicWorkerSource toDynamicWorkerSource(jsg::Lock& js,
+      IoContext& ioctx,
       CompatibilityDateValidation compatDateValidation,
       WorkerCode code);
 

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -338,6 +338,23 @@ struct DynamicWorkerSource {
   //  this is false, then it is perfectly safe to transfer ownership of ownContent between threads
   //  and keep it alive indefinitely long.
   bool ownContentIsRpcResponse = true;
+
+  // Clone the DynamicWorkerSource. Caller must provide a new reference to use as `ownContent`,
+  // which must be a refcount on the same content since the pointers will not be updated. Note
+  // that if `ownContentIsRpcResponse` is false, then `ownContent` could be passed off to other
+  // threads and as such the refcount had better be atomic.
+  DynamicWorkerSource clone(kj::Own<void> newOwnContent) {
+    return {
+      .source = source.clone(),
+      .compatibilityFlags = compatibilityFlags,
+      .env = env.clone(),
+      .globalOutbound = mapAddRef(globalOutbound),
+      .tails = KJ_MAP(t, tails) { return kj::addRef(*t); },
+      .streamingTails = KJ_MAP(t, streamingTails) { return kj::addRef(*t); },
+      .ownContent = kj::mv(newOwnContent),
+      .ownContentIsRpcResponse = ownContentIsRpcResponse,
+    };
+  }
 };
 
 // A Frankenvalue::CapTableEntry which directly references a numbered I/O channel. This is ONLY

--- a/src/workerd/io/worker-source.h
+++ b/src/workerd/io/worker-source.h
@@ -86,6 +86,46 @@ struct WorkerSource {
 
     // Hack for tests: register this as an internal module. Not allowed in production.
     bool treatAsInternalForTest = false;
+
+    Module clone() {
+      Module result{.name = name};
+
+      // TODO(cleanup): kj::OneOf should have a clone() method.
+      KJ_SWITCH_ONEOF(content) {
+        KJ_CASE_ONEOF(content, EsModule) {
+          result.content = content;
+        }
+        KJ_CASE_ONEOF(content, TextModule) {
+          result.content = content;
+        }
+        KJ_CASE_ONEOF(content, DataModule) {
+          result.content = content;
+        }
+        KJ_CASE_ONEOF(content, WasmModule) {
+          result.content = content;
+        }
+        KJ_CASE_ONEOF(content, JsonModule) {
+          result.content = content;
+        }
+        KJ_CASE_ONEOF(content, CommonJsModule) {
+          result.content = CommonJsModule{.body = content.body,
+            .namedExports = content.namedExports.map([](const kj::Array<kj::StringPtr>& other) {
+            return KJ_MAP(e, other) { return e; };
+          })};
+        }
+        KJ_CASE_ONEOF(content, PythonModule) {
+          result.content = content;
+        }
+        KJ_CASE_ONEOF(content, PythonRequirement) {
+          result.content = content;
+        }
+        KJ_CASE_ONEOF(content, CapnpModule) {
+          result.content = content;
+        }
+      }
+
+      return result;
+    }
   };
 
   // Representation of source code for a worker using Service Workers syntax (deprecated, but will
@@ -127,6 +167,15 @@ struct WorkerSource {
     // The worker may have a bundle of capnp schemas attached. (In Service Workers syntax, these
     // can't be referenced directly by the app, but they may be used by bindings.)
     capnp::List<capnp::schema::Node>::Reader capnpSchemas;
+
+    ScriptSource clone() {
+      return {
+        .mainScript = mainScript,
+        .mainScriptName = mainScriptName,
+        .globals = KJ_MAP(g, globals) { return g.clone(); },
+        .capnpSchemas = capnpSchemas,
+      };
+    }
   };
 
   // Representation of source code for a worker using ES Modules syntax.
@@ -146,6 +195,16 @@ struct WorkerSource {
     // Optional Python memory snapshot. The actual capnp type is declared in the internal codebase,
     // so we use AnyStruct here. This is deprecated anyway.
     kj::Maybe<capnp::AnyStruct::Reader> pythonMemorySnapshot;
+
+    ModulesSource clone() {
+      return {
+        .mainModule = mainModule,
+        .modules = KJ_MAP(m, modules) { return m.clone(); },
+        .capnpSchemas = capnpSchemas,
+        .isPython = isPython,
+        .pythonMemorySnapshot = pythonMemorySnapshot,
+      };
+    }
   };
 
   // The overall value is either ScriptSource or ModulesSource.
@@ -156,6 +215,20 @@ struct WorkerSource {
 
   WorkerSource(ScriptSource source): variant(kj::mv(source)) {}
   WorkerSource(ModulesSource source): variant(kj::mv(source)) {}
+
+  // Clones everything owned by the `WorkerSource`. But where it contains external pointers, those
+  // pointers are kept as-is.
+  WorkerSource clone() {
+    KJ_SWITCH_ONEOF(variant) {
+      KJ_CASE_ONEOF(script, ScriptSource) {
+        return WorkerSource(script.clone());
+      }
+      KJ_CASE_ONEOF(modules, ModulesSource) {
+        return WorkerSource(modules.clone());
+      }
+    }
+    KJ_UNREACHABLE;
+  }
 };
 
 // Bit of a hack: a `WorkerSource` can contain a `DynamicEnvBuilder`, which is an object that

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4185,6 +4185,7 @@ interface WorkerLoader {
     name: string | null,
     getCode: () => WorkerLoaderWorkerCode | Promise<WorkerLoaderWorkerCode>,
   ): WorkerStub;
+  load(code: WorkerLoaderWorkerCode): WorkerStub;
 }
 interface WorkerLoaderModule {
   js?: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4191,6 +4191,7 @@ export interface WorkerLoader {
     name: string | null,
     getCode: () => WorkerLoaderWorkerCode | Promise<WorkerLoaderWorkerCode>,
   ): WorkerStub;
+  load(code: WorkerLoaderWorkerCode): WorkerStub;
 }
 export interface WorkerLoaderModule {
   js?: string;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -3876,6 +3876,7 @@ interface WorkerLoader {
     name: string | null,
     getCode: () => WorkerLoaderWorkerCode | Promise<WorkerLoaderWorkerCode>,
   ): WorkerStub;
+  load(code: WorkerLoaderWorkerCode): WorkerStub;
 }
 interface WorkerLoaderModule {
   js?: string;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -3882,6 +3882,7 @@ export interface WorkerLoader {
     name: string | null,
     getCode: () => WorkerLoaderWorkerCode | Promise<WorkerLoaderWorkerCode>,
   ): WorkerStub;
+  load(code: WorkerLoaderWorkerCode): WorkerStub;
 }
 export interface WorkerLoaderModule {
   js?: string;


### PR DESCRIPTION
`LOADER.load(code)` is equivalent to `LOADER.get(null, () => code)`. This is nice for the common use case of e.g. agent-generated one-off code.

This change got annoying to the pesky detail that the system might call the callback multiple times, forcing me to create clone() methods for a bunch of structures so that I could build the structure ones and return a clone on every call. The source code itself is refcounted between these clones, at least.

Note: Eventually we might support plain RPC stubs in `env` in this case, but that's a deep change which I'm not going to attempt right now.