### PR TITLE
container: Be able to specify interceptOutboundHttp with hostname globs, and make sure that interceptAllOutboundHttp can intercept all hostname globs

### DIFF
--- a/build/deps/oci.MODULE.bazel
+++ b/build/deps/oci.MODULE.bazel
@@ -14,7 +14,7 @@ oci.pull(
 )
 oci.pull(
     name = "proxy_everything",
-    digest = "sha256:f159d9e1b0f28bc01bd106f38d62479c018d050e3f95b365c5f9b5f83f60df82",
+    digest = "sha256:0ef6716c52430096900b150d84a3302057d6cd2319dae7987128c85d0733e3c8",
     image = "docker.io/cloudflare/proxy-everything",
     platforms = [
         "linux/amd64",

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -118,7 +118,9 @@ interface Container @0x9aaceefc06523bca {
   setEgressHttp @8 (hostPort :Text, channelToken :Data);
   # Configures egress HTTP routing for the container. When the container attempts to connect to the
   # specified host:port, the connection should be routed back to the Workers runtime using the channel token.
-  # The format of hostPort can be '<ip|cidr>[':'<port>]'. If port is omitted, it's assumed to only cover port 80.
+  # The format of hostPort can be '<ip|cidr|hostnameGlob>[':'<port>]'. If the host part is not an
+  # IP or CIDR, it is treated as a hostname glob.
+  # If port is omitted, it's assumed to only cover port 80.
   # This method does not support HTTPs yet.
 
 

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -283,6 +283,8 @@ wd_cc_library(
         "//src/workerd/io",
         "//src/workerd/io:container_capnp",
         "//src/workerd/jsg",
+        "//src/workerd/util:strings",
+        "@ada-url",
         "@capnp-cpp//src/capnp/compat:http-over-capnp",
         "@capnp-cpp//src/kj",
         "@capnp-cpp//src/kj:kj-async",

--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -4,11 +4,14 @@
 
 #include "container-client.h"
 
+#include "ada.h"
+
 #include <workerd/io/container.capnp.h>
 #include <workerd/io/worker-interface.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/url.h>
 #include <workerd/server/docker-api.capnp.h>
+#include <workerd/util/strings.h>
 
 #include <capnp/compat/json.h>
 #include <capnp/message.h>
@@ -28,7 +31,7 @@ namespace {
 constexpr uint16_t SIDECAR_INGRESS_PORT = 39001;
 
 struct ParsedAddress {
-  kj::CidrRange cidr;
+  kj::OneOf<kj::CidrRange, kj::String> destination;
   kj::Maybe<uint16_t> port;
 };
 
@@ -85,13 +88,96 @@ kj::CidrRange makeCidr(kj::StringPtr host) {
   return kj::CidrRange(kj::str(host, isIpv6 ? "/128" : "/32"));
 }
 
+kj::Maybe<kj::CidrRange> tryMakeCidr(kj::StringPtr host) {
+  kj::Maybe<kj::CidrRange> cidr;
+  KJ_IF_SOME(_, kj::runCatchingExceptions([&]() { cidr = makeCidr(host); })) {
+    return kj::none;
+  }
+
+  return kj::mv(cidr);
+}
+
+// normalizeHostname normalizes the hostname. It's designed to receive the hostname when
+// proxy-everything sends the HTTP CONNECT with the X-Hostname hint.
+kj::String normalizeHostname(kj::StringPtr hostname) {
+  auto url = kj::str("http://", hostname);
+  auto parsed = ada::parse<ada::url_aggregator>({url.begin(), url.size()}, nullptr);
+  KJ_REQUIRE(parsed.has_value(), "Invalid X-Hostname URL hint.", hostname);
+  auto normalizedHostname = parsed->get_hostname();
+  return kj::heapString(normalizedHostname.data(), normalizedHostname.size());
+}
+
+// hostnameGlobMatches should match patterns like:
+//   cloudflare.*.com
+//   cloudflare.com
+//   cloudflare
+//   *
+//
+// hostname must be normalized beforehand
+bool hostnameGlobMatches(kj::StringPtr pattern, kj::StringPtr hostname) {
+  size_t patternIndex = 0;
+  size_t hostnameIndex = 0;
+  size_t restartHostnameIndex = 0;
+  kj::Maybe<size_t> starPatternIndex;
+
+  while (hostnameIndex < hostname.size()) {
+    if (patternIndex < pattern.size() && pattern[patternIndex] == '*') {
+      starPatternIndex = patternIndex++;
+      restartHostnameIndex = hostnameIndex;
+      continue;
+    }
+
+    if (patternIndex < pattern.size() && pattern[patternIndex] == hostname[hostnameIndex]) {
+      ++patternIndex;
+      ++hostnameIndex;
+      continue;
+    }
+
+    KJ_IF_SOME(starIndex, starPatternIndex) {
+      patternIndex = starIndex + 1;
+      hostnameIndex = ++restartHostnameIndex;
+      continue;
+    }
+
+    return false;
+  }
+
+  while (patternIndex < pattern.size() && pattern[patternIndex] == '*') {
+    ++patternIndex;
+  }
+
+  return patternIndex == pattern.size();
+}
+
+kj::Maybe<kj::StringPtr> getHeader(const kj::HttpHeaders& headers, kj::StringPtr name) {
+  kj::Maybe<kj::StringPtr> result;
+  headers.forEach([&](kj::StringPtr headerName, kj::StringPtr value) {
+    if (result == kj::none && workerd::strcaseeq(headerName, name)) {
+      result = value;
+    }
+  });
+  return result;
+}
+
 // Parses "host[:port]" strings. Handles:
 // - IPv4: "10.0.0.1", "10.0.0.1:8080", "10.0.0.0/8", "10.0.0.0/8:8080"
 // - IPv6 with brackets: "[::1]", "[::1]:8080", "[fe80::1]", "[fe80::/10]:8080"
 // - IPv6 without brackets: "::1", "fe80::1", "fe80::/10"
 ParsedAddress parseHostPort(kj::StringPtr str) {
   auto hostAndPort = stripPort(str);
-  return {makeCidr(hostAndPort.host), hostAndPort.port};
+  KJ_REQUIRE(hostAndPort.host.size() > 0, "Host must not be empty.", str);
+
+  KJ_IF_SOME(cidr, tryMakeCidr(hostAndPort.host)) {
+    return {
+      .destination = kj::mv(cidr),
+      .port = hostAndPort.port,
+    };
+  }
+
+  return {
+    .destination = workerd::toLower(hostAndPort.host),
+    .port = hostAndPort.port,
+  };
 }
 
 kj::StringPtr signalToString(uint32_t signal) {
@@ -349,20 +435,33 @@ class EgressHttpService final: public kj::HttpService {
       ConnectResponse& response,
       kj::HttpConnectSettings settings) override {
     auto destAddr = kj::str(host);
+    kj::Maybe<kj::String> requestHostname;
+    // X-Hostname is set by proxy-everything
+    // when it peeks over a connection and sees a HTTP header.
+    KJ_IF_SOME(value, getHeader(headers, "X-Hostname")) {
+      requestHostname = kj::str(value);
+    }
 
     kj::HttpHeaders responseHeaders(headerTable);
     response.accept(200, "OK", responseHeaders);
 
-    auto mapping = containerClient.findEgressMapping(destAddr, /*defaultPort=*/80);
+    auto mapping = containerClient.findEgressMapping(destAddr, /*defaultPort=*/80,
+        requestHostname.map([](auto& hostname) {
+      return kj::Maybe<kj::StringPtr>(hostname);
+    }).orDefault(kj::none));
 
     if (mapping != kj::none) {
       // Layer an HttpServer on top of the tunnel to handle HTTP parsing/serialization.
       // InnerEgressService looks up the mapping on each request so channel replacements
       // via interceptOutboundHttp are picked up on existing tunnels.
       auto innerService = kj::heap<InnerEgressService>(
-          [&client = containerClient, addr = kj::str(destAddr)]()
-              -> kj::Maybe<kj::Own<IoChannelFactory::SubrequestChannel>> {
-        return client.findEgressMapping(addr, /*defaultPort=*/80);
+          [&client = containerClient, addr = kj::str(destAddr),
+              hostname = kj::mv(
+                  requestHostname)]() -> kj::Maybe<kj::Own<IoChannelFactory::SubrequestChannel>> {
+        return client.findEgressMapping(addr, /*defaultPort=*/80,
+            hostname.map([](auto& value) {
+          return kj::Maybe<kj::StringPtr>(value);
+        }).orDefault(kj::none));
       },
           destAddr);
       auto innerServer =
@@ -373,7 +472,7 @@ class EgressHttpService final: public kj::HttpService {
       co_return;
     }
 
-    if (!containerClient.internetEnabled) {
+    if (!containerClient.internetEnabled.orDefault(false)) {
       connection.shutdownWrite();
       co_return;
     }
@@ -626,11 +725,39 @@ kj::Promise<void> ContainerClient::updateSidecarEgressPort(
   auto jsonRoot = message.initRoot<docker_api::ProxyEverything::Port>();
   jsonRoot.setPort(egressPort);
 
+  auto body = codec.encode(jsonRoot);
   auto response = co_await dockerApiRequest(network, kj::str("127.0.0.1:", ingressHostPort),
-      kj::HttpMethod::PUT, kj::str("/egress"), codec.encode(jsonRoot));
+      kj::HttpMethod::PUT, kj::str("/egress"), kj::mv(body));
 
   JSG_REQUIRE(response.statusCode >= 200 && response.statusCode < 300, Error,
       "Updating sidecar egress port failed with: ", response.statusCode, " ", response.body);
+}
+
+kj::Promise<void> ContainerClient::updateSidecarEgressConfig(
+    uint16_t ingressHostPort, uint16_t egressPort) {
+  capnp::JsonCodec codec;
+  codec.handleByAnnotation<docker_api::ProxyEverything::Port>();
+  capnp::MallocMessageBuilder message;
+  auto jsonRoot = message.initRoot<docker_api::ProxyEverything::Port>();
+  jsonRoot.setPort(egressPort);
+
+  auto allowHostnames = getDnsAllowHostnames();
+  auto dns = jsonRoot.initDns();
+  auto allowHostnamesList = dns.initAllowHostnames(allowHostnames.size());
+  for (auto i: kj::indices(allowHostnames)) {
+    allowHostnamesList.set(i, allowHostnames[i]);
+  }
+
+  KJ_IF_SOME(enabled, internetEnabled) {
+    jsonRoot.initInternet().setEnabled(enabled);
+  }
+
+  auto body = codec.encode(jsonRoot);
+  auto response = co_await dockerApiRequest(network, kj::str("127.0.0.1:", ingressHostPort),
+      kj::HttpMethod::PUT, kj::str("/egress"), kj::mv(body));
+
+  JSG_REQUIRE(response.statusCode >= 200 && response.statusCode < 300, Error,
+      "Updating sidecar egress config failed with: ", response.statusCode, " ", response.body);
 }
 
 kj::Promise<void> ContainerClient::createContainer(
@@ -770,8 +897,9 @@ kj::Promise<void> ContainerClient::createSidecarContainer(
 
   auto ipv6Enabled = co_await isDaemonIpv6Enabled();
 
+  // determined by the number of flags we need to pass to proxy-everything
   uint32_t cmdSize =
-      6;  // --http-egress-port <port> --http-ingress-address 0.0.0.0:<port> --docker-gateway-cidr <cidr>
+      7;  // --http-egress-port <port> --http-ingress-address 0.0.0.0:<port> --docker-gateway-cidr <cidr> --dns-enabled
   if (!ipv6Enabled) cmdSize += 1;  // --disable-ipv6
 
   auto cmd = jsonRoot.initCmd(cmdSize);
@@ -782,6 +910,7 @@ kj::Promise<void> ContainerClient::createSidecarContainer(
   cmd.set(idx++, kj::str("0.0.0.0:", SIDECAR_INGRESS_PORT));
   cmd.set(idx++, "--docker-gateway-cidr");
   cmd.set(idx++, networkCidr);
+  cmd.set(idx++, "--dns-enabled");
   if (!ipv6Enabled) {
     cmd.set(idx++, "--disable-ipv6");
   }
@@ -988,9 +1117,26 @@ kj::Promise<void> ContainerClient::listenTcp(ListenTcpContext context) {
 }
 
 void ContainerClient::upsertEgressMapping(EgressMapping mapping) {
-  auto cidrStr = mapping.cidr.toString();
   for (auto& m: egressMappings) {
-    if (m.port == mapping.port && m.cidr.toString() == cidrStr) {
+    if (m.port != mapping.port) {
+      continue;
+    }
+
+    bool matches = false;
+    KJ_SWITCH_ONEOF(m.destination) {
+      KJ_CASE_ONEOF(existingCidr, kj::CidrRange) {
+        KJ_IF_SOME(newCidr, mapping.destination.tryGet<kj::CidrRange>()) {
+          matches = existingCidr.toString() == newCidr.toString();
+        }
+      }
+      KJ_CASE_ONEOF(existingHostnameGlob, kj::String) {
+        KJ_IF_SOME(newHostnameGlob, mapping.destination.tryGet<kj::String>()) {
+          matches = existingHostnameGlob == newHostnameGlob;
+        }
+      }
+    }
+
+    if (matches) {
       m.channel = kj::mv(mapping.channel);
       return;
     }
@@ -999,17 +1145,65 @@ void ContainerClient::upsertEgressMapping(EgressMapping mapping) {
   egressMappings.add(kj::mv(mapping));
 }
 
-kj::Maybe<kj::Own<workerd::IoChannelFactory::SubrequestChannel>> ContainerClient::findEgressMapping(
-    kj::StringPtr destAddr, uint16_t defaultPort) {
-  auto hostAndPort = stripPort(destAddr);
-  uint16_t port = hostAndPort.port.orDefault(defaultPort);
+kj::Vector<kj::String> ContainerClient::getDnsAllowHostnames() const {
+  // result N can be at most size of egressMappings.
+  kj::Vector<kj::String> result;
 
   for (auto& mapping: egressMappings) {
-    if (mapping.cidr.matches(hostAndPort.host)) {
-      // CIDR matches, now check port.
-      // If the port is 0, we match anything.
-      if (mapping.port == 0 || mapping.port == port) {
-        return kj::addRef(*mapping.channel);
+    KJ_SWITCH_ONEOF(mapping.destination) {
+      KJ_CASE_ONEOF(_, kj::CidrRange) {
+        result.add(kj::str("*"));
+        return result;
+      }
+      KJ_CASE_ONEOF(hostnameGlob, kj::String) {
+        bool alreadyPresent = false;
+        // Check if we have the hostnameGlob already present in the DNS allow
+        // list.
+        for (auto& existing: result) {
+          if (existing == hostnameGlob) {
+            alreadyPresent = true;
+            break;
+          }
+        }
+
+        if (!alreadyPresent) {
+          result.add(kj::str(hostnameGlob));
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+kj::Maybe<kj::Own<workerd::IoChannelFactory::SubrequestChannel>> ContainerClient::findEgressMapping(
+    kj::StringPtr destAddr, uint16_t defaultPort, kj::Maybe<kj::StringPtr> hostname) {
+  auto hostAndPort = stripPort(destAddr);
+  uint16_t port = hostAndPort.port.orDefault(defaultPort);
+  kj::Maybe<kj::String> normalizedHostname;
+  KJ_IF_SOME(hostnameValue, hostname) {
+    normalizedHostname = normalizeHostname(hostnameValue);
+  }
+
+  for (auto& mapping: egressMappings) {
+    // Mappings can differ in port, and cidr/hostname.
+    // Users can specify things like google.com:7070, or 0.0.0.0:7070
+    if (mapping.port != 0 && mapping.port != port) {
+      continue;
+    }
+
+    KJ_SWITCH_ONEOF(mapping.destination) {
+      KJ_CASE_ONEOF(cidr, kj::CidrRange) {
+        if (cidr.matches(hostAndPort.host)) {
+          return kj::addRef(*mapping.channel);
+        }
+      }
+      KJ_CASE_ONEOF(hostnameGlob, kj::String) {
+        KJ_IF_SOME(hostnameValue, normalizedHostname) {
+          if (hostnameGlobMatches(hostnameGlob, hostnameValue)) {
+            return kj::addRef(*mapping.channel);
+          }
+        }
       }
     }
   }
@@ -1035,7 +1229,7 @@ kj::Promise<void> ContainerClient::ensureSidecarStarted() {
   auto sidecar = KJ_REQUIRE_NONNULL(co_await inspectSidecar(), "started sidecar not running");
   this->sidecarIngressHostPort = sidecar.ingressHostPort;
 
-  // Wait for the sidecar's HTTP server to be ready by calling updateSidecarEgressPort
+  // Wait for the sidecar's HTTP server to be ready by calling updateSidecarEgressConfig
   // in a retry loop with a per-attempt timeout.
   constexpr int MAX_READY_RETRIES = 10;
   constexpr auto READY_RETRY_DELAY = 200 * kj::MILLISECONDS;
@@ -1044,7 +1238,7 @@ kj::Promise<void> ContainerClient::ensureSidecarStarted() {
     kj::Maybe<kj::Exception> maybeError;
     try {
       co_await timer.timeoutAfter(READY_ATTEMPT_TIMEOUT,
-          updateSidecarEgressPort(sidecar.ingressHostPort, egressListenerPort));
+          updateSidecarEgressConfig(sidecar.ingressHostPort, egressListenerPort));
     } catch (...) {
       maybeError = kj::getCaughtExceptionAsKj();
     }
@@ -1082,7 +1276,6 @@ kj::Promise<void> ContainerClient::setEgressHttp(SetEgressHttpContext context) {
 
   auto parsed = parseHostPort(hostPortStr);
   uint16_t port = parsed.port.orDefault(80);
-  auto cidr = kj::mv(parsed.cidr);
 
   co_await ensureEgressListenerStarted();
 
@@ -1096,10 +1289,14 @@ kj::Promise<void> ContainerClient::setEgressHttp(SetEgressHttpContext context) {
       workerd::IoChannelFactory::ChannelTokenUsage::RPC, tokenBytes);
 
   upsertEgressMapping(EgressMapping{
-    .cidr = kj::mv(cidr),
+    .destination = kj::mv(parsed.destination),
     .port = port,
     .channel = kj::mv(subrequestChannel),
   });
+
+  KJ_IF_SOME(ingressHostPort, sidecarIngressHostPort) {
+    co_await updateSidecarEgressConfig(ingressHostPort, egressListenerPort);
+  }
 
   co_return;
 }

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -138,6 +138,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   kj::Promise<InspectResponse> inspectContainer();
 
   kj::Promise<void> updateSidecarEgressPort(uint16_t ingressHostPort, uint16_t egressPort);
+  kj::Promise<void> updateSidecarEgressConfig(uint16_t ingressHostPort, uint16_t egressPort);
   kj::Promise<void> createContainer(kj::Maybe<capnp::List<capnp::Text>::Reader> entrypoint,
       kj::Maybe<capnp::List<capnp::Text>::Reader> environment,
       rpc::Container::StartParams::Reader params);
@@ -162,26 +163,28 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   // For redeeming channel tokens received via setEgressHttp
   ChannelTokenHandler& channelTokenHandler;
 
-  // Represents a parsed egress mapping with CIDR and port matching
+  // Represents a parsed egress mapping. IP/CIDR mappings match all hostnames,
+  // while hostnameGlob mappings only match requests carrying a matching hostname.
   struct EgressMapping {
-    kj::CidrRange cidr;
+    kj::OneOf<kj::CidrRange, kj::String> destination;
     uint16_t port;  // 0 means match all ports
     kj::Own<workerd::IoChannelFactory::SubrequestChannel> channel;
   };
 
   kj::Vector<EgressMapping> egressMappings;
 
-  // Insert or replace an egress mapping. If a mapping with the same CIDR and port
+  // Insert or replace an egress mapping. If a mapping with the same destination and port
   // already exists, its channel is replaced; otherwise a new mapping is added.
   void upsertEgressMapping(EgressMapping mapping);
+  kj::Vector<kj::String> getDnsAllowHostnames() const;
 
   // Find a matching egress mapping for the given destination address (host:port format).
   // Returns an addRef'd Own so the channel stays alive even if the mapping is later replaced.
   kj::Maybe<kj::Own<workerd::IoChannelFactory::SubrequestChannel>> findEgressMapping(
-      kj::StringPtr destAddr, uint16_t defaultPort);
+      kj::StringPtr destAddr, uint16_t defaultPort, kj::Maybe<kj::StringPtr> hostname);
 
-  // Whether general internet access is enabled for this container
-  bool internetEnabled = false;
+  // Whether general internet access is enabled for this container, when known.
+  kj::Maybe<bool> internetEnabled = kj::none;
 
   std::atomic_bool containerStarted = false;
   std::atomic_bool containerSidecarStarted = false;

--- a/src/workerd/server/docker-api.capnp
+++ b/src/workerd/server/docker-api.capnp
@@ -316,7 +316,17 @@ struct Docker {
 }
 
 struct ProxyEverything {
+  struct Dns {
+    allowHostnames @0 :List(Text) $Json.name("allowHostnames");
+  }
+
+  struct Internet {
+    enabled @0 :Bool $Json.name("enabled");
+  }
+
   struct Port {
     port @0 :UInt16 $Json.name("port");
+    dns @1 :Dns $Json.name("dns");
+    internet @2 :Internet $Json.name("internet");
   }
 }

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -273,6 +273,21 @@ export class DurableObjectExample extends DurableObject {
     }
   }
 
+  async fetchIntercept(host) {
+    return await this.ctx.container
+      .getTcpPort(8080)
+      .fetch('http://foo/intercept', {
+        headers: { 'x-host': host },
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_DURATION),
+      });
+  }
+
+  async expectIntercept(host, expectedStatus, expectedBody) {
+    const response = await this.fetchIntercept(host);
+    assert.equal(response.status, expectedStatus);
+    assert.equal(await response.text(), expectedBody);
+  }
+
   async testPortNotListening() {
     const container = this.ctx.container;
     if (container.running) {
@@ -327,6 +342,121 @@ export class DurableObjectExample extends DurableObject {
     assert.strictEqual(container.running, false);
 
     return data;
+  }
+
+  async testSetEgressHttpWithInternet() {
+    const container = this.ctx.container;
+    if (container.running) {
+      let monitor = container.monitor().catch((_err) => {});
+      await container.destroy();
+      await monitor;
+    }
+
+    container.start({ enableInternet: true });
+
+    await this.waitUntilContainerIsHealthy();
+
+    await container.interceptOutboundHttp(
+      'googlefakedomain.com',
+      this.ctx.exports.TestService({ props: { id: 2 } })
+    );
+
+    await this.expectIntercept(
+      'googlefakedomain.com',
+      200,
+      'hello binding: 2 http://googlefakedomain.com/'
+    );
+
+    await this.expectIntercept(
+      'googlefakedomainother.com',
+      500,
+      'googlefakedomainother.com fetch failed'
+    );
+
+    await container.interceptAllOutboundHttp(
+      this.ctx.exports.TestService({ props: { id: 5 } })
+    );
+
+    await this.expectIntercept(
+      'google.com',
+      200,
+      'hello binding: 5 http://google.com/'
+    );
+  }
+
+  async testSetEgressHttpNoInternet() {
+    const container = this.ctx.container;
+
+    if (!container.running) container.start();
+
+    // wait for container to be available
+    await this.waitUntilContainerIsHealthy();
+
+    await container.interceptOutboundHttp(
+      'google.com',
+      this.ctx.exports.TestService({ props: { id: 2 } })
+    );
+
+    await this.expectIntercept(
+      'google.com',
+      200,
+      'hello binding: 2 http://google.com/'
+    );
+
+    // This should fail as there is no hostname that matches it.
+    await this.expectIntercept('google2.com', 500, 'google2.com fetch failed');
+
+    await container.interceptOutboundHttp(
+      'google2.com',
+      this.ctx.exports.TestService({ props: { id: 4 } })
+    );
+
+    await this.expectIntercept(
+      'google.com',
+      200,
+      'hello binding: 2 http://google.com/'
+    );
+    await this.expectIntercept(
+      'google2.com',
+      200,
+      'hello binding: 4 http://google2.com/'
+    );
+
+    // From now on, all hostnames resolve to Workerd.
+    await container.interceptAllOutboundHttp(
+      this.ctx.exports.TestService({ props: { id: 6 } })
+    );
+
+    await this.expectIntercept(
+      'google.com',
+      200,
+      'hello binding: 2 http://google.com/'
+    );
+
+    await this.expectIntercept(
+      'google2.com',
+      200,
+      'hello binding: 4 http://google2.com/'
+    );
+
+    await this.expectIntercept(
+      'google3.com',
+      200,
+      'hello binding: 6 http://google3.com/'
+    );
+
+    await this.expectIntercept(
+      '1.1.1.1',
+      200,
+      'hello binding: 6 http://1.1.1.1/'
+    );
+
+    await this.expectIntercept('1.1.1.1:90', 500, '1.1.1.1:90 fetch failed');
+    await this.expectIntercept(
+      'google.com:9000',
+      500,
+      'google.com:9000 fetch failed'
+    );
   }
 
   async testSetEgressHttp() {
@@ -788,6 +918,29 @@ export const testPidNamespace = {
       /container-client-test/,
       `Expected PID 1 to be the container entrypoint, but got: ${data.init}`
     );
+  },
+};
+
+// Test setEgressHttp hostname functionality with internet (check we can establish
+// outbound with others).
+export const testSetEgressHttpWithInternet = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testSetEgressHttpWithInternet')
+    );
+    let stub = env.MY_CONTAINER.get(id);
+    await stub.testSetEgressHttpWithInternet();
+  },
+};
+
+// Test setEgressHttp hostname functionality with no internet
+export const testSetEgressHttpNoInternet = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testSetEgressHttpNoInternet')
+    );
+    let stub = env.MY_CONTAINER.get(id);
+    await stub.testSetEgressHttpNoInternet();
   },
 };
 


### PR DESCRIPTION
How this works is that we will start resolving DNS queries for the user in local dev. When they intercept HTTP, they will be able to specify which hostnames they want to receive traffic from. With interceptAllOutboundHttp, they are specifying they want to receive all traffic, even non existent domains, to their Worker.

The user can decide which domains they want to intercept by just using interceptOutboundHttp before it hits their worker.