### PR TITLE
Add IoChannelCapTableEntry::getType().

### DIFF
--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -371,6 +371,10 @@ class IoChannelCapTableEntry final: public Frankenvalue::CapTableEntry {
 
   IoChannelCapTableEntry(Type type, uint channel): type(type), channel(channel) {}
 
+  Type getType() const {
+    return type;
+  }
+
   // Throws if type doesn't match.
   uint getChannelNumber(Type expectedType);
 


### PR DESCRIPTION
There's one place in the internal codebase that needs it.