### PR TITLE
Have node-internal Buffer use JsUint8Array instead of BufferSource

### DIFF
--- a/src/workerd/api/node/buffer.c++
+++ b/src/workerd/api/node/buffer.c++
@@ -31,19 +31,17 @@ kj::Maybe<uint> tryFromHexDigit(char c) {
   return kj::none;
 }
 
-jsg::BackingStore decodeHexTruncated(
+jsg::JsUint8Array decodeHexTruncated(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> text, bool strict = false) {
   // We do not use kj::decodeHex because we need to match Node.js'
   // behavior of truncating the response at the first invalid hex
   // pair as opposed to just marking that an error happened and
   // trying to continue with the decode.
   if (text.size() % 2 != 0) {
-    if (strict) {
-      JSG_FAIL_REQUIRE(TypeError, "The text is not valid hex");
-    }
+    JSG_REQUIRE(!strict, TypeError, "The text is not valid hex");
     text = text.first(text.size() - 1);
   }
-  auto vec = jsg::BackingStore::alloc<v8::Uint8Array>(js, text.size() / 2);
+  auto vec = jsg::JsUint8Array::create(js, text.size() / 2);
   auto ptr = vec.asArrayPtr();
   size_t len = 0;
 
@@ -52,24 +50,23 @@ jsg::BackingStore decodeHexTruncated(
     KJ_IF_SOME(d1, tryFromHexDigit(text[i])) {
       b = d1 << 4;
     } else {
-      if (strict) {
-        JSG_FAIL_REQUIRE(TypeError, "The text is not valid hex");
-      }
+      JSG_REQUIRE(!strict, TypeError, "The text is not valid hex");
       break;
     }
     KJ_IF_SOME(d2, tryFromHexDigit(text[i + 1])) {
       b |= d2;
     } else {
-      if (strict) {
-        JSG_FAIL_REQUIRE(TypeError, "The text is not valid hex");
-      }
+      JSG_REQUIRE(!strict, TypeError, "The text is not valid hex");
       break;
     }
     ptr[len++] = b;
   }
 
-  vec.limit(len);
-  return kj::mv(vec);
+  if (len == vec.size()) {
+    return vec;
+  }
+
+  return vec.slice(js, len);
 }
 
 uint32_t writeInto(jsg::Lock& js,
@@ -134,10 +131,12 @@ uint32_t writeInto(jsg::Lock& js,
   }
 }
 
-jsg::BackingStore decodeStringImpl(
+jsg::JsUint8Array decodeStringImpl(
     jsg::Lock& js, const jsg::JsString& string, Encoding encoding, bool strict = false) {
   auto length = string.length(js);
-  if (length == 0) return jsg::BackingStore::alloc<v8::Uint8Array>(js, 0);
+  if (length == 0) {
+    return jsg::JsUint8Array::create(js, 0);
+  }
 
   static constexpr jsg::JsString::WriteFlags options = jsg::JsString::REPLACE_INVALID_UTF8;
 
@@ -145,18 +144,18 @@ jsg::BackingStore decodeStringImpl(
     case Encoding::ASCII:
       // Fall-through
     case Encoding::LATIN1: {
-      auto dest = jsg::BackingStore::alloc<v8::Uint8Array>(js, length);
-      writeInto(js, dest, string, 0, dest.size(), Encoding::LATIN1);
+      auto dest = jsg::JsUint8Array::create(js, length);
+      writeInto(js, dest.asArrayPtr(), string, 0, dest.size(), Encoding::LATIN1);
       return kj::mv(dest);
     }
     case Encoding::UTF8: {
-      auto dest = jsg::BackingStore::alloc<v8::Uint8Array>(js, string.utf8Length(js));
-      writeInto(js, dest, string, 0, dest.size(), Encoding::UTF8);
+      auto dest = jsg::JsUint8Array::create(js, string.utf8Length(js));
+      writeInto(js, dest.asArrayPtr(), string, 0, dest.size(), Encoding::UTF8);
       return kj::mv(dest);
     }
     case Encoding::UTF16LE: {
-      auto dest = jsg::BackingStore::alloc<v8::Uint8Array>(js, length * sizeof(uint16_t));
-      writeInto(js, dest, string, 0, dest.size(), Encoding::UTF16LE);
+      auto dest = jsg::JsUint8Array::create(js, length * sizeof(uint16_t));
+      writeInto(js, dest.asArrayPtr(), string, 0, dest.size(), Encoding::UTF16LE);
       return kj::mv(dest);
     }
     case Encoding::BASE64:
@@ -168,12 +167,13 @@ jsg::BackingStore decodeStringImpl(
       KJ_STACK_ARRAY(kj::byte, buf, length, 1024, 536870888);
       auto result = string.writeInto(js, buf, options);
       auto len = result.written;
-      auto dest =
-          jsg::BackingStore::alloc<v8::Uint8Array>(js, nbytes::Base64DecodedSize(buf.begin(), len));
+      auto dest = jsg::JsUint8Array::create(js, nbytes::Base64DecodedSize(buf.begin(), len));
       len = nbytes::Base64Decode(
           dest.asArrayPtr<char>().begin(), dest.size(), buf.begin(), buf.size());
-      dest.limit(len);
-      return kj::mv(dest);
+      if (len < dest.size()) {
+        return dest.slice(js, len);
+      }
+      return dest;
     }
     case Encoding::HEX: {
       KJ_STACK_ARRAY(kj::byte, buf, length, 1024, 536870888);
@@ -191,11 +191,11 @@ uint32_t BufferUtil::byteLength(jsg::Lock& js, jsg::JsString str) {
 }
 
 int BufferUtil::compare(jsg::Lock& js,
-    jsg::BufferSource one,
-    jsg::BufferSource two,
+    jsg::JsUint8Array one,
+    jsg::JsUint8Array two,
     jsg::Optional<CompareOptions> maybeOptions) {
-  kj::ArrayPtr<kj::byte> ptrOne = one;
-  kj::ArrayPtr<kj::byte> ptrTwo = two;
+  kj::ArrayPtr<kj::byte> ptrOne = one.asArrayPtr();
+  kj::ArrayPtr<kj::byte> ptrTwo = two.asArrayPtr();
 
   // The options allow comparing subranges within the two inputs.
   KJ_IF_SOME(options, maybeOptions) {
@@ -224,13 +224,8 @@ int BufferUtil::compare(jsg::Lock& js,
   return result > 0 ? 1 : -1;
 }
 
-jsg::BufferSource BufferUtil::concat(
-    jsg::Lock& js, kj::Array<jsg::BufferSource> list, uint32_t length) {
-  if (length == 0) {
-    auto backing = jsg::BackingStore::alloc<v8::Uint8Array>(js, 0);
-    return jsg::BufferSource(js, kj::mv(backing));
-  }
-
+jsg::JsUint8Array BufferUtil::concat(
+    jsg::Lock& js, kj::Array<jsg::JsUint8Array> list, uint32_t length) {
   // The Node.js Buffer.concat is interesting in that it doesn't just append
   // the buffers together as is. The length parameter is used to determine the
   // length of the result which can be lesser or greater than the actual
@@ -239,50 +234,41 @@ jsg::BufferSource BufferUtil::concat(
   // the result will be the combined buffers with the remaining space filled
   // with zeroes.
 
-  auto dest = jsg::BackingStore::alloc<v8::Uint8Array>(js, length);
-  auto view = dest.asArrayPtr();
+  JSG_REQUIRE(length <= v8::ArrayBuffer::kMaxByteLength, RangeError, "The length is too large");
 
-  for (auto& src: list) {
-    // Guard against resizable ArrayBuffers whose underlying buffer may have been
-    // resized by a getter during the array-unwrap phase, making the cached
-    // byteLength stale. Re-read the live ArrayBuffer byte length and clamp.
-    size_t effectiveSize = 0;
-    KJ_IF_SOME(abSize, src.underlyingArrayBufferSize(js)) {
-      auto offset = src.getOffset();
-      effectiveSize = kj::min(src.size(), abSize > offset ? abSize - offset : 0);
-    }
+  auto dest = jsg::JsUint8Array::create(js, length);
+  if (length > 0) {
+    auto view = dest.asArrayPtr();
 
-    if (effectiveSize == 0) continue;
-    // NOTE: ptr.size() may exceed effectiveSize because BackingStore caches byteLength
-    // from construction time, not the live ArrayBuffer size. Always use effectiveSize
-    // (which reflects the re-validated live size) for copy bounds.
-
-    auto ptr = src.asArrayPtr();
-    if (src.size() == 0) continue;
-    // The amount to copy is the lesser of the remaining space in the destination or
-    // the effective size of the chunk we're copying.
-    auto amountToCopy = kj::min(effectiveSize, view.size());
-    view.first(amountToCopy).copyFrom(ptr.first(amountToCopy));
-    view = view.slice(amountToCopy);
-    // If there's no more space in the destination, we're done.
-    if (view == nullptr) {
-      return jsg::BufferSource(js, kj::mv(dest));
+    for (auto& src: list) {
+      // JsUint8Array is a view directly on the v8::Uint8Array, so we don't
+      // really need to worry about whether the underlying ArrayBuffer is
+      // detached or resized, etc. The length is not cached.
+      auto ptr = src.asArrayPtr();
+      if (ptr.size() == 0) continue;
+      // The amount to copy is the lesser of the remaining space in the destination or
+      // the size of the chunk we're copying.
+      auto amountToCopy = kj::min(ptr.size(), view.size());
+      view.first(amountToCopy).copyFrom(ptr.first(amountToCopy));
+      view = view.slice(amountToCopy);
+      // If there's no more space in the destination, we're done.
+      if (view == nullptr) {
+        break;
+      }
     }
   }
 
-  // Fill any remaining space in the destination with zeroes.
-  view.fill(0);
-  return jsg::BufferSource(js, kj::mv(dest));
+  return dest;
 }
 
-jsg::BufferSource BufferUtil::decodeString(
+jsg::JsUint8Array BufferUtil::decodeString(
     jsg::Lock& js, jsg::JsString string, EncodingValue encoding) {
-  return jsg::BufferSource(js, decodeStringImpl(js, string, static_cast<Encoding>(encoding)));
+  return decodeStringImpl(js, string, static_cast<Encoding>(encoding));
 }
 
 void BufferUtil::fillImpl(jsg::Lock& js,
-    jsg::BufferSource buffer,
-    kj::OneOf<jsg::JsString, jsg::BufferSource> value,
+    jsg::JsUint8Array buffer,
+    kj::OneOf<jsg::JsString, jsg::JsUint8Array> value,
     uint32_t start,
     uint32_t end,
     jsg::Optional<EncodingValue> encoding) {
@@ -298,9 +284,9 @@ void BufferUtil::fillImpl(jsg::Lock& js,
         ptr.fill(0);
         return;
       }
-      ptr.fill(decoded);
+      ptr.fill(decoded.asArrayPtr());
     }
-    KJ_CASE_ONEOF(source, jsg::BufferSource) {
+    KJ_CASE_ONEOF(source, jsg::JsUint8Array) {
       if (source.size() == 0) {
         ptr.fill(0);
         return;
@@ -348,7 +334,7 @@ int32_t indexOfOffset(size_t length, int32_t offset, int32_t needle_length, bool
 
 jsg::Optional<uint32_t> indexOfBuffer(jsg::Lock& js,
     kj::ArrayPtr<kj::byte> hayStack,
-    jsg::BufferSource needle,
+    jsg::JsUint8Array needle,
     int32_t byteOffset,
     EncodingValue encoding,
     bool isForward) {
@@ -499,24 +485,25 @@ jsg::JsString toStringImpl(
 }  // namespace
 
 jsg::Optional<uint32_t> BufferUtil::indexOf(jsg::Lock& js,
-    jsg::BufferSource buffer,
-    kj::OneOf<jsg::JsString, jsg::BufferSource> value,
+    jsg::JsUint8Array buffer,
+    kj::OneOf<jsg::JsString, jsg::JsUint8Array> value,
     int32_t byteOffset,
     EncodingValue encoding,
     bool isForward) {
 
   KJ_SWITCH_ONEOF(value) {
     KJ_CASE_ONEOF(string, jsg::JsString) {
-      return indexOfString(js, buffer, string, byteOffset, encoding, isForward);
+      return indexOfString(js, buffer.asArrayPtr(), string, byteOffset, encoding, isForward);
     }
-    KJ_CASE_ONEOF(source, jsg::BufferSource) {
-      return indexOfBuffer(js, buffer, kj::mv(source), byteOffset, encoding, isForward);
+    KJ_CASE_ONEOF(source, jsg::JsUint8Array) {
+      return indexOfBuffer(
+          js, buffer.asArrayPtr(), kj::mv(source), byteOffset, encoding, isForward);
     }
   }
   KJ_UNREACHABLE;
 }
 
-void BufferUtil::swap(jsg::Lock& js, jsg::BufferSource buffer, int size) {
+void BufferUtil::swap(jsg::Lock& js, jsg::JsUint8Array buffer, int size) {
   if (buffer.size() <= 1) return;
   switch (size) {
     case 16: {
@@ -540,21 +527,22 @@ void BufferUtil::swap(jsg::Lock& js, jsg::BufferSource buffer, int size) {
 }
 
 jsg::JsString BufferUtil::toString(
-    jsg::Lock& js, jsg::BufferSource bytes, uint32_t start, uint32_t end, EncodingValue encoding) {
+    jsg::Lock& js, jsg::JsUint8Array bytes, uint32_t start, uint32_t end, EncodingValue encoding) {
   end = kj::min(bytes.size(), end);
   if (end <= start) return js.str();
-  return toStringImpl(js, bytes, start, end, static_cast<Encoding>(encoding));
+  return toStringImpl(js, bytes.asArrayPtr(), start, end, static_cast<Encoding>(encoding));
 }
 
 uint32_t BufferUtil::write(jsg::Lock& js,
-    jsg::BufferSource buffer,
+    jsg::JsUint8Array buffer,
     jsg::JsString string,
     uint32_t offset,
     uint32_t length,
     EncodingValue encoding) {
   length = kj::min(length, buffer.size() - offset);
   if (length == 0) return 0;
-  return writeInto(js, buffer, string, offset, length, static_cast<Encoding>(encoding));
+  return writeInto(
+      js, buffer.asArrayPtr(), string, offset, length, static_cast<Encoding>(encoding));
 }
 
 // ======================================================================================
@@ -631,43 +619,43 @@ jsg::JsString getBufferedString(jsg::Lock& js, kj::ArrayPtr<kj::byte> state) {
 }
 }  // namespace
 
-jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::BufferSource bytes, jsg::BufferSource state) {
+jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::JsUint8Array bytes, jsg::JsUint8Array state) {
   JSG_REQUIRE(state.size() == BufferUtil::kSize, TypeError, "Invalid StringDecoder");
-  auto enc = getEncoding(state);
+  auto bytesPtr = bytes.asArrayPtr();
+  auto statePtr = state.asArrayPtr();
+  auto enc = getEncoding(statePtr);
   if (enc == Encoding::ASCII || enc == Encoding::LATIN1 || enc == Encoding::HEX) {
     // For ascii, latin1, and hex, we can just use the regular
     // toString option since there will never be a case where
     // these have left-over characters.
-    return toStringImpl(js, bytes, 0, bytes.size(), enc);
+    return toStringImpl(js, bytesPtr, 0, bytesPtr.size(), enc);
   }
 
   jsg::JsString prepend = js.str();
   jsg::JsString body = js.str();
-  auto nread = bytes.size();
+  auto nread = bytesPtr.size();
 
   // If bytes is empty there's nothing to decode.
-  if (bytes.size() == 0) return js.str();
+  if (bytesPtr.size() == 0) return js.str();
 
-  auto data = bytes.asArrayPtr().begin();
+  auto data = bytesPtr.begin();
 
-  auto statePtr = state.asArrayPtr();
-  if (getMissingBytes(state) > 0) {
-    JSG_REQUIRE(
-        getMissingBytes(state) + getBufferedBytes(state) <= BufferUtil::kIncompleteCharactersEnd,
+  if (getMissingBytes(statePtr) > 0) {
+    JSG_REQUIRE(getMissingBytes(statePtr) + getBufferedBytes(statePtr) <=
+            BufferUtil::kIncompleteCharactersEnd,
         Error, "Invalid StringDecoder state");
     if (enc == Encoding::UTF8) {
       // For UTF-8, we need special treatment to align with the V8 decoder:
       // If an incomplete character is found at a chunk boundary, we use
       // its remainder and pass it to V8 as-is.
-      auto statePtr = state.asArrayPtr();
-      for (size_t i = 0; i < nread && i < getMissingBytes(state); ++i) {
+      for (size_t i = 0; i < nread && i < getMissingBytes(statePtr); ++i) {
         if ((data[i] & 0xC0) != 0x80) {
           // This byte is not a continuation byte even though it should have
           // been one. We stop decoding of the incomplete character at this
           // point (but still use the rest of the incomplete bytes from this
           // chunk) and assume that the new, unexpected byte starts a new one.
           statePtr[kMissingBytes] = 0;
-          memcpy(getIncompleteCharacterBuffer(state) + getBufferedBytes(state), data, i);
+          memcpy(getIncompleteCharacterBuffer(statePtr) + getBufferedBytes(statePtr), data, i);
           statePtr[kBufferedBytes] += i;
           data += i;
           nread -= i;
@@ -676,9 +664,9 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::BufferSource bytes, jsg::Bu
       }
     }
 
-    size_t found_bytes = std::min(nread, static_cast<size_t>(getMissingBytes(state)));
+    size_t found_bytes = std::min(nread, static_cast<size_t>(getMissingBytes(statePtr)));
     KJ_ASSERT(data != nullptr);
-    memcpy(getIncompleteCharacterBuffer(state) + getBufferedBytes(state), data, found_bytes);
+    memcpy(getIncompleteCharacterBuffer(statePtr) + getBufferedBytes(statePtr), data, found_bytes);
     // Adjust the two buffers.
     data += found_bytes;
     nread -= found_bytes;
@@ -686,9 +674,9 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::BufferSource bytes, jsg::Bu
     statePtr[kMissingBytes] -= found_bytes;
     statePtr[kBufferedBytes] += found_bytes;
 
-    if (getMissingBytes(state) == 0) {
+    if (getMissingBytes(statePtr) == 0) {
       // If no more bytes are missing, create a small string that we will later prepend.
-      prepend = getBufferedString(js, state);
+      prepend = getBufferedString(js, statePtr);
     }
   }
 
@@ -696,8 +684,8 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::BufferSource bytes, jsg::Bu
     body = prepend.length(js) ? prepend : js.str();
     prepend = js.str();
   } else {
-    JSG_REQUIRE(getMissingBytes(state) == 0, Error, "Invalid StringDecoder state");
-    JSG_REQUIRE(getBufferedBytes(state) == 0, Error, "Invalid StringDecoder state");
+    JSG_REQUIRE(getMissingBytes(statePtr) == 0, Error, "Invalid StringDecoder state");
+    JSG_REQUIRE(getBufferedBytes(statePtr) == 0, Error, "Invalid StringDecoder state");
 
     // See whether there is a character that we may have to cut off and
     // finish when receiving the next chunk.
@@ -737,7 +725,7 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::BufferSource bytes, jsg::Bu
             break;
           }
 
-          if (getBufferedBytes(state) >= getMissingBytes(state)) {
+          if (getBufferedBytes(statePtr) >= getMissingBytes(statePtr)) {
             // Received more or exactly as many trailing bytes than the lead
             // character would indicate. In the "==" case, we have valid
             // data and don't need to slice anything off;
@@ -762,14 +750,14 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::BufferSource bytes, jsg::Bu
       }
     } else if (enc == Encoding::BASE64 || enc == Encoding::BASE64URL) {
       statePtr[kBufferedBytes] = nread % 3;
-      if (statePtr[kBufferedBytes] > 0) statePtr[kMissingBytes] = 3 - getBufferedBytes(state);
+      if (statePtr[kBufferedBytes] > 0) statePtr[kMissingBytes] = 3 - getBufferedBytes(statePtr);
     }
 
-    if (getBufferedBytes(state) > 0) {
+    if (getBufferedBytes(statePtr) > 0) {
       // Copy the requested number of buffered bytes from the end of the
       // input into the incomplete character buffer.
-      nread -= getBufferedBytes(state);
-      memcpy(getIncompleteCharacterBuffer(state), data + nread, getBufferedBytes(state));
+      nread -= getBufferedBytes(statePtr);
+      memcpy(getIncompleteCharacterBuffer(statePtr), data + nread, getBufferedBytes(statePtr));
     }
 
     if (nread > 0) {
@@ -788,43 +776,43 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::BufferSource bytes, jsg::Bu
   return js.str();
 }
 
-jsg::JsString BufferUtil::flush(jsg::Lock& js, jsg::BufferSource state) {
+jsg::JsString BufferUtil::flush(jsg::Lock& js, jsg::JsUint8Array state) {
   JSG_REQUIRE(state.size() == BufferUtil::kSize, TypeError, "Invalid StringDecoder");
-  auto enc = getEncoding(state);
+  auto statePtr = state.asArrayPtr();
+  auto enc = getEncoding(statePtr);
   if (enc == Encoding::ASCII || enc == Encoding::HEX || enc == Encoding::LATIN1) {
-    JSG_REQUIRE(getMissingBytes(state) == 0, Error, "Invalid StringDecoder state");
-    JSG_REQUIRE(getBufferedBytes(state) == 0, Error, "Invalid StringDecoder state");
+    JSG_REQUIRE(getMissingBytes(statePtr) == 0, Error, "Invalid StringDecoder state");
+    JSG_REQUIRE(getBufferedBytes(statePtr) == 0, Error, "Invalid StringDecoder state");
   }
 
-  auto statePtr = state.asArrayPtr();
-  if (enc == Encoding::UTF16LE && getBufferedBytes(state) % 2 == 1) {
+  if (enc == Encoding::UTF16LE && getBufferedBytes(statePtr) % 2 == 1) {
     // Ignore a single trailing byte, like the JS decoder does.
     statePtr[kMissingBytes]--;
     statePtr[kBufferedBytes]--;
   }
 
-  if (getBufferedBytes(state) == 0) {
+  if (getBufferedBytes(statePtr) == 0) {
     return js.str();
   }
 
-  auto ret = getBufferedString(js, state);
+  auto ret = getBufferedString(js, statePtr);
   statePtr[kMissingBytes] = 0;
 
   return ret;
 }
 
-bool BufferUtil::isAscii(jsg::BufferSource buffer) {
+bool BufferUtil::isAscii(jsg::JsUint8Array buffer) {
   if (buffer.size() == 0) return true;
   return simdutf::validate_ascii(buffer.asArrayPtr().asChars().begin(), buffer.size());
 }
 
-bool BufferUtil::isUtf8(jsg::BufferSource buffer) {
+bool BufferUtil::isUtf8(jsg::JsUint8Array buffer) {
   if (buffer.size() == 0) return true;
   return simdutf::validate_utf8(buffer.asArrayPtr().asChars().begin(), buffer.size());
 }
 
-jsg::BufferSource BufferUtil::transcode(jsg::Lock& js,
-    jsg::BufferSource source,
+jsg::JsUint8Array BufferUtil::transcode(jsg::Lock& js,
+    jsg::JsUint8Array source,
     EncodingValue rawFromEncoding,
     EncodingValue rawToEncoding) {
   auto fromEncoding = static_cast<Encoding>(rawFromEncoding);
@@ -833,7 +821,7 @@ jsg::BufferSource BufferUtil::transcode(jsg::Lock& js,
   JSG_REQUIRE(i18n::canBeTranscoded(fromEncoding) && i18n::canBeTranscoded(toEncoding), Error,
       "Unable to transcode buffer due to unsupported encoding");
 
-  return i18n::transcode(js, source, fromEncoding, toEncoding);
+  return i18n::transcode(js, source.asArrayPtr(), fromEncoding, toEncoding);
 }
 
 }  // namespace workerd::api::node

--- a/src/workerd/api/node/buffer.h
+++ b/src/workerd/api/node/buffer.h
@@ -27,35 +27,35 @@ class BufferUtil final: public jsg::Object {
   };
 
   int compare(jsg::Lock& js,
-      jsg::BufferSource one,
-      jsg::BufferSource two,
+      jsg::JsUint8Array one,
+      jsg::JsUint8Array two,
       jsg::Optional<CompareOptions> maybeOptions);
 
-  jsg::BufferSource concat(jsg::Lock& js, kj::Array<jsg::BufferSource> list, uint32_t length);
+  jsg::JsUint8Array concat(jsg::Lock& js, kj::Array<jsg::JsUint8Array> list, uint32_t length);
 
-  jsg::BufferSource decodeString(jsg::Lock& js, jsg::JsString string, EncodingValue encoding);
+  jsg::JsUint8Array decodeString(jsg::Lock& js, jsg::JsString string, EncodingValue encoding);
 
   void fillImpl(jsg::Lock& js,
-      jsg::BufferSource buffer,
-      kj::OneOf<jsg::JsString, jsg::BufferSource> value,
+      jsg::JsUint8Array buffer,
+      kj::OneOf<jsg::JsString, jsg::JsUint8Array> value,
       uint32_t start,
       uint32_t end,
       jsg::Optional<EncodingValue> encoding);
 
   jsg::Optional<uint32_t> indexOf(jsg::Lock& js,
-      jsg::BufferSource buffer,
-      kj::OneOf<jsg::JsString, jsg::BufferSource> value,
+      jsg::JsUint8Array buffer,
+      kj::OneOf<jsg::JsString, jsg::JsUint8Array> value,
       int32_t byteOffset,
       EncodingValue encoding,
       bool isForward);
 
-  void swap(jsg::Lock& js, jsg::BufferSource buffer, int size);
+  void swap(jsg::Lock& js, jsg::JsUint8Array buffer, int size);
 
   jsg::JsString toString(
-      jsg::Lock& js, jsg::BufferSource bytes, uint32_t start, uint32_t end, EncodingValue encoding);
+      jsg::Lock& js, jsg::JsUint8Array bytes, uint32_t start, uint32_t end, EncodingValue encoding);
 
   uint32_t write(jsg::Lock& js,
-      jsg::BufferSource buffer,
+      jsg::JsUint8Array buffer,
       jsg::JsString string,
       uint32_t offset,
       uint32_t length,
@@ -70,12 +70,12 @@ class BufferUtil final: public jsg::Object {
     kSize = 7,
   };
 
-  jsg::JsString decode(jsg::Lock& js, jsg::BufferSource bytes, jsg::BufferSource state);
-  jsg::JsString flush(jsg::Lock& js, jsg::BufferSource state);
-  bool isAscii(jsg::BufferSource bytes);
-  bool isUtf8(jsg::BufferSource bytes);
-  jsg::BufferSource transcode(jsg::Lock& js,
-      jsg::BufferSource source,
+  jsg::JsString decode(jsg::Lock& js, jsg::JsUint8Array bytes, jsg::JsUint8Array state);
+  jsg::JsString flush(jsg::Lock& js, jsg::JsUint8Array state);
+  bool isAscii(jsg::JsUint8Array bytes);
+  bool isUtf8(jsg::JsUint8Array bytes);
+  jsg::JsUint8Array transcode(jsg::Lock& js,
+      jsg::JsUint8Array source,
       EncodingValue rawFromEncoding,
       EncodingValue rawToEncoding);
 

--- a/src/workerd/api/node/i18n.c++
+++ b/src/workerd/api/node/i18n.c++
@@ -40,10 +40,10 @@ constexpr const char* getEncodingName(Encoding input) {
   }
 }
 
-using TranscodeImpl = kj::Function<kj::Maybe<jsg::BufferSource>(
+using TranscodeImpl = kj::Function<kj::Maybe<jsg::JsUint8Array>(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding)>;
 
-kj::Maybe<jsg::BufferSource> TranscodeDefault(
+kj::Maybe<jsg::JsUint8Array> TranscodeDefault(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding) {
   Converter to(toEncoding);
   auto substitute = kj::str(kj::repeat('?', to.minCharSize()));
@@ -52,13 +52,12 @@ kj::Maybe<jsg::BufferSource> TranscodeDefault(
 
   size_t limit = source.size() * to.maxCharSize();
   if (limit == 0) {
-    auto empty = jsg::BackingStore::alloc<v8::Uint8Array>(js, 0);
-    return jsg::BufferSource(js, kj::mv(empty));
+    return jsg::JsUint8Array::create(js, 0);
   }
   // Workers are limited to 128MB so this isn't actually a realistic concern, but sanity check.
   JSG_REQUIRE(limit <= ISOLATE_LIMIT, Error, "Source buffer is too large to transcode");
 
-  auto out = jsg::BackingStore::alloc<v8::Uint8Array>(js, limit);
+  auto out = jsg::JsUint8Array::create(js, limit);
   auto outPtr = out.asArrayPtr().asChars();
   char* target = outPtr.begin();
   const char* source_ = source.asChars().begin();
@@ -66,26 +65,28 @@ kj::Maybe<jsg::BufferSource> TranscodeDefault(
   ucnv_convertEx(to.conv(), from.conv(), &target, target + limit, &source_, source_ + source.size(),
       nullptr, nullptr, nullptr, nullptr, true, true, &status);
   if (U_SUCCESS(status)) {
-    out.limit(target - outPtr.begin());
-    return jsg::BufferSource(js, kj::mv(out));
+    auto written = target - outPtr.begin();
+    if (written < out.size()) {
+      return out.slice(js, written);
+    }
+    return out;
   }
 
   return kj::none;
 }
 
-kj::Maybe<jsg::BufferSource> TranscodeLatin1ToUTF16(
+kj::Maybe<jsg::JsUint8Array> TranscodeLatin1ToUTF16(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding) {
   auto length_in_chars = source.size() * sizeof(char16_t);
   // Workers are limited to 128MB so this isn't actually a realistic concern, but sanity check.
   JSG_REQUIRE(length_in_chars <= ISOLATE_LIMIT, Error, "Source buffer is too large to transcode");
 
   if (length_in_chars == 0) {
-    auto empty = jsg::BackingStore::alloc<v8::Uint8Array>(js, 0);
-    return jsg::BufferSource(js, kj::mv(empty));
+    return jsg::JsUint8Array::create(js, 0);
   }
 
   Converter from(fromEncoding);
-  auto destBuf = jsg::BackingStore::alloc<v8::Uint8Array>(js, length_in_chars);
+  auto destBuf = jsg::JsUint8Array::create(js, length_in_chars);
   auto destPtr = destBuf.asArrayPtr<char16_t>();
   auto actual_length =
       simdutf::convert_latin1_to_utf16(source.asChars().begin(), source.size(), destPtr.begin());
@@ -95,11 +96,14 @@ kj::Maybe<jsg::BufferSource> TranscodeLatin1ToUTF16(
     return kj::none;
   }
 
-  destBuf.limit(actual_length * sizeof(char16_t));
-  return jsg::BufferSource(js, kj::mv(destBuf));
+  auto written = actual_length * sizeof(char16_t);
+  if (written < destBuf.size()) {
+    return destBuf.slice(js, written);
+  }
+  return destBuf;
 }
 
-kj::Maybe<jsg::BufferSource> TranscodeFromUTF16(
+kj::Maybe<jsg::JsUint8Array> TranscodeFromUTF16(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding) {
   Converter to(toEncoding);
   auto substitute = kj::str(kj::repeat('?', to.minCharSize()));
@@ -116,25 +120,26 @@ kj::Maybe<jsg::BufferSource> TranscodeFromUTF16(
   JSG_REQUIRE(limit <= ISOLATE_LIMIT, Error, "Buffer is too large to transcode");
 
   if (limit == 0) {
-    auto empty = jsg::BackingStore::alloc<v8::Uint8Array>(js, 0);
-    return jsg::BufferSource(js, kj::mv(empty));
+    return jsg::JsUint8Array::create(js, 0);
   }
 
-  auto destBuf = jsg::BackingStore::alloc<v8::Uint8Array>(js, limit);
+  auto destBuf = jsg::JsUint8Array::create(js, limit);
   auto destPtr = destBuf.asArrayPtr().asChars();
   UErrorCode status{};
   auto len = ucnv_fromUChars(
       to.conv(), destPtr.begin(), destPtr.size(), utf16_input.begin(), utf16_input.size(), &status);
 
   if (U_SUCCESS(status)) {
-    destBuf.limit(len);
-    return jsg::BufferSource(js, kj::mv(destBuf));
+    if (len < destBuf.size()) {
+      destBuf = destBuf.slice(js, len);
+    }
+    return destBuf;
   }
 
   return kj::none;
 }
 
-kj::Maybe<jsg::BufferSource> TranscodeUTF16FromUTF8(
+kj::Maybe<jsg::JsUint8Array> TranscodeUTF16FromUTF8(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding) {
   size_t expected_utf16_length =
       simdutf::utf16_length_from_utf8(source.asChars().begin(), source.size());
@@ -144,11 +149,10 @@ kj::Maybe<jsg::BufferSource> TranscodeUTF16FromUTF8(
 
   auto length_in_chars = expected_utf16_length * sizeof(char16_t);
   if (length_in_chars == 0) {
-    auto empty = jsg::BackingStore::alloc<v8::Uint8Array>(js, 0);
-    return jsg::BufferSource(js, kj::mv(empty));
+    return jsg::JsUint8Array::create(js, 0);
   }
 
-  auto destBuf = jsg::BackingStore::alloc<v8::Uint8Array>(js, length_in_chars);
+  auto destBuf = jsg::JsUint8Array::create(js, length_in_chars);
   auto destPtr = destBuf.asArrayPtr<char16_t>();
 
   size_t actual_length =
@@ -161,10 +165,10 @@ kj::Maybe<jsg::BufferSource> TranscodeUTF16FromUTF8(
 
   JSG_REQUIRE(actual_length == expected_utf16_length, Error, "Expected UTF16 length mismatch");
 
-  return jsg::BufferSource(js, kj::mv(destBuf));
+  return destBuf;
 }
 
-kj::Maybe<jsg::BufferSource> TranscodeUTF8FromUTF16(
+kj::Maybe<jsg::JsUint8Array> TranscodeUTF8FromUTF16(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding) {
   JSG_REQUIRE(source.size() % 2 == 0, Error, "UTF-16le input size should be multiple of 2");
   auto utf16_input =
@@ -177,11 +181,10 @@ kj::Maybe<jsg::BufferSource> TranscodeUTF8FromUTF16(
       "Expected UTF-8 length is too large to transcode");
 
   if (expected_utf8_length == 0) {
-    auto empty = jsg::BackingStore::alloc<v8::Uint8Array>(js, 0);
-    return jsg::BufferSource(js, kj::mv(empty));
+    return jsg::JsUint8Array::create(js, 0);
   }
 
-  auto destBuf = jsg::BackingStore::alloc<v8::Uint8Array>(js, expected_utf8_length);
+  auto destBuf = jsg::JsUint8Array::create(js, expected_utf8_length);
   auto destPtr = destBuf.asArrayPtr().asChars();
 
   size_t actual_length =
@@ -193,7 +196,7 @@ kj::Maybe<jsg::BufferSource> TranscodeUTF8FromUTF16(
     return kj::none;
   }
 
-  return jsg::BufferSource(js, kj::mv(destBuf));
+  return destBuf;
 }
 
 }  // namespace
@@ -235,7 +238,7 @@ void Converter::setSubstituteChars(kj::StringPtr sub) {
   }
 }
 
-jsg::BufferSource transcode(
+jsg::JsUint8Array transcode(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding) {
   TranscodeImpl transcode_function = &TranscodeDefault;
   switch (fromEncoding) {

--- a/src/workerd/api/node/i18n.h
+++ b/src/workerd/api/node/i18n.h
@@ -56,7 +56,7 @@ class Converter final {
   kj::Own<UConverter> conv_;
 };
 
-jsg::BufferSource transcode(
+jsg::JsUint8Array transcode(
     jsg::Lock& js, kj::ArrayPtr<kj::byte> source, Encoding fromEncoding, Encoding toEncoding);
 
 }  // namespace i18n

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -651,4 +651,29 @@ BufferSource Lock::bytes(kj::Array<kj::byte> data) {
   return BufferSource(*this, BackingStore::from(*this, kj::mv(data)));
 }
 
+JsUint8Array JsUint8Array::create(Lock& js, size_t length) {
+  JSG_REQUIRE(length < v8::ArrayBuffer::kMaxByteLength, RangeError, "The length is too large");
+  auto backing = v8::ArrayBuffer::NewBackingStore(js.v8Isolate, length,
+      v8::BackingStoreInitializationMode::kZeroInitialized,
+      v8::BackingStoreOnFailureMode::kReturnNull);
+  JSG_REQUIRE(backing != nullptr, RangeError, "Failed to allocate memory for Uint8Array");
+  return create(js, kj::mv(backing), 0, length);
+}
+
+JsUint8Array JsUint8Array::create(
+    Lock& js, std::unique_ptr<v8::BackingStore> backingStore, size_t byteOffset, size_t length) {
+  return JsUint8Array(v8::Uint8Array::New(
+      v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backingStore)), byteOffset, length));
+}
+
+JsUint8Array JsUint8Array::slice(Lock& js, size_t newLength) const {
+  JSG_REQUIRE(newLength <= size(), RangeError, "New length exceeds array length");
+  auto u8 = v8::Uint8Array::New(inner->Buffer(), inner->ByteOffset(), newLength);
+  return JsUint8Array(u8);
+}
+
+size_t JsUint8Array::size() const {
+  return inner->ByteLength();
+}
+
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -254,20 +254,22 @@ class JsArrayBufferView final: public JsBase<v8::ArrayBufferView, JsArrayBufferV
 
 class JsUint8Array final: public JsBase<v8::Uint8Array, JsUint8Array> {
  public:
+  static JsUint8Array create(Lock& js, size_t length);
+
   static JsUint8Array create(
-      Lock& js, std::unique_ptr<v8::BackingStore> backingStore, size_t byteOffset, size_t length) {
-    return JsUint8Array(v8::Uint8Array::New(
-        v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backingStore)), byteOffset, length));
-  }
+      Lock& js, std::unique_ptr<v8::BackingStore> backingStore, size_t byteOffset, size_t length);
+
+  JsUint8Array slice(Lock& js, size_t newLength) const;
 
   template <typename T = kj::byte>
   kj::ArrayPtr<T> asArrayPtr() {
     v8::Local<v8::Uint8Array> inner = *this;
     auto buf = inner->Buffer();
     T* data = static_cast<T*>(buf->Data()) + inner->ByteOffset();
-    size_t length = inner->ByteLength();
-    return kj::ArrayPtr(data, length);
+    return kj::ArrayPtr(data, size());
   }
+
+  size_t size() const;
 
   using JsBase<v8::Uint8Array, JsUint8Array>::JsBase;
 };


### PR DESCRIPTION
Use of `BufferSource` has too much overhead for the way that node-internal `Buffer` is used.

A precursor to converting it all to rust.