### PR TITLE
Add .rollback() api for workflow step promises

### DIFF
--- a/src/cloudflare/internal/test/workflows/BUILD.bazel
+++ b/src/cloudflare/internal/test/workflows/BUILD.bazel
@@ -11,3 +11,10 @@ wd_test(
     args = ["--experimental"],
     data = glob(["*.js"]),
 )
+
+wd_test(
+    src = "workflows-no-rollback-test.wd-test",
+    args = ["--experimental"],
+    data = glob(["*.js"]),
+    # Flag-disabled regression: same JS, no workflows_step_rollback flag.
+)

--- a/src/cloudflare/internal/test/workflows/BUILD.bazel
+++ b/src/cloudflare/internal/test/workflows/BUILD.bazel
@@ -5,3 +5,9 @@ wd_test(
     args = ["--experimental"],
     data = glob(["*.js"]),
 )
+
+wd_test(
+    src = "workflows-step-promise-test.wd-test",
+    args = ["--experimental"],
+    data = glob(["*.js"]),
+)

--- a/src/cloudflare/internal/test/workflows/workflows-no-rollback-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-no-rollback-test.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { RpcTarget } from 'cloudflare:workers';
+import assert from 'node:assert';
+
+// Minimal mock step for the flag-disabled path.
+class MockStep extends RpcTarget {
+  calls = [];
+
+  async do(...args) {
+    const callback = typeof args[1] === 'function' ? args[1] : args[2];
+    this.calls.push({ method: 'do', name: args[0] });
+    return await callback();
+  }
+
+  async sleep(name) {
+    this.calls.push({ method: 'sleep', name });
+  }
+
+  async sleepUntil(name) {
+    this.calls.push({ method: 'sleepUntil', name });
+  }
+
+  async waitForEvent(name) {
+    this.calls.push({ method: 'waitForEvent', name });
+    return { payload: 'data', timestamp: '2024-01-01' };
+  }
+}
+
+// Without workflows_step_rollback, step is the raw RPC stub.
+// All basic step methods still work without wrapping.
+export const noRollbackWithoutFlag = {
+  async test(_, env) {
+    const mock = new MockStep();
+    const result = await env.BasicWorkflow.run({ payload: 'test' }, mock);
+
+    assert.strictEqual(result.doResult, 'hello');
+    assert.strictEqual(result.slept, true);
+    assert.strictEqual(result.waited, true);
+    assert.strictEqual(mock.calls.length, 4);
+  },
+};

--- a/src/cloudflare/internal/test/workflows/workflows-no-rollback-test.wd-test
+++ b/src/cloudflare/internal/test/workflows/workflows-no-rollback-test.wd-test
@@ -1,0 +1,33 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+# Regression test: exercises workflows WITHOUT the workflows_step_rollback flag.
+# Reuses BasicWorkflow from workflows-step-promise-workflows.js but does not
+# enable the flag, verifying the unwrapped step RPC stub works normally.
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "workflows-no-rollback-test",
+      worker = .testWorker,
+    ),
+    ( name = "workflows",
+      worker = .workflowsWorker,
+    ),
+  ]
+);
+
+const testWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "workflows-no-rollback-test.js"),
+  ],
+  compatibilityFlags = ["nodejs_compat", "experimental"],
+  bindings = [
+    (name = "BasicWorkflow", service = (name = "workflows", entrypoint = "BasicWorkflow")),
+  ],
+);
+
+const workflowsWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "workflows-step-promise-workflows.js"),
+  ],
+  compatibilityFlags = ["nodejs_compat", "experimental"],
+);

--- a/src/cloudflare/internal/test/workflows/workflows-step-promise-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-step-promise-test.js
@@ -3,14 +3,11 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import { RpcTarget } from 'cloudflare:workers';
-import * as assert from 'node:assert';
+import assert from 'node:assert';
 
 // Mock step that records calls for verification.
 class MockStep extends RpcTarget {
-  constructor() {
-    super();
-    this.calls = [];
-  }
+  calls = [];
 
   async do(...args) {
     const name = args[0];
@@ -60,10 +57,7 @@ class MockStep extends RpcTarget {
 
 // Mock step that invokes the rollback fn, simulating engine compensation.
 class RollbackCallingMockStep extends RpcTarget {
-  constructor() {
-    super();
-    this.rollbackResult = null;
-  }
+  rollbackResult = null;
 
   async do(...args) {
     const name = args[0];

--- a/src/cloudflare/internal/test/workflows/workflows-step-promise-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-step-promise-test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Cloudflare, Inc.
+// Copyright (c) 2026 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
@@ -56,8 +56,9 @@ class MockStep extends RpcTarget {
 }
 
 // Mock step that invokes the rollback fn, simulating engine compensation.
+// Captures the args passed to the rollback fn so the test can verify them.
 class RollbackCallingMockStep extends RpcTarget {
-  rollbackResult = null;
+  rollbackArgs = null;
 
   async do(...args) {
     const name = args[0];
@@ -65,12 +66,14 @@ class RollbackCallingMockStep extends RpcTarget {
     const rollbackFn =
       typeof args[1] === 'function' ? args[2] || null : args[3] || null;
     const result = await callback();
-    if (rollbackFn) {
-      this.rollbackResult = await rollbackFn({
+    if (rollbackFn !== null) {
+      const ctx = {
         error: 'simulated-error',
         output: result,
         stepName: name,
-      });
+      };
+      await rollbackFn(ctx);
+      this.rollbackArgs = ctx;
     }
     return result;
   }
@@ -161,8 +164,8 @@ export const rollbackCallable = {
       mock
     );
     assert.strictEqual(result.value, 'step-output');
-    assert.strictEqual(mock.rollbackResult.receivedOutput, 'step-output');
-    assert.strictEqual(mock.rollbackResult.receivedStepName, 'my-step');
-    assert.strictEqual(mock.rollbackResult.receivedError, 'simulated-error');
+    assert.strictEqual(mock.rollbackArgs.output, 'step-output');
+    assert.strictEqual(mock.rollbackArgs.stepName, 'my-step');
+    assert.strictEqual(mock.rollbackArgs.error, 'simulated-error');
   },
 };

--- a/src/cloudflare/internal/test/workflows/workflows-step-promise-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-step-promise-test.js
@@ -1,0 +1,174 @@
+// Copyright (c) 2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { RpcTarget } from 'cloudflare:workers';
+import * as assert from 'node:assert';
+
+// Mock step that records calls for verification.
+class MockStep extends RpcTarget {
+  constructor() {
+    super();
+    this.calls = [];
+  }
+
+  async do(...args) {
+    const name = args[0];
+    let callback,
+      rollbackFn = null,
+      rollbackConfig = null;
+    if (typeof args[1] === 'function') {
+      callback = args[1];
+      rollbackFn = args[2] || null;
+      rollbackConfig = args[3] || null;
+    } else {
+      callback = args[2];
+      rollbackFn = args[3] || null;
+      rollbackConfig = args[4] || null;
+    }
+    this.calls.push({
+      method: 'do',
+      name,
+      hadRollbackFn: rollbackFn !== null,
+      hadRollbackConfig: rollbackConfig !== null,
+      rollbackConfig,
+    });
+    return await callback();
+  }
+
+  async sleep(name, duration) {
+    this.calls.push({ method: 'sleep', name, duration });
+  }
+
+  async sleepUntil(name, timestamp) {
+    this.calls.push({ method: 'sleepUntil', name, timestamp });
+  }
+
+  async waitForEvent(...args) {
+    this.calls.push({
+      method: 'waitForEvent',
+      name: args[0],
+      hadRollbackFn: (args[2] || null) !== null,
+    });
+    return {
+      payload: 'event-data',
+      timestamp: '2024-01-01',
+      type: args[1]?.type,
+    };
+  }
+}
+
+// Mock step that invokes the rollback fn, simulating engine compensation.
+class RollbackCallingMockStep extends RpcTarget {
+  constructor() {
+    super();
+    this.rollbackResult = null;
+  }
+
+  async do(...args) {
+    const name = args[0];
+    const callback = typeof args[1] === 'function' ? args[1] : args[2];
+    const rollbackFn =
+      typeof args[1] === 'function' ? args[2] || null : args[3] || null;
+    const result = await callback();
+    if (rollbackFn) {
+      this.rollbackResult = await rollbackFn({
+        error: 'simulated-error',
+        output: result,
+        stepName: name,
+      });
+    }
+    return result;
+  }
+
+  async sleep() {}
+  async sleepUntil() {}
+  async waitForEvent(...args) {
+    return {
+      payload: 'event-data',
+      timestamp: '2024-01-01',
+      type: args[1]?.type,
+    };
+  }
+}
+
+// Verifies all forwarding paths: do (no rollback), do+rollback(fn),
+// do+rollback(config,fn), sleep, sleepUntil, waitForEvent+rollback.
+export const forwarding = {
+  async test(_, env) {
+    const mock = new MockStep();
+    const result = await env.ForwardingWorkflow.run({ payload: 'test' }, mock);
+
+    assert.strictEqual(result.basic, 'basic-result');
+    assert.strictEqual(result.withFn, 'fn-result');
+    assert.strictEqual(result.withConfig, 'config-result');
+    assert.strictEqual(result.waited.type, 'approval');
+
+    // 6 calls total: 3x do, sleep, sleepUntil, waitForEvent
+    assert.strictEqual(mock.calls.length, 6);
+
+    // do('basic') — no rollback args
+    assert.strictEqual(mock.calls[0].hadRollbackFn, false);
+
+    // do('with-fn') — rollback fn, no config
+    assert.strictEqual(mock.calls[1].hadRollbackFn, true);
+    assert.strictEqual(mock.calls[1].hadRollbackConfig, false);
+
+    // do('with-config') — rollback fn + config
+    assert.strictEqual(mock.calls[2].hadRollbackFn, true);
+    assert.strictEqual(mock.calls[2].hadRollbackConfig, true);
+    assert.deepStrictEqual(mock.calls[2].rollbackConfig, {
+      retries: { limit: 3, delay: '5 seconds', backoff: 'linear' },
+      timeout: '30 seconds',
+    });
+
+    // sleep / sleepUntil pass through
+    assert.strictEqual(mock.calls[3].method, 'sleep');
+    assert.strictEqual(mock.calls[4].method, 'sleepUntil');
+
+    // waitForEvent with rollback
+    assert.strictEqual(mock.calls[5].method, 'waitForEvent');
+    assert.strictEqual(mock.calls[5].hadRollbackFn, true);
+  },
+};
+
+// .rollback() guards: called twice, after await, with invalid arg
+export const errorGuards = {
+  async test(_, env) {
+    const mock = new MockStep();
+    const result = await env.ErrorGuardsWorkflow.run({ payload: 'test' }, mock);
+
+    assert.strictEqual(result.errors.length, 3);
+    assert.match(result.errors[0], /can only be called once/);
+    assert.match(result.errors[1], /must be called before the step is awaited/);
+    assert.match(result.errors[2], /expects a function/);
+  },
+};
+
+// Step callback error surfaces through StepPromise
+export const errorPropagation = {
+  async test(_, env) {
+    const mock = new MockStep();
+    const result = await env.ErrorPropagationWorkflow.run(
+      { payload: 'test' },
+      mock
+    );
+    assert.strictEqual(result.threw, true);
+    assert.strictEqual(result.message, 'step-boom');
+  },
+};
+
+// Rollback fn is callable over RPC with correct context
+export const rollbackCallable = {
+  async test(_, env) {
+    const mock = new RollbackCallingMockStep();
+    const result = await env.RollbackCallableWorkflow.run(
+      { payload: 'test' },
+      mock
+    );
+    assert.strictEqual(result.value, 'step-output');
+    assert.strictEqual(mock.rollbackResult.receivedOutput, 'step-output');
+    assert.strictEqual(mock.rollbackResult.receivedStepName, 'my-step');
+    assert.strictEqual(mock.rollbackResult.receivedError, 'simulated-error');
+  },
+};

--- a/src/cloudflare/internal/test/workflows/workflows-step-promise-test.wd-test
+++ b/src/cloudflare/internal/test/workflows/workflows-step-promise-test.wd-test
@@ -1,0 +1,32 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "workflows-step-promise-test",
+      worker = .testWorker,
+    ),
+    ( name = "workflows",
+      worker = .workflowsWorker,
+    ),
+  ]
+);
+
+const testWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "workflows-step-promise-test.js"),
+  ],
+  compatibilityFlags = ["nodejs_compat", "experimental"],
+  bindings = [
+    (name = "ForwardingWorkflow", service = (name = "workflows", entrypoint = "ForwardingWorkflow")),
+    (name = "ErrorGuardsWorkflow", service = (name = "workflows", entrypoint = "ErrorGuardsWorkflow")),
+    (name = "ErrorPropagationWorkflow", service = (name = "workflows", entrypoint = "ErrorPropagationWorkflow")),
+    (name = "RollbackCallableWorkflow", service = (name = "workflows", entrypoint = "RollbackCallableWorkflow")),
+  ],
+);
+
+const workflowsWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "workflows-step-promise-workflows.js"),
+  ],
+  compatibilityFlags = ["nodejs_compat", "experimental"],
+);

--- a/src/cloudflare/internal/test/workflows/workflows-step-promise-test.wd-test
+++ b/src/cloudflare/internal/test/workflows/workflows-step-promise-test.wd-test
@@ -15,7 +15,7 @@ const testWorker :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "workflows-step-promise-test.js"),
   ],
-  compatibilityFlags = ["nodejs_compat", "experimental"],
+  compatibilityFlags = ["nodejs_compat", "experimental", "workflows_step_rollback"],
   bindings = [
     (name = "ForwardingWorkflow", service = (name = "workflows", entrypoint = "ForwardingWorkflow")),
     (name = "ErrorGuardsWorkflow", service = (name = "workflows", entrypoint = "ErrorGuardsWorkflow")),
@@ -28,5 +28,5 @@ const workflowsWorker :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "workflows-step-promise-workflows.js"),
   ],
-  compatibilityFlags = ["nodejs_compat", "experimental"],
+  compatibilityFlags = ["nodejs_compat", "experimental", "workflows_step_rollback"],
 );

--- a/src/cloudflare/internal/test/workflows/workflows-step-promise-workflows.js
+++ b/src/cloudflare/internal/test/workflows/workflows-step-promise-workflows.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Cloudflare, Inc.
+// Copyright (c) 2026 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
@@ -83,17 +83,15 @@ export class ErrorPropagationWorkflow extends WorkflowEntrypoint {
   }
 }
 
-// Rollback fn callable over RPC — mock invokes it, verifies round-trip
+// Rollback fn callable over RPC — mock invokes it, verifies round-trip.
+// The rollback fn returns void (per the contract); the mock captures args separately.
 export class RollbackCallableWorkflow extends WorkflowEntrypoint {
   async run(event, step) {
     const value = await step
       .do('my-step', async () => 'step-output')
       .rollback(async ({ error, output, stepName }) => {
-        return {
-          receivedError: error,
-          receivedOutput: output,
-          receivedStepName: stepName,
-        };
+        // Rollback is a side-effect — nothing to return.
+        // The mock captures error/output/stepName from the args it passes in.
       });
     return { value };
   }

--- a/src/cloudflare/internal/test/workflows/workflows-step-promise-workflows.js
+++ b/src/cloudflare/internal/test/workflows/workflows-step-promise-workflows.js
@@ -1,0 +1,100 @@
+// Copyright (c) 2024 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { WorkflowEntrypoint } from 'cloudflare:workers';
+
+// Exercises all the forwarding paths in a single workflow:
+//   - step.do() without rollback
+//   - step.do().rollback(fn)
+//   - step.do().rollback(config, fn)
+//   - step.sleep() / step.sleepUntil() passthrough
+//   - step.waitForEvent().rollback(fn)
+export class ForwardingWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    const basic = await step.do('basic', async () => 'basic-result');
+    const withFn = await step
+      .do('with-fn', async () => 'fn-result')
+      .rollback(async ({ error, output }) => {});
+    const withConfig = await step
+      .do('with-config', async () => 'config-result')
+      .rollback(
+        {
+          retries: { limit: 3, delay: '5 seconds', backoff: 'linear' },
+          timeout: '30 seconds',
+        },
+        async ({ error, output }) => {}
+      );
+    await step.sleep('s1', '10 seconds');
+    await step.sleepUntil('s2', new Date('2025-01-01'));
+    const waited = await step
+      .waitForEvent('my-wait', { type: 'approval', timeout: '5 minutes' })
+      .rollback(async ({ output }) => {});
+    return { basic, withFn, withConfig, waited };
+  }
+}
+
+// Exercises all three error guards in a single workflow
+export class ErrorGuardsWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    const errors = [];
+
+    // .rollback() called twice
+    try {
+      await step
+        .do('s1', async () => 'r')
+        .rollback(async () => {})
+        .rollback(async () => {});
+    } catch (e) {
+      errors.push(e.message);
+    }
+
+    // .rollback() after await
+    const promise = step.do('s2', async () => 'r');
+    await promise;
+    try {
+      promise.rollback(async () => {});
+    } catch (e) {
+      errors.push(e.message);
+    }
+
+    // .rollback(null)
+    try {
+      await step.do('s3', async () => 'r').rollback(null);
+    } catch (e) {
+      errors.push(e.message);
+    }
+
+    return { errors };
+  }
+}
+
+// Step callback throws — error surfaces through StepPromise
+export class ErrorPropagationWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    try {
+      await step.do('fail', async () => {
+        throw new Error('step-boom');
+      });
+      return { threw: false };
+    } catch (e) {
+      return { threw: true, message: e.message };
+    }
+  }
+}
+
+// Rollback fn callable over RPC — mock invokes it, verifies round-trip
+export class RollbackCallableWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    const value = await step
+      .do('my-step', async () => 'step-output')
+      .rollback(async ({ error, output, stepName }) => {
+        return {
+          receivedError: error,
+          receivedOutput: output,
+          receivedStepName: stepName,
+        };
+      });
+    return { value };
+  }
+}

--- a/src/cloudflare/internal/test/workflows/workflows-step-promise-workflows.js
+++ b/src/cloudflare/internal/test/workflows/workflows-step-promise-workflows.js
@@ -96,3 +96,15 @@ export class RollbackCallableWorkflow extends WorkflowEntrypoint {
     return { value };
   }
 }
+
+// Used by the flag-disabled regression test. Without workflows_step_rollback,
+// step is the raw RPC stub — no wrapping, no .rollback().
+export class BasicWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    const doResult = await step.do('my-step', async () => 'hello');
+    await step.sleep('s1', '10 seconds');
+    await step.sleepUntil('s2', new Date('2025-01-01'));
+    await step.waitForEvent('w1', { type: 'approval' });
+    return { doResult, slept: true, waited: true };
+  }
+}

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -231,23 +231,31 @@ class WorkflowEntrypointWrapper extends entrypoints.WorkflowEntrypoint {
   constructor(ctx: unknown, env: unknown) {
     super(ctx, env);
 
-    // Patch the run method on the subclass prototype if it defines its own run and hasn't been
-    // patched yet. We use hasOwnProperty to avoid double-wrapping when a subclass inherits run
-    // from a parent that was already patched (e.g. class B extends A extends WorkflowEntrypoint
-    // where only A defines run).
-    const proto = Object.getPrototypeOf(this) as Record<string, unknown>;
-    if (
-      !wrappedProtos.has(proto) &&
-      Object.prototype.hasOwnProperty.call(proto, 'run') &&
-      typeof proto.run === 'function'
-    ) {
-      const originalRun = proto.run as (
-        event: unknown,
-        step: unknown,
-        ...rest: unknown[]
-      ) => unknown;
-      proto.run = makeWrappedRun(originalRun);
-      wrappedProtos.add(proto);
+    // Walk the prototype chain to find the prototype that owns run() and wrap it.
+    // We stop at WorkflowEntrypointWrapper.prototype to avoid patching the C++ base.
+    // This handles inheritance: class B extends A extends WorkflowEntrypoint where
+    // only A defines run() — getPrototypeOf(b) is B.prototype which doesn't own run,
+    // so we walk up to A.prototype which does.
+    let proto: Record<string, unknown> | null = Object.getPrototypeOf(
+      this
+    ) as Record<string, unknown>;
+    const stop = WorkflowEntrypointWrapper.prototype as unknown;
+    while (proto !== null && proto !== stop) {
+      if (
+        !wrappedProtos.has(proto) &&
+        Object.prototype.hasOwnProperty.call(proto, 'run') &&
+        typeof proto.run === 'function'
+      ) {
+        const originalRun = proto.run as (
+          event: unknown,
+          step: unknown,
+          ...rest: unknown[]
+        ) => unknown;
+        proto.run = makeWrappedRun(originalRun);
+        wrappedProtos.add(proto);
+        break;
+      }
+      proto = Object.getPrototypeOf(proto) as Record<string, unknown> | null;
     }
 
     // NOTE: Arrow function class properties (e.g. `run = async () => {}`) are NOT supported.

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -25,25 +25,10 @@ type ExecuteFn = (
 ) => Promise<unknown>;
 type RunFn = (event: unknown, step: unknown, ...rest: unknown[]) => unknown;
 
-// The step RPC stub interface — mirrors what the engine exposes via JS RPC.
 interface StepRpcStub {
   do(...args: unknown[]): Promise<unknown>;
-  sleep(name: string, duration: unknown): Promise<void>;
-  sleepUntil(name: string, timestamp: unknown): Promise<void>;
   waitForEvent(...args: unknown[]): Promise<unknown>;
-}
-
-// The wrapped step interface returned by wrapStep(). Matches StepRpcStub but do() and
-// waitForEvent() return StepPromise instead of plain Promise.
-interface WrappedStep {
-  do(
-    name: string,
-    configOrCallback: unknown,
-    maybeCallback?: unknown
-  ): StepPromise;
-  sleep(name: string, duration: unknown): Promise<void>;
-  sleepUntil(name: string, timestamp: unknown): Promise<void>;
-  waitForEvent(name: string, options: unknown): StepPromise;
+  [method: string]: (...args: unknown[]) => unknown;
 }
 
 // StepPromise is a real Promise subclass that captures .rollback() synchronously before
@@ -143,58 +128,58 @@ class StepPromise extends Promise<unknown> {
 }
 
 // Wraps the step RPC stub so that step.do() and step.waitForEvent() return StepPromise instances.
-// sleep() and sleepUntil() are passed through unchanged (they return Promise<void>, no rollback).
-function wrapStep(jsStep: StepRpcStub): WrappedStep {
-  return {
-    do(
-      name: string,
-      configOrCallback: unknown,
-      maybeCallback?: unknown
-    ): StepPromise {
-      return new StepPromise(
-        (rollbackFn: RollbackFn, rollbackConfig: RollbackConfig) => {
-          const args: unknown[] = [name];
-          if (maybeCallback !== undefined) {
-            // do(name, config, callback) form
-            args.push(configOrCallback, maybeCallback);
-          } else {
-            // do(name, callback) form
-            args.push(configOrCallback);
-          }
-          if (rollbackFn !== null) {
-            args.push(rollbackFn);
-            if (rollbackConfig !== null) {
-              args.push(rollbackConfig);
+// All other methods (sleep, sleepUntil, and any future additions) are forwarded unchanged via Proxy.
+function wrapStep(jsStep: StepRpcStub): StepRpcStub {
+  return new Proxy(jsStep, {
+    get(
+      target: StepRpcStub,
+      prop: string | symbol,
+      receiver: unknown
+    ): unknown {
+      if (prop === 'do') {
+        return (
+          name: string,
+          configOrCallback: unknown,
+          maybeCallback?: unknown
+        ): StepPromise => {
+          return new StepPromise(
+            (rollbackFn: RollbackFn, rollbackConfig: RollbackConfig) => {
+              const args: unknown[] = [name];
+              if (maybeCallback !== undefined) {
+                args.push(configOrCallback, maybeCallback);
+              } else {
+                args.push(configOrCallback);
+              }
+              if (rollbackFn !== null) {
+                args.push(rollbackFn);
+                if (rollbackConfig !== null) {
+                  args.push(rollbackConfig);
+                }
+              }
+              return target.do(...args);
             }
-          }
-          return jsStep.do(...args);
-        }
-      );
-    },
-
-    sleep(name: string, duration: unknown): Promise<void> {
-      return jsStep.sleep(name, duration);
-    },
-
-    sleepUntil(name: string, timestamp: unknown): Promise<void> {
-      return jsStep.sleepUntil(name, timestamp);
-    },
-
-    waitForEvent(name: string, options: unknown): StepPromise {
-      return new StepPromise(
-        (rollbackFn: RollbackFn, rollbackConfig: RollbackConfig) => {
-          const args: unknown[] = [name, options];
-          if (rollbackFn !== null) {
-            args.push(rollbackFn);
-            if (rollbackConfig !== null) {
-              args.push(rollbackConfig);
+          );
+        };
+      }
+      if (prop === 'waitForEvent') {
+        return (name: string, options: unknown): StepPromise => {
+          return new StepPromise(
+            (rollbackFn: RollbackFn, rollbackConfig: RollbackConfig) => {
+              const args: unknown[] = [name, options];
+              if (rollbackFn !== null) {
+                args.push(rollbackFn);
+                if (rollbackConfig !== null) {
+                  args.push(rollbackConfig);
+                }
+              }
+              return target.waitForEvent(...args);
             }
-          }
-          return jsStep.waitForEvent(...args);
-        }
-      );
+          );
+        };
+      }
+      return Reflect.get(target, prop, receiver) as unknown;
     },
-  };
+  });
 }
 
 // Wraps a run function so that its second argument (step) is replaced with wrapStep(step).

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -23,6 +23,7 @@ type ExecuteFn = (
   rollbackFn: RollbackFn,
   rollbackConfig: RollbackConfig
 ) => Promise<unknown>;
+type RunFn = (event: unknown, step: unknown, ...rest: unknown[]) => unknown;
 
 // The step RPC stub interface — mirrors what the engine exposes via JS RPC.
 interface StepRpcStub {
@@ -197,9 +198,7 @@ function wrapStep(jsStep: StepRpcStub): WrappedStep {
 }
 
 // Wraps a run function so that its second argument (step) is replaced with wrapStep(step).
-function makeWrappedRun(
-  originalRun: (event: unknown, step: unknown, ...rest: unknown[]) => unknown
-): (event: unknown, step: unknown, ...rest: unknown[]) => unknown {
+function makeWrappedRun(originalRun: RunFn): RunFn {
   return function (
     this: unknown,
     event: unknown,
@@ -246,11 +245,7 @@ class WorkflowEntrypointWrapper extends entrypoints.WorkflowEntrypoint {
         Object.prototype.hasOwnProperty.call(proto, 'run') &&
         typeof proto.run === 'function'
       ) {
-        const originalRun = proto.run as (
-          event: unknown,
-          step: unknown,
-          ...rest: unknown[]
-        ) => unknown;
+        const originalRun = proto.run as RunFn;
         proto.run = makeWrappedRun(originalRun);
         wrappedProtos.add(proto);
         break;
@@ -266,9 +261,8 @@ class WorkflowEntrypointWrapper extends entrypoints.WorkflowEntrypoint {
   }
 }
 
-export const WorkflowEntrypoint = Cloudflare.compatibilityFlags[
-  'workflows_step_rollback'
-]
+export const WorkflowEntrypoint = Cloudflare.compatibilityFlags
+  .workflows_step_rollback
   ? WorkflowEntrypointWrapper
   : entrypoints.WorkflowEntrypoint;
 

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -16,7 +16,237 @@ export const RpcPromise = entrypoints.RpcPromise;
 export const RpcProperty = entrypoints.RpcProperty;
 export const RpcTarget = entrypoints.RpcTarget;
 export const ServiceStub = entrypoints.ServiceStub;
-export const WorkflowEntrypoint = entrypoints.WorkflowEntrypoint;
+
+type RollbackFn = ((...args: unknown[]) => Promise<void>) | null;
+type RollbackConfig = Record<string, unknown> | null;
+type ExecuteFn = (
+  rollbackFn: RollbackFn,
+  rollbackConfig: RollbackConfig
+) => Promise<unknown>;
+
+// The step RPC stub interface — mirrors what the engine exposes via JS RPC.
+interface StepRpcStub {
+  do(...args: unknown[]): Promise<unknown>;
+  sleep(name: string, duration: unknown): Promise<void>;
+  sleepUntil(name: string, timestamp: unknown): Promise<void>;
+  waitForEvent(...args: unknown[]): Promise<unknown>;
+}
+
+// StepPromise is a deferred thenable that captures .rollback() synchronously before firing
+// the actual RPC. This is necessary because step.do() returns an RPC promise -- accessing
+// .rollback() on it after resolution would be interpreted as a pipelined RPC call on the
+// resolved value. By deferring execution until .then(), we can bundle the callback and rollback
+// function in a single RPC call.
+class StepPromise {
+  #execute: ExecuteFn | null;
+  #rollbackFn: RollbackFn = null;
+  #rollbackConfig: RollbackConfig = null;
+  #hasRollback = false;
+  #promise: Promise<unknown> | null = null;
+  #launched = false;
+
+  get [Symbol.toStringTag](): string {
+    return 'StepPromise';
+  }
+
+  constructor(execute: ExecuteFn) {
+    this.#execute = execute;
+  }
+
+  rollback(
+    configOrFn: RollbackConfig | RollbackFn,
+    maybeFn?: RollbackFn
+  ): StepPromise {
+    if (this.#launched) {
+      throw new Error('.rollback() must be called before the step is awaited');
+    }
+    if (this.#hasRollback) {
+      throw new Error('.rollback() can only be called once per step');
+    }
+    this.#hasRollback = true;
+
+    if (typeof configOrFn === 'function') {
+      // rollback(fn)
+      this.#rollbackFn = configOrFn;
+    } else if (
+      configOrFn !== null &&
+      configOrFn !== undefined &&
+      typeof configOrFn === 'object'
+    ) {
+      // rollback(config, fn)
+      if (typeof maybeFn !== 'function') {
+        throw new TypeError(
+          '.rollback(config, fn) requires the second argument to be a function'
+        );
+      }
+      this.#rollbackConfig = configOrFn;
+      this.#rollbackFn = maybeFn;
+    } else {
+      throw new TypeError(
+        '.rollback() expects a function, or a config object followed by a function'
+      );
+    }
+
+    return this;
+  }
+
+  #getPromise(): Promise<unknown> {
+    if (!this.#promise) {
+      this.#launched = true;
+      // #execute is non-null here because #promise is only set in this block.
+      this.#promise = this.#execute!(this.#rollbackFn, this.#rollbackConfig);
+      // Allow GC of the closure and rollback references now that the RPC has been dispatched.
+      this.#execute = null;
+      this.#rollbackFn = null;
+      this.#rollbackConfig = null;
+    }
+    return this.#promise;
+  }
+
+  then(
+    onFulfilled?: ((value: unknown) => unknown) | null,
+    onRejected?: ((reason: unknown) => unknown) | null
+  ): Promise<unknown> {
+    return this.#getPromise().then(onFulfilled, onRejected);
+  }
+
+  catch(onRejected?: ((reason: unknown) => unknown) | null): Promise<unknown> {
+    return this.#getPromise().catch(onRejected);
+  }
+
+  finally(onFinally?: (() => void) | null): Promise<unknown> {
+    return this.#getPromise().finally(onFinally);
+  }
+}
+
+// Wraps the step RPC stub so that step.do() and step.waitForEvent() return StepPromise instances.
+// sleep() and sleepUntil() are passed through unchanged (they return Promise<void>, no rollback).
+function wrapStep(jsStep: StepRpcStub): unknown {
+  return {
+    do(
+      name: string,
+      configOrCallback: unknown,
+      maybeCallback?: unknown
+    ): StepPromise {
+      return new StepPromise(
+        (rollbackFn: RollbackFn, rollbackConfig: RollbackConfig) => {
+          // Build the args for the underlying RPC call.
+          // Engine signature: do(name, configOrCallback, callback?, rollbackFn?, rollbackConfig?)
+          const args: unknown[] = [name];
+          if (maybeCallback !== undefined) {
+            // do(name, config, callback) form
+            args.push(configOrCallback, maybeCallback);
+          } else {
+            // do(name, callback) form
+            args.push(configOrCallback);
+          }
+          if (rollbackFn) {
+            args.push(rollbackFn);
+            if (rollbackConfig) {
+              args.push(rollbackConfig);
+            }
+          }
+          return jsStep.do(...args);
+        }
+      );
+    },
+
+    sleep(name: string, duration: unknown): Promise<void> {
+      return jsStep.sleep(name, duration);
+    },
+
+    sleepUntil(name: string, timestamp: unknown): Promise<void> {
+      return jsStep.sleepUntil(name, timestamp);
+    },
+
+    waitForEvent(name: string, options: unknown): StepPromise {
+      return new StepPromise(
+        (rollbackFn: RollbackFn, rollbackConfig: RollbackConfig) => {
+          // Engine signature: waitForEvent(name, options, rollbackFn?, rollbackConfig?)
+          const args: unknown[] = [name, options];
+          if (rollbackFn) {
+            args.push(rollbackFn);
+            if (rollbackConfig) {
+              args.push(rollbackConfig);
+            }
+          }
+          return jsStep.waitForEvent(...args);
+        }
+      );
+    },
+  };
+}
+
+// Wrap WorkflowEntrypoint to intercept run() calls and wrap the step argument before it reaches
+// user code. This provides an extension point for step-level features (rollback, future additions)
+// without modifying the C++ entrypoint.
+//
+// We use a JS subclass (not a Proxy) because the runtime walks the constructor prototype chain
+// to classify entrypoints (workflowClasses vs actorClasses vs statelessClasses). A Proxy breaks
+// identity comparison: `Proxy !== target`. A JS subclass preserves the chain:
+//   UserWorkflow -> our JS class -> C++ WorkflowEntrypoint (matched by runtime)
+const BaseWorkflowEntrypoint =
+  entrypoints.WorkflowEntrypoint as unknown as new (
+    ...args: unknown[]
+  ) => Record<string, unknown>;
+
+const kStepWrapped = Symbol('stepWrapped');
+
+// Wraps a run function so that its second argument (step) is replaced with wrapStep(step).
+function makeWrappedRun(
+  originalRun: (event: unknown, step: unknown, ...rest: unknown[]) => unknown
+): (event: unknown, step: unknown, ...rest: unknown[]) => unknown {
+  return function (
+    this: unknown,
+    event: unknown,
+    step: unknown,
+    ...rest: unknown[]
+  ): unknown {
+    return originalRun.call(
+      this,
+      event,
+      wrapStep(step as StepRpcStub),
+      ...rest
+    );
+  };
+}
+
+class WorkflowEntrypointWrapper extends BaseWorkflowEntrypoint {
+  constructor(...args: unknown[]) {
+    super(...args);
+
+    // Patch the run method on the subclass prototype if it defines its own run and hasn't been
+    // patched yet. We use hasOwnProperty to avoid double-wrapping when a subclass inherits run
+    // from a parent that was already patched (e.g. class B extends A extends WorkflowEntrypoint
+    // where only A defines run).
+    const proto = Object.getPrototypeOf(this) as Record<
+      string | symbol,
+      unknown
+    >;
+    if (
+      proto &&
+      Object.prototype.hasOwnProperty.call(proto, 'run') &&
+      typeof proto.run === 'function' &&
+      !proto[kStepWrapped]
+    ) {
+      const originalRun = proto.run as (
+        event: unknown,
+        step: unknown,
+        ...rest: unknown[]
+      ) => unknown;
+      proto.run = makeWrappedRun(originalRun);
+      proto[kStepWrapped] = true;
+    }
+
+    // NOTE: Arrow function class properties (e.g. `run = async () => {}`) are NOT supported.
+    // They define `run` as an instance property, not a prototype method. The C++ RPC dispatch
+    // resolves methods via the prototype chain, so arrow function `run` is invisible to RPC.
+    // This is a workerd-level constraint that applies to all entrypoints (WorkerEntrypoint,
+    // DurableObject, WorkflowEntrypoint).
+  }
+}
+
+export const WorkflowEntrypoint = WorkflowEntrypointWrapper;
 
 export function withEnv(newEnv: unknown, fn: () => unknown): unknown {
   return innerEnv.withEnv(newEnv, fn);

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -68,11 +68,7 @@ class StepPromise {
     if (typeof configOrFn === 'function') {
       // rollback(fn)
       this.#rollbackFn = configOrFn;
-    } else if (
-      configOrFn !== null &&
-      configOrFn !== undefined &&
-      typeof configOrFn === 'object'
-    ) {
+    } else if (configOrFn != null && typeof configOrFn === 'object') {
       // rollback(config, fn)
       if (typeof maybeFn !== 'function') {
         throw new TypeError(
@@ -93,8 +89,11 @@ class StepPromise {
   #getPromise(): Promise<unknown> {
     if (!this.#promise) {
       this.#launched = true;
-      // #execute is non-null here because #promise is only set in this block.
-      this.#promise = this.#execute!(this.#rollbackFn, this.#rollbackConfig);
+      const execute = this.#execute;
+      if (execute === null) {
+        throw new Error('StepPromise execute function is missing');
+      }
+      this.#promise = execute(this.#rollbackFn, this.#rollbackConfig);
       // Allow GC of the closure and rollback references now that the RPC has been dispatched.
       this.#execute = null;
       this.#rollbackFn = null;

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Cloudflare, Inc.
+// Copyright (c) 2026 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
@@ -32,12 +32,28 @@ interface StepRpcStub {
   waitForEvent(...args: unknown[]): Promise<unknown>;
 }
 
-// StepPromise is a deferred thenable that captures .rollback() synchronously before firing
-// the actual RPC. This is necessary because step.do() returns an RPC promise -- accessing
-// .rollback() on it after resolution would be interpreted as a pipelined RPC call on the
-// resolved value. By deferring execution until .then(), we can bundle the callback and rollback
-// function in a single RPC call.
-class StepPromise {
+// The wrapped step interface returned by wrapStep(). Matches StepRpcStub but do() and
+// waitForEvent() return StepPromise instead of plain Promise.
+interface WrappedStep {
+  do(
+    name: string,
+    configOrCallback: unknown,
+    maybeCallback?: unknown
+  ): StepPromise;
+  sleep(name: string, duration: unknown): Promise<void>;
+  sleepUntil(name: string, timestamp: unknown): Promise<void>;
+  waitForEvent(name: string, options: unknown): StepPromise;
+}
+
+// StepPromise is a real Promise subclass that captures .rollback() synchronously before
+// firing the actual RPC. This is necessary because step.do() returns an RPC promise --
+// accessing .rollback() on it after resolution would be interpreted as a pipelined RPC call
+// on the resolved value. By deferring execution until .then(), we can bundle the callback
+// and rollback function in a single RPC call.
+//
+// We extend Promise so that instanceof Promise is true and the d.ts declaration
+// (StepPromise<T> extends Promise<T>) is accurate at runtime.
+class StepPromise extends Promise<unknown> {
   #execute: ExecuteFn | null;
   #rollbackFn: RollbackFn = null;
   #rollbackConfig: RollbackConfig = null;
@@ -45,18 +61,26 @@ class StepPromise {
   #promise: Promise<unknown> | null = null;
   #launched = false;
 
-  get [Symbol.toStringTag](): string {
-    return 'StepPromise';
+  // Tell the engine to construct plain Promises (not StepPromise) for internal
+  // operations like finally(). Without this, finally() would try to construct a
+  // StepPromise using the standard (resolve, reject) executor contract, which
+  // our constructor does not implement.
+  static override get [Symbol.species](): PromiseConstructor {
+    return Promise;
   }
 
   constructor(execute: ExecuteFn) {
+    // No-op executor — the real work is deferred until .then() is called.
+    // This is required by the Promise constructor but we never use the
+    // resolve/reject it provides; instead we delegate to #getPromise().
+    super(() => {});
     this.#execute = execute;
   }
 
   rollback(
     configOrFn: RollbackConfig | RollbackFn,
     maybeFn?: RollbackFn
-  ): StepPromise {
+  ): this {
     if (this.#launched) {
       throw new Error('.rollback() must be called before the step is awaited');
     }
@@ -102,25 +126,24 @@ class StepPromise {
     return this.#promise;
   }
 
-  then(
-    onFulfilled?: ((value: unknown) => unknown) | null,
-    onRejected?: ((reason: unknown) => unknown) | null
-  ): Promise<unknown> {
+  // Override then() to delegate to the deferred promise rather than the no-op
+  // super promise. This is what makes the lazy execution work. catch() delegates
+  // through then() per the ES spec; finally() uses Symbol.species (set above)
+  // to construct a plain Promise instead of a StepPromise.
+  //
+  // The generic signature matches Promise.prototype.then from lib.es5.d.ts —
+  // TypeScript requires it for a compatible override.
+  override then<TResult1 = unknown, TResult2 = never>(
+    onFulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
     return this.#getPromise().then(onFulfilled, onRejected);
-  }
-
-  catch(onRejected?: ((reason: unknown) => unknown) | null): Promise<unknown> {
-    return this.#getPromise().catch(onRejected);
-  }
-
-  finally(onFinally?: (() => void) | null): Promise<unknown> {
-    return this.#getPromise().finally(onFinally);
   }
 }
 
 // Wraps the step RPC stub so that step.do() and step.waitForEvent() return StepPromise instances.
 // sleep() and sleepUntil() are passed through unchanged (they return Promise<void>, no rollback).
-function wrapStep(jsStep: StepRpcStub): unknown {
+function wrapStep(jsStep: StepRpcStub): WrappedStep {
   return {
     do(
       name: string,
@@ -129,8 +152,6 @@ function wrapStep(jsStep: StepRpcStub): unknown {
     ): StepPromise {
       return new StepPromise(
         (rollbackFn: RollbackFn, rollbackConfig: RollbackConfig) => {
-          // Build the args for the underlying RPC call.
-          // Engine signature: do(name, configOrCallback, callback?, rollbackFn?, rollbackConfig?)
           const args: unknown[] = [name];
           if (maybeCallback !== undefined) {
             // do(name, config, callback) form
@@ -139,9 +160,9 @@ function wrapStep(jsStep: StepRpcStub): unknown {
             // do(name, callback) form
             args.push(configOrCallback);
           }
-          if (rollbackFn) {
+          if (rollbackFn !== null) {
             args.push(rollbackFn);
-            if (rollbackConfig) {
+            if (rollbackConfig !== null) {
               args.push(rollbackConfig);
             }
           }
@@ -161,11 +182,10 @@ function wrapStep(jsStep: StepRpcStub): unknown {
     waitForEvent(name: string, options: unknown): StepPromise {
       return new StepPromise(
         (rollbackFn: RollbackFn, rollbackConfig: RollbackConfig) => {
-          // Engine signature: waitForEvent(name, options, rollbackFn?, rollbackConfig?)
           const args: unknown[] = [name, options];
-          if (rollbackFn) {
+          if (rollbackFn !== null) {
             args.push(rollbackFn);
-            if (rollbackConfig) {
+            if (rollbackConfig !== null) {
               args.push(rollbackConfig);
             }
           }
@@ -175,21 +195,6 @@ function wrapStep(jsStep: StepRpcStub): unknown {
     },
   };
 }
-
-// Wrap WorkflowEntrypoint to intercept run() calls and wrap the step argument before it reaches
-// user code. This provides an extension point for step-level features (rollback, future additions)
-// without modifying the C++ entrypoint.
-//
-// We use a JS subclass (not a Proxy) because the runtime walks the constructor prototype chain
-// to classify entrypoints (workflowClasses vs actorClasses vs statelessClasses). A Proxy breaks
-// identity comparison: `Proxy !== target`. A JS subclass preserves the chain:
-//   UserWorkflow -> our JS class -> C++ WorkflowEntrypoint (matched by runtime)
-const BaseWorkflowEntrypoint =
-  entrypoints.WorkflowEntrypoint as unknown as new (
-    ...args: unknown[]
-  ) => Record<string, unknown>;
-
-const kStepWrapped = Symbol('stepWrapped');
 
 // Wraps a run function so that its second argument (step) is replaced with wrapStep(step).
 function makeWrappedRun(
@@ -210,23 +215,31 @@ function makeWrappedRun(
   };
 }
 
-class WorkflowEntrypointWrapper extends BaseWorkflowEntrypoint {
-  constructor(...args: unknown[]) {
-    super(...args);
+// Wrap WorkflowEntrypoint to intercept run() calls and wrap the step argument before it reaches
+// user code. This provides an extension point for step-level features (rollback, future additions)
+// without modifying the C++ entrypoint.
+//
+// We use a JS subclass (not a Proxy) because the runtime walks the constructor prototype chain
+// to classify entrypoints (workflowClasses vs actorClasses vs statelessClasses). A Proxy breaks
+// identity comparison: `Proxy !== target`. A JS subclass preserves the chain:
+//   UserWorkflow -> our JS class -> C++ WorkflowEntrypoint (matched by runtime)
+// Tracks which prototypes have already had their run() wrapped, so we don't
+// double-wrap on the second instantiation of the same class.
+const wrappedProtos = new WeakSet<object>();
+
+class WorkflowEntrypointWrapper extends entrypoints.WorkflowEntrypoint {
+  constructor(ctx: unknown, env: unknown) {
+    super(ctx, env);
 
     // Patch the run method on the subclass prototype if it defines its own run and hasn't been
     // patched yet. We use hasOwnProperty to avoid double-wrapping when a subclass inherits run
     // from a parent that was already patched (e.g. class B extends A extends WorkflowEntrypoint
     // where only A defines run).
-    const proto = Object.getPrototypeOf(this) as Record<
-      string | symbol,
-      unknown
-    >;
+    const proto = Object.getPrototypeOf(this) as Record<string, unknown>;
     if (
-      proto &&
+      !wrappedProtos.has(proto) &&
       Object.prototype.hasOwnProperty.call(proto, 'run') &&
-      typeof proto.run === 'function' &&
-      !proto[kStepWrapped]
+      typeof proto.run === 'function'
     ) {
       const originalRun = proto.run as (
         event: unknown,
@@ -234,7 +247,7 @@ class WorkflowEntrypointWrapper extends BaseWorkflowEntrypoint {
         ...rest: unknown[]
       ) => unknown;
       proto.run = makeWrappedRun(originalRun);
-      proto[kStepWrapped] = true;
+      wrappedProtos.add(proto);
     }
 
     // NOTE: Arrow function class properties (e.g. `run = async () => {}`) are NOT supported.
@@ -245,7 +258,11 @@ class WorkflowEntrypointWrapper extends BaseWorkflowEntrypoint {
   }
 }
 
-export const WorkflowEntrypoint = WorkflowEntrypointWrapper;
+export const WorkflowEntrypoint = Cloudflare.compatibilityFlags[
+  'workflows_step_rollback'
+]
+  ? WorkflowEntrypointWrapper
+  : entrypoints.WorkflowEntrypoint;
 
 export function withEnv(newEnv: unknown, fn: () => unknown): unknown {
   return innerEnv.withEnv(newEnv, fn);

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1521,4 +1521,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # enabled, `hasSubscribers` becomes a read-only getter that evaluates directly
   # to a boolean, matching Node.js behavior.
   # See: https://nodejs.org/dist/latest-v20.x/docs/api/diagnostics_channel.html#channelhassubscribers
+
+  workflowsStepRollback @175 :Bool
+    $compatEnableFlag("workflows_step_rollback")
+    $experimental;
+  # When enabled, WorkflowEntrypoint wraps the step object so that step.do()
+  # and step.waitForEvent() return a StepPromise with a .rollback() method.
+  # The rollback function is bundled into the RPC call for the engine to invoke
+  # as a compensation action on failure. Without this flag, the step object is
+  # passed through unwrapped and .rollback() is not available.
 }

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
@@ -9,7 +9,7 @@ const config :Workerd.Config = (
 );
 
 const pyWorker :Workerd.Worker = (
-  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "python_workflows_implicit_dependencies"],
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "python_workflows_implicit_dependencies", "workflows_step_rollback"],
 
   modules = [
     (name = "workflow.py", pythonModule = embed "workflow.py"),
@@ -21,7 +21,7 @@ const pyWorker :Workerd.Worker = (
 );
 
 const pyWorkerOld :Workerd.Worker = (
-  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "no_python_workflows_implicit_dependencies"],
+  compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "no_python_workflows_implicit_dependencies", "workflows_step_rollback"],
 
   modules = [
     (name = "workflow-old.py", pythonModule = embed "workflow-old.py"),

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -148,15 +148,13 @@ declare namespace Rpc {
   export type Provider<
     T extends object,
     Reserved extends string = never,
-  > = MaybeCallableProvider<T> & Pick<
-    {
-      [K in keyof T]: MethodOrProperty<T[K]>;
-    },
-    Exclude<
-      keyof T,
-      Reserved | symbol | keyof StubBase<never>
-    >
-  >
+  > = MaybeCallableProvider<T> &
+    Pick<
+      {
+        [K in keyof T]: MethodOrProperty<T[K]>;
+      },
+      Exclude<keyof T, Reserved | symbol | keyof StubBase<never>>
+    >;
 }
 
 declare namespace Cloudflare {
@@ -190,27 +188,26 @@ declare namespace Cloudflare {
 
   // Evaluates to the type of a property in GlobalProps, defaulting to `Default` if it is not
   // present.
-  type GlobalProp<K extends string, Default> =
-      K extends keyof GlobalProps ? GlobalProps[K] : Default;
+  type GlobalProp<K extends string, Default> = K extends keyof GlobalProps
+    ? GlobalProps[K]
+    : Default;
 
   // The type of the program's main module exports, if known. Requires `GlobalProps` to declare the
   // `mainModule` property.
-  type MainModule = GlobalProp<"mainModule", {}>;
+  type MainModule = GlobalProp<'mainModule', {}>;
 
   // The type of ctx.exports, which contains loopback bindings for all top-level exports.
   type Exports = {
-    [K in keyof MainModule]:
-        & LoopbackForExport<MainModule[K]>
-
-        // If the export is listed in `durableNamespaces`, then it is also a
-        // DurableObjectNamespace.
-        & (K extends GlobalProp<"durableNamespaces", never>
-            ?  MainModule[K] extends new (...args: any[]) => infer DoInstance
-                ? DoInstance extends Rpc.DurableObjectBranded
-                    ? DurableObjectNamespace<DoInstance>
-                    : DurableObjectNamespace<undefined>
-                : DurableObjectNamespace<undefined>
-            : {});
+    [K in keyof MainModule]: LoopbackForExport<MainModule[K]> &
+      // If the export is listed in `durableNamespaces`, then it is also a
+      // DurableObjectNamespace.
+      (K extends GlobalProp<'durableNamespaces', never>
+        ? MainModule[K] extends new (...args: any[]) => infer DoInstance
+          ? DoInstance extends Rpc.DurableObjectBranded
+            ? DurableObjectNamespace<DoInstance>
+            : DurableObjectNamespace<undefined>
+          : DurableObjectNamespace<undefined>
+        : {});
   };
 }
 
@@ -226,10 +223,8 @@ declare namespace CloudflareWorkersModule {
 
   // `protected` fields don't appear in `keyof`s, so can't be accessed over RPC
 
-  export abstract class WorkerEntrypoint<
-    Env = Cloudflare.Env,
-    Props = {},
-  > implements Rpc.WorkerEntrypointBranded
+  export abstract class WorkerEntrypoint<Env = Cloudflare.Env, Props = {}>
+    implements Rpc.WorkerEntrypointBranded
   {
     [Rpc.__WORKER_ENTRYPOINT_BRAND]: never;
 
@@ -243,15 +238,17 @@ declare namespace CloudflareWorkersModule {
     queue?(batch: MessageBatch): void | Promise<void>;
     scheduled?(controller: ScheduledController): void | Promise<void>;
     tail?(events: TraceItem[]): void | Promise<void>;
-    tailStream?(event: TailStream.TailEvent<TailStream.Onset>): TailStream.TailEventHandlerType | Promise<TailStream.TailEventHandlerType>;
+    tailStream?(
+      event: TailStream.TailEvent<TailStream.Onset>
+    ):
+      | TailStream.TailEventHandlerType
+      | Promise<TailStream.TailEventHandlerType>;
     test?(controller: TestController): void | Promise<void>;
     trace?(traces: TraceItem[]): void | Promise<void>;
   }
 
-  export abstract class DurableObject<
-    Env = Cloudflare.Env,
-    Props = {},
-  > implements Rpc.DurableObjectBranded
+  export abstract class DurableObject<Env = Cloudflare.Env, Props = {}>
+    implements Rpc.DurableObjectBranded
   {
     [Rpc.__DURABLE_OBJECT_BRAND]: never;
 
@@ -333,13 +330,11 @@ declare namespace CloudflareWorkersModule {
   }
 
   export interface StepPromise<T> extends Promise<T> {
-    rollback(
-      fn: (ctx: RollbackContext<T>) => Promise<void>,
-    ): Promise<T>;
+    rollback(fn: (ctx: RollbackContext<T>) => Promise<void>): StepPromise<T>;
     rollback(
       config: WorkflowStepConfig,
-      fn: (ctx: RollbackContext<T>) => Promise<void>,
-    ): Promise<T>;
+      fn: (ctx: RollbackContext<T>) => Promise<void>
+    ): StepPromise<T>;
   }
 
   export abstract class WorkflowStep {
@@ -377,7 +372,8 @@ declare namespace CloudflareWorkersModule {
   export abstract class WorkflowEntrypoint<
     Env = unknown,
     T extends Rpc.Serializable<T> | unknown = unknown,
-  > implements Rpc.WorkflowEntrypointBranded
+  >
+    implements Rpc.WorkflowEntrypointBranded
   {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
 
@@ -395,10 +391,7 @@ declare namespace CloudflareWorkersModule {
   export function waitUntil(promise: Promise<unknown>): void;
 
   export function withEnv(newEnv: unknown, fn: () => unknown): unknown;
-  export function withExports(
-    newExports: unknown,
-    fn: () => unknown
-  ): unknown;
+  export function withExports(newExports: unknown, fn: () => unknown): unknown;
   export function withEnvAndExports(
     newEnv: unknown,
     newExports: unknown,

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -325,7 +325,7 @@ declare namespace CloudflareWorkersModule {
 
   export interface RollbackContext<T> {
     error: Error;
-    output: T | undefined;
+    output: NonNullable<T> | undefined;
     stepName: string;
   }
 

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -326,16 +326,32 @@ declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
 
+  export interface RollbackContext<T> {
+    error: Error;
+    output: T | undefined;
+    stepName: string;
+  }
+
+  export interface StepPromise<T> extends Promise<T> {
+    rollback(
+      fn: (ctx: RollbackContext<T>) => Promise<void>,
+    ): Promise<T>;
+    rollback(
+      config: WorkflowStepConfig,
+      fn: (ctx: RollbackContext<T>) => Promise<void>,
+    ): Promise<T>;
+  }
+
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>
-    ): Promise<T>;
+    ): StepPromise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>
-    ): Promise<T>;
+    ): StepPromise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
     waitForEvent<T extends Rpc.Serializable<T>>(
@@ -344,7 +360,7 @@ declare namespace CloudflareWorkersModule {
         type: string;
         timeout?: WorkflowTimeoutDuration | number;
       }
-    ): Promise<WorkflowStepEvent<T>>;
+    ): StepPromise<WorkflowStepEvent<T>>;
   }
 
   export type WorkflowInstanceStatus =

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14355,16 +14355,28 @@ declare namespace CloudflareWorkersModule {
     attempt: number;
     config: WorkflowStepConfig;
   };
+  export interface RollbackContext<T> {
+    error: Error;
+    output: NonNullable<T> | undefined;
+    stepName: string;
+  }
+  export interface StepPromise<T> extends Promise<T> {
+    rollback(fn: (ctx: RollbackContext<T>) => Promise<void>): StepPromise<T>;
+    rollback(
+      config: WorkflowStepConfig,
+      fn: (ctx: RollbackContext<T>) => Promise<void>,
+    ): StepPromise<T>;
+  }
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-    ): Promise<T>;
+    ): StepPromise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-    ): Promise<T>;
+    ): StepPromise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
     waitForEvent<T extends Rpc.Serializable<T>>(
@@ -14373,7 +14385,7 @@ declare namespace CloudflareWorkersModule {
         type: string;
         timeout?: WorkflowTimeoutDuration | number;
       },
-    ): Promise<WorkflowStepEvent<T>>;
+    ): StepPromise<WorkflowStepEvent<T>>;
   }
   export type WorkflowInstanceStatus =
     | "queued"

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14326,16 +14326,28 @@ export declare namespace CloudflareWorkersModule {
     attempt: number;
     config: WorkflowStepConfig;
   };
+  export interface RollbackContext<T> {
+    error: Error;
+    output: NonNullable<T> | undefined;
+    stepName: string;
+  }
+  export interface StepPromise<T> extends Promise<T> {
+    rollback(fn: (ctx: RollbackContext<T>) => Promise<void>): StepPromise<T>;
+    rollback(
+      config: WorkflowStepConfig,
+      fn: (ctx: RollbackContext<T>) => Promise<void>,
+    ): StepPromise<T>;
+  }
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-    ): Promise<T>;
+    ): StepPromise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-    ): Promise<T>;
+    ): StepPromise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
     waitForEvent<T extends Rpc.Serializable<T>>(
@@ -14344,7 +14356,7 @@ export declare namespace CloudflareWorkersModule {
         type: string;
         timeout?: WorkflowTimeoutDuration | number;
       },
-    ): Promise<WorkflowStepEvent<T>>;
+    ): StepPromise<WorkflowStepEvent<T>>;
   }
   export type WorkflowInstanceStatus =
     | "queued"

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -13691,16 +13691,28 @@ declare namespace CloudflareWorkersModule {
     attempt: number;
     config: WorkflowStepConfig;
   };
+  export interface RollbackContext<T> {
+    error: Error;
+    output: NonNullable<T> | undefined;
+    stepName: string;
+  }
+  export interface StepPromise<T> extends Promise<T> {
+    rollback(fn: (ctx: RollbackContext<T>) => Promise<void>): StepPromise<T>;
+    rollback(
+      config: WorkflowStepConfig,
+      fn: (ctx: RollbackContext<T>) => Promise<void>,
+    ): StepPromise<T>;
+  }
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-    ): Promise<T>;
+    ): StepPromise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-    ): Promise<T>;
+    ): StepPromise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
     waitForEvent<T extends Rpc.Serializable<T>>(
@@ -13709,7 +13721,7 @@ declare namespace CloudflareWorkersModule {
         type: string;
         timeout?: WorkflowTimeoutDuration | number;
       },
-    ): Promise<WorkflowStepEvent<T>>;
+    ): StepPromise<WorkflowStepEvent<T>>;
   }
   export type WorkflowInstanceStatus =
     | "queued"

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -13662,16 +13662,28 @@ export declare namespace CloudflareWorkersModule {
     attempt: number;
     config: WorkflowStepConfig;
   };
+  export interface RollbackContext<T> {
+    error: Error;
+    output: NonNullable<T> | undefined;
+    stepName: string;
+  }
+  export interface StepPromise<T> extends Promise<T> {
+    rollback(fn: (ctx: RollbackContext<T>) => Promise<void>): StepPromise<T>;
+    rollback(
+      config: WorkflowStepConfig,
+      fn: (ctx: RollbackContext<T>) => Promise<void>,
+    ): StepPromise<T>;
+  }
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-    ): Promise<T>;
+    ): StepPromise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-    ): Promise<T>;
+    ): StepPromise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
     waitForEvent<T extends Rpc.Serializable<T>>(
@@ -13680,7 +13692,7 @@ export declare namespace CloudflareWorkersModule {
         type: string;
         timeout?: WorkflowTimeoutDuration | number;
       },
-    ): Promise<WorkflowStepEvent<T>>;
+    ): StepPromise<WorkflowStepEvent<T>>;
   }
   export type WorkflowInstanceStatus =
     | "queued"


### PR DESCRIPTION
adds steppromise wrapper with .rollback() api for workflow saga rollbacks. step.do() and step.waitforevent() now return steppromise which lets users register a compensation function before the step rpc fires. 
- sleep/sleepuntil are unchanged. 
- includes type declarations and tests.