### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/_bazel.yml
+++ b/.github/workflows/_bazel.yml
@@ -85,13 +85,13 @@ jobs:
   bazel:
     runs-on: ${{ inputs.image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           show-progress: false
           fetch-depth: ${{ inputs.fetch_depth }}
       - name: Cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/bazel-disk-cache
           key: bazel-disk-cache${{ inputs.phase}}-${{ inputs.os_name }}-${{ runner.arch }}${{ inputs.suffix }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel') }}
@@ -171,7 +171,7 @@ jobs:
           bazel build --config=parse_headers --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci ${{ inputs.extra_bazel_args }} //src/workerd/util
       - name: Upload test logs
         if: always() && inputs.upload_test_logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs-${{ inputs.os_name }}-${{ inputs.arch_name }}${{ inputs.suffix }}.zip
           path: bazel-testlogs/**/test.xml
@@ -210,14 +210,14 @@ jobs:
 
       - name: Upload binary
         if: inputs.upload_binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.os_name }}-${{ inputs.arch_name }}${{ inputs.suffix }}-binary
           path: bazel-bin/src/workerd/server/workerd${{ runner.os == 'Windows' && '.exe' || '' }}
           if-no-files-found: error
       - name: Upload build statistics
         if: always() && inputs.run_tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.os_name }}${{ inputs.arch_name }}${{ inputs.suffix }}-bazel-profile
           path: '*.bazel-profile.gz'

--- a/.github/workflows/_wpt.yml
+++ b/.github/workflows/_wpt.yml
@@ -24,9 +24,9 @@ jobs:
   wpt-report:
     runs-on: ${{ inputs.image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download test logs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: ${{ inputs.logs_artifact }}
@@ -34,7 +34,7 @@ jobs:
       - name: Generate WPT report and stats
         run: ./tools/cross/wpt_logs.py --print-stats --write-report=wpt-report.json testlogs/ >> $GITHUB_STEP_SUMMARY
       - name: Upload WPT report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.report_artifact }}
           path: wpt-report.json

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -28,13 +28,13 @@ jobs:
     env:
       BAZEL_ARGS: --config=benchmark --@google_benchmark//:codspeed_mode=simulation --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           show-progress: false
 
       - name: Cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/bazel-disk-cache
           key: bazel-disk-cache-benchmarks-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel') }}

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.DEVPROD_PAT }}
           ref: main

--- a/.github/workflows/deps-updater.yml
+++ b/.github/workflows/deps-updater.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           show-progress: false
           token: ${{ secrets.DEVPROD_PAT }}

--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -6,7 +6,7 @@ jobs:
   block-fixup:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Block Fixup Commit Merge
       uses: 13rac1/block-fixup-merge-action@v2.0.0
 

--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       # Try to checkout the merge commit - will fail if PR isn't mergeable
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         id: checkout_merge
         continue-on-error: true
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           show-progress: false
       - name: Configure git hooks

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 30 # Fetch some history; not all of it
 

--- a/.github/workflows/release-python-runtime.yml
+++ b/.github/workflows/release-python-runtime.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-22.04
     name: build Python runtime
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Setup Runner

--- a/.github/workflows/release-python-snapshots.yml
+++ b/.github/workflows/release-python-snapshots.yml
@@ -29,16 +29,16 @@ jobs:
     runs-on: ubuntu-22.04
     name: Build and upload Python memory snapshots
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Setup Runner
         uses: ./.github/actions/setup-runner
       - name: Download workerd binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-X64-binary
           path: /tmp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     # the build job uses 22.04 for libc compatibility.
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: echo
         run: |
           echo "date=$(cat src/workerd/io/release-version.txt)" >> $GITHUB_OUTPUT;
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: mukunku/tag-exists-action@v1.6.0
@@ -60,7 +60,7 @@ jobs:
     if: ${{ needs.check-tag.outputs.exists != 'true' }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
@@ -147,12 +147,12 @@ jobs:
             name: Windows-X64
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download ${{ matrix.name }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.name }}-binary
           path: /tmp
@@ -181,7 +181,7 @@ jobs:
 
       # Upload release to npm
       - name: Use Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Modify package.json version
@@ -202,14 +202,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout workers-sdk
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: cloudflare/workers-sdk
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: 'pnpm'
@@ -217,7 +217,7 @@ jobs:
         run: pnpm install
 
       - name: Download workerd binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Linux-X64-binary
           path: /tmp
@@ -238,18 +238,18 @@ jobs:
     runs-on: ubuntu-22.04-16core
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Use Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
       - name: Cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         # Use same cache and build configuration as release build, this allows us to keep download
         # sizes small and generate types with optimization enabled, should be slightly faster.
         with:
@@ -295,16 +295,16 @@ jobs:
     runs-on: ubuntu-22.04-16core
     needs: [version, upload-artifacts]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           show-progress: false
       - name: Use Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24 # needed for a version of npm that supports "trusted publishing".
       - name: Cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         # Use same cache and build configuration as release build, this allows us to keep download
         # sizes small and generate types with optimization enabled, should be slightly faster.
         with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: semgrep ci
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,12 +110,12 @@ jobs:
   check-snapshot:
     runs-on: ubuntu-22.04-16core
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           show-progress: false
       - name: Cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         # Use same cache and build configuration as release build, this allows us to keep download
         # sizes small and generate types with optimization enabled, should be slightly faster.
         with:
@@ -139,7 +139,7 @@ jobs:
             cat types.diff
             echo EOF
           } >> "$GITHUB_ENV"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         id: artifact-upload-step
         with:
           name: generated-snapshot
@@ -173,14 +173,14 @@ jobs:
     runs-on: ubuntu-22.04-16core
     steps:
       - name: Checkout workers-sdk
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: cloudflare/workers-sdk
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           # Match workers-sdk node version
           node-version: 20.19.6
@@ -189,7 +189,7 @@ jobs:
         run: pnpm install
 
       - name: Download workerd binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-X64-binary
           path: /tmp
@@ -198,7 +198,7 @@ jobs:
         run: chmod +x /tmp/workerd
 
       - name: Download generated types
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: generated-snapshot
           path: /tmp/test-types


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@v4, actions/cache@v4, actions/upload-artifact@v4, actions/download-artifact@v4, actions/setup-node@v4.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Diff](https://github.com/actions/cache/compare/v4...v5) | _bazel.yml, codspeed.yml, release.yml, test.yml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Diff](https://github.com/actions/checkout/compare/v4...v6) | _bazel.yml, _wpt.yml, bigbonk.yml, bonk.yml, codspeed.yml, daily-release.yml, deps-updater.yml, fixup.yml, internal-build.yml, lint.yml, new-pr-review.yml, release-python-runtime.yml, release-python-snapshots.yml, release.yml, semgrep.yml, test.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v8`](https://github.com/actions/download-artifact/releases/tag/v8) | [Diff](https://github.com/actions/download-artifact/compare/v4...v8) | _wpt.yml, release-python-snapshots.yml, release.yml, test.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Diff](https://github.com/actions/setup-node/compare/v4...v6) | release.yml, test.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Diff](https://github.com/actions/setup-python/compare/v5...v6) | release-python-runtime.yml, release-python-snapshots.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7) | [Diff](https://github.com/actions/upload-artifact/compare/v4...v7) | _bazel.yml, _wpt.yml, test.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
