### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deps-updater.yml
+++ b/.github/workflows/deps-updater.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./tools/cross/format.py git
       - name: Open pull request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "update dependencies to latest version"
           branch: "automatic-update-deps"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: mukunku/tag-exists-action@v1.6.0
+      - uses: mukunku/tag-exists-action@v1.7.0
         id: check_tag
         with:
           tag: v${{ needs.version.outputs.version }}
@@ -207,7 +207,7 @@ jobs:
           repository: cloudflare/workers-sdk
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
           path: bazel-bin/types/definitions/
       - name: 'Comment on PR with error details'
         if: failure()
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987  # v3.0.2
         with:
           message: |
             The generated output of `@cloudflare/workers-types` has been changed by this PR. If this is intentional, run `just generate-types` to update the snapshot. Alternatively, you can download the full generated types: ${{ steps.artifact-upload-step.outputs.artifact-url }}
@@ -161,7 +161,7 @@ jobs:
             </details>
       - name: 'Comment on PR with error details'
         if: success()
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987  # v3.0.2
         with:
           only_update: true
           message: |
@@ -178,7 +178,7 @@ jobs:
           repository: cloudflare/workers-sdk
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `marocchino/sticky-pull-request-comment` | [`52423e0`](https://github.com/marocchino/sticky-pull-request-comment/commit/52423e01640425a022ef5fd42c6fb5f633a02728) | [`70d2764`](https://github.com/marocchino/sticky-pull-request-comment/commit/70d2764d1a7d5d9560b100cbea0077fc8f633987) | [Diff](https://github.com/marocchino/sticky-pull-request-comment/compare/52423e016404...70d2764d1a7d) | test.yml |
| `mukunku/tag-exists-action` | [`v1.6.0`](https://github.com/mukunku/tag-exists-action/releases/tag/v1.6.0) | [`v1.7.0`](https://github.com/mukunku/tag-exists-action/releases/tag/v1.7.0) | [Diff](https://github.com/mukunku/tag-exists-action/compare/v1.6.0...v1.7.0) | release.yml |
| `peter-evans/create-pull-request` | [`v7`](https://github.com/peter-evans/create-pull-request/releases/tag/v7) | [`v8`](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | [Diff](https://github.com/peter-evans/create-pull-request/compare/v7...v8) | deps-updater.yml |
| `pnpm/action-setup` | [`v4`](https://github.com/pnpm/action-setup/releases/tag/v4) | [`v5`](https://github.com/pnpm/action-setup/releases/tag/v5) | [Diff](https://github.com/pnpm/action-setup/compare/v4...v5) | release.yml, test.yml |

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
