### PR TITLE
Revert "Delete all alarms on `abortAllDurableObjects()`"

### DIFF
--- a/src/workerd/server/alarm-scheduler.c++
+++ b/src/workerd/server/alarm-scheduler.c++
@@ -153,25 +153,6 @@ bool AlarmScheduler::deleteAlarm(ActorKey actor) {
   return query.changeCount() > 0;
 }
 
-void AlarmScheduler::deleteAllAlarms() {
-  stmtDeleteAllAlarms.run();
-
-  alarms.eraseAll([this](ActorKey& key, ScheduledAlarm& value) {
-    KJ_IF_SOME(queued, value.queuedAlarm) {
-      if (value.status == AlarmStatus::STARTED) {
-        // If we are currently running an alarm, we want to delete the queued instead of current.
-        value.queuedAlarm = kj::none;
-      } else {
-        alarms.upsert(key, scheduleAlarm(clock.now(), kj::mv(value.actor), queued));
-      }
-      return false;
-    } else {
-      // We can't remove running alarms.
-      return value.status != AlarmStatus::STARTED;
-    }
-  });
-}
-
 kj::Promise<AlarmScheduler::RetryInfo> AlarmScheduler::runAlarm(
     const ActorKey& actor, kj::Date scheduledTime, uint32_t retryCount) {
   KJ_IF_SOME(ns, namespaces.find(actor.uniqueKey)) {

--- a/src/workerd/server/alarm-scheduler.h
+++ b/src/workerd/server/alarm-scheduler.h
@@ -66,7 +66,6 @@ class AlarmScheduler final: kj::TaskSet::ErrorHandler {
   kj::Maybe<kj::Date> getAlarm(ActorKey actor);
   bool setAlarm(ActorKey actor, kj::Date scheduledTime);
   bool deleteAlarm(ActorKey actor);
-  void deleteAllAlarms();
 
   void registerNamespace(kj::StringPtr uniqueKey, GetActorFn getActor);
 
@@ -128,9 +127,6 @@ class AlarmScheduler final: kj::TaskSet::ErrorHandler {
   )");
   SqliteDatabase::Statement stmtDeleteAlarm = db->prepare(R"(
     DELETE FROM _cf_ALARM WHERE actor_unique_key = ? AND actor_id = ?
-  )");
-  SqliteDatabase::Statement stmtDeleteAllAlarms = db->prepare(R"(
-    DELETE FROM _cf_ALARM
   )");
 
   void taskFailed(kj::Exception&& exception) override;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3985,13 +3985,6 @@ void Server::abortAllActors(kj::Maybe<const kj::Exception&> reason) {
       }
     }
   }
-
-  // When using vitest-pool-workers and DOs have alarms, alarms can still attempt to run after the tests
-  // end running that leads to internal reference errors.
-  // On more complex setups with multiple DOs that have alarms and all of them communicate with one another,
-  // there might be cases where there are isolated storage errors when calling DOs wake one another.
-  // Deleting all of them at the same time guarantees that user's implementations don't affect tests runs
-  alarmScheduler->deleteAllAlarms();
 }
 
 // WorkerDef is an intermediate representation of everything from `config::Worker::Reader` that

--- a/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
+++ b/src/workerd/server/tests/unsafe-module/unsafe-module-test.js
@@ -1,6 +1,5 @@
 import assert from 'node:assert';
 import unsafe from 'workerd:unsafe';
-import { DurableObject } from 'cloudflare:workers';
 
 function createTestObject(type) {
   return class {
@@ -18,19 +17,6 @@ export const TestEphemeralObject = createTestObject('ephemeral');
 export const TestEphemeralObjectPreventEviction = createTestObject(
   'ephemeral-prevent-eviction'
 );
-
-let alarmTriggers = 0;
-export class AlarmObject extends DurableObject {
-  get scheduledTime() {
-    return this.ctx.storage.getAlarm();
-  }
-  async scheduleIn(delay) {
-    await this.ctx.storage.setAlarm(Date.now() + delay);
-  }
-  alarm() {
-    alarmTriggers++;
-  }
-}
 
 export const test_abort_all_durable_objects = {
   async test(ctrl, env, ctx) {
@@ -97,26 +83,5 @@ export const test_abort_all_durable_objects = {
       ephemeralPreventEvictionRes1,
       ephemeralPreventEvictionRes2
     );
-  },
-};
-
-export const test_abort_all_durable_objects_alarms = {
-  async test(ctrl, env, ctx) {
-    const id = env.ALARM.newUniqueId();
-    const stub = env.ALARM.get(id);
-
-    // Check we can schedule an alarm as usual
-    assert.strictEqual(await stub.scheduledTime, null);
-    await stub.scheduleIn(500);
-    assert.notStrictEqual(await stub.scheduledTime, null);
-    await scheduler.wait(1000);
-    assert.strictEqual(alarmTriggers, 1);
-    assert.strictEqual(await stub.scheduledTime, null);
-
-    // Check `abortAllDurableObjects()` deletes all alarms
-    await stub.scheduleIn(500);
-    await unsafe.abortAllDurableObjects();
-    await scheduler.wait(1000);
-    assert.strictEqual(alarmTriggers, 1); // (same as before)
   },
 };

--- a/src/workerd/server/tests/unsafe-module/unsafe-module-test.wd-test
+++ b/src/workerd/server/tests/unsafe-module/unsafe-module-test.wd-test
@@ -2,27 +2,24 @@ using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
   services = [
-    ( name = "TEST_TMPDIR", disk = (writable = true) ),
     ( name = "unsafe-module-test",
       worker = (
         modules = [
           ( name = "worker", esModule = embed "unsafe-module-test.js" ),
         ],
-        compatibilityFlags = ["nodejs_compat", "unsafe_module", "rpc"],
+        compatibilityFlags = ["nodejs_compat", "unsafe_module"],
         durableObjectNamespaces = [
           ( className = "TestDurableObject", uniqueKey = "durable" ),
           ( className = "TestDurableObjectPreventEviction", uniqueKey = "durable-prevent-eviction", preventEviction = true ),
           ( className = "TestEphemeralObject", ephemeralLocal = void ),
           ( className = "TestEphemeralObjectPreventEviction", ephemeralLocal = void, preventEviction = true ),
-          ( className = "AlarmObject",  uniqueKey = "alarm" ),
         ],
-        durableObjectStorage = ( localDisk = "TEST_TMPDIR" ),
+        durableObjectStorage = (inMemory = void),
         bindings = [
           ( name = "DURABLE", durableObjectNamespace = "TestDurableObject" ),
           ( name = "DURABLE_PREVENT_EVICTION", durableObjectNamespace = "TestDurableObjectPreventEviction" ),
           ( name = "EPHEMERAL", durableObjectNamespace = "TestEphemeralObject" ),
           ( name = "EPHEMERAL_PREVENT_EVICTION", durableObjectNamespace = "TestEphemeralObjectPreventEviction" ),
-          ( name = "ALARM", durableObjectNamespace = "AlarmObject" ),
         ],
      )
     ),


### PR DESCRIPTION
Reverts cloudflare/workerd#1918

Ironically, a week after this PR was merged, vitest-pool-workers actually removed its usage of this API. After two years of waiting...

And after some discussion, we feel that it doesn't make sense for abortAllDurableObjects() to cancel alarms. Cancelling alarms is essentially _deleting data_ from the DOs, but since it doesn't delete _all_ data, it leaves them in an inconsistent state.

It could make sense to add a new deleteAllDurableObjects() API which aborts DOs, cancels alarms, and deletes underlying data, but that should be a separate API.