### PR TITLE
implement Autogate support for Rust JSG

### DIFF
--- a/src/rust/autogate/BUILD.bazel
+++ b/src/rust/autogate/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
+load("//:build/wd_rust_crate.bzl", "wd_rust_crate")
+
+# C++ header exposing the AutogateKey enum and is_enabled() wrapper.
+# Include this from C++ code that needs to call through to Rust's AutogateKey.
+wd_cc_library(
+    name = "ffi-hdr",
+    hdrs = ["ffi.h"],
+    visibility = ["//visibility:public"],
+    deps = ["//src/workerd/util:autogate"],
+)
+
+wd_rust_crate(
+    name = "autogate",
+    visibility = ["//visibility:public"],
+    deps = [
+        # Provides workerd_autogate_is_enabled with C linkage (in autogate.c++).
+        "//src/workerd/util:autogate",
+    ],
+)

--- a/src/rust/autogate/ffi.h
+++ b/src/rust/autogate/ffi.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+#pragma once
+
+#include <workerd/util/autogate.h>
+
+namespace workerd::rust::autogate {
+
+// AutogateKey is defined in Rust (ffi.rs) as a #[repr(C)] enum whose variant
+// values are derived from the C++ util::AutogateKey enum via this X-macro table.
+// The static_assert below verifies at compile time that no new gates were added
+// to autogate.h without a matching entry here and in ffi.rs.
+//
+// When adding a gate:
+//   1. Add WD_AUTOGATE_KEYS entry in src/workerd/util/autogate.h  (single source of truth)
+//   2. Add a matching entry to WD_AUTOGATE_FFI_KEYS below
+//   3. Add the variant to the AutogateKey enum in ffi.rs
+//   4. Update the static_assert count below
+
+#define WD_AUTOGATE_FFI_KEYS(X)                                                                    \
+  X(TestWorkerd, TEST_WORKERD)                                                                     \
+  X(V8FastApi, V8_FAST_API)                                                                        \
+  X(StreamingTailWorker, STREAMING_TAIL_WORKER)                                                    \
+  X(TailStreamRefactor, TAIL_STREAM_REFACTOR)                                                      \
+  X(RustBackedNodeDns, RUST_BACKED_NODE_DNS)                                                       \
+  X(RpcUseExternalPusher, RPC_USE_EXTERNAL_PUSHER)                                                 \
+  X(WasmShutdownSignalShim, WASM_SHUTDOWN_SIGNAL_SHIM)                                             \
+  X(EnableFastTextencoder, ENABLE_FAST_TEXTENCODER)                                                \
+  X(EnableDrainingReadOnStandardStreams, ENABLE_DRAINING_READ_ON_STANDARD_STREAMS)
+
+// Build the AutogateKey enum with values cast directly from the C++ enum —
+// C++ is the authority on ordinal values, no manual numbers here.
+#define WD_AUTOGATE_FFI_ENUM(rust_name, cpp_name)                                                  \
+  rust_name = static_cast<int>(util::AutogateKey::cpp_name),
+
+enum class AutogateKey : int { WD_AUTOGATE_FFI_KEYS(WD_AUTOGATE_FFI_ENUM) };
+
+#undef WD_AUTOGATE_FFI_ENUM
+
+// If this fires, a gate was added to autogate.h but not to WD_AUTOGATE_FFI_KEYS
+// and the Rust enum in ffi.rs. Update both.
+static_assert(static_cast<int>(util::AutogateKey::NumOfKeys) == 9,
+    "New gate detected in AutogateKey — add it to WD_AUTOGATE_FFI_KEYS in "
+    "src/rust/autogate/ffi.h and to the AutogateKey enum in src/rust/autogate/ffi.rs");
+
+// One array lookup — AutogateKey is ABI-compatible with util::AutogateKey
+// (same int backing, same ordinals), so the cast is always valid.
+inline bool is_enabled(AutogateKey key) {
+  return util::Autogate::isEnabled(static_cast<util::AutogateKey>(key));
+}
+
+}  // namespace workerd::rust::autogate

--- a/src/rust/autogate/ffi.rs
+++ b/src/rust/autogate/ffi.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// When adding a gate:
+//   1. Add WD_AUTOGATE_KEYS entry in src/workerd/util/autogate.h  (single source of truth)
+//   2. Add matching entry to WD_AUTOGATE_FFI_KEYS in src/rust/autogate/ffi.h
+//   3. Add the variant here (value from the C++ enum via ffi.h)
+//   4. Update the static_assert count in ffi.h
+
+/// Mirrors `workerd::util::AutogateKey`.
+///
+/// `#[repr(C)]` with discriminants that match the C++ enum ordinals.
+/// Defined once here — `ffi.h` builds its `AutogateKey` enum from this same
+/// list (via `WD_AUTOGATE_FFI_KEYS`) so both sides always agree.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AutogateKey {
+    TestWorkerd = 0,
+    V8FastApi = 1,
+    StreamingTailWorker = 2,
+    TailStreamRefactor = 3,
+    RustBackedNodeDns = 4,
+    RpcUseExternalPusher = 5,
+    WasmShutdownSignalShim = 6,
+    EnableFastTextencoder = 7,
+    EnableDrainingReadOnStandardStreams = 8,
+}
+
+unsafe extern "C" {
+    // Implemented in src/workerd/util/autogate.c++ — one array lookup.
+    #[link_name = "workerd_autogate_is_enabled"]
+    fn autogate_is_enabled(key: AutogateKey) -> bool;
+}
+
+pub fn is_enabled(key: AutogateKey) -> bool {
+    // SAFETY: reads from a process-global bool array written once at startup.
+    unsafe { autogate_is_enabled(key) }
+}

--- a/src/rust/autogate/lib.rs
+++ b/src/rust/autogate/lib.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+//! Rust interface to the C++ `workerd::util::Autogate` system.
+//!
+//! Autogates are temporary runtime feature gates for gradual rollout of risky
+//! changes. They can be toggled independently of binary releases.
+//!
+//! # Adding a gate
+//!
+//! 1. Add a `WD_AUTOGATE_KEYS` entry in `src/workerd/util/autogate.h` (single source of truth)
+//! 2. Add a matching entry to `WD_AUTOGATE_FFI_KEYS` in `src/rust/autogate/ffi.h`
+//! 3. Add the variant to [`AutogateKey`] below
+//! 4. Update the `static_assert` count in `ffi.h`
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use autogate::{Autogate, AutogateKey};
+//!
+//! if Autogate::is_enabled(AutogateKey::RustBackedNodeDns) {
+//!     // fast path
+//! }
+//! ```
+
+/// Mirrors `workerd::util::AutogateKey`.
+///
+/// `#[repr(C)]` with discriminants matching the C++ enum ordinals — ABI-compatible
+/// so values pass through `extern "C"` without any cast. The `static_assert` in
+/// `ffi.h` verifies at compile time that neither side has drifted.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AutogateKey {
+    TestWorkerd = 0,
+    V8FastApi = 1,
+    StreamingTailWorker = 2,
+    TailStreamRefactor = 3,
+    RustBackedNodeDns = 4,
+    RpcUseExternalPusher = 5,
+    WasmShutdownSignalShim = 6,
+    EnableFastTextencoder = 7,
+    EnableDrainingReadOnStandardStreams = 8,
+}
+
+unsafe extern "C" {
+    // Implemented in src/workerd/util/autogate.c++ — one array lookup.
+    #[link_name = "workerd_autogate_is_enabled"]
+    fn autogate_is_enabled(key: AutogateKey) -> bool;
+}
+
+/// Thin wrapper around `workerd::util::Autogate`.
+///
+/// [`Autogate::is_enabled`] passes [`AutogateKey`] directly through `extern "C"`
+/// — one array lookup in C++, no strings, no allocation.
+pub struct Autogate;
+
+impl Autogate {
+    #[inline]
+    pub fn is_enabled(key: AutogateKey) -> bool {
+        // SAFETY: reads from a process-global bool array written once at startup.
+        unsafe { autogate_is_enabled(key) }
+    }
+}

--- a/src/rust/jsg-test/tests/autogate.rs
+++ b/src/rust/jsg-test/tests/autogate.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+//! Tests for the Rust `autogate` crate, exercised via the `jsg` re-exports.
+//!
+//! The global autogate is not initialized in the test harness, so all gates
+//! fall back to the `WORKERD_ALL_AUTOGATES` env-var check. Without that
+//! variable set, every gate returns `false`.
+
+use jsg::Autogate;
+use jsg::AutogateKey;
+
+const ALL_KEYS: &[AutogateKey] = &[
+    AutogateKey::TestWorkerd,
+    AutogateKey::V8FastApi,
+    AutogateKey::StreamingTailWorker,
+    AutogateKey::TailStreamRefactor,
+    AutogateKey::RustBackedNodeDns,
+    AutogateKey::RpcUseExternalPusher,
+    AutogateKey::WasmShutdownSignalShim,
+    AutogateKey::EnableFastTextencoder,
+    AutogateKey::EnableDrainingReadOnStandardStreams,
+];
+
+/// Without the env-var or a config, all known gates return false.
+#[test]
+fn all_known_gates_return_false_by_default() {
+    for &key in ALL_KEYS {
+        assert!(
+            !Autogate::is_enabled(key),
+            "expected gate {key:?} to be disabled"
+        );
+    }
+}
+
+/// ALL_KEYS must list every variant — catches a gate added to C++ but not here.
+/// The static_assert in ffi.h catches the reverse (ffi.rs out of date).
+#[test]
+fn all_keys_covers_all_variants() {
+    // AutogateKey is #[repr(C)] with contiguous discriminants starting at 0.
+    // The highest discriminant + 1 must equal the number of entries in ALL_KEYS.
+    let max = ALL_KEYS.iter().map(|k| *k as u32).max().unwrap();
+    assert_eq!(
+        max + 1,
+        ALL_KEYS.len() as u32,
+        "ALL_KEYS has gaps or duplicates"
+    );
+}
+
+/// Discriminants are contiguous from 0 — catches reordering in C++.
+#[test]
+fn key_discriminants_are_contiguous() {
+    for (i, &key) in ALL_KEYS.iter().enumerate() {
+        assert_eq!(
+            key as u32, i as u32,
+            "key {key:?} has unexpected discriminant"
+        );
+    }
+}
+
+/// `AutogateKey` is a zero-overhead enum — same size as its repr.
+#[test]
+fn autogate_key_is_int_sized() {
+    assert_eq!(
+        std::mem::size_of::<AutogateKey>(),
+        std::mem::size_of::<i32>()
+    );
+}
+
+/// `Autogate` itself carries no state.
+#[test]
+fn autogate_struct_is_zero_sized() {
+    assert_eq!(std::mem::size_of::<Autogate>(), 0);
+}

--- a/src/rust/jsg-test/tests/mod.rs
+++ b/src/rust/jsg-test/tests/mod.rs
@@ -1,4 +1,5 @@
 mod arrays;
+mod autogate;
 mod eval;
 mod function;
 mod jsg_oneof;

--- a/src/rust/jsg/BUILD.bazel
+++ b/src/rust/jsg/BUILD.bazel
@@ -14,6 +14,7 @@ wd_rust_crate(
     visibility = ["//visibility:public"],
     deps = [
         ":ffi",
+        "//src/rust/autogate",
         "//src/workerd/io:compatibility-date_capnp_rust",
         "@crates_vendor//:capnp",
     ],

--- a/src/rust/jsg/lib.rs
+++ b/src/rust/jsg/lib.rs
@@ -14,6 +14,8 @@ pub mod modules;
 pub mod v8;
 mod wrappable;
 
+pub use autogate::Autogate;
+pub use autogate::AutogateKey;
 pub use feature_flags::FeatureFlags;
 pub use v8::BigInt64Array;
 pub use v8::BigUint64Array;

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -17,24 +17,11 @@ kj::Maybe<Autogate> globalAutogate;
 
 kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
   switch (key) {
-    case AutogateKey::TEST_WORKERD:
-      return "test-workerd"_kj;
-    case AutogateKey::V8_FAST_API:
-      return "v8-fast-api"_kj;
-    case AutogateKey::STREAMING_TAIL_WORKER:
-      return "streaming-tail-worker"_kj;
-    case AutogateKey::TAIL_STREAM_REFACTOR:
-      return "tail-stream-refactor"_kj;
-    case AutogateKey::RUST_BACKED_NODE_DNS:
-      return "rust-backed-node-dns"_kj;
-    case AutogateKey::RPC_USE_EXTERNAL_PUSHER:
-      return "rpc-use-external-pusher"_kj;
-    case AutogateKey::WASM_SHUTDOWN_SIGNAL_SHIM:
-      return "wasm-shutdown-signal-shim"_kj;
-    case AutogateKey::ENABLE_FAST_TEXTENCODER:
-      return "enable-fast-textencoder"_kj;
-    case AutogateKey::ENABLE_DRAINING_READ_ON_STANDARD_STREAMS:
-      return "enable-draining-read-on-standard-streams"_kj;
+#define WD_AUTOGATE_CASE(name, kebab)                                                              \
+  case AutogateKey::name:                                                                          \
+    return kj::StringPtr(kebab, sizeof(kebab) - 1);
+    WD_AUTOGATE_KEYS(WD_AUTOGATE_CASE)
+#undef WD_AUTOGATE_CASE
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }
@@ -111,3 +98,10 @@ void Autogate::initAutogateNamesForTest(std::initializer_list<kj::StringPtr> gat
 }
 
 }  // namespace workerd::util
+
+// C linkage entry point for src/rust/autogate/ffi.rs.
+// The Rust #[repr(C)] AutogateKey enum is ABI-compatible with util::AutogateKey
+// (same int backing, same ordinals — enforced by the static_assert in ffi.h).
+extern "C" bool workerd_autogate_is_enabled(workerd::util::AutogateKey key) {
+  return workerd::util::Autogate::isEnabled(key);
+}

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -19,27 +19,42 @@ namespace workerd::util {
 // selective gate configs (with forceOff / toggle support).
 WD_STRONG_BOOL(IgnoreAllAutogatesEnv);
 
+// X-macro list of all autogate keys.
+//
+// Each entry is WD_AUTOGATE_KEY(ENUM_NAME, "kebab-case-name").
+// This list is the single source of truth — it drives:
+//   - The AutogateKey enum (below)
+//   - KJ_STRINGIFY (autogate.c++)
+//   - The Rust FFI constexpr accessors (src/rust/jsg/autogate/ffi.h)
+//
+// To add a gate: add one WD_AUTOGATE_KEY line here, then add a matching
+// method in src/rust/jsg/autogate/lib.rs.
+#define WD_AUTOGATE_KEYS(X)                                                                        \
+  X(TEST_WORKERD, "test-workerd")                                                                  \
+  X(V8_FAST_API, "v8-fast-api")                                                                    \
+  /* Enables support for the streaming tail worker. Note that this is currently also guarded
+     behind an experimental compat flag. */       \
+  X(STREAMING_TAIL_WORKER, "streaming-tail-worker")                                                \
+  /* Enable refactor used to consolidate the different tail worker stream implementations. */      \
+  X(TAIL_STREAM_REFACTOR, "tail-stream-refactor")                                                  \
+  /* Enable Rust-backed Node.js DNS implementation */                                              \
+  X(RUST_BACKED_NODE_DNS, "rust-backed-node-dns")                                                  \
+  /* Use ExternalPusher instead of StreamSink to handle streams in RPC. */                         \
+  X(RPC_USE_EXTERNAL_PUSHER, "rpc-use-external-pusher")                                            \
+  /* Enable the WebAssembly.instantiate shim that detects modules exporting __instance_signal /
+     __instance_terminated and registers them for receiving the CPU-limit shutdown signal. */    \
+  X(WASM_SHUTDOWN_SIGNAL_SHIM, "wasm-shutdown-signal-shim")                                        \
+  /* Enable fast TextEncoder implementation using simdutf */                                       \
+  X(ENABLE_FAST_TEXTENCODER, "enable-fast-textencoder")                                            \
+  /* Enable draining read on standard streams */                                                   \
+  X(ENABLE_DRAINING_READ_ON_STANDARD_STREAMS, "enable-draining-read-on-standard-streams")
+
 // Workerd-specific list of autogate keys (can also be used in internal repo).
 enum class AutogateKey {
-  TEST_WORKERD,
-  V8_FAST_API,
-  // Enables support for the streaming tail worker. Note that this is currently also guarded behind
-  // an experimental compat flag.
-  STREAMING_TAIL_WORKER,
-  // Enable refactor used to consolidate the different tail worker stream implementations.
-  TAIL_STREAM_REFACTOR,
-  // Enable Rust-backed Node.js DNS implementation
-  RUST_BACKED_NODE_DNS,
-  // Use ExternalPusher instead of StreamSink to handle streams in RPC.
-  RPC_USE_EXTERNAL_PUSHER,
-  // Enable the WebAssembly.instantiate shim that detects modules exporting __instance_signal /
-  // __instance_terminated and registers them for receiving the CPU-limit shutdown signal.
-  WASM_SHUTDOWN_SIGNAL_SHIM,
-  // Enable fast TextEncoder implementation using simdutf
-  ENABLE_FAST_TEXTENCODER,
-  // Enable draining read on standard streams
-  ENABLE_DRAINING_READ_ON_STANDARD_STREAMS,
-  NumOfKeys  // Reserved for iteration.
+#define WD_AUTOGATE_ENUM(name, _kebab) name,
+  WD_AUTOGATE_KEYS(WD_AUTOGATE_ENUM)
+#undef WD_AUTOGATE_ENUM
+      NumOfKeys  // Reserved for iteration.
 };
 
 // This class allows code changes to be rolled out independent of full binary releases. It enables


### PR DESCRIPTION
Found a workaround for keeping the C++ and Rust implementations in sync. We could potentially get rid of the C++ Autogate in favor of Rust, if it makes sense in the future.