### PR TITLE
STREAM-6700: drop upload via File support

### DIFF
--- a/types/defines/stream.d.ts
+++ b/types/defines/stream.d.ts
@@ -28,17 +28,6 @@ interface StreamBinding {
    */
   video(id: string): StreamVideoHandle;
   /**
-   * Uploads a new video from a File.
-   * @param file The video file to upload.
-   * @returns The uploaded video details.
-   * @throws {BadRequestError} if the upload parameter is invalid
-   * @throws {QuotaReachedError} if the account storage capacity is exceeded
-   * @throws {MaxFileSizeError} if the file size is too large
-   * @throws {RateLimitedError} if the server received too many requests
-   * @throws {InternalError} if an unexpected error occurs
-   */
-  upload(file: File): Promise<StreamVideo>;
-  /**
    * Uploads a new video from a provided URL.
    * @param url The URL to upload from.
    * @param params Optional upload parameters.

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -13347,17 +13347,6 @@ interface StreamBinding {
    */
   video(id: string): StreamVideoHandle;
   /**
-   * Uploads a new video from a File.
-   * @param file The video file to upload.
-   * @returns The uploaded video details.
-   * @throws {BadRequestError} if the upload parameter is invalid
-   * @throws {QuotaReachedError} if the account storage capacity is exceeded
-   * @throws {MaxFileSizeError} if the file size is too large
-   * @throws {RateLimitedError} if the server received too many requests
-   * @throws {InternalError} if an unexpected error occurs
-   */
-  upload(file: File): Promise<StreamVideo>;
-  /**
    * Uploads a new video from a provided URL.
    * @param url The URL to upload from.
    * @param params Optional upload parameters.

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -13304,17 +13304,6 @@ export interface StreamBinding {
    */
   video(id: string): StreamVideoHandle;
   /**
-   * Uploads a new video from a File.
-   * @param file The video file to upload.
-   * @returns The uploaded video details.
-   * @throws {BadRequestError} if the upload parameter is invalid
-   * @throws {QuotaReachedError} if the account storage capacity is exceeded
-   * @throws {MaxFileSizeError} if the file size is too large
-   * @throws {RateLimitedError} if the server received too many requests
-   * @throws {InternalError} if an unexpected error occurs
-   */
-  upload(file: File): Promise<StreamVideo>;
-  /**
    * Uploads a new video from a provided URL.
    * @param url The URL to upload from.
    * @param params Optional upload parameters.

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12686,17 +12686,6 @@ interface StreamBinding {
    */
   video(id: string): StreamVideoHandle;
   /**
-   * Uploads a new video from a File.
-   * @param file The video file to upload.
-   * @returns The uploaded video details.
-   * @throws {BadRequestError} if the upload parameter is invalid
-   * @throws {QuotaReachedError} if the account storage capacity is exceeded
-   * @throws {MaxFileSizeError} if the file size is too large
-   * @throws {RateLimitedError} if the server received too many requests
-   * @throws {InternalError} if an unexpected error occurs
-   */
-  upload(file: File): Promise<StreamVideo>;
-  /**
    * Uploads a new video from a provided URL.
    * @param url The URL to upload from.
    * @param params Optional upload parameters.

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12643,17 +12643,6 @@ export interface StreamBinding {
    */
   video(id: string): StreamVideoHandle;
   /**
-   * Uploads a new video from a File.
-   * @param file The video file to upload.
-   * @returns The uploaded video details.
-   * @throws {BadRequestError} if the upload parameter is invalid
-   * @throws {QuotaReachedError} if the account storage capacity is exceeded
-   * @throws {MaxFileSizeError} if the file size is too large
-   * @throws {RateLimitedError} if the server received too many requests
-   * @throws {InternalError} if an unexpected error occurs
-   */
-  upload(file: File): Promise<StreamVideo>;
-  /**
    * Uploads a new video from a provided URL.
    * @param url The URL to upload from.
    * @param params Optional upload parameters.


### PR DESCRIPTION
Removes uploading videos via `File` in favor of users uploading via link. We want users to upload files via ReadableStream instead but that will come in a later iteration