### PR TITLE
Add preview metadata to buffered tail traces

### DIFF
--- a/src/workerd/api/trace.c++
+++ b/src/workerd/api/trace.c++
@@ -216,6 +216,7 @@ TraceItem::TraceItem(jsg::Lock& js, const Trace& trace)
       scriptTags(getTraceScriptTags(trace)),
       tailAttributes(trace.tailAttributes.map(
           [](auto& tags) { return KJ_MAP(tag, tags) { return tag.clone(); }; })),
+      preview(trace.preview.map([](auto& p) { return TracePreviewInfo(p); })),
       durableObjectId(mapCopyString(trace.durableObjectId)),
       executionModel(kj::str(trace.executionModel)),
       outcome(kj::str(trace.outcome)),
@@ -310,6 +311,10 @@ jsg::Optional<jsg::Dict<TraceItem::TailAttributeValue>> TraceItem::getTailAttrib
     },
     };
   });
+}
+
+jsg::Optional<TracePreviewInfo> TraceItem::getPreview() {
+  return preview;
 }
 
 jsg::Optional<kj::StringPtr> TraceItem::getDurableObjectId() {
@@ -542,6 +547,16 @@ ScriptVersion::ScriptVersion(const ScriptVersion& other)
     : id{mapCopyString(other.id)},
       tag{mapCopyString(other.tag)},
       message{mapCopyString(other.message)} {}
+
+TracePreviewInfo::TracePreviewInfo(const tracing::TracePreview& preview)
+    : id(kj::str(preview.id)),
+      slug(kj::str(preview.slug)),
+      name(kj::str(preview.name)) {}
+
+TracePreviewInfo::TracePreviewInfo(const TracePreviewInfo& other)
+    : id(kj::str(other.id)),
+      slug(kj::str(other.slug)),
+      name(kj::str(other.name)) {}
 
 TraceItem::CustomEventInfo::CustomEventInfo(
     const Trace& trace, const tracing::CustomEventInfo& eventInfo)
@@ -787,6 +802,7 @@ void TraceItem::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
       }
     }
   }
+  tracker.trackField("preview", preview);
   tracker.trackField("outcome", outcome);
 }
 

--- a/src/workerd/api/trace.h
+++ b/src/workerd/api/trace.h
@@ -67,6 +67,23 @@ struct ScriptVersion {
   }
 };
 
+struct TracePreviewInfo {
+  explicit TracePreviewInfo(const tracing::TracePreview& preview);
+  TracePreviewInfo(const TracePreviewInfo&);
+
+  kj::String id;
+  kj::String slug;
+  kj::String name;
+
+  JSG_STRUCT(id, slug, name);
+
+  JSG_MEMORY_INFO(TracePreviewInfo) {
+    tracker.trackField("id", id);
+    tracker.trackField("slug", slug);
+    tracker.trackField("name", name);
+  }
+};
+
 class TraceItem final: public jsg::Object {
  public:
   using TailAttributeValue = kj::OneOf<bool, double, kj::String>;
@@ -105,6 +122,7 @@ class TraceItem final: public jsg::Object {
   jsg::Optional<ScriptVersion> getScriptVersion();
   jsg::Optional<kj::StringPtr> getDispatchNamespace();
   jsg::Optional<kj::Array<kj::StringPtr>> getScriptTags();
+  jsg::Optional<TracePreviewInfo> getPreview();
   jsg::Optional<jsg::Dict<TailAttributeValue>> getTailAttributes();
   jsg::Optional<kj::StringPtr> getDurableObjectId();
   kj::StringPtr getExecutionModel();
@@ -126,6 +144,7 @@ class TraceItem final: public jsg::Object {
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(dispatchNamespace, getDispatchNamespace);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(scriptTags, getScriptTags);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(tailAttributes, getTailAttributes);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(preview, getPreview);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(durableObjectId, getDurableObjectId);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(outcome, getOutcome);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(executionModel, getExecutionModel);
@@ -148,6 +167,7 @@ class TraceItem final: public jsg::Object {
   kj::Maybe<kj::String> dispatchNamespace;
   jsg::Optional<kj::Array<kj::String>> scriptTags;
   kj::Maybe<kj::Array<tracing::Attribute>> tailAttributes;
+  jsg::Optional<TracePreviewInfo> preview;
   kj::Maybe<kj::String> durableObjectId;
   kj::String executionModel;
   kj::String outcome;
@@ -659,13 +679,14 @@ class TraceCustomEvent final: public WorkerInterface::CustomEvent {
 };
 
 #define EW_TRACE_ISOLATE_TYPES                                                                     \
-  api::ScriptVersion, api::TailEvent, api::TraceItem, api::TraceItem::AlarmEventInfo,              \
-      api::TraceItem::ConnectEventInfo, api::TraceItem::CustomEventInfo,                           \
-      api::TraceItem::ScheduledEventInfo, api::TraceItem::QueueEventInfo,                          \
-      api::TraceItem::EmailEventInfo, api::TraceItem::TailEventInfo,                               \
-      api::TraceItem::TailEventInfo::TailItem, api::TraceItem::FetchEventInfo,                     \
-      api::TraceItem::FetchEventInfo::Request, api::TraceItem::FetchEventInfo::Response,           \
-      api::TraceItem::JsRpcEventInfo, api::TraceItem::HibernatableWebSocketEventInfo,              \
+  api::TracePreviewInfo, api::ScriptVersion, api::TailEvent, api::TraceItem,                       \
+      api::TraceItem::AlarmEventInfo, api::TraceItem::ConnectEventInfo,                            \
+      api::TraceItem::CustomEventInfo, api::TraceItem::ScheduledEventInfo,                         \
+      api::TraceItem::QueueEventInfo, api::TraceItem::EmailEventInfo,                              \
+      api::TraceItem::TailEventInfo, api::TraceItem::TailEventInfo::TailItem,                      \
+      api::TraceItem::FetchEventInfo, api::TraceItem::FetchEventInfo::Request,                     \
+      api::TraceItem::FetchEventInfo::Response, api::TraceItem::JsRpcEventInfo,                    \
+      api::TraceItem::HibernatableWebSocketEventInfo,                                              \
       api::TraceItem::HibernatableWebSocketEventInfo::Message,                                     \
       api::TraceItem::HibernatableWebSocketEventInfo::Close,                                       \
       api::TraceItem::HibernatableWebSocketEventInfo::Error, api::TraceLog, api::TraceException,   \

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -577,6 +577,27 @@ KJ_TEST("Read/Write TailEvent with Multiple Attributes") {
   KJ_ASSERT(attrs2[1].name == "bar"_kj);
 }
 
+KJ_TEST("Trace with Preview") {
+  auto trace = kj::refcounted<Trace>(kj::str("test-stable-id"), kj::str("test-script"),
+      kj::none,  // scriptVersion
+      kj::str("test-namespace"), kj::str("test-script-id"),
+      kj::Array<kj::String>(),  // scriptTags
+      kj::str("test-entrypoint"), ExecutionModel::STATELESS,
+      kj::none,  // durableObjectId
+      TracePreview(kj::str("63bafce9179948688866bb22268eb1c6"), kj::str("feature-my-branch"),
+          kj::str("feature/my-branch")));
+
+  capnp::MallocMessageBuilder builder;
+  auto traceBuilder = builder.initRoot<rpc::Trace>();
+  trace->copyTo(traceBuilder);
+
+  auto trace2 = kj::refcounted<Trace>(traceBuilder.asReader());
+  auto& preview = KJ_ASSERT_NONNULL(trace2->preview);
+  KJ_ASSERT(preview.id == "63bafce9179948688866bb22268eb1c6"_kj);
+  KJ_ASSERT(preview.slug == "feature-my-branch"_kj);
+  KJ_ASSERT(preview.name == "feature/my-branch"_kj);
+}
+
 KJ_TEST("Trace with Durable Object ID") {
   auto trace = kj::refcounted<Trace>(kj::str("test-stable-id"), kj::str("test-script"),
       kj::none,  // scriptVersion

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -508,6 +508,26 @@ TraceEventInfo TraceEventInfo::clone() const {
   return TraceEventInfo(KJ_MAP(item, traces) { return item.clone(); });
 }
 
+TracePreview::TracePreview(kj::String id, kj::String slug, kj::String name)
+    : id(kj::mv(id)),
+      slug(kj::mv(slug)),
+      name(kj::mv(name)) {}
+
+TracePreview::TracePreview(rpc::Trace::TracePreviewInfo::Reader reader)
+    : id(kj::str(reader.getId())),
+      slug(kj::str(reader.getSlug())),
+      name(kj::str(reader.getName())) {}
+
+void TracePreview::copyTo(rpc::Trace::TracePreviewInfo::Builder builder) const {
+  builder.setId(id);
+  builder.setSlug(slug);
+  builder.setName(name);
+}
+
+TracePreview TracePreview::clone() const {
+  return TracePreview(kj::str(id), kj::str(slug), kj::str(name));
+}
+
 TraceEventInfo::TraceItem::TraceItem(kj::Maybe<kj::String> scriptName)
     : scriptName(kj::mv(scriptName)) {}
 
@@ -707,7 +727,8 @@ Trace::Trace(kj::Maybe<kj::String> stableId,
     kj::Array<kj::String> scriptTags,
     kj::Maybe<kj::String> entrypoint,
     ExecutionModel executionModel,
-    kj::Maybe<kj::String> durableObjectId)
+    kj::Maybe<kj::String> durableObjectId,
+    kj::Maybe<tracing::TracePreview> preview)
     : stableId(kj::mv(stableId)),
       scriptName(kj::mv(scriptName)),
       scriptVersion(kj::mv(scriptVersion)),
@@ -715,6 +736,7 @@ Trace::Trace(kj::Maybe<kj::String> stableId,
       scriptId(kj::mv(scriptId)),
       scriptTags(kj::mv(scriptTags)),
       entrypoint(kj::mv(entrypoint)),
+      preview(kj::mv(preview)),
       durableObjectId(kj::mv(durableObjectId)),
       executionModel(executionModel) {}
 Trace::Trace(rpc::Trace::Reader reader) {
@@ -772,6 +794,10 @@ void Trace::copyTo(rpc::Trace::Builder builder) const {
 
   KJ_IF_SOME(e, entrypoint) {
     builder.setEntrypoint(e);
+  }
+
+  KJ_IF_SOME(p, preview) {
+    p.copyTo(builder.initPreview());
   }
 
   KJ_IF_SOME(id, durableObjectId) {
@@ -886,6 +912,10 @@ void Trace::mergeFrom(rpc::Trace::Reader reader, PipelineLogLevel pipelineLogLev
 
   if (reader.hasEntrypoint()) {
     entrypoint = kj::str(reader.getEntrypoint());
+  }
+
+  if (reader.hasPreview()) {
+    preview = tracing::TracePreview(reader.getPreview());
   }
 
   if (reader.hasDurableObjectId()) {

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -432,6 +432,21 @@ struct EmailEventInfo final {
 };
 
 // Describes a buffered tail worker request
+struct TracePreview final {
+  explicit TracePreview(kj::String id, kj::String slug, kj::String name);
+  TracePreview(rpc::Trace::TracePreviewInfo::Reader reader);
+  TracePreview(TracePreview&&) = default;
+  TracePreview& operator=(TracePreview&&) = default;
+  KJ_DISALLOW_COPY(TracePreview);
+
+  kj::String id;
+  kj::String slug;
+  kj::String name;
+
+  void copyTo(rpc::Trace::TracePreviewInfo::Builder builder) const;
+  TracePreview clone() const;
+};
+
 struct TraceEventInfo final {
   struct TraceItem;
 
@@ -895,7 +910,8 @@ class Trace final: public kj::Refcounted {
       kj::Array<kj::String> scriptTags,
       kj::Maybe<kj::String> entrypoint,
       ExecutionModel executionModel,
-      kj::Maybe<kj::String> durableObjectId = kj::none);
+      kj::Maybe<kj::String> durableObjectId = kj::none,
+      kj::Maybe<tracing::TracePreview> preview = kj::none);
   Trace(rpc::Trace::Reader reader);
   ~Trace() noexcept(false);
   KJ_DISALLOW_COPY_AND_MOVE(Trace);
@@ -918,6 +934,7 @@ class Trace final: public kj::Refcounted {
   kj::Array<kj::String> scriptTags;
   kj::Maybe<kj::Array<tracing::Attribute>> tailAttributes;
   kj::Maybe<kj::String> entrypoint;
+  kj::Maybe<tracing::TracePreview> preview;
   kj::Maybe<kj::String> durableObjectId;
 
   kj::Vector<tracing::Log> logs;

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -138,6 +138,12 @@ struct Trace @0x8e8d911203762d34 {
     rawSize @2 :UInt32;
   }
 
+  struct TracePreviewInfo {
+    id @0 :Text;
+    slug @1 :Text;
+    name @2 :Text;
+  }
+
   struct TraceEventInfo {
     struct TraceItem {
       scriptName @0 :Text;
@@ -171,6 +177,7 @@ struct Trace @0x8e8d911203762d34 {
   scriptTags @14 :List(Text);
 
   entrypoint @22 :Text;
+  preview @30 :TracePreviewInfo;
   durableObjectId @27 :Text;
   tailAttributes @28 :List(Attribute);
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3266,6 +3266,11 @@ interface QueuingStrategyInit {
    */
   highWaterMark: number;
 }
+interface TracePreviewInfo {
+  id: string;
+  slug: string;
+  name: string;
+}
 interface ScriptVersion {
   id?: string;
   tag?: string;
@@ -3300,6 +3305,7 @@ interface TraceItem {
   readonly dispatchNamespace?: string;
   readonly scriptTags?: string[];
   readonly tailAttributes?: Record<string, boolean | number | string>;
+  readonly preview?: TracePreviewInfo;
   readonly durableObjectId?: string;
   readonly outcome: string;
   readonly executionModel: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3272,6 +3272,11 @@ export interface QueuingStrategyInit {
    */
   highWaterMark: number;
 }
+export interface TracePreviewInfo {
+  id: string;
+  slug: string;
+  name: string;
+}
 export interface ScriptVersion {
   id?: string;
   tag?: string;
@@ -3306,6 +3311,7 @@ export interface TraceItem {
   readonly dispatchNamespace?: string;
   readonly scriptTags?: string[];
   readonly tailAttributes?: Record<string, boolean | number | string>;
+  readonly preview?: TracePreviewInfo;
   readonly durableObjectId?: string;
   readonly outcome: string;
   readonly executionModel: string;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -3115,6 +3115,11 @@ interface QueuingStrategyInit {
    */
   highWaterMark: number;
 }
+interface TracePreviewInfo {
+  id: string;
+  slug: string;
+  name: string;
+}
 interface ScriptVersion {
   id?: string;
   tag?: string;
@@ -3149,6 +3154,7 @@ interface TraceItem {
   readonly dispatchNamespace?: string;
   readonly scriptTags?: string[];
   readonly tailAttributes?: Record<string, boolean | number | string>;
+  readonly preview?: TracePreviewInfo;
   readonly durableObjectId?: string;
   readonly outcome: string;
   readonly executionModel: string;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -3121,6 +3121,11 @@ export interface QueuingStrategyInit {
    */
   highWaterMark: number;
 }
+export interface TracePreviewInfo {
+  id: string;
+  slug: string;
+  name: string;
+}
 export interface ScriptVersion {
   id?: string;
   tag?: string;
@@ -3155,6 +3160,7 @@ export interface TraceItem {
   readonly dispatchNamespace?: string;
   readonly scriptTags?: string[];
   readonly tailAttributes?: Record<string, boolean | number | string>;
+  readonly preview?: TracePreviewInfo;
   readonly durableObjectId?: string;
   readonly outcome: string;
   readonly executionModel: string;


### PR DESCRIPTION
### Summary

 Add preview metadata to buffered tail traces.

 This exposes:

 ```js
   trace.preview = { id, slug, name }
 ```

 to classic/buffered tail workers.

####  Why Why

 edgeworker needs to surface pipeline-level preview identity in classic tail worker
 observability.

 That requires workerd to support carrying preview metadata through the buffered trace path;
 otherwise classic tail workers only receive traces without any preview context.

 #### Changes

 - add top-level preview field to rpc::Trace
 - add in-memory TracePreview
 - serialize / deserialize it through io/trace.*
 - expose it on the JS buffered tail trace API as trace.preview
 - add a focused round-trip trace test

 #### Notes

 This only adds the workerd support layer. The corresponding edgeworker change is what populates
 this field from pipeline preview metadata.