### PR TITLE
Implement abortIsolate() in cloudflare:workers module

### DIFF
--- a/src/cloudflare/internal/workers.d.ts
+++ b/src/cloudflare/internal/workers.d.ts
@@ -61,3 +61,6 @@ export interface CacheContext {
 }
 
 export function getCtxCache(): CacheContext | undefined;
+
+// Only defined when the `workerd_experimental` compat flag is enabled.
+export function abortIsolate(reason?: string): never;

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -438,3 +438,19 @@ export const cache = new Proxy(
 );
 
 export const tracing = innerTracing;
+
+// `abortIsolate` is only defined on `entrypoints` when the
+// `workerd_experimental` compat flag is enabled. When the flag is disabled,
+// calling it throws a clear error rather than a cryptic
+// "undefined is not a function".
+const rawAbortIsolate: ((reason?: string) => never) | undefined = (
+  entrypoints as { abortIsolate?: (reason?: string) => never }
+).abortIsolate;
+export const abortIsolate: (reason?: string) => never =
+  rawAbortIsolate !== undefined
+    ? rawAbortIsolate.bind(entrypoints)
+    : (_reason?: string): never => {
+        throw new Error(
+          'abortIsolate() requires the "experimental" compatibility flag.'
+        );
+      };

--- a/src/workerd/api/sockets-test.c++
+++ b/src/workerd/api/sockets-test.c++
@@ -73,6 +73,10 @@ struct ConnectTestIoChannelFactory final: public TestFixture::DummyIoChannelFact
     return kj::heap<MockConnectWorkerInterface>(connectCalled, headerTable, pipeEnd);
   }
 
+  void abortIsolate(kj::StringPtr reason) override {
+    JSG_FAIL_REQUIRE(Error, "abortIsolate() is not implemented for this runtime.");
+  }
+
   bool& connectCalled;
   kj::HttpHeaderTable& headerTable;
   kj::Maybe<kj::AsyncIoStream&>& pipeEnd;

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//:build/wd_test.bzl", "wd_test")
 
 wd_test(
@@ -916,4 +917,24 @@ wd_test(
 wd_test(
     src = "htmlrewriter-transform-cancel-test.wd-test",
     data = ["htmlrewriter-transform-cancel-test.js"],
+)
+
+sh_test(
+    name = "abortIsolate",
+    size = "small",
+    srcs = ["abortIsolate.sh"],
+    args = [
+        "$(location //src/workerd/server:workerd_cross)",
+        "$(location abortIsolate.wd-test)",
+        "$(location abortIsolate.js)",
+    ],
+    data = [
+        "abortIsolate.js",
+        "abortIsolate.wd-test",
+        "//src/workerd/server:workerd_cross",
+    ],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )

--- a/src/workerd/api/tests/abortIsolate.js
+++ b/src/workerd/api/tests/abortIsolate.js
@@ -1,0 +1,15 @@
+import { abortIsolate, env } from 'cloudflare:workers';
+
+if (env.topLevelAbort) {
+  while (true) {
+    try {
+      abortIsolate('Abort at top level');
+    } catch (e) {}
+  }
+}
+
+export const crashTest = {
+  test() {
+    abortIsolate('test reason');
+  },
+};

--- a/src/workerd/api/tests/abortIsolate.sh
+++ b/src/workerd/api/tests/abortIsolate.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Call abortIsolate() and check for:
+#  * exit code nonzero
+#  * fatal uncaught exception message present with the abort reason.
+
+WORKERD=$1
+CONFIG=$2
+JSFILE=$3
+TEST_TMPDIR="${TEST_TMPDIR:-/tmp}"
+
+cp "$JSFILE" "$TEST_TMPDIR"
+
+# Prepare the config with a given topLevelAbort value and run workerd.
+# Sets the global `output` and `exit_code` variables.
+run_test() {
+  local top_level_abort=$1
+  cp "$CONFIG" "$TEST_TMPDIR"
+  sed "s/%topLevelAbort/$top_level_abort/" "$TEST_TMPDIR/abortIsolate.wd-test" \
+    > "$TEST_TMPDIR/abortIsolate.wd-test.tmp" \
+    && mv "$TEST_TMPDIR/abortIsolate.wd-test.tmp" "$TEST_TMPDIR/abortIsolate.wd-test"
+
+  output=$("$WORKERD" test "$TEST_TMPDIR/abortIsolate.wd-test" --experimental --compat-date=2000-01-01 -dTEST_TMPDIR="$TEST_TMPDIR" 2>&1)
+  exit_code=$?
+
+  echo "--- captured output ---" >&2
+  echo "$output" >&2
+  echo "--- end captured output ---" >&2
+  echo "" >&2
+}
+
+# Assert that $output contains the given string; set failed=1 on mismatch.
+expect_in_output() {
+  local msg=$1
+  if ! echo "$output" | grep -qF "$msg"; then
+    echo "FAIL: expected log line not found: $msg" >&2
+    failed=1
+  fi
+}
+
+failed=0
+
+echo "Test 1: topLevelAbort = false"
+run_test false
+
+if [ "$exit_code" -eq 0 ]; then
+  echo "FAIL: expected nonzero exit code" >&2
+  exit 1
+fi
+
+expect_in_output "*** Fatal uncaught kj::Exception:"
+expect_in_output "abortIsolate() called, terminating process; reason = test reason"
+
+echo "Test 2: topLevelAbort = true"
+run_test true
+
+if [ "$exit_code" -eq 0 ]; then
+  echo "FAIL: expected nonzero exit code" >&2
+  exit 1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Success"
+exit 0

--- a/src/workerd/api/tests/abortIsolate.wd-test
+++ b/src/workerd/api/tests/abortIsolate.wd-test
@@ -1,0 +1,20 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "abortIsolate-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "abortIsolate.js"),
+        ],
+        compatibilityFlags = ["experimental"],
+        bindings = [
+          (
+            name = "topLevelAbort",
+            json = "%topLevelAbort"
+          ),
+        ],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/tests/worker-loader-test.js
+++ b/src/workerd/api/tests/worker-loader-test.js
@@ -944,3 +944,108 @@ export let justLoad = {
     }
   },
 };
+
+// Test that abortIsolate() works correctly for dynamic workers.
+// When abortIsolate() is called on a dynamic worker, it should:
+// 1. Terminate the isolate (not the entire process).
+// 2. Cause subsequent lookups by name to reload the isolate from scratch.
+export let abortIsolateDynamic = {
+  async test(ctrl, env, ctx) {
+    // Create a dynamic worker that calls abortIsolate. ping() increments and returns a
+    // module-scoped counter so we can distinguish fresh isolates from reused ones.
+    let loadCount = 0;
+    const getWorkerEntrypoint = () =>
+      env.loader
+        .get('abort-test', () => {
+          loadCount++;
+          return {
+            compatibilityDate: '2025-01-01',
+            compatibilityFlags: ['experimental'],
+            allowExperimental: true,
+            mainModule: 'worker.js',
+            modules: {
+              'worker.js': `
+            import {WorkerEntrypoint, abortIsolate} from "cloudflare:workers";
+            let counter = 0;
+            export class TestEntrypoint extends WorkerEntrypoint {
+              async crash() {
+                abortIsolate('Dynamic worker abort test');
+              }
+              async ping() {
+                return ++counter;
+              }
+            }
+          `,
+            },
+          };
+        })
+        .getEntrypoint('TestEntrypoint');
+
+    let entrypoint = getWorkerEntrypoint();
+    // First, verify the worker works normally. Each ping increments the counter.
+    assert.strictEqual(await entrypoint.ping(), 1);
+    assert.strictEqual(await entrypoint.ping(), 2);
+    assert.strictEqual(loadCount, 1);
+
+    entrypoint = getWorkerEntrypoint();
+    assert.strictEqual(await entrypoint.ping(), 3);
+    assert.strictEqual(loadCount, 1);
+
+    // Now trigger abortIsolate - this should terminate the isolate but not crash the process.
+    await assert.rejects(
+      () => entrypoint.crash(),
+      (err) => {
+        return err.message.startsWith('internal error; reference =');
+      }
+    );
+
+    entrypoint = getWorkerEntrypoint();
+    assert.strictEqual(await entrypoint.ping(), 1);
+    assert.strictEqual(await entrypoint.ping(), 2);
+    assert.strictEqual(loadCount, 2);
+  },
+};
+
+// Test that abortIsolate() works correctly for anonymous dynamic workers.
+// Anonymous workers don't have a name and therefore aren't stored in the loader's map.
+export let abortIsolateDynamicAnonymous = {
+  async test(ctrl, env, ctx) {
+    // Create an anonymous dynamic worker (no name provided to get())
+    let worker = env.loader.get(null, () => {
+      return {
+        compatibilityDate: '2025-01-01',
+        compatibilityFlags: ['experimental'],
+        allowExperimental: true,
+        mainModule: 'worker.js',
+        modules: {
+          'worker.js': `
+            import {WorkerEntrypoint, abortIsolate} from "cloudflare:workers";
+            let counter = 0;
+            export class TestEntrypoint extends WorkerEntrypoint {
+              async crash() {
+                abortIsolate('Anonymous dynamic worker abort test');
+              }
+              async ping() {
+                return ++counter;
+              }
+            }
+          `,
+        },
+      };
+    });
+
+    // First, verify the worker works normally.
+    let entrypoint = worker.getEntrypoint('TestEntrypoint');
+    assert.strictEqual(await entrypoint.ping(), 1);
+    assert.strictEqual(await entrypoint.ping(), 2);
+
+    // Now trigger abortIsolate - this should terminate the isolate
+    // but NOT crash the entire process.
+    await assert.rejects(
+      () => entrypoint.crash(),
+      (err) => {
+        return err.message.startsWith('internal error; reference =');
+      }
+    );
+  },
+};

--- a/src/workerd/api/tests/worker-loader-test.wd-test
+++ b/src/workerd/api/tests/worker-loader-test.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "worker-loader-test.js")
         ],
-        compatibilityFlags = ["nodejs_compat","rpc","enable_ctx_exports"],
+        compatibilityFlags = ["nodejs_compat","rpc","enable_ctx_exports","experimental"],
         bindings = [
           (name = "loader", workerLoader = ()),
           (name = "sharedLoader1", workerLoader = (id = "shared")),

--- a/src/workerd/api/workers-module.c++
+++ b/src/workerd/api/workers-module.c++
@@ -68,4 +68,12 @@ jsg::Optional<jsg::Ref<CacheContext>> EntrypointsModule::getCtxCache(jsg::Lock& 
   return kj::none;
 }
 
+void EntrypointsModule::abortIsolate(jsg::Lock& js, jsg::Optional<kj::String> reason) {
+  auto& r = reason.orDefault(nullptr);
+  KJ_IF_SOME(context, IoContext::tryCurrent()) {
+    context.abortIsolate(r);
+  }
+  js.terminateExecutionNow();
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/workers-module.h
+++ b/src/workerd/api/workers-module.h
@@ -86,7 +86,11 @@ class EntrypointsModule: public jsg::Object {
   // expose an importable `cache` proxy.
   jsg::Optional<jsg::Ref<CacheContext>> getCtxCache(jsg::Lock& js);
 
-  JSG_RESOURCE_TYPE(EntrypointsModule) {
+  // Immediately condemn and terminate the current isolate. In workerd for now this just aborts the
+  // process.
+  void abortIsolate(jsg::Lock& js, jsg::Optional<kj::String> reason);
+
+  JSG_RESOURCE_TYPE(EntrypointsModule, CompatibilityFlags::Reader flags) {
     JSG_NESTED_TYPE(WorkerEntrypoint);
     JSG_NESTED_TYPE(WorkflowEntrypoint);
     JSG_NESTED_TYPE_NAMED(DurableObjectBase, DurableObject);
@@ -98,6 +102,10 @@ class EntrypointsModule: public jsg::Object {
 
     JSG_METHOD(waitUntil);
     JSG_METHOD(getCtxCache);
+
+    if (flags.getWorkerdExperimental()) {
+      JSG_METHOD(abortIsolate);
+    }
   }
 };
 

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -285,6 +285,11 @@ class IoChannelFactory {
     KJ_UNIMPLEMENTED("Only implemented by single-tenant workerd runtime");
   }
 
+  // In workerd, the handler aborts the process (unless used on a dynamic
+  // worker). In the edge runtime it will condemn and terminate the current
+  // isolate.
+  virtual void abortIsolate(kj::StringPtr reason) = 0;
+
   // Use a dynamic Worker loader binding to obtain an Worker by name. If name is null, or if the named Worker doesn't already exist, the callback will be called to fetch the source code from which the Worker should be created.
   virtual kj::Own<WorkerStubChannel> loadIsolate(uint loaderChannel,
       kj::Maybe<kj::String> name,

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -487,6 +487,10 @@ void IoContext::abort(kj::Exception&& e) {
   abortFulfiller->reject(kj::mv(e));
 }
 
+void IoContext::abortIsolate(kj::StringPtr reason) {
+  getIoChannelFactory().abortIsolate(reason);
+}
+
 void IoContext::abortWhen(kj::Promise<void> promise) {
   // Unlike addTask(), abortWhen() always uses `tasks`, even in actors, because we do not want
   // these tasks to block hibernation.

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -887,6 +887,9 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
     getIoChannelFactory().deleteAllActors(reason);
   }
 
+  // Condemn and terminate JS isolate
+  void abortIsolate(kj::StringPtr reason = nullptr);
+
   // Get an HttpClient to use for Cache API subrequests.
   kj::Own<CacheClient> getCacheClient();
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1945,7 +1945,8 @@ class Server::WorkerService final: public Service,
       DeleteActorsCallback deleteActorsCallback,
       kj::Maybe<kj::String> dockerPathParam,
       kj::Maybe<kj::String> containerEgressInterceptorImageParam,
-      bool isDynamic)
+      bool isDynamic,
+      kj::Maybe<kj::Function<void()>> abortIsolateCallback = kj::none)
       : channelTokenHandler(channelTokenHandler),
         serviceName(serviceName),
         threadContext(threadContext),
@@ -1960,7 +1961,8 @@ class Server::WorkerService final: public Service,
         deleteActorsCallback(kj::mv(deleteActorsCallback)),
         dockerPath(kj::mv(dockerPathParam)),
         containerEgressInterceptorImage(kj::mv(containerEgressInterceptorImageParam)),
-        isDynamic(isDynamic) {}
+        isDynamic(isDynamic),
+        abortIsolateCallback(kj::mv(abortIsolateCallback)) {}
 
   // Call immediately after the constructor to set up `actorNamespaces`. This can't happen during
   // the constructor itself since it sets up cyclic references, which will throw an exception if
@@ -3339,6 +3341,7 @@ class Server::WorkerService final: public Service,
   kj::Maybe<kj::String> dockerPath;
   kj::Maybe<kj::String> containerEgressInterceptorImage;
   bool isDynamic;
+  kj::Maybe<kj::Function<void()>> abortIsolateCallback;
 
   class ActorChannelImpl final: public IoChannelFactory::ActorChannel {
    public:
@@ -3563,6 +3566,25 @@ class Server::WorkerService final: public Service,
 
   void deleteAllActors(kj::Maybe<kj::Exception&> reason) override {
     deleteActorsCallback(reason);
+  }
+
+  // For now, in workerd just abort the process for non-dynamic workers.
+  void abortIsolate(kj::StringPtr reason) noexcept override {
+    KJ_IF_SOME(cb, abortIsolateCallback) {
+      // Removes the isolate from the isolates map.
+      //
+      // TODO: Should abort all outstanding calls to the isolate causing them to
+      // throw the reason as the error.
+      cb();
+    } else {
+      // Otherwise, abort the process. Throwing from a noexcept function will call
+      // std::terminate, which produces a nicer error message than ::abort().
+      if (reason == nullptr) {
+        KJ_FAIL_REQUIRE("abortIsolate() called, terminating process");
+      } else {
+        KJ_FAIL_REQUIRE("abortIsolate() called, terminating process", reason);
+      }
+    }
   }
 
   kj::Own<WorkerStubChannel> loadIsolate(uint loaderChannel,
@@ -4153,6 +4175,10 @@ struct Server::WorkerDef {
   // If the WorkerDef was created from a DymamicWorkerSource and that
   // source contains a clone of the source bundle, this will take ownership.
   kj::Maybe<kj::Own<void>> maybeOwnedSourceCode;
+
+  // Callback invoked when abortIsolate() is called. Used by dynamic workers to remove
+  // themselves from the loader's isolate map.
+  kj::Maybe<kj::Function<void()>> abortIsolateCallback;
 };
 
 class Server::WorkerLoaderNamespace: public kj::Refcounted {
@@ -4177,15 +4203,27 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
         // may be used in error logs.
         auto isolateName = kj::str(namespaceName, ':', n);
 
+        // On abort, remove the entry from this namespace's isolates map so
+        // subsequent loadIsolate() calls with the same name will create a fresh
+        // isolate.
+        kj::Function<void()> onAborted = [this, mapKey = kj::str(n)]() { removeIsolate(mapKey); };
+
         return {.key = kj::mv(n),
-          .value = kj::rc<WorkerStubImpl>(server, kj::mv(isolateName), kj::mv(fetchSource))};
+          .value = kj::rc<WorkerStubImpl>(
+              server, kj::mv(isolateName), kj::mv(onAborted), kj::mv(fetchSource))};
       })
           .addRef()
           .toOwn();
     } else {
       auto isolateName = kj::str(namespaceName, ":dynamic:", randomUUID(server.entropySource));
-      return kj::rc<WorkerStubImpl>(server, kj::mv(isolateName), kj::mv(fetchSource)).toOwn();
+      return kj::rc<WorkerStubImpl>(server, kj::mv(isolateName), kj::none, kj::mv(fetchSource))
+          .toOwn();
     }
+  }
+
+  void removeIsolate(kj::StringPtr name) {
+    // This is called by abortIsolate()
+    isolates.erase(name);
   }
 
  private:
@@ -4221,8 +4259,10 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
    public:
     WorkerStubImpl(Server& server,
         kj::String isolateName,
+        kj::Maybe<kj::Function<void()>> onAborted,
         kj::Function<kj::Promise<DynamicWorkerSource>()> fetchSource)
-        : startupTask(start(server, kj::mv(isolateName), kj::mv(fetchSource)).fork()) {}
+        : onAborted(kj::mv(onAborted)),
+          startupTask(start(server, kj::mv(isolateName), kj::mv(fetchSource)).fork()) {}
 
     ~WorkerStubImpl() {
       unlink();
@@ -4245,8 +4285,20 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
     }
 
    private:
+    // Callback to remove the worker stub from the isolates map. None for
+    // unnamed dynamic isolates.
+    kj::Maybe<kj::Function<void()>> onAborted;
+
     kj::Maybe<kj::Own<WorkerService>> service;  // null if still starting up
     kj::ForkedPromise<void> startupTask;        // resolves when `service` is non-null
+
+    void onAbortIsolate() {
+      KJ_IF_SOME(cb, onAborted) {
+        auto callback = kj::mv(cb);
+        onAborted = kj::none;
+        callback();
+      }
+    }
 
     kj::Promise<void> start(Server& server,
         kj::String isolateName,
@@ -4325,6 +4377,9 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
         // ownership issues. For the downstream use, however, we need to be careful
         // to not copy the ownContent if it is an RPC response.
         .maybeOwnedSourceCode = kj::mv(source.ownContent),
+        // The callback is owned by the WorkerService, which is owned by `this`, so a raw
+        // pointer is safe.
+        .abortIsolateCallback = kj::Function<void()>([this]() { onAbortIsolate(); }),
         // clang-format on
       };
 
@@ -4816,6 +4871,9 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
     { auto drop = kj::mv(ctxExportsHandle); }
   });
 
+  // Extract abortIsolateCallback before moving def into linkCallback lambda
+  auto abortIsolateCallback = kj::mv(def.abortIsolateCallback);
+
   auto linkCallback = [this, def = kj::mv(def), totalActorChannels](WorkerService& workerService,
                           Worker::ValidationErrorReporter& errorReporter) mutable {
     WorkerService::LinkedIoChannels result;
@@ -4969,12 +5027,13 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
   kj::Maybe<kj::StringPtr> serviceName;
   if (!def.isDynamic) serviceName = name;
 
-  auto result = kj::refcounted<WorkerService>(channelTokenHandler, serviceName,
-      globalContext->threadContext, monotonicClock, kj::mv(worker),
-      kj::mv(errorReporter.defaultEntrypoint), kj::mv(errorReporter.namedEntrypoints),
-      kj::mv(errorReporter.actorClasses), kj::mv(linkCallback),
-      KJ_BIND_METHOD(*this, abortAllActors), KJ_BIND_METHOD(*this, deleteAllActors),
-      kj::mv(dockerPath), kj::mv(containerEgressInterceptorImage), def.isDynamic);
+  auto result =
+      kj::refcounted<WorkerService>(channelTokenHandler, serviceName, globalContext->threadContext,
+          monotonicClock, kj::mv(worker), kj::mv(errorReporter.defaultEntrypoint),
+          kj::mv(errorReporter.namedEntrypoints), kj::mv(errorReporter.actorClasses),
+          kj::mv(linkCallback), KJ_BIND_METHOD(*this, abortAllActors),
+          KJ_BIND_METHOD(*this, deleteAllActors), kj::mv(dockerPath),
+          kj::mv(containerEgressInterceptorImage), def.isDynamic, kj::mv(abortIsolateCallback));
   result->initActorNamespaces(def.localActorConfigs, network);
   co_return result;
 }

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -130,6 +130,10 @@ struct TestFixture {
     virtual ~DummyIoChannelFactory() = default;
     DummyIoChannelFactory(TimerChannel& timer): timer(timer) {}
 
+    void abortIsolate(kj::StringPtr reason) override {
+      KJ_FAIL_ASSERT("no abortIsolate");
+    }
+
     kj::Own<WorkerInterface> startSubrequest(uint channel, SubrequestMetadata metadata) override {
       KJ_FAIL_ASSERT("no subrequests");
     }


### PR DESCRIPTION
Add abortIsolate(reason) API that condemns and terminates the current JS isolate, like when excessively exceeding memory limit. In production, the next request creates a new isolate.

In workerd, since we don't currently have a mechanism to start a new isolate, for now it just aborts the process. The idea is that when we add a memory limiter implementation for workerd we can actually implement restarting the isolate within the workerd process. For now, this is good enough