### PR TITLE
add several TypedArray methods to Rust JSG

### DIFF
--- a/src/rust/jsg-test/tests/arrays.rs
+++ b/src/rust/jsg-test/tests/arrays.rs
@@ -1377,3 +1377,62 @@ fn biguint64_array_to_js_and_from_js() {
         Ok(())
     });
 }
+
+#[test]
+fn uint8clamped_array_from_js() {
+    let harness = crate::Harness::new();
+    harness.run_in_context(|lock, ctx| {
+        use jsg::v8::Local;
+        use jsg::v8::Uint8ClampedArray;
+
+        let val = ctx
+            .eval_raw("new Uint8ClampedArray([0, 128, 255])")
+            .unwrap();
+        assert!(val.is_uint8clamped_array());
+        assert!(!val.is_uint8_array());
+
+        let arr: Local<Uint8ClampedArray> =
+            // SAFETY: isolate valid; val is a Uint8ClampedArray Local.
+            unsafe { Local::from_ffi(lock.isolate(), val.into_ffi()) };
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr.get(0), 0u8);
+        assert_eq!(arr.get(1), 128u8);
+        assert_eq!(arr.get(2), 255u8);
+        assert_eq!(arr.as_slice(), &[0u8, 128, 255]);
+        assert!(arr.is_integer_type());
+        assert_eq!(arr.element_size(), 1);
+
+        Ok(())
+    });
+}
+
+#[test]
+fn uint8clamped_array_rejects_wrong_type() {
+    let harness = crate::Harness::new();
+    harness.run_in_context(|lock, ctx| {
+        use jsg::FromJS;
+        use jsg::v8::Local;
+        use jsg::v8::Uint8ClampedArray;
+
+        let val = ctx.eval_raw("new Uint8Array([1, 2, 3])").unwrap();
+        let result = Local::<Uint8ClampedArray>::from_js(lock, val);
+        assert!(result.is_err());
+
+        Ok(())
+    });
+}
+
+#[test]
+fn is_float16_array_check() {
+    let harness = crate::Harness::new();
+    harness.run_in_context(|_lock, ctx| {
+        let f16_val = ctx.eval_raw("new Float16Array([1.0, 2.0])").unwrap();
+        assert!(f16_val.is_float16_array());
+        assert!(!f16_val.is_float32_array());
+
+        let f32_val = ctx.eval_raw("new Float32Array([1.0])").unwrap();
+        assert!(!f32_val.is_float16_array());
+
+        Ok(())
+    });
+}

--- a/src/rust/jsg/ffi.c++
+++ b/src/rust/jsg/ffi.c++
@@ -210,6 +210,14 @@ bool local_is_biguint64_array(const Local& val) {
   return local_as_ref_from_ffi<v8::Value>(val)->IsBigUint64Array();
 }
 
+bool local_is_float16_array(const Local& val) {
+  return local_as_ref_from_ffi<v8::Value>(val)->IsFloat16Array();
+}
+
+bool local_is_uint8clamped_array(const Local& val) {
+  return local_as_ref_from_ffi<v8::Value>(val)->IsUint8ClampedArray();
+}
+
 bool local_is_array_buffer(const Local& val) {
   return local_as_ref_from_ffi<v8::Value>(val)->IsArrayBuffer();
 }
@@ -601,6 +609,7 @@ DEFINE_TYPED_ARRAY_GET(float32_array, Float32Array, float)
 DEFINE_TYPED_ARRAY_GET(float64_array, Float64Array, double)
 DEFINE_TYPED_ARRAY_GET(bigint64_array, BigInt64Array, int64_t)
 DEFINE_TYPED_ARRAY_GET(biguint64_array, BigUint64Array, uint64_t)
+DEFINE_TYPED_ARRAY_GET(uint8clamped_array, Uint8ClampedArray, uint8_t)
 
 // Global<T>
 void global_reset(Global& value) {

--- a/src/rust/jsg/ffi.h
+++ b/src/rust/jsg/ffi.h
@@ -139,6 +139,8 @@ bool local_is_float32_array(const Local& val);
 bool local_is_float64_array(const Local& val);
 bool local_is_bigint64_array(const Local& val);
 bool local_is_biguint64_array(const Local& val);
+bool local_is_float16_array(const Local& val);
+bool local_is_uint8clamped_array(const Local& val);
 bool local_is_array_buffer(const Local& val);
 bool local_is_array_buffer_view(const Local& val);
 bool local_is_function(const Local& val);
@@ -220,6 +222,7 @@ float local_float32_array_get(Isolate* isolate, const Local& array, size_t index
 double local_float64_array_get(Isolate* isolate, const Local& array, size_t index);
 int64_t local_bigint64_array_get(Isolate* isolate, const Local& array, size_t index);
 uint64_t local_biguint64_array_get(Isolate* isolate, const Local& array, size_t index);
+uint8_t local_uint8clamped_array_get(Isolate* isolate, const Local& array, size_t index);
 
 // Global<T>
 void global_reset(Global& value);

--- a/src/rust/jsg/v8.rs
+++ b/src/rust/jsg/v8.rs
@@ -209,6 +209,8 @@ pub mod ffi {
         pub unsafe fn local_is_float64_array(value: &Local) -> bool;
         pub unsafe fn local_is_bigint64_array(value: &Local) -> bool;
         pub unsafe fn local_is_biguint64_array(value: &Local) -> bool;
+        pub unsafe fn local_is_float16_array(value: &Local) -> bool;
+        pub unsafe fn local_is_uint8clamped_array(value: &Local) -> bool;
         pub unsafe fn local_is_array_buffer(value: &Local) -> bool;
         pub unsafe fn local_is_array_buffer_view(value: &Local) -> bool;
         pub unsafe fn local_is_function(value: &Local) -> bool;
@@ -376,6 +378,11 @@ pub mod ffi {
             array: &Local,
             index: usize,
         ) -> u64;
+        pub unsafe fn local_uint8clamped_array_get(
+            isolate: *mut Isolate,
+            array: &Local,
+            index: usize,
+        ) -> u8;
 
         // Global<T>
         pub unsafe fn global_reset(value: Pin<&mut Global>);
@@ -815,6 +822,7 @@ pub struct Float32Array;
 pub struct Float64Array;
 pub struct BigInt64Array;
 pub struct BigUint64Array;
+pub struct Uint8ClampedArray;
 
 // Generic Local<'a, T> handle with lifetime
 #[derive(Debug)]
@@ -1008,6 +1016,18 @@ impl<'a, T> Local<'a, T> {
     pub fn is_biguint64_array(&self) -> bool {
         // SAFETY: handle is valid within the current HandleScope.
         unsafe { ffi::local_is_biguint64_array(&self.handle) }
+    }
+
+    /// Returns true if the value is a `Float16Array`.
+    pub fn is_float16_array(&self) -> bool {
+        // SAFETY: handle is valid within the current HandleScope.
+        unsafe { ffi::local_is_float16_array(&self.handle) }
+    }
+
+    /// Returns true if the value is a `Uint8ClampedArray`.
+    pub fn is_uint8clamped_array(&self) -> bool {
+        // SAFETY: handle is valid within the current HandleScope.
+        unsafe { ffi::local_is_uint8clamped_array(&self.handle) }
     }
 
     /// Returns true if the value is an `ArrayBuffer`.
@@ -1229,6 +1249,7 @@ impl_local_cast!(Float32Array -> Value, is_float32_array);
 impl_local_cast!(Float64Array -> Value, is_float64_array);
 impl_local_cast!(BigInt64Array -> Value, is_bigint64_array);
 impl_local_cast!(BigUint64Array -> Value, is_biguint64_array);
+impl_local_cast!(Uint8ClampedArray -> Value, is_uint8clamped_array);
 
 // TypedArray base type to Value. Uses `is_array_buffer_view` which also matches
 // `DataView`, but this is acceptable because `TypedArray` is only constructed from
@@ -1246,6 +1267,7 @@ impl_local_cast!(Float32Array -> TypedArray, is_float32_array);
 impl_local_cast!(Float64Array -> TypedArray, is_float64_array);
 impl_local_cast!(BigInt64Array -> TypedArray, is_bigint64_array);
 impl_local_cast!(BigUint64Array -> TypedArray, is_biguint64_array);
+impl_local_cast!(Uint8ClampedArray -> TypedArray, is_uint8clamped_array);
 
 // Upcasts to Object (Function, Array, TypedArray are all Object subtypes in V8)
 impl_local_cast!(Function -> Object, is_function);
@@ -1634,6 +1656,11 @@ impl_typed_array_from_js!(Float32Array, is_float32_array, "Float32Array");
 impl_typed_array_from_js!(Float64Array, is_float64_array, "Float64Array");
 impl_typed_array_from_js!(BigInt64Array, is_bigint64_array, "BigInt64Array");
 impl_typed_array_from_js!(BigUint64Array, is_biguint64_array, "BigUint64Array");
+impl_typed_array_from_js!(
+    Uint8ClampedArray,
+    is_uint8clamped_array,
+    "Uint8ClampedArray"
+);
 
 impl_typed_array!(Uint8Array, u8, local_uint8_array_get);
 impl_typed_array!(Uint16Array, u16, local_uint16_array_get);
@@ -1645,6 +1672,8 @@ impl_typed_array!(Float32Array, f32, local_float32_array_get);
 impl_typed_array!(Float64Array, f64, local_float64_array_get);
 impl_typed_array!(BigInt64Array, i64, local_bigint64_array_get);
 impl_typed_array!(BigUint64Array, u64, local_biguint64_array_get);
+// Uint8ClampedArray has the same element type as Uint8Array; clamping is a write-side JS concern.
+impl_typed_array!(Uint8ClampedArray, u8, local_uint8clamped_array_get);
 
 // =============================================================================
 // `String`-specific implementations


### PR DESCRIPTION
Adds byte_offset(), byte_length(), data(), as_slice() and as_mut_slice() methods for TypedArray (and other *Array structs)

Changes are splitted from https://github.com/cloudflare/workerd/pull/6360