### PR TITLE
feat: update AI Search type definitions for new binding

### DIFF
--- a/types/defines/ai-search.d.ts
+++ b/types/defines/ai-search.d.ts
@@ -1,9 +1,10 @@
-// AI Search V2 API Error Interfaces
+// ============ AI Search Error Interfaces ============
+
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}
-export interface AiSearchNameNotSetError extends Error {}
 
-// AI Search V2 Request Types
+// ============ AI Search Request Types ============
+
 export type AiSearchSearchRequest = {
   messages: Array<{
     role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
@@ -28,9 +29,8 @@ export type AiSearchSearchRequest = {
       [key: string]: unknown;
     };
     reranking?: {
-      /** Enable reranking (default false) */
       enabled?: boolean;
-      model?: '@cf/baai/bge-reranker-base' | '';
+      model?: '@cf/baai/bge-reranker-base' | string;
       /** Match threshold (0-1, default 0.4) */
       match_threshold?: number;
       [key: string]: unknown;
@@ -43,6 +43,7 @@ export type AiSearchChatCompletionsRequest = {
   messages: Array<{
     role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
     content: string | null;
+    [key: string]: unknown;
   }>;
   model?: string;
   stream?: boolean;
@@ -63,7 +64,7 @@ export type AiSearchChatCompletionsRequest = {
     };
     reranking?: {
       enabled?: boolean;
-      model?: '@cf/baai/bge-reranker-base' | '';
+      model?: '@cf/baai/bge-reranker-base' | string;
       match_threshold?: number;
       [key: string]: unknown;
     };
@@ -72,7 +73,9 @@ export type AiSearchChatCompletionsRequest = {
   [key: string]: unknown;
 };
 
-// AI Search V2 Response Types
+
+// ============ AI Search Response Types ============
+
 export type AiSearchSearchResponse = {
   search_query: string;
   chunks: Array<{
@@ -91,28 +94,72 @@ export type AiSearchSearchResponse = {
       keyword_score?: number;
       /** Vector similarity score (0-1) */
       vector_score?: number;
+      [key: string]: unknown;
     };
   }>;
 };
 
-export type AiSearchListResponse = Array<{
-  id: string;
-  internal_id?: string;
-  account_id?: string;
-  account_tag?: string;
-  /** Whether the instance is enabled (default true) */
-  enable?: boolean;
-  type?: 'r2' | 'web-crawler';
-  source?: string;
+export type AiSearchChatCompletionsResponse = {
+  id?: string;
+  object?: string;
+  model?: string;
+  choices: Array<{
+    index?: number;
+    message: {
+      role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
+      content: string | null;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+  chunks: AiSearchSearchResponse['chunks'];
   [key: string]: unknown;
-}>;
+};
+
+export type AiSearchStatsResponse = {
+  queued?: number;
+  running?: number;
+  completed?: number;
+  error?: number;
+  skipped?: number;
+  outdated?: number;
+  last_activity?: string;
+};
+
+// ============ AI Search Instance Info Types ============
+
+export type AiSearchInstanceInfo = {
+  id: string;
+  type?: 'r2' | 'web-crawler' | string;
+  source?: string;
+  paused?: boolean;
+  status?: string;
+  namespace?: string;
+  created_at?: string;
+  modified_at?: string;
+  [key: string]: unknown;
+};
+
+export type AiSearchListResponse = {
+  result: AiSearchInstanceInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+
+// ============ AI Search Config Types ============
 
 export type AiSearchConfig = {
   /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
   id: string;
-  type: 'r2' | 'web-crawler';
-  source: string;
-  source_params?: object;
+  /** Instance type. Omit to create with built-in storage. */
+  type?: 'r2' | 'web-crawler' | string;
+  /** Source URL (required for web-crawler type). */
+  source?: string;
+  source_params?: unknown;
   /** Token ID (UUID format) */
   token_id?: string;
   ai_gateway_id?: string;
@@ -122,59 +169,337 @@ export type AiSearchConfig = {
   reranking?: boolean;
   embedding_model?: string;
   ai_search_model?: string;
-};
-
-export type AiSearchInstance = {
-  id: string;
-  enable?: boolean;
-  type?: 'r2' | 'web-crawler';
-  source?: string;
   [key: string]: unknown;
 };
 
-// AI Search Instance Service - Instance-level operations
-export declare abstract class AiSearchInstanceService {
+// ============ AI Search Item Types ============
+
+export type AiSearchItemInfo = {
+  id: string;
+  key: string;
+  status: 'completed' | 'error' | 'skipped' | 'queued' | 'processing' | 'outdated';
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type AiSearchItemContentResult = {
+  body: ReadableStream;
+  contentType: string;
+  filename: string;
+  size: number;
+};
+
+export type AiSearchUploadItemOptions = {
+  metadata?: Record<string, unknown>;
+};
+
+export type AiSearchListItemsParams = {
+  page?: number;
+  per_page?: number;
+};
+
+export type AiSearchListItemsResponse = {
+  result: AiSearchItemInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+
+// ============ AI Search Job Types ============
+
+export type AiSearchJobInfo = {
+  id: string;
+  source: 'user' | 'schedule';
+  description?: string;
+  last_seen_at?: string;
+  started_at?: string;
+  ended_at?: string;
+  end_reason?: string;
+};
+
+export type AiSearchJobLog = {
+  id: number;
+  message: string;
+  message_type: number;
+  created_at: number;
+};
+
+export type AiSearchCreateJobParams = {
+  description?: string;
+};
+
+export type AiSearchListJobsParams = {
+  page?: number;
+  per_page?: number;
+};
+
+export type AiSearchListJobsResponse = {
+  result: AiSearchJobInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+
+export type AiSearchJobLogsParams = {
+  page?: number;
+  per_page?: number;
+};
+
+export type AiSearchJobLogsResponse = {
+  result: AiSearchJobLog[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+
+// ============ AI Search Sub-Service Classes ============
+
+/**
+ * Single item service for an AI Search instance.
+ * Provides info, delete, and download operations on a specific item.
+ */
+export declare abstract class AiSearchItem {
+  /** Get metadata about this item. */
+  info(): Promise<AiSearchItemInfo>;
+
+  /**
+   * Download the item's content.
+   * @returns Object with body stream, content type, filename, and size.
+   */
+  download(): Promise<AiSearchItemContentResult>;
+}
+
+/**
+ * Items collection service for an AI Search instance.
+ * Provides list, upload, and access to individual items.
+ */
+export declare abstract class AiSearchItems {
+  /** List items in this instance. */
+  list(params?: AiSearchListItemsParams): Promise<AiSearchListItemsResponse>;
+
+  /**
+   * Upload a file as an item.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The created item info.
+   */
+  upload(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions
+  ): Promise<AiSearchItemInfo>;
+
+  /**
+   * Upload a file and poll until processing completes.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The item info after processing completes (or timeout).
+   */
+  uploadAndPoll(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions
+  ): Promise<AiSearchItemInfo>;
+
+  /**
+   * Get an item by ID.
+   * @param itemId The item identifier.
+   * @returns Item service for info, delete, and download operations.
+   */
+  get(itemId: string): AiSearchItem;
+
+  /** Delete this item from the instance.
+   * @param itemId The item identifier.
+   */
+  delete(itemId: string): Promise<void>;
+}
+
+/**
+ * Single job service for an AI Search instance.
+ * Provides info and logs for a specific job.
+ */
+export declare abstract class AiSearchJob {
+  /** Get metadata about this job. */
+  info(): Promise<AiSearchJobInfo>;
+
+  /** Get logs for this job. */
+  logs(params?: AiSearchJobLogsParams): Promise<AiSearchJobLogsResponse>;
+}
+
+/**
+ * Jobs collection service for an AI Search instance.
+ * Provides list, create, and access to individual jobs.
+ */
+export declare abstract class AiSearchJobs {
+  /** List jobs for this instance. */
+  list(params?: AiSearchListJobsParams): Promise<AiSearchListJobsResponse>;
+
+  /**
+   * Create a new indexing job.
+   * @param params Optional job parameters.
+   * @returns The created job info.
+   */
+  create(params?: AiSearchCreateJobParams): Promise<AiSearchJobInfo>;
+
+  /**
+   * Get a job by ID.
+   * @param jobId The job identifier.
+   * @returns Job service for info and logs operations.
+   */
+  get(jobId: string): AiSearchJob;
+}
+
+// ============ AI Search Binding Classes ============
+
+/**
+ * Instance-level AI Search service.
+ *
+ * Used as:
+ * - The return type of `AiSearchNamespace.get(name)` (namespace binding)
+ * - The type of `env.BLOG_SEARCH` (single instance binding via `ai_search`)
+ *
+ * Provides search, chat, update, stats, items, and jobs operations.
+ *
+ * @example
+ * ```ts
+ * // Via namespace binding
+ * const instance = env.AI_SEARCH.get("blog");
+ * const results = await instance.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // Via single instance binding
+ * const results = await env.BLOG_SEARCH.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ * ```
+ */
+export declare abstract class AiSearchInstance {
   /**
    * Search the AI Search instance for relevant chunks.
-   * @param params Search request with messages and AI search options
-   * @returns Search response with matching chunks
+   * @param params Search request with messages and optional AI search options.
+   * @returns Search response with matching chunks and search query.
    */
   search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
 
   /**
+   * Generate chat completions with AI Search context (streaming).
+   * @param params Chat completions request with stream: true.
+   * @returns ReadableStream of server-sent events.
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest & { stream: true }
+  ): Promise<ReadableStream>;
+
+  /**
    * Generate chat completions with AI Search context.
-   * @param params Chat completions request with optional streaming
-   * @returns Response object (if streaming) or chat completion result
+   * @param params Chat completions request.
+   * @returns Chat completion response with choices and RAG chunks.
    */
   chatCompletions(
     params: AiSearchChatCompletionsRequest
-  ): Promise<Response | object>;
+  ): Promise<AiSearchChatCompletionsResponse>;
 
   /**
-   * Delete this AI Search instance.
+   * Update the instance configuration.
+   * @param config Partial configuration to update.
+   * @returns Updated instance info.
    */
-  delete(): Promise<void>;
+  update(config: Partial<AiSearchConfig>): Promise<AiSearchInstanceInfo>;
+
+  /** Get metadata about this instance. */
+  info(): Promise<AiSearchInstanceInfo>;
+
+  /**
+   * Get instance statistics (item count, indexing status, etc.).
+   * @returns Statistics with counts per status and last activity time.
+   */
+  stats(): Promise<AiSearchStatsResponse>;
+
+  /** Items collection — list, upload, and manage items in this instance. */
+  get items(): AiSearchItems;
+
+  /** Jobs collection — list, create, and inspect indexing jobs. */
+  get jobs(): AiSearchJobs;
 }
 
-// AI Search Account Service - Account-level operations
-export declare abstract class AiSearchAccountService {
+/**
+ * Namespace-level AI Search service.
+ *
+ * Used as the type of `env.AI_SEARCH` (namespace binding via `ai_search_namespaces`).
+ * Scoped to a single namespace. Provides dynamic instance access, creation, and deletion.
+ *
+ * @example
+ * ```ts
+ * // Access an instance within the namespace
+ * const blog = env.AI_SEARCH.get("blog");
+ * const results = await blog.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // List all instances in the namespace
+ * const instances = await env.AI_SEARCH.list();
+ *
+ * // Create a new instance with built-in storage
+ * const tenant = await env.AI_SEARCH.create({
+ *   id: "tenant-123",
+ * });
+ *
+ * // Upload items into the instance
+ * await tenant.items.upload("doc.pdf", fileContent);
+ *
+ * // Delete an instance
+ * await env.AI_SEARCH.delete("tenant-123");
+ * ```
+ */
+export declare abstract class AiSearchNamespace {
   /**
-   * List all AI Search instances in the account.
-   * @returns Array of AI Search instances
+   * Get an instance by name within the bound namespace.
+   * @param name Instance name.
+   * @returns Instance service for search, chat, update, stats, items, and jobs.
+   */
+  get(name: string): AiSearchInstance;
+
+  /**
+   * List all instances in the bound namespace.
+   * @returns Array of instance metadata.
    */
   list(): Promise<AiSearchListResponse>;
 
   /**
-   * Get an AI Search instance by ID.
-   * @param name Instance ID
-   * @returns Instance service for performing operations
+   * Create a new instance within the bound namespace.
+   * @param config Instance configuration. Only `id` is required — omit `type` and `source` to create with built-in storage.
+   * @returns Instance service for the newly created instance.
+   *
+   * @example
+   * ```ts
+   * // Create with built-in storage (upload items manually)
+   * const instance = await env.AI_SEARCH.create({ id: "my-search" });
+   *
+   * // Create with web crawler source
+   * const instance = await env.AI_SEARCH.create({
+   *   id: "docs-search",
+   *   type: "web-crawler",
+   *   source: "https://developers.cloudflare.com",
+   * });
+   * ```
    */
-  get(name: string): AiSearchInstanceService;
+  create(config: AiSearchConfig): Promise<AiSearchInstance>;
 
   /**
-   * Create a new AI Search instance.
-   * @param config Instance configuration
-   * @returns Instance service for performing operations
+   * Delete an instance from the bound namespace.
+   * @param name Instance name to delete.
    */
-  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+  delete(name: string): Promise<void>;
 }

--- a/types/defines/ai.d.ts
+++ b/types/defines/ai.d.ts
@@ -5983,47 +5983,17 @@ export declare abstract class Ai<AiModelList extends AiModelListType = AiModels>
   gateway(gatewayId: string): AiGateway;
 
   /**
-   * Access the AI Search API for managing AI-powered search instances.
-   *
-   * This is the new API that replaces AutoRAG with better namespace separation:
-   * - Account-level operations: `list()`, `create()`
-   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
-   *
-   * @example
-   * ```typescript
-   * // List all AI Search instances
-   * const instances = await env.AI.aiSearch.list();
-   *
-   * // Search an instance
-   * const results = await env.AI.aiSearch.get('my-search').search({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   ai_search_options: {
-   *     retrieval: { max_num_results: 10 }
-   *   }
-   * });
-   *
-   * // Generate chat completions with AI Search context
-   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
-   * });
-   * ```
+   * @deprecated Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
-  aiSearch(): AiSearchAccountService;
+  aiSearch(): AiSearchNamespace;
 
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
-   * Use `env.AI.aiSearch` instead for better API design and new features.
+   * Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    *
-   * Migration guide:
-   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
-   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
-   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
-   *
-   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
-   *
-   * @see AiSearchAccountService
-   * @param autoragId Optional instance ID (omit for account-level operations)
+   * @param autoragId Instance ID
    */
   autorag(autoragId: string): AutoRAG;
   run<Name extends keyof AiModelList, Options extends AiOptions, InputOptions extends AiModelList[Name]["inputs"]>(

--- a/types/defines/autorag.d.ts
+++ b/types/defines/autorag.d.ts
@@ -1,23 +1,24 @@
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
- * @see AiSearchInternalError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGInternalError extends Error {}
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
- * @see AiSearchNotFoundError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGNotFoundError extends Error {}
 
 /**
- * @deprecated This error type is no longer used in the AI Search API.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGUnauthorizedError extends Error {}
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
- * @see AiSearchNameNotSetError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGNameNotSetError extends Error {}
 
@@ -33,9 +34,8 @@ export type CompoundFilter = {
 };
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchRequest with the new API instead.
- * @see AiSearchSearchRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagSearchRequest = {
   query: string;
@@ -53,9 +53,8 @@ export type AutoRagSearchRequest = {
 };
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with the new API instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
@@ -63,9 +62,8 @@ export type AutoRagAiSearchRequest = AutoRagSearchRequest & {
 };
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with stream: true instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
@@ -75,9 +73,8 @@ export type AutoRagAiSearchRequestStreaming = Omit<
 };
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchResponse with the new API instead.
- * @see AiSearchSearchResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagSearchResponse = {
   object: 'vector_store.search_results.page';
@@ -97,9 +94,8 @@ export type AutoRagSearchResponse = {
 };
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchListResponse with the new API instead.
- * @see AiSearchListResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagListResponse = {
   id: string;
@@ -112,54 +108,45 @@ export type AutoRagListResponse = {
 }[];
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * The new API returns different response formats for chat completions.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
 
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use the new AI Search API instead: `env.AI.aiSearch`
- *
- * Migration guide:
- * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
- * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
- * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
- *
- * @see AiSearchAccountService
- * @see AiSearchInstanceService
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export declare abstract class AutoRAG {
   /**
-   * @deprecated Use `env.AI.aiSearch.list()` instead.
-   * @see AiSearchAccountService.list
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   list(): Promise<AutoRagListResponse>;
 
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
-   * Note: The new API uses a messages array instead of a query string.
-   * @see AiSearchInstanceService.search
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
 
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
 
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
 
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(
     params: AutoRagAiSearchRequest

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4574,11 +4574,10 @@ interface EventCounts {
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
 }
-// AI Search V2 API Error Interfaces
+// ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
 interface AiSearchNotFoundError extends Error {}
-interface AiSearchNameNotSetError extends Error {}
-// AI Search V2 Request Types
+// ============ AI Search Request Types ============
 type AiSearchSearchRequest = {
   messages: Array<{
     role: "system" | "developer" | "user" | "assistant" | "tool";
@@ -4603,9 +4602,8 @@ type AiSearchSearchRequest = {
       [key: string]: unknown;
     };
     reranking?: {
-      /** Enable reranking (default false) */
       enabled?: boolean;
-      model?: "@cf/baai/bge-reranker-base" | "";
+      model?: "@cf/baai/bge-reranker-base" | string;
       /** Match threshold (0-1, default 0.4) */
       match_threshold?: number;
       [key: string]: unknown;
@@ -4617,6 +4615,7 @@ type AiSearchChatCompletionsRequest = {
   messages: Array<{
     role: "system" | "developer" | "user" | "assistant" | "tool";
     content: string | null;
+    [key: string]: unknown;
   }>;
   model?: string;
   stream?: boolean;
@@ -4637,7 +4636,7 @@ type AiSearchChatCompletionsRequest = {
     };
     reranking?: {
       enabled?: boolean;
-      model?: "@cf/baai/bge-reranker-base" | "";
+      model?: "@cf/baai/bge-reranker-base" | string;
       match_threshold?: number;
       [key: string]: unknown;
     };
@@ -4645,7 +4644,7 @@ type AiSearchChatCompletionsRequest = {
   };
   [key: string]: unknown;
 };
-// AI Search V2 Response Types
+// ============ AI Search Response Types ============
 type AiSearchSearchResponse = {
   search_query: string;
   chunks: Array<{
@@ -4664,26 +4663,65 @@ type AiSearchSearchResponse = {
       keyword_score?: number;
       /** Vector similarity score (0-1) */
       vector_score?: number;
+      [key: string]: unknown;
     };
   }>;
 };
-type AiSearchListResponse = Array<{
-  id: string;
-  internal_id?: string;
-  account_id?: string;
-  account_tag?: string;
-  /** Whether the instance is enabled (default true) */
-  enable?: boolean;
-  type?: "r2" | "web-crawler";
-  source?: string;
+type AiSearchChatCompletionsResponse = {
+  id?: string;
+  object?: string;
+  model?: string;
+  choices: Array<{
+    index?: number;
+    message: {
+      role: "system" | "developer" | "user" | "assistant" | "tool";
+      content: string | null;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+  chunks: AiSearchSearchResponse["chunks"];
   [key: string]: unknown;
-}>;
+};
+type AiSearchStatsResponse = {
+  queued?: number;
+  running?: number;
+  completed?: number;
+  error?: number;
+  skipped?: number;
+  outdated?: number;
+  last_activity?: string;
+};
+// ============ AI Search Instance Info Types ============
+type AiSearchInstanceInfo = {
+  id: string;
+  type?: "r2" | "web-crawler" | string;
+  source?: string;
+  paused?: boolean;
+  status?: string;
+  namespace?: string;
+  created_at?: string;
+  modified_at?: string;
+  [key: string]: unknown;
+};
+type AiSearchListResponse = {
+  result: AiSearchInstanceInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Config Types ============
 type AiSearchConfig = {
   /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
   id: string;
-  type: "r2" | "web-crawler";
-  source: string;
-  source_params?: object;
+  /** Instance type. Omit to create with built-in storage. */
+  type?: "r2" | "web-crawler" | string;
+  /** Source URL (required for web-crawler type). */
+  source?: string;
+  source_params?: unknown;
   /** Token ID (UUID format) */
   token_id?: string;
   ai_gateway_id?: string;
@@ -4693,54 +4731,307 @@ type AiSearchConfig = {
   reranking?: boolean;
   embedding_model?: string;
   ai_search_model?: string;
-};
-type AiSearchInstance = {
-  id: string;
-  enable?: boolean;
-  type?: "r2" | "web-crawler";
-  source?: string;
   [key: string]: unknown;
 };
-// AI Search Instance Service - Instance-level operations
-declare abstract class AiSearchInstanceService {
+// ============ AI Search Item Types ============
+type AiSearchItemInfo = {
+  id: string;
+  key: string;
+  status:
+    | "completed"
+    | "error"
+    | "skipped"
+    | "queued"
+    | "processing"
+    | "outdated";
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+type AiSearchItemContentResult = {
+  body: ReadableStream;
+  contentType: string;
+  filename: string;
+  size: number;
+};
+type AiSearchUploadItemOptions = {
+  metadata?: Record<string, unknown>;
+};
+type AiSearchListItemsParams = {
+  page?: number;
+  per_page?: number;
+};
+type AiSearchListItemsResponse = {
+  result: AiSearchItemInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Job Types ============
+type AiSearchJobInfo = {
+  id: string;
+  source: "user" | "schedule";
+  description?: string;
+  last_seen_at?: string;
+  started_at?: string;
+  ended_at?: string;
+  end_reason?: string;
+};
+type AiSearchJobLog = {
+  id: number;
+  message: string;
+  message_type: number;
+  created_at: number;
+};
+type AiSearchCreateJobParams = {
+  description?: string;
+};
+type AiSearchListJobsParams = {
+  page?: number;
+  per_page?: number;
+};
+type AiSearchListJobsResponse = {
+  result: AiSearchJobInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+type AiSearchJobLogsParams = {
+  page?: number;
+  per_page?: number;
+};
+type AiSearchJobLogsResponse = {
+  result: AiSearchJobLog[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Sub-Service Classes ============
+/**
+ * Single item service for an AI Search instance.
+ * Provides info, delete, and download operations on a specific item.
+ */
+declare abstract class AiSearchItem {
+  /** Get metadata about this item. */
+  info(): Promise<AiSearchItemInfo>;
+  /**
+   * Download the item's content.
+   * @returns Object with body stream, content type, filename, and size.
+   */
+  download(): Promise<AiSearchItemContentResult>;
+}
+/**
+ * Items collection service for an AI Search instance.
+ * Provides list, upload, and access to individual items.
+ */
+declare abstract class AiSearchItems {
+  /** List items in this instance. */
+  list(params?: AiSearchListItemsParams): Promise<AiSearchListItemsResponse>;
+  /**
+   * Upload a file as an item.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The created item info.
+   */
+  upload(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions,
+  ): Promise<AiSearchItemInfo>;
+  /**
+   * Upload a file and poll until processing completes.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The item info after processing completes (or timeout).
+   */
+  uploadAndPoll(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions,
+  ): Promise<AiSearchItemInfo>;
+  /**
+   * Get an item by ID.
+   * @param itemId The item identifier.
+   * @returns Item service for info, delete, and download operations.
+   */
+  get(itemId: string): AiSearchItem;
+  /** Delete this item from the instance.
+   * @param itemId The item identifier.
+   */
+  delete(itemId: string): Promise<void>;
+}
+/**
+ * Single job service for an AI Search instance.
+ * Provides info and logs for a specific job.
+ */
+declare abstract class AiSearchJob {
+  /** Get metadata about this job. */
+  info(): Promise<AiSearchJobInfo>;
+  /** Get logs for this job. */
+  logs(params?: AiSearchJobLogsParams): Promise<AiSearchJobLogsResponse>;
+}
+/**
+ * Jobs collection service for an AI Search instance.
+ * Provides list, create, and access to individual jobs.
+ */
+declare abstract class AiSearchJobs {
+  /** List jobs for this instance. */
+  list(params?: AiSearchListJobsParams): Promise<AiSearchListJobsResponse>;
+  /**
+   * Create a new indexing job.
+   * @param params Optional job parameters.
+   * @returns The created job info.
+   */
+  create(params?: AiSearchCreateJobParams): Promise<AiSearchJobInfo>;
+  /**
+   * Get a job by ID.
+   * @param jobId The job identifier.
+   * @returns Job service for info and logs operations.
+   */
+  get(jobId: string): AiSearchJob;
+}
+// ============ AI Search Binding Classes ============
+/**
+ * Instance-level AI Search service.
+ *
+ * Used as:
+ * - The return type of `AiSearchNamespace.get(name)` (namespace binding)
+ * - The type of `env.BLOG_SEARCH` (single instance binding via `ai_search`)
+ *
+ * Provides search, chat, update, stats, items, and jobs operations.
+ *
+ * @example
+ * ```ts
+ * // Via namespace binding
+ * const instance = env.AI_SEARCH.get("blog");
+ * const results = await instance.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // Via single instance binding
+ * const results = await env.BLOG_SEARCH.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ * ```
+ */
+declare abstract class AiSearchInstance {
   /**
    * Search the AI Search instance for relevant chunks.
-   * @param params Search request with messages and AI search options
-   * @returns Search response with matching chunks
+   * @param params Search request with messages and optional AI search options.
+   * @returns Search response with matching chunks and search query.
    */
   search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
   /**
+   * Generate chat completions with AI Search context (streaming).
+   * @param params Chat completions request with stream: true.
+   * @returns ReadableStream of server-sent events.
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest & {
+      stream: true;
+    },
+  ): Promise<ReadableStream>;
+  /**
    * Generate chat completions with AI Search context.
-   * @param params Chat completions request with optional streaming
-   * @returns Response object (if streaming) or chat completion result
+   * @param params Chat completions request.
+   * @returns Chat completion response with choices and RAG chunks.
    */
   chatCompletions(
     params: AiSearchChatCompletionsRequest,
-  ): Promise<Response | object>;
+  ): Promise<AiSearchChatCompletionsResponse>;
   /**
-   * Delete this AI Search instance.
+   * Update the instance configuration.
+   * @param config Partial configuration to update.
+   * @returns Updated instance info.
    */
-  delete(): Promise<void>;
-}
-// AI Search Account Service - Account-level operations
-declare abstract class AiSearchAccountService {
+  update(config: Partial<AiSearchConfig>): Promise<AiSearchInstanceInfo>;
+  /** Get metadata about this instance. */
+  info(): Promise<AiSearchInstanceInfo>;
   /**
-   * List all AI Search instances in the account.
-   * @returns Array of AI Search instances
+   * Get instance statistics (item count, indexing status, etc.).
+   * @returns Statistics with counts per status and last activity time.
+   */
+  stats(): Promise<AiSearchStatsResponse>;
+  /** Items collection — list, upload, and manage items in this instance. */
+  get items(): AiSearchItems;
+  /** Jobs collection — list, create, and inspect indexing jobs. */
+  get jobs(): AiSearchJobs;
+}
+/**
+ * Namespace-level AI Search service.
+ *
+ * Used as the type of `env.AI_SEARCH` (namespace binding via `ai_search_namespaces`).
+ * Scoped to a single namespace. Provides dynamic instance access, creation, and deletion.
+ *
+ * @example
+ * ```ts
+ * // Access an instance within the namespace
+ * const blog = env.AI_SEARCH.get("blog");
+ * const results = await blog.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // List all instances in the namespace
+ * const instances = await env.AI_SEARCH.list();
+ *
+ * // Create a new instance with built-in storage
+ * const tenant = await env.AI_SEARCH.create({
+ *   id: "tenant-123",
+ * });
+ *
+ * // Upload items into the instance
+ * await tenant.items.upload("doc.pdf", fileContent);
+ *
+ * // Delete an instance
+ * await env.AI_SEARCH.delete("tenant-123");
+ * ```
+ */
+declare abstract class AiSearchNamespace {
+  /**
+   * Get an instance by name within the bound namespace.
+   * @param name Instance name.
+   * @returns Instance service for search, chat, update, stats, items, and jobs.
+   */
+  get(name: string): AiSearchInstance;
+  /**
+   * List all instances in the bound namespace.
+   * @returns Array of instance metadata.
    */
   list(): Promise<AiSearchListResponse>;
   /**
-   * Get an AI Search instance by ID.
-   * @param name Instance ID
-   * @returns Instance service for performing operations
+   * Create a new instance within the bound namespace.
+   * @param config Instance configuration. Only `id` is required — omit `type` and `source` to create with built-in storage.
+   * @returns Instance service for the newly created instance.
+   *
+   * @example
+   * ```ts
+   * // Create with built-in storage (upload items manually)
+   * const instance = await env.AI_SEARCH.create({ id: "my-search" });
+   *
+   * // Create with web crawler source
+   * const instance = await env.AI_SEARCH.create({
+   *   id: "docs-search",
+   *   type: "web-crawler",
+   *   source: "https://developers.cloudflare.com",
+   * });
+   * ```
    */
-  get(name: string): AiSearchInstanceService;
+  create(config: AiSearchConfig): Promise<AiSearchInstance>;
   /**
-   * Create a new AI Search instance.
-   * @param config Instance configuration
-   * @returns Instance service for performing operations
+   * Delete an instance from the bound namespace.
+   * @param name Instance name to delete.
    */
-  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+  delete(name: string): Promise<void>;
 }
 type AiImageClassificationInput = {
   image: number[];
@@ -10781,46 +11072,16 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
   /**
-   * Access the AI Search API for managing AI-powered search instances.
-   *
-   * This is the new API that replaces AutoRAG with better namespace separation:
-   * - Account-level operations: `list()`, `create()`
-   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
-   *
-   * @example
-   * ```typescript
-   * // List all AI Search instances
-   * const instances = await env.AI.aiSearch.list();
-   *
-   * // Search an instance
-   * const results = await env.AI.aiSearch.get('my-search').search({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   ai_search_options: {
-   *     retrieval: { max_num_results: 10 }
-   *   }
-   * });
-   *
-   * // Generate chat completions with AI Search context
-   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
-   * });
-   * ```
+   * @deprecated Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
-  aiSearch(): AiSearchAccountService;
+  aiSearch(): AiSearchNamespace;
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
-   * Use `env.AI.aiSearch` instead for better API design and new features.
+   * Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    *
-   * Migration guide:
-   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
-   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
-   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
-   *
-   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
-   *
-   * @see AiSearchAccountService
-   * @param autoragId Optional instance ID (omit for account-level operations)
+   * @param autoragId Instance ID
    */
   autorag(autoragId: string): AutoRAG;
   run<
@@ -10979,22 +11240,23 @@ declare abstract class AiGateway {
   getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
 }
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
- * @see AiSearchInternalError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 interface AutoRAGInternalError extends Error {}
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
- * @see AiSearchNotFoundError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 interface AutoRAGNotFoundError extends Error {}
 /**
- * @deprecated This error type is no longer used in the AI Search API.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 interface AutoRAGUnauthorizedError extends Error {}
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
- * @see AiSearchNameNotSetError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 interface AutoRAGNameNotSetError extends Error {}
 type ComparisonFilter = {
@@ -11007,9 +11269,8 @@ type CompoundFilter = {
   filters: ComparisonFilter[];
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchRequest with the new API instead.
- * @see AiSearchSearchRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagSearchRequest = {
   query: string;
@@ -11026,18 +11287,16 @@ type AutoRagSearchRequest = {
   rewrite_query?: boolean;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with the new API instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
   system_prompt?: string;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with stream: true instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
@@ -11046,9 +11305,8 @@ type AutoRagAiSearchRequestStreaming = Omit<
   stream: true;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchResponse with the new API instead.
- * @see AiSearchSearchResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagSearchResponse = {
   object: "vector_store.search_results.page";
@@ -11067,9 +11325,8 @@ type AutoRagSearchResponse = {
   next_page: string | null;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchListResponse with the new API instead.
- * @see AiSearchListResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagListResponse = {
   id: string;
@@ -11081,49 +11338,40 @@ type AutoRagListResponse = {
   status: string;
 }[];
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * The new API returns different response formats for chat completions.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use the new AI Search API instead: `env.AI.aiSearch`
- *
- * Migration guide:
- * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
- * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
- * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
- *
- * @see AiSearchAccountService
- * @see AiSearchInstanceService
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 declare abstract class AutoRAG {
   /**
-   * @deprecated Use `env.AI.aiSearch.list()` instead.
-   * @see AiSearchAccountService.list
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   list(): Promise<AutoRagListResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
-   * Note: The new API uses a messages array instead of a query string.
-   * @see AiSearchInstanceService.search
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(
     params: AutoRagAiSearchRequest,

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4580,11 +4580,10 @@ export interface EventCounts {
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
 }
-// AI Search V2 API Error Interfaces
+// ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}
-export interface AiSearchNameNotSetError extends Error {}
-// AI Search V2 Request Types
+// ============ AI Search Request Types ============
 export type AiSearchSearchRequest = {
   messages: Array<{
     role: "system" | "developer" | "user" | "assistant" | "tool";
@@ -4609,9 +4608,8 @@ export type AiSearchSearchRequest = {
       [key: string]: unknown;
     };
     reranking?: {
-      /** Enable reranking (default false) */
       enabled?: boolean;
-      model?: "@cf/baai/bge-reranker-base" | "";
+      model?: "@cf/baai/bge-reranker-base" | string;
       /** Match threshold (0-1, default 0.4) */
       match_threshold?: number;
       [key: string]: unknown;
@@ -4623,6 +4621,7 @@ export type AiSearchChatCompletionsRequest = {
   messages: Array<{
     role: "system" | "developer" | "user" | "assistant" | "tool";
     content: string | null;
+    [key: string]: unknown;
   }>;
   model?: string;
   stream?: boolean;
@@ -4643,7 +4642,7 @@ export type AiSearchChatCompletionsRequest = {
     };
     reranking?: {
       enabled?: boolean;
-      model?: "@cf/baai/bge-reranker-base" | "";
+      model?: "@cf/baai/bge-reranker-base" | string;
       match_threshold?: number;
       [key: string]: unknown;
     };
@@ -4651,7 +4650,7 @@ export type AiSearchChatCompletionsRequest = {
   };
   [key: string]: unknown;
 };
-// AI Search V2 Response Types
+// ============ AI Search Response Types ============
 export type AiSearchSearchResponse = {
   search_query: string;
   chunks: Array<{
@@ -4670,26 +4669,65 @@ export type AiSearchSearchResponse = {
       keyword_score?: number;
       /** Vector similarity score (0-1) */
       vector_score?: number;
+      [key: string]: unknown;
     };
   }>;
 };
-export type AiSearchListResponse = Array<{
-  id: string;
-  internal_id?: string;
-  account_id?: string;
-  account_tag?: string;
-  /** Whether the instance is enabled (default true) */
-  enable?: boolean;
-  type?: "r2" | "web-crawler";
-  source?: string;
+export type AiSearchChatCompletionsResponse = {
+  id?: string;
+  object?: string;
+  model?: string;
+  choices: Array<{
+    index?: number;
+    message: {
+      role: "system" | "developer" | "user" | "assistant" | "tool";
+      content: string | null;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+  chunks: AiSearchSearchResponse["chunks"];
   [key: string]: unknown;
-}>;
+};
+export type AiSearchStatsResponse = {
+  queued?: number;
+  running?: number;
+  completed?: number;
+  error?: number;
+  skipped?: number;
+  outdated?: number;
+  last_activity?: string;
+};
+// ============ AI Search Instance Info Types ============
+export type AiSearchInstanceInfo = {
+  id: string;
+  type?: "r2" | "web-crawler" | string;
+  source?: string;
+  paused?: boolean;
+  status?: string;
+  namespace?: string;
+  created_at?: string;
+  modified_at?: string;
+  [key: string]: unknown;
+};
+export type AiSearchListResponse = {
+  result: AiSearchInstanceInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Config Types ============
 export type AiSearchConfig = {
   /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
   id: string;
-  type: "r2" | "web-crawler";
-  source: string;
-  source_params?: object;
+  /** Instance type. Omit to create with built-in storage. */
+  type?: "r2" | "web-crawler" | string;
+  /** Source URL (required for web-crawler type). */
+  source?: string;
+  source_params?: unknown;
   /** Token ID (UUID format) */
   token_id?: string;
   ai_gateway_id?: string;
@@ -4699,54 +4737,307 @@ export type AiSearchConfig = {
   reranking?: boolean;
   embedding_model?: string;
   ai_search_model?: string;
-};
-export type AiSearchInstance = {
-  id: string;
-  enable?: boolean;
-  type?: "r2" | "web-crawler";
-  source?: string;
   [key: string]: unknown;
 };
-// AI Search Instance Service - Instance-level operations
-export declare abstract class AiSearchInstanceService {
+// ============ AI Search Item Types ============
+export type AiSearchItemInfo = {
+  id: string;
+  key: string;
+  status:
+    | "completed"
+    | "error"
+    | "skipped"
+    | "queued"
+    | "processing"
+    | "outdated";
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+export type AiSearchItemContentResult = {
+  body: ReadableStream;
+  contentType: string;
+  filename: string;
+  size: number;
+};
+export type AiSearchUploadItemOptions = {
+  metadata?: Record<string, unknown>;
+};
+export type AiSearchListItemsParams = {
+  page?: number;
+  per_page?: number;
+};
+export type AiSearchListItemsResponse = {
+  result: AiSearchItemInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Job Types ============
+export type AiSearchJobInfo = {
+  id: string;
+  source: "user" | "schedule";
+  description?: string;
+  last_seen_at?: string;
+  started_at?: string;
+  ended_at?: string;
+  end_reason?: string;
+};
+export type AiSearchJobLog = {
+  id: number;
+  message: string;
+  message_type: number;
+  created_at: number;
+};
+export type AiSearchCreateJobParams = {
+  description?: string;
+};
+export type AiSearchListJobsParams = {
+  page?: number;
+  per_page?: number;
+};
+export type AiSearchListJobsResponse = {
+  result: AiSearchJobInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+export type AiSearchJobLogsParams = {
+  page?: number;
+  per_page?: number;
+};
+export type AiSearchJobLogsResponse = {
+  result: AiSearchJobLog[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Sub-Service Classes ============
+/**
+ * Single item service for an AI Search instance.
+ * Provides info, delete, and download operations on a specific item.
+ */
+export declare abstract class AiSearchItem {
+  /** Get metadata about this item. */
+  info(): Promise<AiSearchItemInfo>;
+  /**
+   * Download the item's content.
+   * @returns Object with body stream, content type, filename, and size.
+   */
+  download(): Promise<AiSearchItemContentResult>;
+}
+/**
+ * Items collection service for an AI Search instance.
+ * Provides list, upload, and access to individual items.
+ */
+export declare abstract class AiSearchItems {
+  /** List items in this instance. */
+  list(params?: AiSearchListItemsParams): Promise<AiSearchListItemsResponse>;
+  /**
+   * Upload a file as an item.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The created item info.
+   */
+  upload(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions,
+  ): Promise<AiSearchItemInfo>;
+  /**
+   * Upload a file and poll until processing completes.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The item info after processing completes (or timeout).
+   */
+  uploadAndPoll(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions,
+  ): Promise<AiSearchItemInfo>;
+  /**
+   * Get an item by ID.
+   * @param itemId The item identifier.
+   * @returns Item service for info, delete, and download operations.
+   */
+  get(itemId: string): AiSearchItem;
+  /** Delete this item from the instance.
+   * @param itemId The item identifier.
+   */
+  delete(itemId: string): Promise<void>;
+}
+/**
+ * Single job service for an AI Search instance.
+ * Provides info and logs for a specific job.
+ */
+export declare abstract class AiSearchJob {
+  /** Get metadata about this job. */
+  info(): Promise<AiSearchJobInfo>;
+  /** Get logs for this job. */
+  logs(params?: AiSearchJobLogsParams): Promise<AiSearchJobLogsResponse>;
+}
+/**
+ * Jobs collection service for an AI Search instance.
+ * Provides list, create, and access to individual jobs.
+ */
+export declare abstract class AiSearchJobs {
+  /** List jobs for this instance. */
+  list(params?: AiSearchListJobsParams): Promise<AiSearchListJobsResponse>;
+  /**
+   * Create a new indexing job.
+   * @param params Optional job parameters.
+   * @returns The created job info.
+   */
+  create(params?: AiSearchCreateJobParams): Promise<AiSearchJobInfo>;
+  /**
+   * Get a job by ID.
+   * @param jobId The job identifier.
+   * @returns Job service for info and logs operations.
+   */
+  get(jobId: string): AiSearchJob;
+}
+// ============ AI Search Binding Classes ============
+/**
+ * Instance-level AI Search service.
+ *
+ * Used as:
+ * - The return type of `AiSearchNamespace.get(name)` (namespace binding)
+ * - The type of `env.BLOG_SEARCH` (single instance binding via `ai_search`)
+ *
+ * Provides search, chat, update, stats, items, and jobs operations.
+ *
+ * @example
+ * ```ts
+ * // Via namespace binding
+ * const instance = env.AI_SEARCH.get("blog");
+ * const results = await instance.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // Via single instance binding
+ * const results = await env.BLOG_SEARCH.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ * ```
+ */
+export declare abstract class AiSearchInstance {
   /**
    * Search the AI Search instance for relevant chunks.
-   * @param params Search request with messages and AI search options
-   * @returns Search response with matching chunks
+   * @param params Search request with messages and optional AI search options.
+   * @returns Search response with matching chunks and search query.
    */
   search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
   /**
+   * Generate chat completions with AI Search context (streaming).
+   * @param params Chat completions request with stream: true.
+   * @returns ReadableStream of server-sent events.
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest & {
+      stream: true;
+    },
+  ): Promise<ReadableStream>;
+  /**
    * Generate chat completions with AI Search context.
-   * @param params Chat completions request with optional streaming
-   * @returns Response object (if streaming) or chat completion result
+   * @param params Chat completions request.
+   * @returns Chat completion response with choices and RAG chunks.
    */
   chatCompletions(
     params: AiSearchChatCompletionsRequest,
-  ): Promise<Response | object>;
+  ): Promise<AiSearchChatCompletionsResponse>;
   /**
-   * Delete this AI Search instance.
+   * Update the instance configuration.
+   * @param config Partial configuration to update.
+   * @returns Updated instance info.
    */
-  delete(): Promise<void>;
-}
-// AI Search Account Service - Account-level operations
-export declare abstract class AiSearchAccountService {
+  update(config: Partial<AiSearchConfig>): Promise<AiSearchInstanceInfo>;
+  /** Get metadata about this instance. */
+  info(): Promise<AiSearchInstanceInfo>;
   /**
-   * List all AI Search instances in the account.
-   * @returns Array of AI Search instances
+   * Get instance statistics (item count, indexing status, etc.).
+   * @returns Statistics with counts per status and last activity time.
+   */
+  stats(): Promise<AiSearchStatsResponse>;
+  /** Items collection — list, upload, and manage items in this instance. */
+  get items(): AiSearchItems;
+  /** Jobs collection — list, create, and inspect indexing jobs. */
+  get jobs(): AiSearchJobs;
+}
+/**
+ * Namespace-level AI Search service.
+ *
+ * Used as the type of `env.AI_SEARCH` (namespace binding via `ai_search_namespaces`).
+ * Scoped to a single namespace. Provides dynamic instance access, creation, and deletion.
+ *
+ * @example
+ * ```ts
+ * // Access an instance within the namespace
+ * const blog = env.AI_SEARCH.get("blog");
+ * const results = await blog.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // List all instances in the namespace
+ * const instances = await env.AI_SEARCH.list();
+ *
+ * // Create a new instance with built-in storage
+ * const tenant = await env.AI_SEARCH.create({
+ *   id: "tenant-123",
+ * });
+ *
+ * // Upload items into the instance
+ * await tenant.items.upload("doc.pdf", fileContent);
+ *
+ * // Delete an instance
+ * await env.AI_SEARCH.delete("tenant-123");
+ * ```
+ */
+export declare abstract class AiSearchNamespace {
+  /**
+   * Get an instance by name within the bound namespace.
+   * @param name Instance name.
+   * @returns Instance service for search, chat, update, stats, items, and jobs.
+   */
+  get(name: string): AiSearchInstance;
+  /**
+   * List all instances in the bound namespace.
+   * @returns Array of instance metadata.
    */
   list(): Promise<AiSearchListResponse>;
   /**
-   * Get an AI Search instance by ID.
-   * @param name Instance ID
-   * @returns Instance service for performing operations
+   * Create a new instance within the bound namespace.
+   * @param config Instance configuration. Only `id` is required — omit `type` and `source` to create with built-in storage.
+   * @returns Instance service for the newly created instance.
+   *
+   * @example
+   * ```ts
+   * // Create with built-in storage (upload items manually)
+   * const instance = await env.AI_SEARCH.create({ id: "my-search" });
+   *
+   * // Create with web crawler source
+   * const instance = await env.AI_SEARCH.create({
+   *   id: "docs-search",
+   *   type: "web-crawler",
+   *   source: "https://developers.cloudflare.com",
+   * });
+   * ```
    */
-  get(name: string): AiSearchInstanceService;
+  create(config: AiSearchConfig): Promise<AiSearchInstance>;
   /**
-   * Create a new AI Search instance.
-   * @param config Instance configuration
-   * @returns Instance service for performing operations
+   * Delete an instance from the bound namespace.
+   * @param name Instance name to delete.
    */
-  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+  delete(name: string): Promise<void>;
 }
 export type AiImageClassificationInput = {
   image: number[];
@@ -10792,46 +11083,16 @@ export declare abstract class Ai<
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
   /**
-   * Access the AI Search API for managing AI-powered search instances.
-   *
-   * This is the new API that replaces AutoRAG with better namespace separation:
-   * - Account-level operations: `list()`, `create()`
-   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
-   *
-   * @example
-   * ```typescript
-   * // List all AI Search instances
-   * const instances = await env.AI.aiSearch.list();
-   *
-   * // Search an instance
-   * const results = await env.AI.aiSearch.get('my-search').search({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   ai_search_options: {
-   *     retrieval: { max_num_results: 10 }
-   *   }
-   * });
-   *
-   * // Generate chat completions with AI Search context
-   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
-   * });
-   * ```
+   * @deprecated Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
-  aiSearch(): AiSearchAccountService;
+  aiSearch(): AiSearchNamespace;
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
-   * Use `env.AI.aiSearch` instead for better API design and new features.
+   * Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    *
-   * Migration guide:
-   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
-   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
-   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
-   *
-   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
-   *
-   * @see AiSearchAccountService
-   * @param autoragId Optional instance ID (omit for account-level operations)
+   * @param autoragId Instance ID
    */
   autorag(autoragId: string): AutoRAG;
   run<
@@ -10990,22 +11251,23 @@ export declare abstract class AiGateway {
   getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
 }
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
- * @see AiSearchInternalError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGInternalError extends Error {}
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
- * @see AiSearchNotFoundError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGNotFoundError extends Error {}
 /**
- * @deprecated This error type is no longer used in the AI Search API.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGUnauthorizedError extends Error {}
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
- * @see AiSearchNameNotSetError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGNameNotSetError extends Error {}
 export type ComparisonFilter = {
@@ -11018,9 +11280,8 @@ export type CompoundFilter = {
   filters: ComparisonFilter[];
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchRequest with the new API instead.
- * @see AiSearchSearchRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagSearchRequest = {
   query: string;
@@ -11037,18 +11298,16 @@ export type AutoRagSearchRequest = {
   rewrite_query?: boolean;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with the new API instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
   system_prompt?: string;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with stream: true instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
@@ -11057,9 +11316,8 @@ export type AutoRagAiSearchRequestStreaming = Omit<
   stream: true;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchResponse with the new API instead.
- * @see AiSearchSearchResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagSearchResponse = {
   object: "vector_store.search_results.page";
@@ -11078,9 +11336,8 @@ export type AutoRagSearchResponse = {
   next_page: string | null;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchListResponse with the new API instead.
- * @see AiSearchListResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagListResponse = {
   id: string;
@@ -11092,49 +11349,40 @@ export type AutoRagListResponse = {
   status: string;
 }[];
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * The new API returns different response formats for chat completions.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use the new AI Search API instead: `env.AI.aiSearch`
- *
- * Migration guide:
- * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
- * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
- * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
- *
- * @see AiSearchAccountService
- * @see AiSearchInstanceService
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export declare abstract class AutoRAG {
   /**
-   * @deprecated Use `env.AI.aiSearch.list()` instead.
-   * @see AiSearchAccountService.list
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   list(): Promise<AutoRagListResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
-   * Note: The new API uses a messages array instead of a query string.
-   * @see AiSearchInstanceService.search
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(
     params: AutoRagAiSearchRequest,

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -3919,11 +3919,10 @@ declare abstract class Performance {
    */
   toJSON(): object;
 }
-// AI Search V2 API Error Interfaces
+// ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
 interface AiSearchNotFoundError extends Error {}
-interface AiSearchNameNotSetError extends Error {}
-// AI Search V2 Request Types
+// ============ AI Search Request Types ============
 type AiSearchSearchRequest = {
   messages: Array<{
     role: "system" | "developer" | "user" | "assistant" | "tool";
@@ -3948,9 +3947,8 @@ type AiSearchSearchRequest = {
       [key: string]: unknown;
     };
     reranking?: {
-      /** Enable reranking (default false) */
       enabled?: boolean;
-      model?: "@cf/baai/bge-reranker-base" | "";
+      model?: "@cf/baai/bge-reranker-base" | string;
       /** Match threshold (0-1, default 0.4) */
       match_threshold?: number;
       [key: string]: unknown;
@@ -3962,6 +3960,7 @@ type AiSearchChatCompletionsRequest = {
   messages: Array<{
     role: "system" | "developer" | "user" | "assistant" | "tool";
     content: string | null;
+    [key: string]: unknown;
   }>;
   model?: string;
   stream?: boolean;
@@ -3982,7 +3981,7 @@ type AiSearchChatCompletionsRequest = {
     };
     reranking?: {
       enabled?: boolean;
-      model?: "@cf/baai/bge-reranker-base" | "";
+      model?: "@cf/baai/bge-reranker-base" | string;
       match_threshold?: number;
       [key: string]: unknown;
     };
@@ -3990,7 +3989,7 @@ type AiSearchChatCompletionsRequest = {
   };
   [key: string]: unknown;
 };
-// AI Search V2 Response Types
+// ============ AI Search Response Types ============
 type AiSearchSearchResponse = {
   search_query: string;
   chunks: Array<{
@@ -4009,26 +4008,65 @@ type AiSearchSearchResponse = {
       keyword_score?: number;
       /** Vector similarity score (0-1) */
       vector_score?: number;
+      [key: string]: unknown;
     };
   }>;
 };
-type AiSearchListResponse = Array<{
-  id: string;
-  internal_id?: string;
-  account_id?: string;
-  account_tag?: string;
-  /** Whether the instance is enabled (default true) */
-  enable?: boolean;
-  type?: "r2" | "web-crawler";
-  source?: string;
+type AiSearchChatCompletionsResponse = {
+  id?: string;
+  object?: string;
+  model?: string;
+  choices: Array<{
+    index?: number;
+    message: {
+      role: "system" | "developer" | "user" | "assistant" | "tool";
+      content: string | null;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+  chunks: AiSearchSearchResponse["chunks"];
   [key: string]: unknown;
-}>;
+};
+type AiSearchStatsResponse = {
+  queued?: number;
+  running?: number;
+  completed?: number;
+  error?: number;
+  skipped?: number;
+  outdated?: number;
+  last_activity?: string;
+};
+// ============ AI Search Instance Info Types ============
+type AiSearchInstanceInfo = {
+  id: string;
+  type?: "r2" | "web-crawler" | string;
+  source?: string;
+  paused?: boolean;
+  status?: string;
+  namespace?: string;
+  created_at?: string;
+  modified_at?: string;
+  [key: string]: unknown;
+};
+type AiSearchListResponse = {
+  result: AiSearchInstanceInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Config Types ============
 type AiSearchConfig = {
   /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
   id: string;
-  type: "r2" | "web-crawler";
-  source: string;
-  source_params?: object;
+  /** Instance type. Omit to create with built-in storage. */
+  type?: "r2" | "web-crawler" | string;
+  /** Source URL (required for web-crawler type). */
+  source?: string;
+  source_params?: unknown;
   /** Token ID (UUID format) */
   token_id?: string;
   ai_gateway_id?: string;
@@ -4038,54 +4076,307 @@ type AiSearchConfig = {
   reranking?: boolean;
   embedding_model?: string;
   ai_search_model?: string;
-};
-type AiSearchInstance = {
-  id: string;
-  enable?: boolean;
-  type?: "r2" | "web-crawler";
-  source?: string;
   [key: string]: unknown;
 };
-// AI Search Instance Service - Instance-level operations
-declare abstract class AiSearchInstanceService {
+// ============ AI Search Item Types ============
+type AiSearchItemInfo = {
+  id: string;
+  key: string;
+  status:
+    | "completed"
+    | "error"
+    | "skipped"
+    | "queued"
+    | "processing"
+    | "outdated";
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+type AiSearchItemContentResult = {
+  body: ReadableStream;
+  contentType: string;
+  filename: string;
+  size: number;
+};
+type AiSearchUploadItemOptions = {
+  metadata?: Record<string, unknown>;
+};
+type AiSearchListItemsParams = {
+  page?: number;
+  per_page?: number;
+};
+type AiSearchListItemsResponse = {
+  result: AiSearchItemInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Job Types ============
+type AiSearchJobInfo = {
+  id: string;
+  source: "user" | "schedule";
+  description?: string;
+  last_seen_at?: string;
+  started_at?: string;
+  ended_at?: string;
+  end_reason?: string;
+};
+type AiSearchJobLog = {
+  id: number;
+  message: string;
+  message_type: number;
+  created_at: number;
+};
+type AiSearchCreateJobParams = {
+  description?: string;
+};
+type AiSearchListJobsParams = {
+  page?: number;
+  per_page?: number;
+};
+type AiSearchListJobsResponse = {
+  result: AiSearchJobInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+type AiSearchJobLogsParams = {
+  page?: number;
+  per_page?: number;
+};
+type AiSearchJobLogsResponse = {
+  result: AiSearchJobLog[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Sub-Service Classes ============
+/**
+ * Single item service for an AI Search instance.
+ * Provides info, delete, and download operations on a specific item.
+ */
+declare abstract class AiSearchItem {
+  /** Get metadata about this item. */
+  info(): Promise<AiSearchItemInfo>;
+  /**
+   * Download the item's content.
+   * @returns Object with body stream, content type, filename, and size.
+   */
+  download(): Promise<AiSearchItemContentResult>;
+}
+/**
+ * Items collection service for an AI Search instance.
+ * Provides list, upload, and access to individual items.
+ */
+declare abstract class AiSearchItems {
+  /** List items in this instance. */
+  list(params?: AiSearchListItemsParams): Promise<AiSearchListItemsResponse>;
+  /**
+   * Upload a file as an item.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The created item info.
+   */
+  upload(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions,
+  ): Promise<AiSearchItemInfo>;
+  /**
+   * Upload a file and poll until processing completes.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The item info after processing completes (or timeout).
+   */
+  uploadAndPoll(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions,
+  ): Promise<AiSearchItemInfo>;
+  /**
+   * Get an item by ID.
+   * @param itemId The item identifier.
+   * @returns Item service for info, delete, and download operations.
+   */
+  get(itemId: string): AiSearchItem;
+  /** Delete this item from the instance.
+   * @param itemId The item identifier.
+   */
+  delete(itemId: string): Promise<void>;
+}
+/**
+ * Single job service for an AI Search instance.
+ * Provides info and logs for a specific job.
+ */
+declare abstract class AiSearchJob {
+  /** Get metadata about this job. */
+  info(): Promise<AiSearchJobInfo>;
+  /** Get logs for this job. */
+  logs(params?: AiSearchJobLogsParams): Promise<AiSearchJobLogsResponse>;
+}
+/**
+ * Jobs collection service for an AI Search instance.
+ * Provides list, create, and access to individual jobs.
+ */
+declare abstract class AiSearchJobs {
+  /** List jobs for this instance. */
+  list(params?: AiSearchListJobsParams): Promise<AiSearchListJobsResponse>;
+  /**
+   * Create a new indexing job.
+   * @param params Optional job parameters.
+   * @returns The created job info.
+   */
+  create(params?: AiSearchCreateJobParams): Promise<AiSearchJobInfo>;
+  /**
+   * Get a job by ID.
+   * @param jobId The job identifier.
+   * @returns Job service for info and logs operations.
+   */
+  get(jobId: string): AiSearchJob;
+}
+// ============ AI Search Binding Classes ============
+/**
+ * Instance-level AI Search service.
+ *
+ * Used as:
+ * - The return type of `AiSearchNamespace.get(name)` (namespace binding)
+ * - The type of `env.BLOG_SEARCH` (single instance binding via `ai_search`)
+ *
+ * Provides search, chat, update, stats, items, and jobs operations.
+ *
+ * @example
+ * ```ts
+ * // Via namespace binding
+ * const instance = env.AI_SEARCH.get("blog");
+ * const results = await instance.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // Via single instance binding
+ * const results = await env.BLOG_SEARCH.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ * ```
+ */
+declare abstract class AiSearchInstance {
   /**
    * Search the AI Search instance for relevant chunks.
-   * @param params Search request with messages and AI search options
-   * @returns Search response with matching chunks
+   * @param params Search request with messages and optional AI search options.
+   * @returns Search response with matching chunks and search query.
    */
   search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
   /**
+   * Generate chat completions with AI Search context (streaming).
+   * @param params Chat completions request with stream: true.
+   * @returns ReadableStream of server-sent events.
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest & {
+      stream: true;
+    },
+  ): Promise<ReadableStream>;
+  /**
    * Generate chat completions with AI Search context.
-   * @param params Chat completions request with optional streaming
-   * @returns Response object (if streaming) or chat completion result
+   * @param params Chat completions request.
+   * @returns Chat completion response with choices and RAG chunks.
    */
   chatCompletions(
     params: AiSearchChatCompletionsRequest,
-  ): Promise<Response | object>;
+  ): Promise<AiSearchChatCompletionsResponse>;
   /**
-   * Delete this AI Search instance.
+   * Update the instance configuration.
+   * @param config Partial configuration to update.
+   * @returns Updated instance info.
    */
-  delete(): Promise<void>;
-}
-// AI Search Account Service - Account-level operations
-declare abstract class AiSearchAccountService {
+  update(config: Partial<AiSearchConfig>): Promise<AiSearchInstanceInfo>;
+  /** Get metadata about this instance. */
+  info(): Promise<AiSearchInstanceInfo>;
   /**
-   * List all AI Search instances in the account.
-   * @returns Array of AI Search instances
+   * Get instance statistics (item count, indexing status, etc.).
+   * @returns Statistics with counts per status and last activity time.
+   */
+  stats(): Promise<AiSearchStatsResponse>;
+  /** Items collection — list, upload, and manage items in this instance. */
+  get items(): AiSearchItems;
+  /** Jobs collection — list, create, and inspect indexing jobs. */
+  get jobs(): AiSearchJobs;
+}
+/**
+ * Namespace-level AI Search service.
+ *
+ * Used as the type of `env.AI_SEARCH` (namespace binding via `ai_search_namespaces`).
+ * Scoped to a single namespace. Provides dynamic instance access, creation, and deletion.
+ *
+ * @example
+ * ```ts
+ * // Access an instance within the namespace
+ * const blog = env.AI_SEARCH.get("blog");
+ * const results = await blog.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // List all instances in the namespace
+ * const instances = await env.AI_SEARCH.list();
+ *
+ * // Create a new instance with built-in storage
+ * const tenant = await env.AI_SEARCH.create({
+ *   id: "tenant-123",
+ * });
+ *
+ * // Upload items into the instance
+ * await tenant.items.upload("doc.pdf", fileContent);
+ *
+ * // Delete an instance
+ * await env.AI_SEARCH.delete("tenant-123");
+ * ```
+ */
+declare abstract class AiSearchNamespace {
+  /**
+   * Get an instance by name within the bound namespace.
+   * @param name Instance name.
+   * @returns Instance service for search, chat, update, stats, items, and jobs.
+   */
+  get(name: string): AiSearchInstance;
+  /**
+   * List all instances in the bound namespace.
+   * @returns Array of instance metadata.
    */
   list(): Promise<AiSearchListResponse>;
   /**
-   * Get an AI Search instance by ID.
-   * @param name Instance ID
-   * @returns Instance service for performing operations
+   * Create a new instance within the bound namespace.
+   * @param config Instance configuration. Only `id` is required — omit `type` and `source` to create with built-in storage.
+   * @returns Instance service for the newly created instance.
+   *
+   * @example
+   * ```ts
+   * // Create with built-in storage (upload items manually)
+   * const instance = await env.AI_SEARCH.create({ id: "my-search" });
+   *
+   * // Create with web crawler source
+   * const instance = await env.AI_SEARCH.create({
+   *   id: "docs-search",
+   *   type: "web-crawler",
+   *   source: "https://developers.cloudflare.com",
+   * });
+   * ```
    */
-  get(name: string): AiSearchInstanceService;
+  create(config: AiSearchConfig): Promise<AiSearchInstance>;
   /**
-   * Create a new AI Search instance.
-   * @param config Instance configuration
-   * @returns Instance service for performing operations
+   * Delete an instance from the bound namespace.
+   * @param name Instance name to delete.
    */
-  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+  delete(name: string): Promise<void>;
 }
 type AiImageClassificationInput = {
   image: number[];
@@ -10126,46 +10417,16 @@ declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
   /**
-   * Access the AI Search API for managing AI-powered search instances.
-   *
-   * This is the new API that replaces AutoRAG with better namespace separation:
-   * - Account-level operations: `list()`, `create()`
-   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
-   *
-   * @example
-   * ```typescript
-   * // List all AI Search instances
-   * const instances = await env.AI.aiSearch.list();
-   *
-   * // Search an instance
-   * const results = await env.AI.aiSearch.get('my-search').search({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   ai_search_options: {
-   *     retrieval: { max_num_results: 10 }
-   *   }
-   * });
-   *
-   * // Generate chat completions with AI Search context
-   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
-   * });
-   * ```
+   * @deprecated Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
-  aiSearch(): AiSearchAccountService;
+  aiSearch(): AiSearchNamespace;
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
-   * Use `env.AI.aiSearch` instead for better API design and new features.
+   * Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    *
-   * Migration guide:
-   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
-   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
-   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
-   *
-   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
-   *
-   * @see AiSearchAccountService
-   * @param autoragId Optional instance ID (omit for account-level operations)
+   * @param autoragId Instance ID
    */
   autorag(autoragId: string): AutoRAG;
   run<
@@ -10324,22 +10585,23 @@ declare abstract class AiGateway {
   getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
 }
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
- * @see AiSearchInternalError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 interface AutoRAGInternalError extends Error {}
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
- * @see AiSearchNotFoundError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 interface AutoRAGNotFoundError extends Error {}
 /**
- * @deprecated This error type is no longer used in the AI Search API.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 interface AutoRAGUnauthorizedError extends Error {}
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
- * @see AiSearchNameNotSetError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 interface AutoRAGNameNotSetError extends Error {}
 type ComparisonFilter = {
@@ -10352,9 +10614,8 @@ type CompoundFilter = {
   filters: ComparisonFilter[];
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchRequest with the new API instead.
- * @see AiSearchSearchRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagSearchRequest = {
   query: string;
@@ -10371,18 +10632,16 @@ type AutoRagSearchRequest = {
   rewrite_query?: boolean;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with the new API instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
   system_prompt?: string;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with stream: true instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
@@ -10391,9 +10650,8 @@ type AutoRagAiSearchRequestStreaming = Omit<
   stream: true;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchResponse with the new API instead.
- * @see AiSearchSearchResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagSearchResponse = {
   object: "vector_store.search_results.page";
@@ -10412,9 +10670,8 @@ type AutoRagSearchResponse = {
   next_page: string | null;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchListResponse with the new API instead.
- * @see AiSearchListResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagListResponse = {
   id: string;
@@ -10426,49 +10683,40 @@ type AutoRagListResponse = {
   status: string;
 }[];
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * The new API returns different response formats for chat completions.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use the new AI Search API instead: `env.AI.aiSearch`
- *
- * Migration guide:
- * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
- * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
- * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
- *
- * @see AiSearchAccountService
- * @see AiSearchInstanceService
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 declare abstract class AutoRAG {
   /**
-   * @deprecated Use `env.AI.aiSearch.list()` instead.
-   * @see AiSearchAccountService.list
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   list(): Promise<AutoRagListResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
-   * Note: The new API uses a messages array instead of a query string.
-   * @see AiSearchInstanceService.search
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(
     params: AutoRagAiSearchRequest,

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -3925,11 +3925,10 @@ export declare abstract class Performance {
    */
   toJSON(): object;
 }
-// AI Search V2 API Error Interfaces
+// ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}
-export interface AiSearchNameNotSetError extends Error {}
-// AI Search V2 Request Types
+// ============ AI Search Request Types ============
 export type AiSearchSearchRequest = {
   messages: Array<{
     role: "system" | "developer" | "user" | "assistant" | "tool";
@@ -3954,9 +3953,8 @@ export type AiSearchSearchRequest = {
       [key: string]: unknown;
     };
     reranking?: {
-      /** Enable reranking (default false) */
       enabled?: boolean;
-      model?: "@cf/baai/bge-reranker-base" | "";
+      model?: "@cf/baai/bge-reranker-base" | string;
       /** Match threshold (0-1, default 0.4) */
       match_threshold?: number;
       [key: string]: unknown;
@@ -3968,6 +3966,7 @@ export type AiSearchChatCompletionsRequest = {
   messages: Array<{
     role: "system" | "developer" | "user" | "assistant" | "tool";
     content: string | null;
+    [key: string]: unknown;
   }>;
   model?: string;
   stream?: boolean;
@@ -3988,7 +3987,7 @@ export type AiSearchChatCompletionsRequest = {
     };
     reranking?: {
       enabled?: boolean;
-      model?: "@cf/baai/bge-reranker-base" | "";
+      model?: "@cf/baai/bge-reranker-base" | string;
       match_threshold?: number;
       [key: string]: unknown;
     };
@@ -3996,7 +3995,7 @@ export type AiSearchChatCompletionsRequest = {
   };
   [key: string]: unknown;
 };
-// AI Search V2 Response Types
+// ============ AI Search Response Types ============
 export type AiSearchSearchResponse = {
   search_query: string;
   chunks: Array<{
@@ -4015,26 +4014,65 @@ export type AiSearchSearchResponse = {
       keyword_score?: number;
       /** Vector similarity score (0-1) */
       vector_score?: number;
+      [key: string]: unknown;
     };
   }>;
 };
-export type AiSearchListResponse = Array<{
-  id: string;
-  internal_id?: string;
-  account_id?: string;
-  account_tag?: string;
-  /** Whether the instance is enabled (default true) */
-  enable?: boolean;
-  type?: "r2" | "web-crawler";
-  source?: string;
+export type AiSearchChatCompletionsResponse = {
+  id?: string;
+  object?: string;
+  model?: string;
+  choices: Array<{
+    index?: number;
+    message: {
+      role: "system" | "developer" | "user" | "assistant" | "tool";
+      content: string | null;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+  chunks: AiSearchSearchResponse["chunks"];
   [key: string]: unknown;
-}>;
+};
+export type AiSearchStatsResponse = {
+  queued?: number;
+  running?: number;
+  completed?: number;
+  error?: number;
+  skipped?: number;
+  outdated?: number;
+  last_activity?: string;
+};
+// ============ AI Search Instance Info Types ============
+export type AiSearchInstanceInfo = {
+  id: string;
+  type?: "r2" | "web-crawler" | string;
+  source?: string;
+  paused?: boolean;
+  status?: string;
+  namespace?: string;
+  created_at?: string;
+  modified_at?: string;
+  [key: string]: unknown;
+};
+export type AiSearchListResponse = {
+  result: AiSearchInstanceInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Config Types ============
 export type AiSearchConfig = {
   /** Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$) */
   id: string;
-  type: "r2" | "web-crawler";
-  source: string;
-  source_params?: object;
+  /** Instance type. Omit to create with built-in storage. */
+  type?: "r2" | "web-crawler" | string;
+  /** Source URL (required for web-crawler type). */
+  source?: string;
+  source_params?: unknown;
   /** Token ID (UUID format) */
   token_id?: string;
   ai_gateway_id?: string;
@@ -4044,54 +4082,307 @@ export type AiSearchConfig = {
   reranking?: boolean;
   embedding_model?: string;
   ai_search_model?: string;
-};
-export type AiSearchInstance = {
-  id: string;
-  enable?: boolean;
-  type?: "r2" | "web-crawler";
-  source?: string;
   [key: string]: unknown;
 };
-// AI Search Instance Service - Instance-level operations
-export declare abstract class AiSearchInstanceService {
+// ============ AI Search Item Types ============
+export type AiSearchItemInfo = {
+  id: string;
+  key: string;
+  status:
+    | "completed"
+    | "error"
+    | "skipped"
+    | "queued"
+    | "processing"
+    | "outdated";
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+export type AiSearchItemContentResult = {
+  body: ReadableStream;
+  contentType: string;
+  filename: string;
+  size: number;
+};
+export type AiSearchUploadItemOptions = {
+  metadata?: Record<string, unknown>;
+};
+export type AiSearchListItemsParams = {
+  page?: number;
+  per_page?: number;
+};
+export type AiSearchListItemsResponse = {
+  result: AiSearchItemInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Job Types ============
+export type AiSearchJobInfo = {
+  id: string;
+  source: "user" | "schedule";
+  description?: string;
+  last_seen_at?: string;
+  started_at?: string;
+  ended_at?: string;
+  end_reason?: string;
+};
+export type AiSearchJobLog = {
+  id: number;
+  message: string;
+  message_type: number;
+  created_at: number;
+};
+export type AiSearchCreateJobParams = {
+  description?: string;
+};
+export type AiSearchListJobsParams = {
+  page?: number;
+  per_page?: number;
+};
+export type AiSearchListJobsResponse = {
+  result: AiSearchJobInfo[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+export type AiSearchJobLogsParams = {
+  page?: number;
+  per_page?: number;
+};
+export type AiSearchJobLogsResponse = {
+  result: AiSearchJobLog[];
+  result_info?: {
+    count: number;
+    page: number;
+    per_page: number;
+    total_count: number;
+  };
+};
+// ============ AI Search Sub-Service Classes ============
+/**
+ * Single item service for an AI Search instance.
+ * Provides info, delete, and download operations on a specific item.
+ */
+export declare abstract class AiSearchItem {
+  /** Get metadata about this item. */
+  info(): Promise<AiSearchItemInfo>;
+  /**
+   * Download the item's content.
+   * @returns Object with body stream, content type, filename, and size.
+   */
+  download(): Promise<AiSearchItemContentResult>;
+}
+/**
+ * Items collection service for an AI Search instance.
+ * Provides list, upload, and access to individual items.
+ */
+export declare abstract class AiSearchItems {
+  /** List items in this instance. */
+  list(params?: AiSearchListItemsParams): Promise<AiSearchListItemsResponse>;
+  /**
+   * Upload a file as an item.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The created item info.
+   */
+  upload(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions,
+  ): Promise<AiSearchItemInfo>;
+  /**
+   * Upload a file and poll until processing completes.
+   * @param name Filename for the uploaded item.
+   * @param content File content as a ReadableStream, ArrayBuffer, or string.
+   * @param options Optional metadata to attach to the item.
+   * @returns The item info after processing completes (or timeout).
+   */
+  uploadAndPoll(
+    name: string,
+    content: ReadableStream | ArrayBuffer | string,
+    options?: AiSearchUploadItemOptions,
+  ): Promise<AiSearchItemInfo>;
+  /**
+   * Get an item by ID.
+   * @param itemId The item identifier.
+   * @returns Item service for info, delete, and download operations.
+   */
+  get(itemId: string): AiSearchItem;
+  /** Delete this item from the instance.
+   * @param itemId The item identifier.
+   */
+  delete(itemId: string): Promise<void>;
+}
+/**
+ * Single job service for an AI Search instance.
+ * Provides info and logs for a specific job.
+ */
+export declare abstract class AiSearchJob {
+  /** Get metadata about this job. */
+  info(): Promise<AiSearchJobInfo>;
+  /** Get logs for this job. */
+  logs(params?: AiSearchJobLogsParams): Promise<AiSearchJobLogsResponse>;
+}
+/**
+ * Jobs collection service for an AI Search instance.
+ * Provides list, create, and access to individual jobs.
+ */
+export declare abstract class AiSearchJobs {
+  /** List jobs for this instance. */
+  list(params?: AiSearchListJobsParams): Promise<AiSearchListJobsResponse>;
+  /**
+   * Create a new indexing job.
+   * @param params Optional job parameters.
+   * @returns The created job info.
+   */
+  create(params?: AiSearchCreateJobParams): Promise<AiSearchJobInfo>;
+  /**
+   * Get a job by ID.
+   * @param jobId The job identifier.
+   * @returns Job service for info and logs operations.
+   */
+  get(jobId: string): AiSearchJob;
+}
+// ============ AI Search Binding Classes ============
+/**
+ * Instance-level AI Search service.
+ *
+ * Used as:
+ * - The return type of `AiSearchNamespace.get(name)` (namespace binding)
+ * - The type of `env.BLOG_SEARCH` (single instance binding via `ai_search`)
+ *
+ * Provides search, chat, update, stats, items, and jobs operations.
+ *
+ * @example
+ * ```ts
+ * // Via namespace binding
+ * const instance = env.AI_SEARCH.get("blog");
+ * const results = await instance.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // Via single instance binding
+ * const results = await env.BLOG_SEARCH.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ * ```
+ */
+export declare abstract class AiSearchInstance {
   /**
    * Search the AI Search instance for relevant chunks.
-   * @param params Search request with messages and AI search options
-   * @returns Search response with matching chunks
+   * @param params Search request with messages and optional AI search options.
+   * @returns Search response with matching chunks and search query.
    */
   search(params: AiSearchSearchRequest): Promise<AiSearchSearchResponse>;
   /**
+   * Generate chat completions with AI Search context (streaming).
+   * @param params Chat completions request with stream: true.
+   * @returns ReadableStream of server-sent events.
+   */
+  chatCompletions(
+    params: AiSearchChatCompletionsRequest & {
+      stream: true;
+    },
+  ): Promise<ReadableStream>;
+  /**
    * Generate chat completions with AI Search context.
-   * @param params Chat completions request with optional streaming
-   * @returns Response object (if streaming) or chat completion result
+   * @param params Chat completions request.
+   * @returns Chat completion response with choices and RAG chunks.
    */
   chatCompletions(
     params: AiSearchChatCompletionsRequest,
-  ): Promise<Response | object>;
+  ): Promise<AiSearchChatCompletionsResponse>;
   /**
-   * Delete this AI Search instance.
+   * Update the instance configuration.
+   * @param config Partial configuration to update.
+   * @returns Updated instance info.
    */
-  delete(): Promise<void>;
-}
-// AI Search Account Service - Account-level operations
-export declare abstract class AiSearchAccountService {
+  update(config: Partial<AiSearchConfig>): Promise<AiSearchInstanceInfo>;
+  /** Get metadata about this instance. */
+  info(): Promise<AiSearchInstanceInfo>;
   /**
-   * List all AI Search instances in the account.
-   * @returns Array of AI Search instances
+   * Get instance statistics (item count, indexing status, etc.).
+   * @returns Statistics with counts per status and last activity time.
+   */
+  stats(): Promise<AiSearchStatsResponse>;
+  /** Items collection — list, upload, and manage items in this instance. */
+  get items(): AiSearchItems;
+  /** Jobs collection — list, create, and inspect indexing jobs. */
+  get jobs(): AiSearchJobs;
+}
+/**
+ * Namespace-level AI Search service.
+ *
+ * Used as the type of `env.AI_SEARCH` (namespace binding via `ai_search_namespaces`).
+ * Scoped to a single namespace. Provides dynamic instance access, creation, and deletion.
+ *
+ * @example
+ * ```ts
+ * // Access an instance within the namespace
+ * const blog = env.AI_SEARCH.get("blog");
+ * const results = await blog.search({
+ *   messages: [{ role: "user", content: "How does caching work?" }],
+ * });
+ *
+ * // List all instances in the namespace
+ * const instances = await env.AI_SEARCH.list();
+ *
+ * // Create a new instance with built-in storage
+ * const tenant = await env.AI_SEARCH.create({
+ *   id: "tenant-123",
+ * });
+ *
+ * // Upload items into the instance
+ * await tenant.items.upload("doc.pdf", fileContent);
+ *
+ * // Delete an instance
+ * await env.AI_SEARCH.delete("tenant-123");
+ * ```
+ */
+export declare abstract class AiSearchNamespace {
+  /**
+   * Get an instance by name within the bound namespace.
+   * @param name Instance name.
+   * @returns Instance service for search, chat, update, stats, items, and jobs.
+   */
+  get(name: string): AiSearchInstance;
+  /**
+   * List all instances in the bound namespace.
+   * @returns Array of instance metadata.
    */
   list(): Promise<AiSearchListResponse>;
   /**
-   * Get an AI Search instance by ID.
-   * @param name Instance ID
-   * @returns Instance service for performing operations
+   * Create a new instance within the bound namespace.
+   * @param config Instance configuration. Only `id` is required — omit `type` and `source` to create with built-in storage.
+   * @returns Instance service for the newly created instance.
+   *
+   * @example
+   * ```ts
+   * // Create with built-in storage (upload items manually)
+   * const instance = await env.AI_SEARCH.create({ id: "my-search" });
+   *
+   * // Create with web crawler source
+   * const instance = await env.AI_SEARCH.create({
+   *   id: "docs-search",
+   *   type: "web-crawler",
+   *   source: "https://developers.cloudflare.com",
+   * });
+   * ```
    */
-  get(name: string): AiSearchInstanceService;
+  create(config: AiSearchConfig): Promise<AiSearchInstance>;
   /**
-   * Create a new AI Search instance.
-   * @param config Instance configuration
-   * @returns Instance service for performing operations
+   * Delete an instance from the bound namespace.
+   * @param name Instance name to delete.
    */
-  create(config: AiSearchConfig): Promise<AiSearchInstanceService>;
+  delete(name: string): Promise<void>;
 }
 export type AiImageClassificationInput = {
   image: number[];
@@ -10137,46 +10428,16 @@ export declare abstract class Ai<
   aiGatewayLogId: string | null;
   gateway(gatewayId: string): AiGateway;
   /**
-   * Access the AI Search API for managing AI-powered search instances.
-   *
-   * This is the new API that replaces AutoRAG with better namespace separation:
-   * - Account-level operations: `list()`, `create()`
-   * - Instance-level operations: `get(id).search()`, `get(id).chatCompletions()`, `get(id).delete()`
-   *
-   * @example
-   * ```typescript
-   * // List all AI Search instances
-   * const instances = await env.AI.aiSearch.list();
-   *
-   * // Search an instance
-   * const results = await env.AI.aiSearch.get('my-search').search({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   ai_search_options: {
-   *     retrieval: { max_num_results: 10 }
-   *   }
-   * });
-   *
-   * // Generate chat completions with AI Search context
-   * const response = await env.AI.aiSearch.get('my-search').chatCompletions({
-   *   messages: [{ role: 'user', content: 'What is the policy?' }],
-   *   model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
-   * });
-   * ```
+   * @deprecated Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
-  aiSearch(): AiSearchAccountService;
+  aiSearch(): AiSearchNamespace;
   /**
    * @deprecated AutoRAG has been replaced by AI Search.
-   * Use `env.AI.aiSearch` instead for better API design and new features.
+   * Use the standalone `ai_search_namespaces` or `ai_search` Workers bindings instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    *
-   * Migration guide:
-   * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
-   * - `env.AI.autorag('id').search({ query: '...' })` → `env.AI.aiSearch.get('id').search({ messages: [{ role: 'user', content: '...' }] })`
-   * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
-   *
-   * Note: The old API continues to work for backwards compatibility, but new projects should use AI Search.
-   *
-   * @see AiSearchAccountService
-   * @param autoragId Optional instance ID (omit for account-level operations)
+   * @param autoragId Instance ID
    */
   autorag(autoragId: string): AutoRAG;
   run<
@@ -10335,22 +10596,23 @@ export declare abstract class AiGateway {
   getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
 }
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchInternalError instead.
- * @see AiSearchInternalError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGInternalError extends Error {}
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNotFoundError instead.
- * @see AiSearchNotFoundError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGNotFoundError extends Error {}
 /**
- * @deprecated This error type is no longer used in the AI Search API.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGUnauthorizedError extends Error {}
 /**
- * @deprecated AutoRAG has been replaced by AI Search. Use AiSearchNameNotSetError instead.
- * @see AiSearchNameNotSetError
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export interface AutoRAGNameNotSetError extends Error {}
 export type ComparisonFilter = {
@@ -10363,9 +10625,8 @@ export type CompoundFilter = {
   filters: ComparisonFilter[];
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchRequest with the new API instead.
- * @see AiSearchSearchRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagSearchRequest = {
   query: string;
@@ -10382,18 +10643,16 @@ export type AutoRagSearchRequest = {
   rewrite_query?: boolean;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with the new API instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchRequest = AutoRagSearchRequest & {
   stream?: boolean;
   system_prompt?: string;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchChatCompletionsRequest with stream: true instead.
- * @see AiSearchChatCompletionsRequest
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchRequestStreaming = Omit<
   AutoRagAiSearchRequest,
@@ -10402,9 +10661,8 @@ export type AutoRagAiSearchRequestStreaming = Omit<
   stream: true;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchSearchResponse with the new API instead.
- * @see AiSearchSearchResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagSearchResponse = {
   object: "vector_store.search_results.page";
@@ -10423,9 +10681,8 @@ export type AutoRagSearchResponse = {
   next_page: string | null;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use AiSearchListResponse with the new API instead.
- * @see AiSearchListResponse
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagListResponse = {
   id: string;
@@ -10437,49 +10694,40 @@ export type AutoRagListResponse = {
   status: string;
 }[];
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * The new API returns different response formats for chat completions.
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export type AutoRagAiSearchResponse = AutoRagSearchResponse & {
   response: string;
 };
 /**
- * @deprecated AutoRAG has been replaced by AI Search.
- * Use the new AI Search API instead: `env.AI.aiSearch`
- *
- * Migration guide:
- * - `env.AI.autorag().list()` → `env.AI.aiSearch.list()`
- * - `env.AI.autorag('id').search(...)` → `env.AI.aiSearch.get('id').search(...)`
- * - `env.AI.autorag('id').aiSearch(...)` → `env.AI.aiSearch.get('id').chatCompletions(...)`
- *
- * @see AiSearchAccountService
- * @see AiSearchInstanceService
+ * @deprecated Use the standalone AI Search Workers binding instead.
+ * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
  */
 export declare abstract class AutoRAG {
   /**
-   * @deprecated Use `env.AI.aiSearch.list()` instead.
-   * @see AiSearchAccountService.list
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   list(): Promise<AutoRagListResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).search(...)` instead.
-   * Note: The new API uses a messages array instead of a query string.
-   * @see AiSearchInstanceService.search
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
   /**
-   * @deprecated Use `env.AI.aiSearch.get(id).chatCompletions(...)` instead.
-   * @see AiSearchInstanceService.chatCompletions
+   * @deprecated Use the standalone AI Search Workers binding instead.
+   * See https://developers.cloudflare.com/ai-search/usage/workers-binding/
    */
   aiSearch(
     params: AutoRagAiSearchRequest,


### PR DESCRIPTION
Updates the AI Search TypeScript type definitions to align with final binding spec (path-based namespaces, two separate binding types).

This enables Wrangler type generation to produce correct types for the `ai_search_namespaces` and `ai_search` bindings once the workers-sdk PR lands.