### PR TITLE
Add opencode context for module registry

### DIFF
--- a/.opencode/skills/module-registry/SKILL.md
+++ b/.opencode/skills/module-registry/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: module-registry
+description: Load when working with the module registry in workerd — reading, modifying, debugging, or reviewing module resolution, compilation, evaluation, or registration code. Provides pointers to three reference documents covering the legacy registry, V8 module internals, and the new registry design.
+---
+
+## Module Registry Context
+
+When working with any code related to module resolution, compilation, evaluation,
+or registration in workerd, you **must** read the relevant reference documents
+before making changes or providing analysis. These documents capture the design
+decisions, data flow, thread safety model, and integration points that are not
+obvious from reading the source alone.
+
+### Reference Documents
+
+Read these documents (using the Read tool) before proceeding with any module
+registry work:
+
+1. **`docs/reference/detail/new-module-registry.md`** — The new `jsg::modules::ModuleRegistry`
+   implementation. Covers the two-layer architecture (shared `ModuleRegistry` +
+   per-isolate `IsolateModuleRegistry`), bundle types, resolution priority,
+   compile cache, evaluation flow, and thread safety model. **Read this first**
+   for any work on the new registry.
+
+2. **`docs/reference/detail/legacy-module-registry.md`** — The legacy
+   `ModuleRegistryImpl<TypeWrapper>` implementation. Covers the per-isolate
+   design, `ModuleInfo` structure, `DynamicImportHandler`, and how it interfaces
+   with V8. **Read this** when working on code that still uses the legacy path,
+   or when understanding the dispatch between legacy and new.
+
+3. **`docs/reference/detail/v8-module-internals.md`** — How V8 handles modules
+   internally. Covers `v8::Module` status transitions, `InstantiateModule`,
+   `Evaluate`, `SyntheticModule`, resolve callbacks, and `import.meta`. **Read
+   this** when debugging V8 module state issues, understanding callback
+   contracts, or working on the boundary between workerd and V8.
+
+### When to Read Which
+
+| Task                                              | Documents to read                               |
+| ------------------------------------------------- | ----------------------------------------------- |
+| Modifying new registry resolution or caching      | new-module-registry, v8                         |
+| Adding a new built-in module                      | new-module-registry, legacy-module-registry     |
+| Debugging module-not-found errors                 | all three                                       |
+| Modifying legacy registry code                    | legacy-module-registry, v8                      |
+| Understanding legacy-to-new dispatch              | all three                                       |
+| Working on `import.meta` behavior                 | new-module-registry, v8                         |
+| Working on CJS/require() interop                  | new-module-registry, legacy-module-registry     |
+| Debugging module evaluation failures              | new-module-registry, legacy-module-registry, v8 |
+| Reviewing a PR that touches module code           | all three                                       |
+| Working on compile cache or cross-isolate sharing | new-module-registry                             |
+| Working on dynamic import                         | all three                                       |
+| Working on source phase imports (Wasm)            | new-module-registry, v8                         |
+
+### Key Source Files
+
+These are the primary files involved in module handling:
+
+- `src/workerd/jsg/modules-new.h` / `.c++` — New registry implementation
+- `src/workerd/jsg/modules.h` / `.c++` — Legacy registry implementation
+- `src/workerd/jsg/resource.h:1913–1922` — Legacy vs new dispatch at context creation
+- `src/workerd/jsg/jsg.c++:357–395` — `Lock::resolveModule` dispatch
+- `src/workerd/jsg/setup.h:291–297` — `isUsingNewModuleRegistry()` flag
+- `src/workerd/io/worker-modules.h` — `newWorkerModuleRegistry` construction
+- `src/workerd/api/modules.h` — Built-in module registration (both legacy and new)
+- `src/workerd/jsg/observer.h` — `ResolveObserver` metrics interface
+
+### Procedure
+
+1. **Read** the relevant reference documents listed above for your task.
+2. **Identify** whether the code path uses the new or legacy registry (check
+   `isUsingNewModuleRegistry()` usage in the surrounding code).
+3. **Proceed** with your work, using the reference documents to inform your
+   understanding of data flow, thread safety, and integration contracts.
+
+Do not skip reading the reference documents. The module registry has subtle
+invariants around thread safety, V8 module status transitions, and evaluation
+context (IoContext suppression) that are easy to violate without full context.

--- a/docs/reference/detail/legacy-module-registry.md
+++ b/docs/reference/detail/legacy-module-registry.md
@@ -1,0 +1,559 @@
+# Legacy Module Registry (`jsg::ModuleRegistry` / `jsg::ModuleRegistryImpl`)
+
+Reference for reasoning about the original (legacy) module registry implementation,
+how it interfaces with V8's module APIs, and how modules flow from config through
+compilation to evaluation. For V8 module internals, see
+[v8-module-internals.md](v8-module-internals.md).
+
+## Source Files
+
+| File                                   | Role                                                                                                                                       |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/workerd/jsg/modules.h`            | `ModuleRegistry` abstract base, `ModuleRegistryImpl<TypeWrapper>` full implementation, V8 callback templates, `ModuleInfo` / `Entry` types |
+| `src/workerd/jsg/modules.c++`          | V8 resolve callback, synthetic module evaluation callback, `instantiateModule`, `compileEsmModule`, `createSyntheticModule`, `requireImpl` |
+| `src/workerd/jsg/modules.capnp`        | Cap'n Proto schema: `Bundle`, `Module`, `ModuleType` enum                                                                                  |
+| `src/workerd/jsg/resource.h:1913-1922` | Registry installation into V8 context (picks legacy vs new)                                                                                |
+| `src/workerd/jsg/jsg.c++:378-395`      | `Lock::resolveModule` dispatches between legacy and new registry                                                                           |
+| `src/workerd/io/worker-modules.h`      | `newWorkerModuleRegistry` (new registry), `modules::legacy::*` helpers, Python module registration                                         |
+| `src/workerd/io/worker-modules.c++`    | Python metadata state construction                                                                                                         |
+| `src/workerd/server/workerd-api.c++`   | `WorkerdApi::compileModules` (legacy path), `WorkerdApi::newWorkerdModuleRegistry` (new path), extension loading                           |
+| `src/workerd/api/modules.h`            | `registerModules` — registers all built-in API modules (Node.js compat, sockets, crypto, cloudflare bundle, etc.)                          |
+
+## Architecture Overview
+
+```
+ModuleRegistryImpl<TypeWrapper>           (per-isolate, stored in V8 context embedder data)
+  ├── entries: kj::Table<Own<Entry>>      (hash-indexed by (specifier, type))
+  │     Each Entry is one of:
+  │       ├── ModuleInfo                  (already-compiled v8::Module + optional synthetic data)
+  │       ├── kj::ArrayPtr<const char>    (uncompiled source — compiled lazily on first resolve)
+  │       └── ModuleCallback              (factory function — called lazily on first resolve)
+  │
+  ├── dynamicImportHandler                (embedder callback for dynamic import context setup)
+  └── fallbackServiceRedirects            (cache for fallback service redirects)
+```
+
+The registry is installed into the V8 context's embedder data at slot
+`ContextPointerSlot::MODULE_REGISTRY`. It is retrieved via
+`ModuleRegistry::from(js)` which reads the aligned pointer from embedder data.
+
+## Module Types (`ModuleType` enum, `modules.capnp`)
+
+| Type       | Value | Purpose                                                                | Resolution priority                       |
+| ---------- | ----- | ---------------------------------------------------------------------- | ----------------------------------------- |
+| `BUNDLE`   | 0     | User worker modules                                                    | Searched first in DEFAULT resolution      |
+| `BUILTIN`  | 1     | Runtime-provided modules importable by user code (e.g., `node:buffer`) | Searched after BUNDLE                     |
+| `INTERNAL` | 2     | Runtime-internal modules only importable by other builtins             | Searched only in INTERNAL_ONLY resolution |
+
+## The Entry Table
+
+The core data structure is a `kj::Table` with a `kj::HashIndex`:
+
+```cpp
+kj::Table<kj::Own<Entry>, kj::HashIndex<SpecifierHashCallbacks>> entries;
+```
+
+### Entry Key
+
+The hash key is `(kj::Path specifier, ModuleType type)`. This means the **same
+specifier can exist multiple times** in the table with different types. A BUNDLE
+module and a BUILTIN module with the same path are distinct entries.
+
+```cpp
+struct Key {
+  const kj::Path& specifier;
+  const Type type;
+  uint hash;  // kj::hashCode(specifier, type)
+};
+```
+
+### Entry Info — Lazy Compilation
+
+Each `Entry` holds a `kj::OneOf<ModuleInfo, kj::ArrayPtr<const char>, ModuleCallback>`:
+
+| Variant                    | Meaning                                                                     | When                                                                                                |
+| -------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `ModuleInfo`               | Already compiled — ready to use                                             | Worker bundle modules (compiled eagerly at startup), or after first lazy resolve                    |
+| `kj::ArrayPtr<const char>` | Raw source code, not yet compiled                                           | Builtin ESM modules registered via `addBuiltinModule(specifier, sourceCode, type)`                  |
+| `ModuleCallback`           | Factory function `(Lock&, ResolveMethod, Maybe<Path&>) → Maybe<ModuleInfo>` | Builtin modules that need runtime-dependent construction (Wasm, data, JSON, object-wrapper modules) |
+
+The `Entry::module()` method implements lazy compilation:
+
+```cpp
+kj::Maybe<ModuleInfo&> module(jsg::Lock& js, CompilationObserver& observer, ...) {
+  KJ_SWITCH_ONEOF(info) {
+    KJ_CASE_ONEOF(moduleInfo, ModuleInfo) { return moduleInfo; }
+    KJ_CASE_ONEOF(src, kj::ArrayPtr<const char>) {
+      info = ModuleInfo(js, specifier.toString(), src, compileCache,
+          ModuleInfoCompileOption::BUILTIN, observer);
+      return info.tryGet<ModuleInfo>();
+    }
+    KJ_CASE_ONEOF(factory, ModuleCallback) {
+      KJ_IF_SOME(result, factory(js, method, referrer)) { info = kj::mv(result); }
+      return info.tryGet<ModuleInfo>();
+    }
+  }
+}
+```
+
+After lazy compilation, the `info` field is **mutated in place** from source/callback
+to `ModuleInfo`. Subsequent resolves return the cached `ModuleInfo` directly.
+
+## ModuleInfo — The Compiled Module Record
+
+```cpp
+struct ModuleInfo {
+  HashableV8Ref<v8::Module> module;   // The V8 module handle (ESM or Synthetic)
+  kj::Maybe<SyntheticModuleInfo> maybeSynthetic;  // Payload for synthetic modules
+  kj::Maybe<kj::Array<kj::String>> maybeNamedExports;  // CJS named exports
+  kj::Maybe<V8Ref<v8::Object>> maybeModuleSourceObject;  // Source phase import object
+  mutable kj::Maybe<V8Ref<v8::Object>> maybeMutableExports;  // Cached mutable require() wrapper
+};
+```
+
+### SyntheticModuleInfo Variants
+
+```cpp
+using SyntheticModuleInfo = kj::OneOf<
+    CapnpModuleInfo,     // Cap'n Proto schema module (default + named exports)
+    CommonJsModuleInfo,  // CommonJS module (eval func + provider)
+    DataModuleInfo,      // Binary data (ArrayBuffer)
+    TextModuleInfo,      // Text content (String)
+    WasmModuleInfo,      // WebAssembly module (WasmModuleObject)
+    JsonModuleInfo,      // JSON value
+    ObjectModuleInfo     // Wrapped JSG object
+>;
+```
+
+When `maybeSynthetic` is `kj::none`, the module is a real ESM (compiled from
+JavaScript source via `ScriptCompiler::CompileModule`).
+
+When `maybeSynthetic` has a value, the `module` field holds a V8 `SyntheticModule`
+created via `v8::Module::CreateSyntheticModule`, and the variant holds the data
+needed to populate exports during evaluation.
+
+### How ModuleInfo is Constructed
+
+Three constructors:
+
+1. **ESM from source**: `ModuleInfo(js, name, content, compileCache, flags, observer)`
+   → calls `compileEsmModule()` → `ScriptCompiler::CompileModule`
+
+2. **From pre-compiled v8::Module**: `ModuleInfo(js, module, maybeSynthetic)`
+   → wraps an existing V8 module handle
+
+3. **Synthetic module**: `ModuleInfo(js, name, maybeExports, synthetic)`
+   → calls `createSyntheticModule()` → `v8::Module::CreateSyntheticModule`
+   with `evaluateSyntheticModuleCallback` as the evaluation steps
+
+## Resolution Flow
+
+### `resolve(js, specifier, referrer, option, method, rawSpecifier)`
+
+The primary resolution method. Returns `kj::Maybe<ModuleInfo&>`.
+
+```
+resolve(specifier, option=DEFAULT)
+  ├── option == INTERNAL_ONLY?
+  │     └── Look up entries[(specifier, INTERNAL)]
+  ├── option == BUILTIN_ONLY?
+  │     └── Look up entries[(specifier, BUILTIN)]
+  └── option == DEFAULT?
+        ├── Look up entries[(specifier, BUNDLE)]     ← user modules first
+        ├── Look up entries[(specifier, BUILTIN)]    ← then builtins
+        └── Try fallback service (if configured)
+              ├── Check redirect cache
+              ├── Call tryResolveFromFallbackService()
+              └── Insert result into entries, resolve again
+```
+
+### `resolve(js, v8::Local<v8::Module>)` — Reverse Lookup
+
+Given a V8 module handle, finds the corresponding `ModuleRef`. This is needed by
+the V8 resolve callback to identify the referrer module.
+
+**This is a linear scan** over all entries (O(n)):
+
+```cpp
+for (const kj::Own<Entry>& entry: entries) {
+  KJ_IF_SOME(info, entry->info.tryGet<ModuleInfo>()) {
+    if (info.module == module) { return ModuleRef{...}; }
+  }
+}
+```
+
+This is explicitly noted as slow in the code comments. It cannot use hash lookup
+because entries may be lazily compiled (the ModuleInfo might not exist yet for some
+entries, and the v8::Module handle only exists after compilation).
+
+## V8 Callback Integration
+
+### Resolve Callback — `resolveModuleCallback<IsSourcePhase>`
+
+Registered via `module->InstantiateModule(context, resolveModuleCallback<false>,
+resolveModuleCallback<true>)`. Called by V8 during `PrepareInstantiate` for each
+`import` statement.
+
+Template parameter `IsSourcePhase`:
+
+- `false`: evaluation phase import — returns `v8::MaybeLocal<v8::Module>`
+- `true`: source phase import (`import source`) — returns `v8::MaybeLocal<v8::Object>`
+
+Flow:
+
+1. Get the `ModuleRegistry` from context embedder data.
+2. **Reverse-lookup the referrer** via `registry->resolve(js, referrer)` (linear scan).
+3. Determine the referrer's type (BUNDLE vs BUILTIN/INTERNAL).
+4. Parse the specifier, applying `node:` prefix normalization if Node.js compat is enabled.
+5. Resolve against the referrer path: `ref.specifier.parent().eval(spec)`.
+   (Known prefixes `node:`, `cloudflare:`, `workerd:` bypass parent-relative resolution.)
+6. Call `registry->resolve(js, targetPath, ...)` with:
+   - `INTERNAL_ONLY` if the referrer is a builtin/internal module
+   - `DEFAULT` otherwise
+7. For evaluation phase: return `resolved.module.getHandle(js)`.
+8. For source phase: return `resolved.getModuleSourceObject(js)` or throw SyntaxError.
+9. On not-found: retry with absolute path for `node:`/`cloudflare:` prefixed specifiers.
+10. Final fallback: throw `"No such module"` error.
+
+Errors are handled via `js.tryCatch`: exceptions are caught, and
+`js.v8Isolate->ThrowException()` is called to schedule them on the isolate
+(V8 requires exceptions to be scheduled, not thrown as C++ exceptions, during
+resolve callbacks).
+
+### Synthetic Module Evaluation Callback — `evaluateSyntheticModuleCallback`
+
+A single C++ function registered as the `SyntheticModuleEvaluationSteps` for **all**
+synthetic modules. Called by V8 during `SyntheticModule::Evaluate`.
+
+Flow:
+
+1. Get the `ModuleRegistry` from context embedder data.
+2. **Reverse-lookup the module** via `registry->resolve(js, module)` (linear scan).
+3. Extract `ref.module.maybeSynthetic` — must be non-none.
+4. Switch on the synthetic variant type:
+
+| Variant              | Export Behavior                                                                                                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CapnpModuleInfo`    | Sets `default` to `fileScope`, then each named export from `topLevelDecls`                                                                                                          |
+| `CommonJsModuleInfo` | Calls `evalFunc()` (runs the CJS body), then sets `default` to the `exports` object. If `maybeNamedExports` is set, also sets each named export by reading from the exports object. |
+| `TextModuleInfo`     | Sets `default` to the text string                                                                                                                                                   |
+| `DataModuleInfo`     | Sets `default` to the ArrayBuffer                                                                                                                                                   |
+| `WasmModuleInfo`     | Sets `default` to the WasmModuleObject                                                                                                                                              |
+| `JsonModuleInfo`     | Sets `default` to the parsed JSON value                                                                                                                                             |
+| `ObjectModuleInfo`   | Sets `default` to the wrapped C++ object                                                                                                                                            |
+
+All non-CJS variants follow the same pattern:
+
+```cpp
+module->SetSyntheticModuleExport(js.v8Isolate, defaultStr, value)
+```
+
+5. On success: return a resolved Promise (V8 requires this).
+6. On error: schedule the exception on the isolate and return empty MaybeLocal.
+
+### Dynamic Import Callback — `dynamicImportCallback<TypeWrapper>`
+
+Registered on the isolate via `isolate->SetHostImportModuleDynamicallyCallback`.
+
+Flow:
+
+1. Check import attributes — reject if unrecognized and the compat flag is set.
+2. Parse the referrer's resource name into a `kj::Path`.
+3. Apply `node:` prefix normalization.
+4. Special-case `node:process` → redirect to internal module based on compat flag.
+5. Resolve the specifier against the referrer path.
+6. Call `registry->resolveDynamicImport(js, specifierPath, referrerPath, rawSpec)`.
+7. The `resolveDynamicImport` method:
+   - Determines the referrer's type (BUNDLE → DEFAULT resolution, BUILTIN → INTERNAL_ONLY).
+   - Resolves the module.
+   - If a `dynamicImportHandler` is set: wraps the instantiation in the handler
+     (used to set up `SuppressIoContextScope`).
+   - Calls `instantiateModule(js, module)` and returns `module->GetModuleNamespace()`.
+8. Returns a Promise that resolves to the module namespace.
+
+## Module Instantiation — `instantiateModule`
+
+```cpp
+void instantiateModule(jsg::Lock& js, v8::Local<v8::Module>& module,
+    InstantiateModuleOptions options);
+```
+
+This is workerd's wrapper around V8's `InstantiateModule` + `Evaluate`:
+
+1. If status is `kErrored`: throw the module's exception immediately.
+2. If status is `kEvaluated` or `kEvaluating`: return (already done).
+3. If status is `kUninstantiated`: call `module->InstantiateModule(context,
+resolveModuleCallback<false>, resolveModuleCallback<true>)`.
+   This triggers the V8 two-phase instantiation, calling back into
+   `resolveModuleCallback` for each dependency.
+4. Call `module->Evaluate(context)` — returns a Promise.
+5. If the module graph is async and the promise is pending:
+   - If `NO_TOP_LEVEL_AWAIT` option: throw error.
+6. Run `js.runMicrotasks()` to attempt settling pending promises.
+7. Check the promise state:
+   - `kPending`: throw `"Top-level await in module is unsettled."`
+   - `kRejected`: throw the module's exception.
+   - `kFulfilled`: success.
+
+### `onlyInstantiateModule` — Link Without Evaluating
+
+```cpp
+void onlyInstantiateModule(jsg::Lock& js, v8::Local<v8::Module>& module);
+```
+
+Calls `InstantiateModule` but **not** `Evaluate`. Used when the caller only
+needs the module linked but will defer evaluation.
+
+## CommonJS Module Support
+
+CommonJS modules are implemented as synthetic modules with special evaluation:
+
+### `CommonJsModuleInfo`
+
+```cpp
+struct CommonJsModuleInfo {
+  kj::Own<CommonJsModuleProvider> provider;  // getContext(), getExports()
+  jsg::Function<void()> evalFunc;            // compiled wrapper function
+};
+```
+
+The CJS module body is compiled as a function (not a module) via
+`v8::ScriptCompiler::CompileFunction`, with the CJS context object
+(`module`, `exports`, `require`, etc.) as the extension object.
+
+During synthetic module evaluation:
+
+1. `evalFunc()` is called — this runs the CJS body, populating `module.exports`.
+2. `commonjs.getExports(js)` retrieves the final exports.
+3. The result is set as the synthetic module's `default` export.
+4. If `maybeNamedExports` is present, each named property is also set as an
+   individual export on the synthetic module.
+
+### Circular Dependency Handling
+
+In `requireImpl`, if the module status is `kEvaluating` or `kInstantiating`
+(indicating a circular dependency), the CJS provider's current exports are
+returned directly — matching Node.js behavior for circular CJS requires.
+
+## `require()` Implementation — `requireImpl`
+
+`ModuleRegistry::requireImpl(js, info, options)` implements the `require()`
+function used by CJS modules and Node.js compat:
+
+1. Get the v8::Module handle from `info.module`.
+2. Check for circular dependency (kEvaluating/kInstantiating with CJS → return
+   current exports).
+3. Check top-level-await compat flag.
+4. Call `instantiateModule(js, module, opts)`.
+5. Apply `require(esm)` conventions:
+   - If ESM and `__cjsUnwrapDefault` is true → return default export.
+   - If ESM and `module.exports` key exists → return that (Node.js `require(esm)` convention).
+   - If `EXPORT_DEFAULT` option → return `namespace.default`.
+   - If `require_returns_default_export` flag → return default export or mutable copy.
+   - Otherwise → return the full module namespace.
+
+## Registry Setup and Population
+
+### 1. Installation (`resource.h:1913-1922`)
+
+During V8 context creation (`JsContext` construction):
+
+```cpp
+// Legacy path:
+ModuleRegistryImpl<TypeWrapper>::install(isolate, context, compilationObserver);
+// This allocates the registry on the heap, stores a raw pointer in context
+// embedder data, and sets the dynamic import callback on the isolate.
+```
+
+### 2. Worker Bundle Compilation (`WorkerdApi::compileModules`)
+
+Called during `Worker::Script` construction. For each module in the worker bundle:
+
+1. Reads the module definition from the Cap'n Proto config.
+2. Calls `tryCompileLegacyModule` which dispatches by content type:
+   - `EsModule` → `ModuleInfo(js, name, content, compileCache, BUNDLE, observer)`
+   - `TextModule` → `ModuleInfo(js, name, none, TextModuleInfo(js, string))`
+   - `DataModule` → `ModuleInfo(js, name, none, DataModuleInfo(js, arrayBuffer))`
+   - `WasmModule` → `ModuleInfo(js, name, none, WasmModuleInfo(js, wasmModule))`
+   - `JsonModule` → `ModuleInfo(js, name, none, JsonModuleInfo(js, parsedValue))`
+   - `CommonJsModule` → `ModuleInfo(js, name, namedExports, CommonJsModuleInfo(...))`
+   - `CapnpModule` → `addCapnpModule<JsgIsolate>(lock, typeId, name)`
+3. Inserts each `ModuleInfo` into the registry as `Type::BUNDLE`.
+
+### 3. Built-in Module Registration (`api::registerModules`)
+
+Called after bundle compilation:
+
+```cpp
+void registerModules(Registry& registry, auto featureFlags) {
+  node::registerNodeJsCompatModules(registry, featureFlags);
+  registerUnsafeModules(registry, featureFlags);
+  registerSocketsModule(registry, featureFlags);
+  registerBase64Module(registry, featureFlags);
+  registerMessageChannelModule(registry, featureFlags);
+  registry.addBuiltinBundle(CLOUDFLARE_BUNDLE);
+  registerWorkersModule(registry, featureFlags);
+  registerTracingModule(registry, featureFlags);
+  // ... internal modules ...
+}
+```
+
+Each `addBuiltinModule` call creates an `Entry` with type BUILTIN or INTERNAL.
+ESM builtins are registered as raw source (`kj::ArrayPtr<const char>`) for lazy
+compilation. Object-wrapper builtins use `ModuleCallback` factories.
+
+### 4. Extensions (`workerd-api.c++:563-568`)
+
+Server extensions (loaded from config) are registered as BUILTIN or INTERNAL:
+
+```cpp
+for (auto extension: impl->extensions) {
+  for (auto module: extension.getModules()) {
+    modules->addBuiltinModule(module.getName(), module.getEsModule().asArray(),
+        module.getInternal() ? Type::INTERNAL : Type::BUILTIN);
+  }
+}
+```
+
+### 5. Python Modules
+
+Python workers have special handling via `registerPythonWorkerdModules`, which:
+
+- Replaces the main module with a JS shim (`PYTHON_ENTRYPOINT`).
+- Registers pyodide packages and runtime infrastructure as INTERNAL modules.
+
+## Resolution Priority and Isolation Rules
+
+### By Resolve Option
+
+| Option          | Search order                | Use case                         |
+| --------------- | --------------------------- | -------------------------------- |
+| `DEFAULT`       | BUNDLE → BUILTIN → fallback | User code imports                |
+| `BUILTIN_ONLY`  | BUILTIN only                | Explicit builtin resolution      |
+| `INTERNAL_ONLY` | INTERNAL only               | Builtin code importing internals |
+
+### Referrer-Based Isolation
+
+When the V8 resolve callback fires, the referrer's type determines isolation:
+
+- **BUNDLE referrer** → `DEFAULT` resolution (can see BUNDLE + BUILTIN)
+- **BUILTIN or INTERNAL referrer** → `INTERNAL_ONLY` resolution (can only see INTERNAL)
+
+This means:
+
+- User code **can** import builtins (e.g., `import { Buffer } from 'node:buffer'`).
+- User code **cannot** import internal modules.
+- Builtin code **can** import internal modules.
+- Builtin code **cannot** import user bundle modules.
+- User bundle modules with the same name as a builtin **shadow** the builtin
+  (BUNDLE is searched before BUILTIN in DEFAULT resolution).
+
+### Dynamic Import Isolation
+
+`resolveDynamicImport` performs the same referrer-based check:
+
+```cpp
+if (entries.find(Key(referrer, Type::BUNDLE)) != kj::none) {
+  resolveOption = DEFAULT;
+} else if (entries.find(Key(referrer, Type::BUILTIN)) != kj::none) {
+  resolveOption = INTERNAL_ONLY;
+}
+```
+
+## Fallback Service
+
+When resolution fails and a fallback service is configured
+(`IsolateBase::tryGetModuleFallback`), the registry attempts to load the module
+from an external service. This is used in local development (e.g., `wrangler dev`)
+where not all modules may be present in the bundle.
+
+Results from the fallback service are:
+
+- `ModuleInfo`: inserted into the registry as BUNDLE (or BUILTIN if the specifier
+  has a known prefix).
+- `kj::String`: a redirect — stored in `fallbackServiceRedirects` for future lookups,
+  then resolution retries with the redirected path.
+
+## How V8 Modules Map to ModuleInfo
+
+### ESM Modules (maybeSynthetic == kj::none)
+
+```
+v8::ScriptCompiler::CompileModule(isolate, &source)
+  → v8::Module (SourceTextModule internally)
+  → Stored in ModuleInfo.module
+  → V8 handles all import/export resolution via resolveModuleCallback
+  → Evaluation runs the module's JavaScript code
+```
+
+### Synthetic Modules (maybeSynthetic has a value)
+
+```
+v8::Module::CreateSyntheticModule(isolate, name, exportNames, evaluateSyntheticModuleCallback)
+  → v8::Module (SyntheticModule internally)
+  → Stored in ModuleInfo.module
+  → V8 calls evaluateSyntheticModuleCallback during Evaluate
+  → Callback looks up the ModuleInfo via reverse scan
+  → Switches on SyntheticModuleInfo variant to set exports
+```
+
+All synthetic modules share the **same** evaluation callback function
+(`evaluateSyntheticModuleCallback`). The callback uses the reverse module lookup to
+find which `ModuleInfo` corresponds to the `v8::Module` being evaluated, then reads
+the synthetic data from it.
+
+### Export Names
+
+For synthetic modules, export names are declared at creation time:
+
+- All synthetic modules always have a `"default"` export.
+- CJS modules with `maybeNamedExports` also declare those names.
+- Cap'n Proto modules declare names for each nested schema node.
+
+For ESM modules, export names are determined by V8 during compilation (extracted
+from the source text).
+
+## Key Characteristics and Limitations
+
+1. **Per-isolate, not shared.** Each V8 isolate has its own `ModuleRegistryImpl`
+   instance. Modules compiled in one isolate cannot be shared with another. The
+   same source code is recompiled for each isolate.
+
+2. **Eager compilation for bundle modules.** All worker bundle modules are compiled
+   during `compileModules`, before any request is served. Builtin modules are lazily
+   compiled on first import.
+
+3. **Path-based specifiers using `kj::Path`.** All specifiers are parsed into
+   `kj::Path` objects. Relative imports are resolved against the referrer's parent
+   path. This means `./foo` from `bar/baz.js` resolves to `bar/foo`.
+
+4. **Linear-scan reverse lookup.** Finding a `ModuleInfo` from a `v8::Module` handle
+   requires iterating all entries. This is O(n) in the number of registered modules.
+
+5. **Single evaluation callback for all synthetic modules.** The
+   `evaluateSyntheticModuleCallback` is a global function shared by all synthetic
+   modules. It relies on the reverse lookup to determine which module is being
+   evaluated.
+
+6. **No URL-based resolution.** The legacy registry uses `kj::Path` for specifiers,
+   not URLs. There is no URL normalization, no query parameter handling, and no
+   protocol-based dispatch. Known prefixes (`node:`, `cloudflare:`, `workerd:`) are
+   handled as special cases in the resolve callback.
+
+7. **Module type is part of the key.** The same path can exist as both BUNDLE and
+   BUILTIN, with BUNDLE taking priority in DEFAULT resolution. This enables user
+   code to shadow built-in modules.
+
+8. **Mutable registry.** Entries can be added at any time (fallback service, lazy
+   compilation). The `info` field within entries mutates from source/callback to
+   `ModuleInfo` on first access.
+
+9. **Top-level await handling.** After V8's `Evaluate` returns, `instantiateModule`
+   runs microtasks and checks the promise state. If the promise is still pending,
+   it throws — workerd does not support long-lived TLA during module loading (the
+   worker must be fully initialized before serving requests).
+
+10. **require() is module evaluation + namespace extraction.** The `requireImpl`
+    function calls the same `instantiateModule` path as ESM imports, then extracts
+    the appropriate export(s) from the module namespace. CJS modules are synthetic
+    modules under the hood.

--- a/docs/reference/detail/new-module-registry.md
+++ b/docs/reference/detail/new-module-registry.md
@@ -1,0 +1,685 @@
+# New Module Registry (`jsg::modules::ModuleRegistry`)
+
+Reference for reasoning about the new module registry implementation, how it
+interfaces with V8's module APIs, and how modules flow from config through
+compilation to evaluation. For V8 module internals, see
+[v8-module-internals.md](v8-module-internals.md). For the legacy implementation,
+see [legacy-module-registry.md](legacy-module-registry.md).
+
+## Source Files
+
+| File                                 | Role                                                                                                              |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `src/workerd/jsg/modules-new.h`      | `Module`, `ModuleBundle`, `ModuleRegistry` classes; `ResolveContext`; builder APIs; `IsolateModuleRegistry` (fwd) |
+| `src/workerd/jsg/modules-new.c++`    | All implementation: `EsModule`, `SyntheticModule`, `IsolateModuleRegistry`, V8 callbacks, bundle builders         |
+| `src/workerd/jsg/observer.h`         | `ResolveObserver` — metrics/tracing hooks for module resolution                                                   |
+| `src/workerd/jsg/url.h`              | `jsg::Url` — WHATWG URL wrapper (ada-url); used as specifier keys throughout                                      |
+| `src/workerd/jsg/resource.h:1913–22` | Context creation: picks legacy vs new registry based on `NewContextOptions`                                       |
+| `src/workerd/jsg/jsg.c++:357–395`    | `Lock::resolveModule` / `Lock::resolveInternalModule` dispatches between legacy and new                           |
+| `src/workerd/jsg/setup.h:291–297`    | `IsolateBase::isUsingNewModuleRegistry()` flag                                                                    |
+| `src/workerd/io/worker-modules.h`    | `newWorkerModuleRegistry<TypeWrapper>` — creates `ModuleRegistry` from worker config                              |
+| `src/workerd/api/modules.h`          | `registerModules` (legacy), `registerBuiltinModules` (new) — registers all built-in API modules                   |
+| `src/workerd/server/workerd-api.c++` | `WorkerdApi::newWorkerdModuleRegistry` — workerd-specific new registry construction                               |
+
+## Design Goals and Key Differences from Legacy
+
+The new module registry was designed to address several limitations of the legacy
+`ModuleRegistryImpl<TypeWrapper>`:
+
+1. **Thread-safe and shareable across isolate replicas.** The `ModuleRegistry` is
+   `kj::AtomicRefcounted` and protected by `kj::MutexGuarded`. Multiple
+   `Worker::Isolate` replicas can share a single `ModuleRegistry` instance. The
+   legacy registry was per-isolate with no sharing.
+
+2. **URL-based specifiers.** All specifiers are handled as `jsg::Url` objects
+   (WHATWG-compliant, backed by ada-url). The legacy registry used `kj::Path`.
+   This enables proper protocol-based dispatch (`node:`, `cloudflare:`, `file:`)
+   and correct relative resolution.
+
+3. **Fully lazy compilation and evaluation.** No modules are compiled during
+   `ModuleRegistry` construction. Both ESM compilation and synthetic module
+   evaluation happen on first import. The legacy registry eagerly compiled all
+   worker bundle ESM modules at startup.
+
+4. **Cross-isolate compile cache.** ESM modules cache their V8 compiled bytecode
+   in a `kj::MutexGuarded` field on the `Module` object itself. When a second
+   isolate imports the same module, the cached bytecode is consumed, skipping
+   recompilation. The legacy registry had no compile cache sharing.
+
+5. **Separation of definition from instantiation.** `Module` objects are
+   isolate-independent definitions. `IsolateModuleRegistry` holds the per-isolate
+   V8 handles. This clean split enables the sharing model.
+
+6. **`import.meta` support.** The new registry provides `import.meta.url`,
+   `import.meta.main`, and `import.meta.resolve()` on all ESM modules. The legacy
+   registry had no `import.meta` support.
+
+7. **Modular bundle architecture.** The `ModuleBundle` abstraction allows
+   composing registries from multiple independent sources (worker bundle, builtins,
+   internal-only, fallback) without coupling them.
+
+## Architecture Overview
+
+The system has a two-layer design: a shared, isolate-independent layer
+(`ModuleRegistry` + `ModuleBundle` + `Module`) and a per-isolate layer
+(`IsolateModuleRegistry`).
+
+### Shared Layer (owned by `Worker::Script`, thread-safe)
+
+```
+ModuleRegistry (kj::AtomicRefcounted)
+  |-- observer: const ResolveObserver&     (metrics hooks)
+  |-- bundleBase: const jsg::Url&          (e.g. "file:///bundle/")
+  |-- schemaLoader: capnp::SchemaLoader    (for capnp modules)
+  |-- maybeEvalCallback: EvalCallback      (ensures eval outside IoContext)
+  +-- impl: kj::MutexGuarded<Impl>
+        +-- bundles: FixedArray<Array<Own<ModuleBundle>>, 4>
+              [kBundle]      -> worker bundle modules
+              [kBuiltin]     -> runtime builtins importable by user code
+              [kBuiltinOnly] -> internal-only modules
+              [kFallback]    -> fallback service (local dev only)
+```
+
+### Per-Isolate Layer (owned by `JsContext`, destroyed with context)
+
+```
+IsolateModuleRegistry
+  |-- inner: const ModuleRegistry&         (back-reference to shared registry)
+  |-- observer: const CompilationObserver& (compilation metrics)
+  +-- lookupCache: kj::Table<Entry>        (triple-indexed)
+        Each Entry:
+          |-- key: HashableV8Ref<v8::Module>   (V8 module handle)
+          |-- context: SpecifierContext         (type + URL)
+          +-- module: const Module&            (back-ref to definition)
+        Indices:
+          |-- HashIndex<EntryCallbacks>    -- lookup by v8::Module identity
+          |-- HashIndex<ContextCallbacks>  -- lookup by (type, URL)
+          +-- HashIndex<UrlCallbacks>      -- lookup by URL alone
+```
+
+## Module Types
+
+### `Module::Type` enum
+
+| Type           | Value | Purpose                                                        |
+| -------------- | ----- | -------------------------------------------------------------- |
+| `BUNDLE`       | 0     | User worker modules (from config)                              |
+| `BUILTIN`      | 1     | Runtime-provided, importable by user code (e.g. `node:buffer`) |
+| `BUILTIN_ONLY` | 2     | Runtime-internal, only importable by other builtins            |
+| `FALLBACK`     | 3     | Dynamically resolved from fallback service (local dev only)    |
+
+### `Module::Flags` bitmask
+
+| Flag   | Bit  | Meaning                                                            |
+| ------ | ---- | ------------------------------------------------------------------ |
+| `NONE` | 0x00 | No flags                                                           |
+| `MAIN` | 0x01 | `import.meta.main = true` (worker entrypoint)                      |
+| `ESM`  | 0x02 | ECMAScript module (vs synthetic)                                   |
+| `EVAL` | 0x04 | Requires evaluation outside IoContext (deferred to `EvalCallback`) |
+| `WASM` | 0x08 | WebAssembly module                                                 |
+
+## Module Subclasses
+
+`Module` is an abstract base class. Two concrete implementations exist
+(both file-private in `modules-new.c++`):
+
+### `EsModule` — ECMAScript Modules
+
+```
+EsModule extends Module {
+  source:     kj::ArrayPtr<const char>                      // Raw source text
+  cachedData: MutexGuarded<Maybe<Own<CachedData>>>          // Cross-isolate compile cache
+}
+```
+
+- `getDescriptor()`: Compiles the source via `v8::ScriptCompiler::CompileModule`.
+  Checks the `cachedData` shared cache first (shared lock for reading, exclusive
+  lock for writing). On cache miss, generates and stores bytecode after compilation.
+- `evaluate()`: Calls `v8::Module::Evaluate()`. For modules with `Flags::EVAL`,
+  delegates to the `Evaluator` to run evaluation outside the IoContext.
+- Always has `Flags::ESM | Flags::EVAL` set.
+
+#### Compile Cache Flow
+
+```
+First isolate compiles module:
+  1. lockShared(cachedData) -> empty -> no cached data
+  2. CompileModule(source) -> v8::Module
+  3. lockExclusive(cachedData) -> still empty?
+     -> CreateCodeCache(module) -> store Own<CachedData>
+
+Second isolate compiles same module:
+  1. lockShared(cachedData) -> has data -> copy bytes
+     -> kConsumeCodeCache -> CompileModule(source, cache)
+  2. No exclusive lock needed (cache already populated)
+```
+
+### `SyntheticModule` — All Non-ESM Modules
+
+```
+SyntheticModule extends Module {
+  callback:     EvaluateCallback    // Sets exports during evaluation
+  namedExports: Array<String>       // Declared export names (besides "default")
+}
+```
+
+- `getDescriptor()`: Calls `v8::Module::CreateSyntheticModule` with the declared
+  export names (always includes `"default"` plus any `namedExports`).
+- `evaluate()`: Creates a resolved Promise, calls the `callback` which uses the
+  `ModuleNamespace` helper to set exports via `SetSyntheticModuleExport`.
+- For modules with `Flags::EVAL`, delegates to the `Evaluator` first.
+
+### Static `evaluationSteps` Callback
+
+All synthetic modules share a single static `evaluationSteps` function, registered
+as the V8 `SyntheticModuleEvaluationSteps`. When V8 calls it:
+
+1. Gets the `IsolateModuleRegistry` from context embedder data.
+2. Looks up the `Entry` by v8::Module identity (hash-indexed, O(1) — unlike the
+   legacy registry's O(n) linear scan).
+3. Calls `module.evaluate()` on the found entry.
+
+## ModuleBundle — Sources of Modules
+
+A `ModuleBundle` is an immutable collection of module definitions. The
+`ModuleRegistry` composes multiple bundles and searches them in priority order.
+
+### `StaticModuleBundle` (file-private)
+
+The default bundle type, created by `Builder::finish()`. Contains:
+
+- `modules`: `HashMap<Url, ResolveCallback>` — URL to factory
+- `aliases`: `HashMap<Url, Url>` — alias to target
+- `cache`: `HashMap<Url, Own<Module>>` — resolved modules (populated on first lookup)
+
+Each `ResolveCallback` is a factory `(ResolveContext) -> Maybe<OneOf<String, Own<Module>>>`.
+It returns either a `Module` (resolved), a redirect string, or `kj::none` (not found).
+
+### `FallbackModuleBundle` (file-private)
+
+Used only for local development (`workerd` binary). Contains a single
+`ResolveCallback` that calls an external service. Caches results in internal
+`storage` and `aliases` maps.
+
+### `BundleBuilder` — Building Worker Bundle Modules
+
+`BundleBuilder` creates `BUNDLE`-type modules. Module names are processed relative
+to the `bundleBase` URL (typically `file:///bundle/`):
+
+```cpp
+BundleBuilder builder(bundleBase);
+builder.addEsmModule("index.js", source, Flags::ESM | Flags::MAIN);
+builder.addSyntheticModule("data.json", Module::newJsonModuleHandler(jsonData));
+builder.addWasmModule("module.wasm", wasmBytes);
+auto bundle = builder.finish();
+```
+
+Name normalization (`normalizeModuleName`):
+
+1. Parse name as URL relative to `bundleBase`.
+2. Normalize path (remove `.`/`..`, normalize percent-encoding).
+3. Strip fragments and query parameters.
+4. Validate: must be subordinate to `bundleBase`, no `cloudflare:` or `workerd:` protocol.
+
+### `BuiltinBuilder` — Building Runtime Modules
+
+`BuiltinBuilder` creates `BUILTIN` or `BUILTIN_ONLY` modules. Specifiers must be
+absolute URLs with non-`file:` protocols:
+
+```cpp
+BuiltinBuilder builder(BuiltinBuilder::Type::BUILTIN);
+builder.addEsm("node:buffer"_url, NODE_BUFFER_SOURCE);
+builder.addSynthetic("node:path"_url, pathCallback);
+builder.addObject<CryptoModule, TypeWrapper>("node:crypto"_url);
+auto bundle = builder.finish();
+```
+
+## Resolution Flow
+
+### Lookup Priority by Context Type
+
+When `ModuleRegistry::lookup()` is called, it acquires an exclusive lock on the
+`MutexGuarded<Impl>` and searches bundles in order:
+
+| `ResolveContext::Type` | Search order                     | Use case                                   |
+| ---------------------- | -------------------------------- | ------------------------------------------ |
+| `BUNDLE`               | kBundle -> kBuiltin -> kFallback | User code imports                          |
+| `BUILTIN`              | kBuiltin -> kBuiltinOnly         | Builtin code importing other builtins      |
+| `BUILTIN_ONLY`         | kBuiltinOnly only                | Internal modules importing other internals |
+| `PUBLIC_BUILTIN`       | kBuiltin only                    | `process.getBuiltinModule()` and similar   |
+
+### Complete Resolution Sequence (Static Import)
+
+```
+User code: import { foo } from './bar.js'
+
+1. V8 calls resolveModuleCallback<false>(context, specifier, attrs, referrer)
+
+2. Look up referrer in IsolateModuleRegistry by v8::Module identity
+   -> Determines referrer's type (BUNDLE/BUILTIN/BUILTIN_ONLY)
+   -> Gets referrer's URL for relative resolution
+
+3. Normalize specifier:
+   a. If Node.js compat enabled, check for bare node specifier -> prefix "node:"
+   b. Check for node:process redirect (v1 vs v2)
+   c. Resolve specifier relative to referrer URL -> absolute URL
+   d. Normalize path (percent-encoding normalization)
+
+4. Build ResolveContext { type, source=STATIC_IMPORT, normalizedSpecifier, referrer }
+
+5. IsolateModuleRegistry::resolve(js, context)
+   a. Check lookupCache by (type, URL) -> cache hit? Return v8::Module handle
+   b. Cache miss -> call resolveWithCaching(js, context)
+      i.   Strip query params and fragments from specifier
+      ii.  Call inner.lookup(innerContext)  [acquires MutexGuarded exclusive lock]
+      iii. ModuleRegistry::lookupImpl searches bundles in priority order
+      iv.  Each bundle's lookup() checks aliases, cache, then resolve callbacks
+      v.   If redirect (alias): recurse once with new specifier (max depth 1)
+      vi.  If Module found: call module.getDescriptor(js, observer) -> v8::Module
+      vii. Insert Entry{v8Module, context, module} into lookupCache
+   c. Return v8::Module handle from the new Entry
+
+6. V8 receives the v8::Module and continues PrepareInstantiate
+```
+
+### Dynamic Import Flow
+
+```
+User code: const mod = await import('./bar.js')
+
+1. V8 calls dynamicImport(context, host_options, resource_name, specifier, attrs)
+
+2. Reject any import attributes (not yet supported)
+
+3. Parse referrer from resource_name (or fall back to bundleBase)
+
+4. Normalize specifier (same as static: node: prefix, process redirect, URL resolve)
+
+5. IsolateModuleRegistry::dynamicResolve(js, normalizedSpec, referrer, rawSpec, sourcePhase)
+   a. Look up referrer in lookupCache -> get referrer's module type
+   b. Build ResolveContext { type from referrer, source=DYNAMIC_IMPORT, ... }
+   c. Check lookupCache or call resolveWithCaching (same as static)
+   d. Call module.evaluate(js, v8Module, observer, maybeEvaluate) -> Promise
+   e. Chain: .then(namespace -> resolve Promise with module namespace)
+
+6. Return Promise to V8
+```
+
+### `require()` Flow
+
+```
+CJS code: const foo = require('./bar.js')
+
+1. IsolateModuleRegistry::require(js, context, option)
+
+2. Check for node:process redirect
+
+3. Resolve module (same cache + lookup path as static import)
+
+4. Evaluate the module:
+   a. If status == kErrored -> throw the stored exception
+   b. If ESM and status == kEvaluating -> throw circular dependency error
+   c. If status == kEvaluated or kEvaluating -> return namespace directly
+      (allows CJS circular deps with incomplete exports, same as Node.js)
+   d. Otherwise: call module.evaluate() -> Promise
+   e. Run microtasks
+   f. Check promise state:
+      - kFulfilled -> return module namespace
+      - kRejected -> throw rejection reason
+      - kPending -> throw "top-level await" error
+
+5. Return the module namespace as v8::Object
+```
+
+## Evaluation and the Evaluator Pattern
+
+Module evaluation has a key constraint: it must occur **outside** any
+`IoContext`. The `Module::Evaluator` pattern enforces this.
+
+### The EvalCallback
+
+Set during registry construction via `Builder::setEvalCallback`. The standard
+implementation (from `worker-modules.h`) creates a `SuppressIoContextScope`:
+
+```cpp
+builder.setEvalCallback([](Lock& js, const auto& module, auto v8Module,
+                            const auto& observer) -> Promise<Value> {
+  return js.tryOrReject<Value>([&] {
+    SuppressIoContextScope suppressIoContextScope;
+    KJ_DASSERT(!IoContext::hasCurrent());
+    return check(v8Module->Evaluate(js.v8Context()));
+  });
+});
+```
+
+### How it flows
+
+1. `module.evaluate(js, v8Module, observer, evaluator)` is called.
+2. For modules with `Flags::EVAL` set (all ESM modules, and synthetic modules
+   that opt in):
+   - The `evaluator(js, module, v8Module, observer)` is invoked.
+   - The evaluator calls `ModuleRegistry::evaluateImpl` which invokes the
+     `EvalCallback`.
+   - If the callback returns a `Promise<Value>`, it is wrapped and returned.
+3. If the evaluator returns `kj::none` (no callback set), or the module doesn't
+   have `Flags::EVAL`, the module's `actuallyEvaluate()` is called directly.
+4. For ESM: `actuallyEvaluate` calls `v8::Module::Evaluate()`.
+5. For Synthetic: `actuallyEvaluate` creates a resolved Promise, then invokes
+   the synthetic `callback` to set exports.
+
+## `import.meta` Support
+
+The `importMeta` callback is registered on the isolate during
+`IsolateModuleRegistry` construction. When V8 creates an `import.meta` object:
+
+1. Looks up the module in the `IsolateModuleRegistry` by v8::Module handle.
+2. Sets three properties via `CreateDataProperty`:
+   - `import.meta.main` — `true` if `Module::Flags::MAIN` is set
+   - `import.meta.url` — the module's URL (e.g. `"file:///bundle/index.js"`)
+   - `import.meta.resolve(specifier)` — resolves `specifier` relative to
+     `import.meta.url` using WHATWG URL resolution. Returns the resolved URL
+     string, or `null` if unparseable. Does **not** check if the resolved URL
+     matches a module in the registry.
+
+## The `ModuleNamespace` Helper
+
+`Module::ModuleNamespace` wraps a `v8::Local<v8::Module>` and provides a safe
+interface for synthetic module evaluation callbacks:
+
+```cpp
+class ModuleNamespace {
+  bool set(Lock& js, kj::StringPtr name, JsValue value);    // Set a named export
+  bool setDefault(Lock& js, JsValue value);                  // Set the "default" export
+  kj::ArrayPtr<const kj::StringPtr> getNamedExports();       // Declared named exports
+};
+```
+
+Internally calls `v8::Module::SetSyntheticModuleExport`. Returns `false` if the
+export cannot be set (export name not declared, or V8 error). Validates that
+`name` is in the declared exports set.
+
+## Common Synthetic Module Handlers
+
+Static factory methods on `Module` create `EvaluateCallback` closures for common
+module types:
+
+| Handler                | Created by                     | Export behavior                                  |
+| ---------------------- | ------------------------------ | ------------------------------------------------ |
+| `newTextModuleHandler` | `Module::newTextModuleHandler` | `default` = JS string from char data             |
+| `newDataModuleHandler` | `Module::newDataModuleHandler` | `default` = ArrayBuffer (copied from byte data)  |
+| `newJsonModuleHandler` | `Module::newJsonModuleHandler` | `default` = `JSON.parse(data)`                   |
+| `newWasmModuleHandler` | `Module::newWasmModuleHandler` | `default` = `WebAssembly.Module` (compiled Wasm) |
+
+The Wasm handler has its own cross-isolate cache: a `MutexGuarded<Maybe<CompiledWasmModule>>`
+that stores the compiled module for reuse across isolates (similar to the ESM
+compile cache).
+
+### CJS-Style Module Handler
+
+`Module::newCjsStyleModuleHandler<T, TypeWrapper>` is a template that creates a
+handler for CommonJS-style modules:
+
+1. Guards against re-evaluation with `EvaluateOnce` (CJS modules evaluate once).
+2. Allocates a JSG resource object of type `T` (e.g. `CommonJsModuleContext`).
+3. Compiles the source as a function via `ScriptCompiler::CompileFunction` with
+   the JSG object as extension object (providing `module`, `exports`, `require`).
+4. Calls the compiled function.
+5. Extracts `exports` from the JSG object and sets them on the module namespace.
+
+## Specifier Processing
+
+### Bundle Module Names
+
+Worker bundle module names (from config) are processed through `processModuleName`:
+
+1. **Normalize**: resolve relative to `bundleBase`, remove `.`/`..`, normalize
+   percent-encoding, strip query/fragment.
+2. **Validate URL structure**: must be subordinate to `bundleBase` path.
+3. **Protocol restrictions**: `cloudflare:`, `workerd:`, and `data:` protocols
+   are forbidden in bundle module names (reserved for runtime use).
+
+Result: a `file:///bundle/<path>` URL for file-protocol modules, or a fully
+qualified URL for other protocols.
+
+### Builtin Module Specifiers
+
+Builtin modules use non-`file:` protocols (enforced by `ensureIsNotBundleSpecifier`):
+
+- `node:buffer`, `node:crypto`, etc.
+- `cloudflare:sockets`, `cloudflare:workers`, etc.
+- `node-internal:*` (internal-only modules)
+- `workerd:*` (internal-only modules)
+
+These are parsed as absolute URLs where the protocol is the scheme and the
+pathname is the module identifier.
+
+### Node.js Compatibility Handling
+
+When Node.js compat is enabled (`isNodeJsCompatEnabled(js)`):
+
+- Bare specifiers like `"buffer"` are prefixed to `"node:buffer"` via `checkNodeSpecifier`.
+- `"node:process"` is redirected to either `"node-internal:public_process"` or
+  `"node-internal:legacy_process"` based on the `enable_nodejs_process_v2` flag.
+
+## IsolateModuleRegistry — Per-Isolate Cache
+
+The `IsolateModuleRegistry` binds the shared `ModuleRegistry` to a specific
+V8 isolate. It is stored in context embedder data at
+`ContextPointerSlot::MODULE_REGISTRY` and retrieved via
+`IsolateModuleRegistry::from(isolate)`.
+
+### Lookup Cache
+
+The cache is a `kj::Table<Entry>` with **three hash indices**:
+
+| Index              | Key type                      | Used by                                 |
+| ------------------ | ----------------------------- | --------------------------------------- |
+| `EntryCallbacks`   | `HashableV8Ref<v8::Module>`   | Reverse lookup (V8 handle to Entry)     |
+| `ContextCallbacks` | `SpecifierContext` (type+URL) | Primary resolution (specifier to Entry) |
+| `UrlCallbacks`     | `Url`                         | Referrer lookup for dynamic imports     |
+
+This triple-indexing means:
+
+- **Resolving by specifier** is O(1) hash lookup (vs legacy's O(n) scan for some paths).
+- **Reverse lookup** (v8::Module to Module definition) is O(1) hash lookup
+  (vs legacy's O(n) linear scan over all entries).
+- **Referrer lookup** (by URL alone, ignoring type) is O(1).
+
+### Cache Population
+
+On first resolution of a specifier:
+
+1. `resolveWithCaching` strips query params and fragments from the specifier.
+2. Calls `inner.lookup()` on the shared `ModuleRegistry` (acquires exclusive lock).
+3. If found, calls `module.getDescriptor(js, observer)` to create the v8::Module.
+4. Inserts a new `Entry` into the `lookupCache`.
+5. Subsequent lookups for the same specifier hit the cache directly.
+
+## V8 Callback Registration
+
+During `IsolateModuleRegistry` construction, three callbacks are registered:
+
+```cpp
+setAlignedPointerInEmbedderData(context, MODULE_REGISTRY, this);
+isolate->SetHostImportModuleDynamicallyCallback(&dynamicImport);
+isolate->SetHostImportModuleWithPhaseDynamicallyCallback(&dynamicImportWithPhase);
+isolate->SetHostInitializeImportMetaObjectCallback(&importMeta);
+```
+
+The `resolveModuleCallback<false>` and `resolveModuleCallback<true>` are passed
+to `InstantiateModule` during each module instantiation (not set globally on the
+isolate).
+
+### Source Phase Imports
+
+Source phase imports (`import source x from "mod"`) are handled through:
+
+- `resolveModuleCallback<true>` — returns `v8::Object` (not `v8::Module`)
+- `dynamicImportWithPhase` — wraps `dynamicImportModuleCallback` with `SourcePhase::YES`
+
+Only WebAssembly modules support source phase imports. The resolved Wasm
+module is evaluated, and the `WebAssembly.Module` object (the compiled Wasm,
+not an instance) is extracted from the module's `default` export and returned.
+All other module types throw `SyntaxError`.
+
+## Registry Setup and Population
+
+### 1. Construction (`newWorkerModuleRegistry<TypeWrapper>` in `worker-modules.h`)
+
+The main entry point. Called during `Worker::Script` construction:
+
+```
+newWorkerModuleRegistry<TypeWrapper>(resolveObserver, maybeSource, flags, bundleBase, setupForApi)
+  |
+  |-- Create ModuleRegistry::Builder
+  |
+  |-- Set EvalCallback (SuppressIoContextScope wrapper)
+  |
+  |-- registerBuiltinModules<TypeWrapper>(builder, featureFlags)
+  |     |-- Node.js compat modules (internal + external bundles)
+  |     |-- Sockets, Base64, MessageChannel, RPC modules
+  |     |-- Unsafe modules (if enabled)
+  |     |-- RTTI module (if enabled)
+  |     |-- Cloudflare bundle (from CLOUDFLARE_BUNDLE capnp)
+  |     |-- Workers module, Tracing module
+  |     +-- Internal-only: EnvModule, FileSystemModule
+  |
+  |-- Register worker bundle modules (if any)
+  |     |-- Load capnp schemas into SchemaLoader
+  |     |-- Create BundleBuilder(bundleBase)
+  |     |-- For each module in source:
+  |     |     |-- EsModule -> addEsmModule (first gets MAIN flag)
+  |     |     |-- TextModule -> addSyntheticModule(newTextModuleHandler)
+  |     |     |-- DataModule -> addSyntheticModule(newDataModuleHandler)
+  |     |     |-- WasmModule -> addWasmModule
+  |     |     |-- JsonModule -> addSyntheticModule(newJsonModuleHandler)
+  |     |     |-- CommonJsModule -> addSyntheticModule(newCjsStyleModuleHandler)
+  |     |     +-- CapnpModule -> addSyntheticModule(capnp handler with lazy export)
+  |     +-- builder.add(bundleBuilder.finish())
+  |
+  |-- setupForApi(builder, isPythonWorker)   // API-specific extensions
+  |
+  +-- builder.finish() -> kj::Arc<ModuleRegistry>
+```
+
+### 2. Attachment to Isolate (`resource.h:1913-1922`)
+
+During V8 context creation (`JsContext` construction):
+
+```cpp
+if (options.newModuleRegistry) {
+  return newModuleRegistry.attachToIsolate(js, compilationObserver);
+} else {
+  return ModuleRegistryImpl<TypeWrapper>::install(isolate, context, compilationObserver);
+}
+```
+
+`attachToIsolate` creates an `IsolateModuleRegistry`, stores it in embedder data,
+and registers V8 callbacks. Returns `kj::Own<void>` whose destructor cleans up.
+
+### 3. Dispatch Between Legacy and New (`jsg.c++`)
+
+`Lock::resolveModule` and `Lock::resolveInternalModule` check
+`IsolateBase::isUsingNewModuleRegistry()` and dispatch accordingly:
+
+```cpp
+if (isolate.isUsingNewModuleRegistry()) {
+  return modules::ModuleRegistry::tryResolveModuleNamespace(js, specifier, ...);
+} else {
+  // legacy ModuleRegistry path
+}
+```
+
+## Resolution Priority and Isolation Rules
+
+### Referrer-Based Context Determination
+
+When a V8 resolve callback fires, the referrer module's type determines the
+`ResolveContext::Type`:
+
+| Referrer Module Type | Resolve Context Type | Can see                   |
+| -------------------- | -------------------- | ------------------------- |
+| `BUNDLE`             | `BUNDLE`             | Bundle, Builtin, Fallback |
+| `BUILTIN`            | `BUILTIN`            | Builtin, BuiltinOnly      |
+| `BUILTIN_ONLY`       | `BUILTIN_ONLY`       | BuiltinOnly only          |
+| `FALLBACK`           | `BUNDLE`             | Bundle, Builtin, Fallback |
+
+This means:
+
+- User code **can** import builtins (e.g. `import { Buffer } from 'node:buffer'`).
+- User code **cannot** import internal-only modules.
+- Builtin code **can** import internal-only modules.
+- Builtin code **cannot** import user bundle modules.
+- User bundle modules with the same specifier as a builtin **shadow** the builtin
+  (Bundle is searched before Builtin in BUNDLE resolution).
+
+### Alias Handling
+
+Aliases are single-level redirects. When a bundle lookup returns a string
+(redirect) instead of a `Module`:
+
+1. The string is parsed as a URL (relative to `bundleBase` if needed).
+2. `lookupImpl` recurses with the new specifier, but with a `recursed=true`
+   flag that prevents further recursion. Only one level of aliasing is supported.
+
+## Thread Safety Model
+
+### Shared State (ModuleRegistry, ModuleBundle, Module)
+
+- `ModuleRegistry::lookup()` acquires `impl.lockExclusive()` for every call.
+  This serializes all resolution across all isolate replicas.
+- `ModuleBundle` and `Module` objects are immutable after construction, with
+  two exceptions:
+  - `EsModule::cachedData` uses `kj::MutexGuarded` (shared lock for reads,
+    exclusive for writes).
+  - `newWasmModuleHandler` similarly uses `kj::MutexGuarded` for its compiled
+    Wasm cache.
+  - `StaticModuleBundle::cache` and `FallbackModuleBundle::storage/aliases` are
+    mutated during lookup, but are protected by the registry's exclusive lock.
+
+### Per-Isolate State (IsolateModuleRegistry)
+
+- `IsolateModuleRegistry` is created and used only within a single V8 isolate.
+- The `lookupCache` is not thread-safe on its own; safety comes from V8's
+  single-threaded execution model (only one thread holds the isolate lock).
+- V8 callbacks (`resolveModuleCallback`, `dynamicImport`, `importMeta`) always
+  run while holding the isolate lock.
+
+## Key Characteristics
+
+1. **Fully lazy.** No module is compiled until first import. No module is
+   evaluated until first use. Unreferenced modules cost nothing.
+
+2. **URL-based specifiers.** All module identity and resolution uses WHATWG URLs.
+   Relative resolution uses standard URL semantics via ada-url.
+
+3. **O(1) lookups.** Both forward (specifier to module) and reverse
+   (v8::Module to definition) lookups are hash-indexed. The legacy registry's
+   O(n) reverse scan is eliminated.
+
+4. **Cross-isolate caching.** ESM compile cache and Wasm compiled modules are
+   shared across isolate replicas, reducing startup time for subsequent replicas.
+
+5. **Compile cache is transparent.** V8 bytecode caching is handled entirely
+   within `EsModule::getDescriptor()`. Callers never see compile cache details.
+
+6. **Evaluation callbacks are idempotent.** Synthetic module `EvaluateCallback`
+   functions can be called multiple times from multiple isolates. They create
+   fresh JS objects each time.
+
+7. **Import attributes are rejected.** The current implementation throws
+   `TypeError` for any import attributes. This is the spec-recommended default
+   for unrecognized attributes.
+
+8. **No `require(esm)` convention matching.** Unlike the legacy registry which
+   had complex `require()` return value logic (checking `__cjsUnwrapDefault`,
+   `module.exports` key, etc.), the new registry's `require()` always returns
+   the full module namespace. CJS interop is handled at the module handler level.
+
+9. **Python modules are not yet supported.** The new registry currently throws
+   `KJ_FAIL_ASSERT` for `PythonModule` content. Python support remains on the
+   legacy registry path.
+
+10. **Top-level await handling.** Same as legacy: after `Evaluate`, microtasks
+    are drained. If the returned Promise is still pending, a "top-level await"
+    error is thrown. Workers must fully initialize synchronously.

--- a/docs/reference/detail/v8-module-internals.md
+++ b/docs/reference/detail/v8-module-internals.md
@@ -1,0 +1,608 @@
+# V8 Module System Internals
+
+Reference for reasoning about V8's module lifecycle, binding resolution, and evaluation
+semantics. All file paths are relative to the V8 source root
+(`external/+http_archive+v8/`). Line numbers are approximate and may drift across V8
+versions.
+
+## Source Files
+
+| File                                | Role                                                                                |
+| ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `include/v8-script.h`               | Public `v8::Module`, `v8::ModuleRequest` API                                        |
+| `include/v8-callbacks.h`            | `ModuleImportPhase`, host callback typedefs                                         |
+| `src/objects/module.h`              | Internal `Module` base class (C++ header)                                           |
+| `src/objects/module.cc`             | Base class dispatch: `Instantiate`, `Evaluate`, `ResolveExport`, namespace creation |
+| `src/objects/module.tq`             | Torque layout for `Module`, `JSModuleNamespace`, `ScriptOrModule`                   |
+| `src/objects/source-text-module.h`  | `SourceTextModule` header                                                           |
+| `src/objects/source-text-module.cc` | ESM linking, resolution, evaluation, TLA                                            |
+| `src/objects/source-text-module.tq` | Torque layout for `SourceTextModule`, `ModuleRequest`, `SourceTextModuleInfoEntry`  |
+| `src/objects/synthetic-module.h`    | `SyntheticModule` header                                                            |
+| `src/objects/synthetic-module.cc`   | Synthetic module instantiation, evaluation, `SetExport`                             |
+| `src/objects/synthetic-module.tq`   | Torque layout for `SyntheticModule`                                                 |
+| `src/objects/module-inl.h`          | Inline accessors, `UnorderedModuleSet`, `ModuleHandleHash`                          |
+| `src/heap/factory.cc`               | `NewSourceTextModule`, `NewSyntheticModule` factory methods                         |
+| `src/api/api.cc`                    | Public API bridge (`CompileModule`, `CreateSyntheticModule`, etc.)                  |
+
+## Class Hierarchy and Heap Layout
+
+The hierarchy is defined in Torque (`.tq` files), which generates C++ heap object code.
+`Module` is abstract; only `SourceTextModule` and `SyntheticModule` are concrete.
+
+### Module (abstract base — `module.tq`)
+
+```
+Module extends HeapObject {
+  exports:                   ObjectHashTable   // export_name (String) → Cell
+  hash:                      Smi               // identity hash for module-keyed maps
+  status:                    Smi               // lifecycle state enum
+  module_namespace:          Cell | Undefined   // cached JSModuleNamespace (lazy)
+  deferred_module_namespace: Cell | Undefined   // for `import defer` (lazy)
+  exception:                 Object            // error value if status == kErrored
+  top_level_capability:      JSPromise | Undefined  // only set on SCC cycle roots
+}
+```
+
+### SourceTextModule (ESM — `source-text-module.tq`)
+
+```
+SourceTextModule extends Module {
+  code:             SharedFunctionInfo | JSFunction | JSGeneratorObject
+  regular_exports:  FixedArray    // cell_index → Cell (positional)
+  regular_imports:  FixedArray    // cell_index → Cell (positional)
+  requested_modules: FixedArray   // i → Module (resolved dependency for request i)
+  import_meta:      TheHole | JSObject   // lazily created on first access
+  cycle_root:       SourceTextModule | TheHole
+  async_parent_modules: ArrayList
+  dfs_index:              Smi
+  dfs_ancestor_index:     Smi
+  pending_async_dependencies: Smi
+  flags:            SmiTagged<SourceTextModuleFlags>
+    has_toplevel_await:         1 bit
+    async_evaluation_ordinal:  30 bits
+}
+```
+
+### SyntheticModule (`synthetic-module.tq`)
+
+```
+SyntheticModule extends Module {
+  name:             String       // display name (debugging/logging only)
+  export_names:     FixedArray   // declared export name strings
+  evaluation_steps: Foreign      // C++ function pointer (kSyntheticModuleTag)
+}
+```
+
+### Namespace Objects
+
+```
+JSModuleNamespace extends JSSpecialObject {
+  module: Module
+}
+
+JSDeferredModuleNamespace extends JSModuleNamespace {}
+```
+
+A `JSModuleNamespace` is the `import * as ns` object. It is created lazily by
+`Module::GetModuleNamespace` and cached in the `module_namespace` Cell. Properties
+are accessor-based: each export name maps to a `module_namespace_property_accessor`
+that performs a live lookup through the exports table.
+
+`JSDeferredModuleNamespace` is used for `import defer * as ns` and triggers
+synchronous evaluation on first property access (see Import Phases below).
+
+## The Export Table
+
+The `exports` field is an `ObjectHashTable` mapping export name strings to `Cell`
+objects. This is the core binding mechanism for the entire module system.
+
+### How live bindings work
+
+Both the exporting module and all importing modules resolve to the **same `Cell`
+object**. When code in the exporting module updates a `let`/`var` export, it writes
+to the Cell's value. All importers read from the same Cell and immediately see the
+new value. There is no copy step.
+
+### What the table contains at each stage
+
+| Module Status | Contents of `exports` entries                                                                                                                                                                            |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| kUnlinked     | Empty (freshly allocated ObjectHashTable)                                                                                                                                                                |
+| kPreLinking   | For SourceTextModule: regular exports → fresh Cells (value = TheHole), indirect exports → SourceTextModuleInfoEntry placeholders. For SyntheticModule: each export_name → fresh Cell (value = undefined) |
+| kLinking      | Indirect exports progressively replaced with resolved Cells                                                                                                                                              |
+| kLinked+      | All entries are Cells. TheHole value = uninitialized variable (will throw ReferenceError on access)                                                                                                      |
+
+### ObjectHashTable rehashing
+
+`ObjectHashTable::Put` may allocate a new backing table. After any `Put`, the caller
+must re-read the module's exports handle. The implementation is careful about this:
+every export-table mutation follows the pattern:
+
+```cpp
+exports = ObjectHashTable::Put(isolate, exports, name, cell);
+module->set_exports(*exports);
+```
+
+## Lifecycle State Machine
+
+### Internal States (`Module::Status` enum in `module.h`)
+
+```
+kUnlinked(0) → kPreLinking(1) → kLinking(2) → kLinked(3)
+  → kEvaluating(4) → kEvaluatingAsync(5) | kEvaluated(6)
+  any → kErrored(7)
+```
+
+Status transitions are monotonically increasing (`DCHECK_LE(status(), new_status)`)
+**except**:
+
+- `Reset` moves a module from kPreLinking/kLinking back to kUnlinked (on
+  instantiation failure).
+- `RecordError` moves any state to kErrored.
+
+### Public API Mapping (`v8::Module::Status`)
+
+| Internal         | Public          | Notes                                   |
+| ---------------- | --------------- | --------------------------------------- |
+| kUnlinked        | kUninstantiated |                                         |
+| kPreLinking      | kInstantiating  |                                         |
+| kLinking         | kInstantiating  |                                         |
+| kLinked          | kInstantiated   |                                         |
+| kEvaluating      | kEvaluating     |                                         |
+| kEvaluatingAsync | kEvaluated      | Collapsed into kEvaluated in public API |
+| kEvaluated       | kEvaluated      |                                         |
+| kErrored         | kErrored        |                                         |
+
+### The `code` field transitions (SourceTextModule only)
+
+The `code` field is polymorphic. Its type tracks the module's progress:
+
+| Status                                             | `code` type                                                   | Meaning                                     |
+| -------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------- |
+| kUnlinked, kPreLinking                             | `SharedFunctionInfo`                                          | Compiled but not yet linked                 |
+| kLinking                                           | `JSFunction`                                                  | Created from SFI during `FinishInstantiate` |
+| kLinked, kEvaluating, kEvaluatingAsync, kEvaluated | `JSGeneratorObject` (sync) or `JSAsyncFunctionObject` (async) | Created by `RunInitializationCode`          |
+| kErrored                                           | `SharedFunctionInfo`                                          | Reverted by `RecordError`                   |
+
+The revert on error is important: `RecordError` calls
+`self->set_code(self->GetSharedFunctionInfo())` to strip the JSFunction/generator
+and return to the minimal SFI state.
+
+## SourceTextModule: Detailed Lifecycle
+
+### 1. Creation — `Factory::NewSourceTextModule` (`factory.cc`)
+
+Entry point: `ScriptCompiler::CompileModule` → compiles source to `SharedFunctionInfo`
+→ `factory->NewSourceTextModule(sfi)`.
+
+The SFI's `ScopeInfo` contains a `SourceTextModuleInfo` (`module-inl.h:73-74`) with:
+
+- `module_requests()`: `FixedArray` of `ModuleRequest` (specifier + phase + import attributes)
+- `regular_exports()`: triples of (local_name, cell_index, export_names)
+- `regular_imports()`: `SourceTextModuleInfoEntry` (import_name, module_request, cell_index)
+- `special_exports()`: indirect and star re-export entries
+- `namespace_imports()`: namespace import entries
+
+The factory allocates arrays for `regular_exports`, `regular_imports`, and
+`requested_modules` (all initially empty/zeroed), sets status to kUnlinked, and
+initializes all other fields to their zero/hole/undefined states.
+
+### 2. Instantiation — `Module::Instantiate` (`module.cc`)
+
+Two-phase process: `PrepareInstantiate` then `FinishInstantiate`. If either fails,
+`ResetGraph` walks the entire dependency graph and resets all modules in
+kPreLinking/kLinking back to kUnlinked.
+
+#### Phase 1: PrepareInstantiate (`source-text-module.cc:363-481`)
+
+Sets status to kPreLinking, then for each `ModuleRequest`:
+
+**Evaluation/Defer phase imports**: Calls the embedder's `ResolveModuleCallback`
+(specifier-based) or `ResolveModuleByIndexCallback` (index-based). The returned
+`v8::Module` is stored in `requested_modules[i]`.
+
+**Source phase imports** (`import source`): Calls the embedder's `ResolveSourceCallback`
+or `ResolveSourceByIndexCallback`. The returned `v8::Object` is stored in
+`requested_modules[i]` (not a Module — it's an opaque source representation).
+
+Then **recurses** into all evaluation-phase dependencies (skipping source-phase).
+
+After recursion, populates the export table:
+
+- **Regular exports**: For each (cell_index, export_names), creates a Cell and inserts
+  it into both `regular_exports[cell_index]` and `exports[name]` for each export name.
+- **Indirect exports**: For each special_export with a non-undefined export_name,
+  inserts the `SourceTextModuleInfoEntry` as a placeholder in `exports[name]`.
+  This placeholder is later replaced by the resolved Cell during `FinishInstantiate`.
+
+#### Phase 2: FinishInstantiate (`source-text-module.cc:594-687`)
+
+Implements Tarjan's strongly connected components algorithm:
+
+1. Creates `JSFunction` from SFI, stores in `code`. Sets status to kLinking.
+2. Assigns DFS indices, pushes module onto SCC stack.
+3. Recurses into dependencies (skipping source-phase). For each:
+   - Calls `Module::FinishInstantiate` (which dispatches to the subclass).
+   - If the dependency is still kLinking (on the stack), updates
+     `dfs_ancestor_index` to detect the SCC.
+4. Resolves **imports**: For each `regular_import`, calls `ResolveImport` which:
+   - Source phase: wraps the requested object in a new Cell.
+   - Evaluation/Defer phase with a name: calls `Module::ResolveExport` on the
+     target to find the binding Cell.
+   - Evaluation/Defer phase without a name (namespace import): calls
+     `GetModuleNamespaceCell`.
+   - Stores the resolved Cell in `regular_imports[cell_index]`.
+5. Resolves **indirect exports**: For each special_export with a name, calls
+   `ResolveExport` to replace the placeholder entry with the real Cell.
+6. When an SCC root is found (`dfs_ancestor_index == dfs_index`), calls
+   `MaybeTransitionComponent` which pops the entire SCC off the stack, runs
+   `RunInitializationCode` on each (creating module context + generator), and
+   transitions all to kLinked.
+
+#### RunInitializationCode (`source-text-module.cc:483-505`)
+
+Called during SCC completion (not during evaluation). Creates:
+
+1. A `ModuleContext` from the module's scope info.
+2. Sets the JSFunction's context to this new module context.
+3. Calls the function, which returns a `JSGeneratorObject`.
+4. Stores the generator in `code`.
+
+This is the step where variable bindings are initialized (but module body code
+has not run — the generator is paused at the start).
+
+### 3. Export Resolution — `ResolveExport` / `ResolveImport`
+
+#### ResolveExport (`source-text-module.cc:182-250`)
+
+Given an export name, looks it up in the exports table:
+
+- If it's a `Cell`: already resolved, return it.
+- If it's a `SourceTextModuleInfoEntry`: an unresolved indirect export. Follow
+  the chain via `ResolveImport` on the entry's module_request + import_name.
+  On success, replace the entry in the exports table with the resolved Cell.
+- If it's `TheHole`: the name wasn't found as a direct or indirect export.
+  Fall through to `ResolveExportUsingStarExports`.
+
+**Cycle detection**: Uses a `ResolveSet` (map of `Handle<Module>` → `UnorderedStringSet`).
+Before recursing, inserts (module, export_name) into the set. If already present,
+a cycle is detected. With `must_resolve=true`, this throws a SyntaxError
+(`kCyclicModuleDependency`).
+
+#### ResolveExportUsingStarExports (`source-text-module.cc:303-361`)
+
+Walks all star exports (`special_exports` entries where `export_name` is undefined).
+For each, tries `ResolveImport` with the target name. Collects results:
+
+- If exactly one star export provides the name: uses that Cell.
+- If multiple provide it with the same Cell: fine (diamond dependency).
+- If multiple provide different Cells: throws `kAmbiguousExport`.
+- The `default` export is never resolved through star exports (spec requirement).
+
+### 4. Evaluation — `SourceTextModule::Evaluate` (`source-text-module.cc:890-940`)
+
+1. Creates a `JSPromise` as the top-level capability (stored on the SCC cycle root).
+2. Calls `InnerModuleEvaluation` which does a DFS:
+   - Sets status to kEvaluating.
+   - Gathers dependencies (with special handling for deferred imports via
+     `GatherAsynchronousTransitiveDependencies`).
+   - Recursively evaluates all evaluation-phase dependencies.
+   - Tracks `pending_async_dependencies` and `async_parent_modules` for
+     ordering async evaluation.
+   - If the module has TLA or pending async deps: sets `async_evaluation_ordinal`
+     and calls `ExecuteAsyncModule` if no pending deps remain.
+   - If synchronous: calls `ExecuteModule` directly.
+   - Transitions the SCC via `MaybeTransitionComponent` to kEvaluated (or
+     kEvaluatingAsync if async).
+3. Returns the top-level promise.
+
+#### Synchronous execution (`ExecuteModule`, line 1193)
+
+Resumes the `JSGeneratorObject` stored in `code` via `generator_next_internal`.
+Returns the completion value from `JSIteratorResult`.
+
+#### Asynchronous execution (`ExecuteAsyncModule`, line 1102)
+
+The `code` field is a `JSAsyncFunctionObject`. Wires up `onFulfilled` /
+`onRejected` callbacks (built from shared function infos stored in the native
+context) onto a new Promise, then calls `InnerExecuteAsyncModule` which resumes
+the async function via `async_module_evaluate_internal`.
+
+#### Async completion (`AsyncModuleExecutionFulfilled`, line 943)
+
+When an async module completes:
+
+1. Sets status to kEvaluated, resolves the top-level promise.
+2. Calls `GatherAvailableAncestors` — iterates `async_parent_modules`, decrements
+   their `pending_async_dependencies`.
+3. Any ancestor that reaches zero pending deps and has TLA: triggers
+   `ExecuteAsyncModule`.
+4. Any ancestor that reaches zero pending deps and is synchronous: runs
+   `ExecuteModule`, transitions to kEvaluated.
+
+The `async_evaluation_ordinal` provides a deterministic ordering (set sequentially
+as modules enter async evaluation via `isolate->NextModuleAsyncEvaluationOrdinal()`).
+
+### 5. Error Handling
+
+`RecordError` (`module.cc:105-124`):
+
+- For SourceTextModule: reverts `code` to the original SFI.
+- Sets status to kErrored.
+- Stores the exception, or `null` for termination exceptions.
+
+Evaluation error propagation (`MaybeHandleEvaluationException`, line 860):
+
+- If the exception is catchable by JS: records it on all modules in the SCC stack.
+- If it's a termination exception: also records on all, but with `null` as the
+  exception. Returns false to signal the caller that promise rejection should
+  not happen.
+
+Failed evaluations return a rejected promise. Re-evaluating an already-errored
+module returns the same rejected promise (or creates a new one if no
+top_level_capability exists).
+
+## SyntheticModule: Detailed Lifecycle
+
+### 1. Creation — `Factory::NewSyntheticModule` (`factory.cc:3605-3631`)
+
+Entry point: `v8::Module::CreateSyntheticModule(isolate, module_name, export_names,
+evaluation_steps)`.
+
+- `export_names` are internalized strings stored in a `FixedArray`.
+- `evaluation_steps` is a C++ function pointer stored as a `Foreign` with
+  `kSyntheticModuleTag` (for V8 sandbox pointer tagging).
+- Status set to kUnlinked. Exports table allocated but empty.
+
+### 2. Instantiation
+
+#### PrepareInstantiate (`synthetic-module.cc:72-88`)
+
+For each export name in `export_names`:
+
+1. Creates a new mutable `Cell` (initial value: `undefined`, stored as TheHole
+   in the Cell's default constructor — but the implementation uses `NewCell()`
+   which initializes to `undefined`).
+2. Inserts (name → Cell) into the `exports` hash table.
+
+There are no imports or dependencies to resolve.
+
+#### FinishInstantiate (`synthetic-module.cc:93-104`)
+
+Sets status to kLinked. If a namespace object was pre-created, ensures it's
+populated.
+
+SyntheticModules skip the DFS/SCC stack entirely — they go straight to kLinked
+without receiving DFS indices.
+
+### 3. Evaluation (`synthetic-module.cc:108-143`)
+
+1. Sets status to kEvaluating.
+2. Extracts the `evaluation_steps` function pointer from the Foreign object.
+3. Calls the embedder callback: `evaluation_steps(context, module)`.
+4. If the callback returns a value:
+   - Sets status to kEvaluated.
+   - If the return is a JSPromise, uses it as `top_level_capability`.
+   - Otherwise, creates a new resolved Promise (backward compat for pre-TLA hosts).
+5. If the callback throws:
+   - `RecordError` is called → status becomes kErrored.
+   - Returns empty MaybeHandle.
+
+### 4. SetExport (`synthetic-module.cc:21-38`)
+
+The embedder calls `v8::Module::SetSyntheticModuleExport(isolate, name, value)`
+during the evaluation callback.
+
+1. Looks up `name` in the `exports` hash table.
+2. If not found (not in the original `export_names`): throws a ReferenceError
+   (`kModuleExportUndefined`).
+3. If found: sets `cell->set_value(export_value)`.
+
+`SetExportStrict` is a variant that CHECKs instead of throwing — it's a legacy
+method that will be removed.
+
+### Synthetic module constraints
+
+- SyntheticModules **cannot have imports** or dependencies of any kind.
+- They **cannot re-export** from other modules.
+- They **do not participate in SCC detection** (no DFS indices).
+- They are always "leaf" nodes in the module graph.
+- They can only be depended upon by SourceTextModules (or other embedder code).
+
+## Import Phases (`ModuleImportPhase` — `v8-callbacks.h`)
+
+```cpp
+enum class ModuleImportPhase {
+  kSource,      // 0  — import source x from "mod"
+  kDefer,       // 1  — import defer * as ns from "mod"
+  kEvaluation,  // 2  — standard import
+};
+```
+
+Stored as a 2-bit field in `ModuleRequest::flags`.
+
+### Source Phase (`kSource`)
+
+- During `PrepareInstantiate`: calls `ResolveSourceCallback` instead of
+  `ResolveModuleCallback`. The result is a `v8::Object` (not a Module) stored
+  in `requested_modules[i]`.
+- During `FinishInstantiate`: source-phase entries are skipped entirely (no linking).
+- During `ResolveImport`: wraps the stored object in a Cell directly.
+- During evaluation: source-phase entries are skipped.
+
+### Defer Phase (`kDefer`)
+
+- Resolution proceeds identically to kEvaluation (same callback, same Module result).
+- During `ResolveImport`: if importing a namespace (`maybe_name` is empty), calls
+  `GetModuleNamespaceCell(isolate, requested_module, ModuleImportPhase::kDefer)` which
+  stores the namespace in `deferred_module_namespace` instead of `module_namespace`.
+- Creates `JSDeferredModuleNamespace` instead of `JSModuleNamespace`.
+- During evaluation: the deferred module's transitive async dependencies are gathered
+  via `GatherAsynchronousTransitiveDependencies` and eagerly evaluated, but the
+  synchronous module graph is not evaluated until first property access.
+
+### Deferred Evaluation Trigger
+
+`JSDeferredModuleNamespace::TriggersEvaluation` (`module.cc:520-533`) is called
+by the property lookup machinery. Returns true if:
+
+- The holder is a `JSDeferredModuleNamespace`, AND
+- The property is not `then` or a Symbol (thenable check / iterator protocol), AND
+- The module's status is not yet kEvaluated.
+
+When triggered, `EvaluateModuleSync` (`module.cc:482-518`):
+
+1. Checks `ReadyForSyncExecution` — recursively verifies no TLA in the transitive
+   graph. Throws TypeError if not ready.
+2. Calls `Module::Evaluate`.
+3. If the resulting promise is rejected: throws the rejection reason.
+4. Asserts the promise is fulfilled (synchronous completion guaranteed by the
+   ReadyForSyncExecution check).
+
+## Namespace Object Creation — `Module::GetModuleNamespace` (`module.cc:343-424`)
+
+Lazy, cached in the `module_namespace` (or `deferred_module_namespace`) Cell.
+
+1. If the Cell already has a JSModuleNamespace value, return it.
+2. For SourceTextModules: call `FetchStarExports` to collect transitive star exports.
+3. Collect all keys from the exports hash table.
+4. Sort alphabetically (spec requirement: `@@unscopables`, then lexicographic).
+5. Create a `JSModuleNamespace` (or `JSDeferredModuleNamespace`).
+6. Transition to dictionary mode, add each name as an accessor property using
+   `module_namespace_property_accessor`.
+7. Prevent extensions, optimize as prototype (enables Turbofan inlining via
+   `PrototypeInfo::module_namespace`).
+
+Property access on the namespace goes through the accessor, which calls
+`JSModuleNamespace::GetExport` → looks up the Cell in `exports`, reads its value.
+If the value is TheHole (uninitialized binding), throws ReferenceError.
+
+## No Built-in Module Registry
+
+V8 does not maintain any specifier-to-Module mapping. The embedder is responsible
+for:
+
+- Storing compiled Module objects keyed by specifier.
+- Returning the correct Module from `ResolveModuleCallback` /
+  `ResolveModuleByIndexCallback`.
+- Ensuring the same Module object is returned for the same specifier (deduplication).
+- Implementing any URL resolution or path normalization.
+
+V8 calls the resolve callback for every `import` statement encountered during
+`PrepareInstantiate`. If the embedder returns a different Module for the same
+specifier on different calls, V8 will treat them as distinct modules.
+
+## The ResolveModuleCallback Contract
+
+```cpp
+using ResolveModuleCallback = MaybeLocal<Module> (*)(
+    Local<Context> context,
+    Local<String> specifier,
+    Local<FixedArray> import_attributes,  // [key, value, offset, ...]
+    Local<Module> referrer);
+
+using ResolveModuleByIndexCallback = MaybeLocal<Module> (*)(
+    Local<Context> context,
+    size_t module_request_index,
+    Local<Module> referrer);
+```
+
+The by-index variant avoids redundant string comparisons — the index corresponds
+directly to the `module_requests()` array position in the referrer's
+`SourceTextModuleInfo`.
+
+The callback must:
+
+- Return a Module (compiled but not necessarily instantiated) for evaluation-phase.
+- Return empty MaybeLocal to signal an error (must have thrown on the isolate).
+
+V8 will then recursively call `PrepareInstantiate` on the returned module, so the
+embedder does not need to pre-instantiate dependencies.
+
+## Key Invariants
+
+1. **Status is monotonically increasing** (except Reset on failed instantiation and
+   RecordError). Code that checks `status >= kLinked` is checking "at least linked."
+
+2. **SyntheticModules skip SCC detection.** They transition directly from kPreLinking
+   to kLinked in `FinishInstantiate` without DFS indices. In
+   `SourceTextModule::FinishInstantiate`, encountering a kLinking module is asserted
+   to be a SourceTextModule (line 639-644).
+
+3. **Cells are shared, not copied.** The same Cell appears in `regular_exports`,
+   `regular_imports` of dependent modules, and the `exports` hash table. All three
+   are references to the same heap object.
+
+4. **Error on errored re-evaluate.** If `Module::Evaluate` is called on a kErrored
+   module, it returns a rejected promise immediately (`module.cc:276-290`) without
+   re-running any code.
+
+5. **top_level_capability is only set on SCC cycle roots.** For evaluating modules
+   that are part of a cycle, only the root module (lowest DFS index in the SCC) has
+   a top_level_capability. `Module::Evaluate` checks for an existing capability
+   before dispatching to subclass Evaluate, and returns it if present (re-evaluation
+   returns the same promise).
+
+6. **import.meta is lazily initialized.** First access triggers
+   `RunHostInitializeImportMetaObjectCallback`. The result is cached with
+   acquire/release store semantics (`kAcquireLoad` / `kReleaseStore`) because
+   import.meta may be accessed from background compilation threads.
+
+7. **RecordError reverts SourceTextModule code to SFI.** This ensures GC can collect
+   the JSFunction and generator, and prevents dangling references to a partially
+   initialized module context.
+
+8. **Termination exceptions are stored as null.** The exception field contains the
+   JS-visible exception if catchable, or `null` for termination. Callers use
+   `isolate->is_catchable_by_javascript()` to distinguish.
+
+## Common Patterns for Embedders
+
+### Creating an ESM
+
+```cpp
+v8::ScriptOrigin origin(resource_name, /*line=*/0, /*col=*/0,
+                         /*is_shared_cross_origin=*/false,
+                         /*script_id=*/-1, /*source_map=*/{},
+                         /*is_opaque=*/false, /*is_wasm=*/false,
+                         /*is_module=*/true);  // ← must be true
+v8::ScriptCompiler::Source source(code_string, origin);
+v8::Local<v8::Module> module =
+    v8::ScriptCompiler::CompileModule(isolate, &source).ToLocalChecked();
+```
+
+### Creating a SyntheticModule
+
+```cpp
+v8::Local<v8::String> export_names[] = { v8_str("default"), v8_str("foo") };
+v8::Local<v8::Module> module = v8::Module::CreateSyntheticModule(
+    isolate, v8_str("synth:my-module"),
+    v8::MemorySpan<const v8::Local<v8::String>>(export_names, 2),
+    [](v8::Local<v8::Context> context, v8::Local<v8::Module> module)
+        -> v8::MaybeLocal<v8::Value> {
+      v8::Isolate* isolate = context->GetIsolate();
+      module->SetSyntheticModuleExport(isolate, v8_str("default"), v8_int(42));
+      module->SetSyntheticModuleExport(isolate, v8_str("foo"), v8_str("bar"));
+      return v8::Boolean::New(isolate, true);
+    });
+```
+
+### Instantiation + Evaluation
+
+```cpp
+module->InstantiateModule(context, ResolveCallback).Check();
+v8::Local<v8::Value> result = module->Evaluate(context).ToLocalChecked();
+// result is a Promise (always, even for sync modules)
+```
+
+### Checking completion
+
+For synchronous modules, the returned Promise is already settled:
+
+```cpp
+v8::Local<v8::Promise> promise = result.As<v8::Promise>();
+CHECK_EQ(promise->State(), v8::Promise::kFulfilled);
+```
+
+For async modules (TLA), the Promise may be pending and will settle later
+via microtask processing.


### PR DESCRIPTION
Opencode struggles to understand the module registry and how it works, especially on the V8 side. This adds some reference material to help the agent better understand the context