### PR TITLE
Don't throw when dedicated snapshot is missing in dynamic workers.

### DIFF
--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -13,6 +13,7 @@ export const SHOULD_SNAPSHOT_TO_DISK = MetadataReader.shouldSnapshotToDisk();
 export const IS_CREATING_BASELINE_SNAPSHOT =
   MetadataReader.isCreatingBaselineSnapshot();
 export const IS_EW_VALIDATING = ArtifactBundler.isEwValidating();
+export const IS_DYNAMIC_WORKER = ArtifactBundler.isDynamicWorker();
 export const IS_CREATING_SNAPSHOT = IS_EW_VALIDATING || SHOULD_SNAPSHOT_TO_DISK;
 
 // There are two validations that we perform. The first one runs without a _bundled_ memory snapshot

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -15,6 +15,7 @@ import {
   REQUIREMENTS,
   IS_CREATING_SNAPSHOT,
   IS_EW_VALIDATING,
+  IS_DYNAMIC_WORKER,
   IS_DEDICATED_SNAPSHOT_ENABLED,
   COMPATIBILITY_FLAGS,
   type CompatibilityFlags,
@@ -761,6 +762,12 @@ export function isRestoringSnapshot(): boolean {
 
 function checkSnapshotType(snapshotType: string): void {
   if (SHOULD_SNAPSHOT_TO_DISK) {
+    return;
+  }
+  // Dynamic workers don't yet support dedicated snapshots, so they will receive a baseline
+  // snapshot from GCS even when the dedicated snapshot compat flag is enabled. Skip the
+  // snapshot type validation in this case.
+  if (IS_DYNAMIC_WORKER) {
     return;
   }
   if (

--- a/src/pyodide/types/artifacts.d.ts
+++ b/src/pyodide/types/artifacts.d.ts
@@ -12,6 +12,7 @@ declare namespace ArtifactBundler {
 
   const hasMemorySnapshot: () => boolean;
   const isEwValidating: () => boolean;
+  const isDynamicWorker: () => boolean;
   const readMemorySnapshot: (
     offset: number,
     buf: Uint32Array | Uint8Array

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -319,19 +319,25 @@ struct ArtifactBundler_State {
   // to store a memory snapshot.
   bool isValidating;
 
+  // Set when the worker is a dynamically-loaded worker. Dynamic workers don't support dedicated
+  // snapshots yet, so the Python runtime uses this to skip snapshot type validation.
+  bool isDynamicWorkerFlag;
+
   ArtifactBundler_State(kj::Maybe<const PyodidePackageManager&> packageManager,
       kj::Maybe<kj::Array<const kj::byte>> existingSnapshot,
-      bool isValidating = false)
+      bool isValidating = false,
+      bool isDynamicWorker = false)
       : packageManager(packageManager),
         storedSnapshot(kj::none),
         existingSnapshot(kj::mv(existingSnapshot)),
-        isValidating(isValidating) {};
+        isValidating(isValidating),
+        isDynamicWorkerFlag(isDynamicWorker) {};
 
   kj::Own<ArtifactBundler_State> clone() {
     return kj::heap<ArtifactBundler_State>(packageManager,
         existingSnapshot.map(
             [](kj::Array<const kj::byte>& data) { return kj::heapArray<const kj::byte>(data); }),
-        isValidating);
+        isValidating, isDynamicWorkerFlag);
   }
 };
 
@@ -369,6 +375,11 @@ class ArtifactBundler: public jsg::Object {
     return inner->isValidating;
   }
 
+  // Determines whether this ArtifactBundler belongs to a dynamically-loaded worker.
+  bool isDynamicWorker() {
+    return inner->isDynamicWorkerFlag;
+  }
+
   static kj::Own<State> makeDisabledBundler() {
     return kj::heap<State>(kj::none, kj::none);
   }
@@ -404,6 +415,7 @@ class ArtifactBundler: public jsg::Object {
     JSG_METHOD(readMemorySnapshot);
     JSG_METHOD(disposeMemorySnapshot);
     JSG_METHOD(isEwValidating);
+    JSG_METHOD(isDynamicWorker);
     JSG_METHOD(storeMemorySnapshot);
     JSG_METHOD(isEnabled);
     JSG_METHOD(getPackage);


### PR DESCRIPTION
This fixes an issue with dynamic workers created in a Python Worker failing with "Received non-dedicated snapshot but compat flag for dedicated snapshots is enabled"