### PR TITLE
Suggest @cloudflare/worker-loader when trying to load .ts, .tsx, or .jsx modules in worker-loader.c++

### DIFF
--- a/src/workerd/api/tests/worker-loader-test.js
+++ b/src/workerd/api/tests/worker-loader-test.js
@@ -825,6 +825,38 @@ export let noMixedJsPythonModules2 = {
   },
 };
 
+export let suggestWorkerBundlerForTypeScriptModules = {
+  async test(ctrl, env, ctx) {
+    for (let mainModule of ['main.ts', 'main.tsx', 'main.jsx']) {
+      let worker = env.loader.get(mainModule, () => {
+        return {
+          compatibilityDate: '2026-01-01',
+          mainModule,
+          modules: {
+            [mainModule]: `
+              export default {
+                fetch() {
+                  return new Response('ok');
+                }
+              }
+            `,
+          },
+        };
+      });
+
+      await assert.rejects(
+        worker.getEntrypoint().fetch('https://example.com'),
+        {
+          name: 'TypeError',
+          message:
+            `Module name must end with '.js' or '.py' (or the content must be an object indicating the type explicitly). Got: ${mainModule}. ` +
+            "If you're trying to load TypeScript, bundle it first with '@cloudflare/worker-bundler' and pass the generated JavaScript modules.",
+        }
+      );
+    }
+  },
+};
+
 // Test that startup exceptions show proper error messages, not internal errors.
 export let startupException = {
   async test(ctrl, env, ctx) {

--- a/src/workerd/api/worker-loader.c++
+++ b/src/workerd/api/worker-loader.c++
@@ -186,6 +186,15 @@ Worker::Script::Source WorkerLoader::extractSource(jsg::Lock& js, WorkerCode& co
           };
         }
 
+        if (entry.name.endsWith(".ts"_kj) || entry.name.endsWith(".tsx"_kj) ||
+            entry.name.endsWith(".jsx"_kj)) {
+          JSG_FAIL_REQUIRE(TypeError,
+              "Module name must end with '.js' or '.py' (or the content must be an object ",
+              "indicating the type explicitly). Got: ", entry.name,
+              ". If you're trying to load TypeScript, bundle it first with ",
+              "'@cloudflare/worker-bundler' and pass the generated JavaScript modules.");
+        }
+
         JSG_FAIL_REQUIRE(TypeError,
             "Module name must end with '.js' or '.py' (or the content must be an object ",
             "indicating the type explicitly). Got: ", entry.name);


### PR DESCRIPTION
This will help point users to https://www.npmjs.com/package/@cloudflare/worker-bundler when they try to bundle typescript.