### PR TITLE
Add JSG_TS_DEFINE_LITERAL

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -861,7 +861,10 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
     }
 
     JSG_TS_ROOT();
-    JSG_TS_DEFINE(
+    // JSG_TS_DEFINE_LITERAL is used here instead of JSG_TS_DEFINE because the TypeScript definition
+    // contains the `module` keyword, which Clang rejects as a C++20 module directive when it
+    // appears inside macro arguments.
+    JSG_TS_DEFINE_LITERAL(R"(
       interface Console {
         "assert"(condition?: boolean, ...data: any[]): void;
         clear(): void;
@@ -973,7 +976,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
         function instantiate(module: Module, imports?: Imports): Promise<Instance>;
         function validate(bytes: BufferSource): boolean;
       }
-    );
+    )");
     // workerd disables dynamic WebAssembly compilation, so `compile()`, `compileStreaming()`, the
     // `instantiate()` override taking a `BufferSource` and `instantiateStreaming()` are omitted.
     // `Module` is also declared `abstract` to disable its `BufferSource` constructor.

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -609,6 +609,15 @@ using HasGetTemplateOverload = decltype(kj::instance<T&>().getTemplate(
     registry.template registerTypeScriptDefine<DEFINE>();                                          \
   } while (false)
 
+// Like JSG_TS_DEFINE, but accepts a string literal (e.g. a raw string R"(...)") instead of bare tokens.
+// This avoids the preprocessor parsing the TypeScript content as C++ tokens, which is necessary when the
+// TypeScript definition contains C++20 keywords like `module` that Clang rejects inside macro arguments.
+#define JSG_TS_DEFINE_LITERAL(jsg_string_literal)                                                  \
+  do {                                                                                             \
+    static const char DEFINE[] = jsg_string_literal;                                               \
+    registry.template registerTypeScriptDefine<DEFINE>();                                          \
+  } while (false)
+
 // Like JSG_TS_ROOT but for use with JSG_STRUCT. Should be placed adjacent to the JSG_STRUCT declaration,
 // inside the same `struct` definition. See the `## TypeScript` section of the JSG README.md for more
 // details.


### PR DESCRIPTION
In some corner cases, this is needed to avoid the preprocessor from parsing the TypeScript content as C++ tokens, which may confuse Clang.