### PR TITLE
Lower optimization levels for server.c++ and container-client.c++ on Windows release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -429,9 +429,11 @@ build:release_windows --copt="/clang:-O3"
 # clang-cl does not enable strict aliasing by default to match MSVC's approach, unlike clang on
 # Unix which turns it on for opt builds.
 build:release_windows --copt="-fstrict-aliasing"
-# This file breaks our CI windows release builds when compiled using O2/O3
+# These files break our CI windows release builds when compiled using O2/O3.
 # Ref: https://github.com/llvm/llvm-project/issues/136481
 build:release_windows --per_file_copt=.*capnp/rpc\.c++@/clang:-O1
+build:release_windows --per_file_copt=.*src/workerd/server/container-client\.c\+\+@/clang:-O1
+build:release_windows --per_file_copt=.*src/workerd/server/server\.c\+\+@/clang:-O1
 
 build:windows --cxxopt='/std:c++23preview' --host_cxxopt='/std:c++23preview'
 build:windows --copt='/D_CRT_USE_BUILTIN_OFFSETOF' --host_copt='/D_CRT_USE_BUILTIN_OFFSETOF'


### PR DESCRIPTION
These two files have been the source of compiler bugs when built at high optimization levels (see
https://github.com/cloudflare/workerd/actions/workflows/release.yml). Temporarily lower the optimization level until we identify the root cause of why the compiler is failing on these files at higher optimization to unblock releases.