### PR TITLE
Enable nodejs_compat by default 

### DIFF
--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -240,7 +240,8 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
 
   nodeJsCompat @21 :Bool
       $compatEnableFlag("nodejs_compat")
-      $compatDisableFlag("no_nodejs_compat");
+      $compatDisableFlag("no_nodejs_compat")
+      $compatEnableDate("2026-04-14");
   # Enables nodejs compat imports in the application.
 
   obsolete22 @22 :Bool


### PR DESCRIPTION
Adds a `$compatEnableDate("2026-04-14")` to the `nodeJsCompat` flag so that workers with compatibility date >= 2026-04-14 get `nodejs_compat` enabled by default.