### PR TITLE
Make SqlStorage::isAllowedName case-insensitive and enforce it on virtual tables (FTS5)

### DIFF
--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -7,6 +7,9 @@
 #include "actor-state.h"
 
 #include <workerd/io/io-context.h>
+#include <workerd/util/autogate.h>
+
+#include <strings.h>
 
 namespace workerd::api {
 
@@ -135,6 +138,9 @@ double SqlStorage::getDatabaseSize(jsg::Lock& js) {
 }
 
 bool SqlStorage::isAllowedName(kj::StringPtr name) const {
+  if (util::Autogate::isEnabled(util::AutogateKey::SQL_RESTRICT_RESERVED_NAMES)) {
+    return strncasecmp(name.begin(), "_cf_", 4) != 0;
+  }
   return !name.startsWith("_cf_");
 }
 

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -199,6 +199,15 @@ wd_test(
     ],
 )
 
+# Tests for SQL_RESTRICT_RESERVED_NAMES autogate - only runs in @all-autogates variant
+wd_test(
+    src = "sql-restrict-names-test.wd-test",
+    args = ["--experimental"],
+    data = ["sql-restrict-names-test.js"],
+    generate_all_compat_flags_variant = False,
+    generate_default_variant = False,
+)
+
 wd_test(
     src = "sync-kv-test.wd-test",
     args = ["--experimental"],

--- a/src/workerd/api/tests/sql-restrict-names-test.js
+++ b/src/workerd/api/tests/sql-restrict-names-test.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Tests for the SQL_RESTRICT_RESERVED_NAMES autogate.
+// This test only runs in the @all-autogates variant so it can assert the gated behavior.
+
+import * as assert from 'node:assert';
+import { DurableObject } from 'cloudflare:workers';
+
+export class DurableObjectExample extends DurableObject {
+  async fetch(req) {
+    const sql = this.ctx.storage.sql;
+
+    // Case-insensitive _cf_ prefix blocking: mixed-case variants are rejected.
+    for (const name of ['_CF_test', '_Cf_test', '_cF_test']) {
+      assert.throws(
+        () => sql.exec(`CREATE TABLE ${name} (name TEXT)`),
+        /not authorized/,
+        `Expected CREATE TABLE ${name} to be blocked`
+      );
+    }
+
+    // Virtual tables with _cf_ prefix are blocked.
+    assert.throws(
+      () => sql.exec('CREATE VIRTUAL TABLE _cf_fts_test USING fts5(content)'),
+      /not authorized/
+    );
+    assert.throws(
+      () => sql.exec('CREATE VIRTUAL TABLE _CF_fts_test USING fts5(content)'),
+      /not authorized/
+    );
+
+    // Non-_cf_ prefixed virtual tables still work.
+    sql.exec('CREATE VIRTUAL TABLE my_fts USING fts5(content)');
+    sql.exec('DROP TABLE my_fts');
+
+    return Response.json({ ok: true });
+  }
+}
+
+export default {
+  async test(ctrl, env, ctx) {
+    let id = env.ns.idFromName('sql-restrict-names');
+    let stub = env.ns.get(id);
+    let response = await stub.fetch('http://x/test');
+    let result = await response.json();
+    assert.ok(result.ok);
+  },
+};

--- a/src/workerd/api/tests/sql-restrict-names-test.wd-test
+++ b/src/workerd/api/tests/sql-restrict-names-test.wd-test
@@ -1,0 +1,28 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "TEST_TMPDIR", disk = (writable = true)),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  compatibilityFlags = ["nodejs_compat"],
+
+  modules = [
+    (name = "worker", esModule = embed "sql-restrict-names-test.js"),
+  ],
+
+  durableObjectNamespaces = [
+    ( className = "DurableObjectExample",
+      uniqueKey = "sql-restrict-names-test",
+      enableSql = true ),
+  ],
+
+  durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+
+  bindings = [
+    (name = "ns", durableObjectNamespace = "DurableObjectExample"),
+  ],
+);

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -204,6 +204,7 @@ wd_cc_library(
         "sqlite-metadata.h",
     ],
     implementation_deps = [
+        ":autogate",
         "//src/workerd/jsg:exception",
         "@sqlite3",
     ],

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -35,6 +35,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "enable-fast-textencoder"_kj;
     case AutogateKey::ENABLE_DRAINING_READ_ON_STANDARD_STREAMS:
       return "enable-draining-read-on-standard-streams"_kj;
+    case AutogateKey::SQL_RESTRICT_RESERVED_NAMES:
+      return "sql-restrict-reserved-names"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -39,6 +39,8 @@ enum class AutogateKey {
   ENABLE_FAST_TEXTENCODER,
   // Enable draining read on standard streams
   ENABLE_DRAINING_READ_ON_STANDARD_STREAMS,
+  // Make SqlStorage::isAllowedName case-insensitive and enforce it on virtual tables (FTS5).
+  SQL_RESTRICT_RESERVED_NAMES,
   NumOfKeys  // Reserved for iteration.
 };
 

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -4,6 +4,7 @@
 
 #include "sqlite.h"
 
+#include <workerd/util/autogate.h>
 #include <workerd/util/sentry.h>
 
 #include <kj/debug.h>
@@ -1269,6 +1270,9 @@ bool SqliteDatabase::isAuthorized(int actionCode,
         KJ_IF_SOME(moduleName, param2) {
           if (strcasecmp(moduleName.begin(), "fts5") == 0 ||
               strcasecmp(moduleName.begin(), "fts5vocab") == 0) {
+            if (util::Autogate::isEnabled(util::AutogateKey::SQL_RESTRICT_RESERVED_NAMES)) {
+              return regulator.isAllowedName(KJ_ASSERT_NONNULL(param1));
+            }
             return true;
           }
         }


### PR DESCRIPTION
- Ensure tables cannot be created with a `_cf_` prefix by making the check case-insensitive. 
- Enforce isAllowedName on FTS5 virtual table creation/deletion, which previously bypassed the check
- Both changes gated behind SQL_RESTRICT_RESERVED_NAMES