### PR TITLE
[build] Fix Windows build, run Windows test CI job in release configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -429,9 +429,14 @@ build:release_windows --copt="/clang:-O3"
 # clang-cl does not enable strict aliasing by default to match MSVC's approach, unlike clang on
 # Unix which turns it on for opt builds.
 build:release_windows --copt="-fstrict-aliasing"
-# This file breaks our CI windows release builds when compiled using O2/O3
-# Ref: https://github.com/llvm/llvm-project/issues/136481
-build:release_windows --per_file_copt=.*capnp/rpc\.c++@/clang:-O1
+# TODO(soon): Investigate these issues on an actual Windows system.
+# Compiling these files causes clang-cl 20 to crash on Windows release builds, work around this by
+# disabling inlining (using /Od would work too but we still want to have whatever optimizations we
+# can have)
+build:release_windows --per_file_copt="src/workerd/server/server"@/clang:-fno-inline
+build:release_windows --per_file_copt="src/workerd/server/container-client"@/clang:-fno-inline
+# Work around Windows test failures in rpc-related tests
+build:release_windows --per_file_copt=src/workerd/io/worker-interface@/clang:-fno-inline
 
 build:windows --cxxopt='/std:c++23preview' --host_cxxopt='/std:c++23preview'
 build:windows --copt='/D_CRT_USE_BUILTIN_OFFSETOF' --host_copt='/D_CRT_USE_BUILTIN_OFFSETOF'

--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -84,7 +84,9 @@ build:ci-macOS-debug --config=debug
 # Unfortunately on macOS, we need to be able to invoke sudo to configure the network for sidecar tests
 test:ci-macOS --spawn_strategy=local
 
-build:ci-windows --config=windows_no_dbg
+# Windows CI always runs in the release configuration to prevent breaking the release build.
+# build:ci-windows --config=windows_no_dbg
+build:ci-windows --config=release_windows
 build:ci-windows-debug --config=debug
 
 # Some tests (like Python import tests) take a long time to run, especially when debug is enabled


### PR DESCRIPTION
This should avoid Windows release CI failures from now on.
Since I don't have a Windows system available and only found this workaround through many rounds of manually bisecting changes, I don't have a good understanding of which commit introduced these issues or what's causing the test failures that happen when worker-interface gets optimized.
It turns out the capnp/rpc.c++ workaround is no longer needed with clang-cl 20, so we can drop it.