### PR TITLE
Additional new module registry tweaks

### DIFF
--- a/src/workerd/api/tests/new-module-registry-test.js
+++ b/src/workerd/api/tests/new-module-registry-test.js
@@ -333,6 +333,41 @@ export const complexModuleTest = {
   },
 };
 
+// Regression test: getBuiltinModule called from a function defined in eval'd
+// code should work. Previously failed on first invocation with "top-level await"
+// error due to extra microtask tick from wrapSimplePromise().
+export const getBuiltinModuleFromEval = {
+  async test(_, env) {
+    const code = `"use strict";async (exports)=>{
+      exports.getPath = () => process.getBuiltinModule("node:path");
+    }`;
+    const exports = {};
+    const fn = env.unsafe.eval(code);
+    await fn(exports);
+
+    const path = exports.getPath();
+    ok(path.join, 'node:path should have join');
+  },
+};
+
+// Regression test: createRequire called from a function defined in eval'd
+// code should work. Same root cause as getBuiltinModuleFromEval.
+export const createRequireFromEval = {
+  async test(_, env) {
+    const code = `"use strict";async (exports)=>{
+      const { createRequire } = process.getBuiltinModule("node:module");
+      const require = createRequire("/");
+      exports.getUtil = () => require("node:util");
+    }`;
+    const exports = {};
+    const fn = env.unsafe.eval(code);
+    await fn(exports);
+
+    const util = exports.getUtil();
+    ok(util.promisify, 'node:util should have promisify');
+  },
+};
+
 // TODO(now): Tests
 // * [x] Include tests for all known module types
 //   * [x] ESM

--- a/src/workerd/api/tests/new-module-registry-test.wd-test
+++ b/src/workerd/api/tests/new-module-registry-test.wd-test
@@ -77,6 +77,9 @@ const unitTests :Workerd.Config = (
           "new_module_registry",
           "experimental",
         ],
+        bindings = [
+          (name = "unsafe", unsafeEval = void),
+        ],
       ),
     ),
   ],

--- a/src/workerd/io/worker-modules.h
+++ b/src/workerd/io/worker-modules.h
@@ -95,15 +95,20 @@ static kj::Arc<jsg::modules::ModuleRegistry> newWorkerModuleRegistry(
 
   // This callback is used when a module is being loaded to arrange evaluating the
   // module outside of the current IoContext.
-  builder.setEvalCallback([](jsg::Lock& js, const auto& module, auto v8Module,
-                              const auto& observer) -> jsg::Promise<jsg::Value> {
-    return js.tryOrReject<jsg::Value>([&] {
-      // Creating the SuppressIoContextScope here ensures that the current IoContext,
-      // if any, is moved out of the way while we are evaluating.
-      SuppressIoContextScope suppressIoContextScope;
-      KJ_DASSERT(!IoContext::hasCurrent(), "Module evaluation must not be in an IoContext");
-      return jsg::check(v8Module->Evaluate(js.v8Context()));
-    });
+  builder.setEvalCallback(
+      [](jsg::Lock& js, const auto& module, auto v8Module, const auto& observer) -> jsg::JsPromise {
+    // Creating the SuppressIoContextScope here ensures that the current IoContext,
+    // if any, is moved out of the way while we are evaluating.
+    SuppressIoContextScope suppressIoContextScope;
+    KJ_DASSERT(!IoContext::hasCurrent(), "Module evaluation must not be in an IoContext");
+    JSG_TRY(js) {
+      auto ret = jsg::check(v8Module->Evaluate(js.v8Context()));
+      KJ_ASSERT(ret->IsPromise());
+      return jsg::JsPromise(ret.template As<v8::Promise>());
+    }
+    JSG_CATCH(exception) {
+      return js.rejectedJsPromise(jsg::JsValue(exception.getHandle(js)));
+    }
   });
 
   // Add the module bundles that are built into the runtime.

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -372,8 +372,9 @@ kj::Maybe<JsObject> Lock::resolveInternalModule(kj::StringPtr specifier) {
 kj::Maybe<JsObject> Lock::resolvePublicBuiltinModule(kj::StringPtr specifier) {
   auto& isolate = IsolateBase::from(v8Isolate);
   KJ_ASSERT(isolate.isUsingNewModuleRegistry());
-  return jsg::modules::ModuleRegistry::tryResolveModuleNamespace(
-      *this, specifier, jsg::modules::ResolveContext::Type::PUBLIC_BUILTIN)
+  return jsg::modules::ModuleRegistry::tryResolveModuleNamespace(*this, specifier,
+      jsg::modules::ResolveContext::Type::PUBLIC_BUILTIN,
+      jsg::modules::ResolveContext::Source::REQUIRE)
       .map([](JsValue val) { return KJ_ASSERT_NONNULL(val.tryCast<JsObject>()); });
 }
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2563,6 +2563,7 @@ class Lock {
   // Like above, but return a pure-JS promise, not a typed Promise.
   JsPromise rejectedJsPromise(jsg::JsValue exception);
   JsPromise rejectedJsPromise(kj::Exception&& exception, ExceptionToJsOptions options = {});
+  JsPromise resolvedJsPromise(jsg::JsValue value);
 
   // Like `kj::evalNow()`, but returns a jsg::Promise for the result. Synchronous exceptions are
   // caught and returned as a rejected promise.

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -514,6 +514,14 @@ JsPromise Lock::rejectedJsPromise(kj::Exception&& exception, ExceptionToJsOption
   return rejectedJsPromise(exceptionToJsValue(kj::mv(exception), options).getHandle(*this));
 }
 
+JsPromise Lock::resolvedJsPromise(jsg::JsValue value) {
+  v8::EscapableHandleScope handleScope(v8Isolate);
+  auto context = v8Context();
+  auto resolver = check(v8::Promise::Resolver::New(context));
+  check(resolver->Resolve(context, value));
+  return JsPromise(handleScope.Escape(resolver->GetPromise()));
+}
+
 PromiseState JsPromise::state() {
   switch (inner->State()) {
     case v8::Promise::PromiseState::kPending:

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -2059,7 +2059,7 @@ KJ_TEST("Using a deferred eval callback works") {
                       .setEvalCallback([&called](Lock& js, const Module& module, auto v8Module,
                                            const auto& observer) {
     called = true;
-    return js.resolvedPromise<Value>(js.v8Ref<v8::Value>(js.num(123)));
+    return js.resolvedJsPromise(js.num(123));
   }).finish();
 
   PREAMBLE([&](Lock& js) {

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -227,7 +227,8 @@ class EsModule final: public Module {
     }
 
     KJ_IF_SOME(result, maybeEvaluate(js, *this, module, observer)) {
-      return js.wrapSimplePromise(kj::mv(result));
+      v8::Local<v8::Value> val = result;
+      return val;
     }
 
     return actuallyEvaluate(js, module, observer);
@@ -311,7 +312,8 @@ class SyntheticModule final: public Module {
     // is specified, then we defer evaluation to the given callback.
     if (isEval()) {
       KJ_IF_SOME(result, maybeEvaluate(js, *this, module, observer)) {
-        return js.wrapSimplePromise(kj::mv(result));
+        v8::Local<v8::Value> val = result;
+        return val;
       }
     }
     return module->Evaluate(js.v8Context());
@@ -695,7 +697,7 @@ class IsolateModuleRegistry final {
           }
         }
       } else {
-        KJ_ASSERT(promise->State() != v8::Promise::kPending,
+        KJ_ASSERT(!module->IsGraphAsync() && promise->State() != v8::Promise::kPending,
             "Top-level await is not supported in this context, so the module promise "
             "should never be pending");
         if (promise->State() == v8::Promise::kRejected) {
@@ -1669,7 +1671,7 @@ ModuleRegistry::ModuleRegistry(ModuleRegistry::Builder* builder)
       maybeEvalCallback(kj::mv(builder->maybeEvalCallback)),
       schemaLoader(kj::mv(builder->schemaLoader)) {}
 
-kj::Maybe<jsg::Promise<Value>> ModuleRegistry::evaluateImpl(jsg::Lock& js,
+kj::Maybe<jsg::JsPromise> ModuleRegistry::evaluateImpl(jsg::Lock& js,
     const Module& module,
     v8::Local<v8::Module> v8Module,
     const CompilationObserver& observer) const {
@@ -1862,7 +1864,7 @@ Module::Module(Url id, Type type, Flags flags, ContentType contentType)
       flags_(flags),
       contentType_(contentType) {}
 
-kj::Maybe<jsg::Promise<Value>> Module::Evaluator::operator()(jsg::Lock& js,
+kj::Maybe<jsg::JsPromise> Module::Evaluator::operator()(jsg::Lock& js,
     const Module& module,
     v8::Local<v8::Module> v8Module,
     const CompilationObserver& observer) const {

--- a/src/workerd/jsg/modules-new.h
+++ b/src/workerd/jsg/modules-new.h
@@ -274,7 +274,7 @@ class Module {
   class Evaluator final {
    public:
     KJ_DISALLOW_COPY_AND_MOVE(Evaluator);
-    kj::Maybe<jsg::Promise<Value>> operator()(jsg::Lock& js,
+    kj::Maybe<jsg::JsPromise> operator()(jsg::Lock& js,
         const Module& module,
         v8::Local<v8::Module> v8Module,
         const CompilationObserver& observer) const;
@@ -666,7 +666,7 @@ class ModuleRegistry final: public kj::AtomicRefcounted, public ModuleRegistryBa
   // Flag::EVAL on a module is ignored. If the EvalCallback is set, then any
   // Modules that have the Flag::EVAL set will have their evaluation deferred
   // to this callback.
-  using EvalCallback = Function<jsg::Promise<Value>(
+  using EvalCallback = Function<jsg::JsPromise(
       const Module& module, v8::Local<v8::Module> v8Module, const CompilationObserver& observer)>;
 
   class Builder final {
@@ -791,7 +791,7 @@ class ModuleRegistry final: public kj::AtomicRefcounted, public ModuleRegistryBa
       ModuleBundle& bundle,
       const Url& bundleBase) KJ_WARN_UNUSED_RESULT;
 
-  kj::Maybe<jsg::Promise<Value>> evaluateImpl(jsg::Lock& js,
+  kj::Maybe<jsg::JsPromise> evaluateImpl(jsg::Lock& js,
       const Module& module,
       v8::Local<v8::Module> v8Module,
       const CompilationObserver& observer) const;


### PR DESCRIPTION
~~This is still not quite 100% right... there's edge cases in here still that need to be worked out.. but this is another incremental step.~~

Ok, worked out the bit that wasn't working. For the eval callback, it was wrapping the returned promise in an additional `jsg::Promise` which needed an additional microtask pump to fully resolve. However, in an ESM with no top-level-await, the evaluation promise comes back fulfilled, which we need to know immediately rather than deferring for an additional microtask hop.

/cc @jamesopstad 