### PR TITLE
Remove experimental gate from snapshots API

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -96,34 +96,27 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
     }
   }
 
-  if (!flags.getWorkerdExperimental()) {
-    JSG_REQUIRE(options.directorySnapshots == kj::none, Error,
-        "Container snapshot restore requires the 'experimental' compatibility flag.");
-    JSG_REQUIRE(options.containerSnapshot == kj::none, Error,
-        "Container full snapshot restore requires the 'experimental' compatibility flag.");
-  } else {
-    KJ_IF_SOME(directorySnapshots, options.directorySnapshots) {
-      auto list = req.initDirectorySnapshots(directorySnapshots.size());
-      for (auto i: kj::indices(directorySnapshots)) {
-        auto entry = list[i];
-        auto& restore = directorySnapshots[i];
-        auto& snap = restore.snapshot;
-        auto effectiveRestorePath = snap.dir.asPtr();
-        KJ_IF_SOME(mp, restore.mountPoint) {
-          effectiveRestorePath = mp.asPtr();
-        }
-
-        JSG_REQUIRE_NONNULL(parseRestorePath(effectiveRestorePath), Error,
-            "Directory snapshot cannot be restored to root directory.");
-
-        entry.setSnapshotId(snap.id);
-        entry.setRestorePath(effectiveRestorePath);
+  KJ_IF_SOME(directorySnapshots, options.directorySnapshots) {
+    auto list = req.initDirectorySnapshots(directorySnapshots.size());
+    for (auto i: kj::indices(directorySnapshots)) {
+      auto entry = list[i];
+      auto& restore = directorySnapshots[i];
+      auto& snap = restore.snapshot;
+      auto effectiveRestorePath = snap.dir.asPtr();
+      KJ_IF_SOME(mp, restore.mountPoint) {
+        effectiveRestorePath = mp.asPtr();
       }
-    }
 
-    KJ_IF_SOME(containerSnapshot, options.containerSnapshot) {
-      req.setContainerSnapshotId(containerSnapshot.id);
+      JSG_REQUIRE_NONNULL(parseRestorePath(effectiveRestorePath), Error,
+          "Directory snapshot cannot be restored to root directory.");
+
+      entry.setSnapshotId(snap.id);
+      entry.setRestorePath(effectiveRestorePath);
     }
+  }
+
+  KJ_IF_SOME(containerSnapshot, options.containerSnapshot) {
+    req.setContainerSnapshotId(containerSnapshot.id);
   }
 
   req.setCompatibilityFlags(flags);

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -29,11 +29,6 @@ class Container: public jsg::Object {
     jsg::Optional<kj::String> name;
 
     JSG_STRUCT(id, size, dir, name);
-    JSG_STRUCT_TS_OVERRIDE_DYNAMIC(CompatibilityFlags::Reader flags) {
-      if (!flags.getWorkerdExperimental()) {
-        JSG_TS_OVERRIDE(type DirectorySnapshot = never);
-      }
-    }
   };
 
   struct DirectorySnapshotOptions {
@@ -41,11 +36,6 @@ class Container: public jsg::Object {
     jsg::Optional<kj::String> name;
 
     JSG_STRUCT(dir, name);
-    JSG_STRUCT_TS_OVERRIDE_DYNAMIC(CompatibilityFlags::Reader flags) {
-      if (!flags.getWorkerdExperimental()) {
-        JSG_TS_OVERRIDE(type DirectorySnapshotOptions = never);
-      }
-    }
   };
 
   struct DirectorySnapshotRestoreParams {
@@ -53,11 +43,6 @@ class Container: public jsg::Object {
     jsg::Optional<kj::String> mountPoint;
 
     JSG_STRUCT(snapshot, mountPoint);
-    JSG_STRUCT_TS_OVERRIDE_DYNAMIC(CompatibilityFlags::Reader flags) {
-      if (!flags.getWorkerdExperimental()) {
-        JSG_TS_OVERRIDE(type DirectorySnapshotRestoreParams = never);
-      }
-    }
   };
 
   struct Snapshot {
@@ -66,26 +51,12 @@ class Container: public jsg::Object {
     jsg::Optional<kj::String> name;
 
     JSG_STRUCT(id, size, name);
-    JSG_STRUCT_TS_OVERRIDE_DYNAMIC(CompatibilityFlags::Reader flags) {
-      if (!flags.getWorkerdExperimental()) {
-        JSG_TS_OVERRIDE(type Snapshot = never);
-      }
-    }
   };
 
   struct SnapshotOptions {
     jsg::Optional<kj::String> name;
 
     JSG_STRUCT(name);
-    JSG_STRUCT_TS_OVERRIDE_DYNAMIC(CompatibilityFlags::Reader flags) {
-      if (flags.getWorkerdExperimental()) {
-        JSG_TS_OVERRIDE(ContainerSnapshotOptions {
-          name?: string;
-        });
-      } else {
-        JSG_TS_OVERRIDE(type SnapshotOptions = never);
-      }
-    }
   };
 
   struct StartupOptions {
@@ -124,8 +95,8 @@ class Container: public jsg::Object {
           env?: Record<string, string>;
           hardTimeout?: never;
           labels?: Record<string, string>;
-          directorySnapshots?: never;
-          containerSnapshot?: never;
+          directorySnapshots?: ContainerDirectorySnapshotRestoreParams[];
+          containerSnapshot?: ContainerSnapshot;
         });
       }
     }
@@ -164,10 +135,10 @@ class Container: public jsg::Object {
 
     JSG_METHOD(interceptOutboundHttp);
     JSG_METHOD(interceptAllOutboundHttp);
+    JSG_METHOD(snapshotDirectory);
+    JSG_METHOD(snapshotContainer);
     if (flags.getWorkerdExperimental()) {
       JSG_METHOD(interceptOutboundHttps);
-      JSG_METHOD(snapshotDirectory);
-      JSG_METHOD(snapshotContainer);
     }
   }
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3943,13 +3943,13 @@ interface Container {
   setInactivityTimeout(durationMs: number | bigint): Promise<void>;
   interceptOutboundHttp(addr: string, binding: Fetcher): Promise<void>;
   interceptAllOutboundHttp(binding: Fetcher): Promise<void>;
-  interceptOutboundHttps(addr: string, binding: Fetcher): Promise<void>;
   snapshotDirectory(
     options: ContainerDirectorySnapshotOptions,
   ): Promise<ContainerDirectorySnapshot>;
   snapshotContainer(
     options: ContainerSnapshotOptions,
   ): Promise<ContainerSnapshot>;
+  interceptOutboundHttps(addr: string, binding: Fetcher): Promise<void>;
 }
 interface ContainerDirectorySnapshot {
   id: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3949,13 +3949,13 @@ export interface Container {
   setInactivityTimeout(durationMs: number | bigint): Promise<void>;
   interceptOutboundHttp(addr: string, binding: Fetcher): Promise<void>;
   interceptAllOutboundHttp(binding: Fetcher): Promise<void>;
-  interceptOutboundHttps(addr: string, binding: Fetcher): Promise<void>;
   snapshotDirectory(
     options: ContainerDirectorySnapshotOptions,
   ): Promise<ContainerDirectorySnapshot>;
   snapshotContainer(
     options: ContainerSnapshotOptions,
   ): Promise<ContainerSnapshot>;
+  interceptOutboundHttps(addr: string, binding: Fetcher): Promise<void>;
 }
 export interface ContainerDirectorySnapshot {
   id: string;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -3782,12 +3782,42 @@ interface Container {
   setInactivityTimeout(durationMs: number | bigint): Promise<void>;
   interceptOutboundHttp(addr: string, binding: Fetcher): Promise<void>;
   interceptAllOutboundHttp(binding: Fetcher): Promise<void>;
+  snapshotDirectory(
+    options: ContainerDirectorySnapshotOptions,
+  ): Promise<ContainerDirectorySnapshot>;
+  snapshotContainer(
+    options: ContainerSnapshotOptions,
+  ): Promise<ContainerSnapshot>;
+}
+interface ContainerDirectorySnapshot {
+  id: string;
+  size: number;
+  dir: string;
+  name?: string;
+}
+interface ContainerDirectorySnapshotOptions {
+  dir: string;
+  name?: string;
+}
+interface ContainerDirectorySnapshotRestoreParams {
+  snapshot: ContainerDirectorySnapshot;
+  mountPoint?: string;
+}
+interface ContainerSnapshot {
+  id: string;
+  size: number;
+  name?: string;
+}
+interface ContainerSnapshotOptions {
+  name?: string;
 }
 interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
   env?: Record<string, string>;
   labels?: Record<string, string>;
+  directorySnapshots?: ContainerDirectorySnapshotRestoreParams[];
+  containerSnapshot?: ContainerSnapshot;
 }
 /**
  * The **`MessagePort`** interface of the Channel Messaging API represents one of the two ports of a MessageChannel, allowing messages to be sent from one port and listening out for them arriving at the other.

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -3788,12 +3788,42 @@ export interface Container {
   setInactivityTimeout(durationMs: number | bigint): Promise<void>;
   interceptOutboundHttp(addr: string, binding: Fetcher): Promise<void>;
   interceptAllOutboundHttp(binding: Fetcher): Promise<void>;
+  snapshotDirectory(
+    options: ContainerDirectorySnapshotOptions,
+  ): Promise<ContainerDirectorySnapshot>;
+  snapshotContainer(
+    options: ContainerSnapshotOptions,
+  ): Promise<ContainerSnapshot>;
+}
+export interface ContainerDirectorySnapshot {
+  id: string;
+  size: number;
+  dir: string;
+  name?: string;
+}
+export interface ContainerDirectorySnapshotOptions {
+  dir: string;
+  name?: string;
+}
+export interface ContainerDirectorySnapshotRestoreParams {
+  snapshot: ContainerDirectorySnapshot;
+  mountPoint?: string;
+}
+export interface ContainerSnapshot {
+  id: string;
+  size: number;
+  name?: string;
+}
+export interface ContainerSnapshotOptions {
+  name?: string;
 }
 export interface ContainerStartupOptions {
   entrypoint?: string[];
   enableInternet: boolean;
   env?: Record<string, string>;
   labels?: Record<string, string>;
+  directorySnapshots?: ContainerDirectorySnapshotRestoreParams[];
+  containerSnapshot?: ContainerSnapshot;
 }
 /**
  * The **`MessagePort`** interface of the Channel Messaging API represents one of the two ports of a MessageChannel, allowing messages to be sent from one port and listening out for them arriving at the other.


### PR DESCRIPTION
Remove the experimental gate from the snapshots API so that it's ready to use by external users before Agents week.

cc @mikenomitch 