### PR TITLE
Cache purge stub

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -19,6 +19,7 @@
 #include <workerd/api/system-streams.h>
 #include <workerd/api/trace.h>
 #include <workerd/api/util.h>
+#include <workerd/api/worker-rpc.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/io/features.h>
 #include <workerd/io/io-context.h>
@@ -63,6 +64,23 @@ void ExecutionContext::waitUntil(kj::Promise<void> promise) {
 
 void ExecutionContext::passThroughOnException() {
   IoContext::current().setFailOpen();
+}
+
+jsg::Optional<jsg::Ref<CacheContext>> ExecutionContext::getCache(jsg::Lock& js) {
+  // Hook for the embedding application to provide a CacheContext.
+  // The default Worker::Api implementation returns kj::none.
+  if (IoContext::hasCurrent()) {
+    return Worker::Isolate::from(js).getApi().getCtxCacheProperty(js);
+  }
+  return kj::none;
+}
+
+jsg::Promise<CachePurgeResult> CacheContext::purge(jsg::Lock& js,
+    CachePurgeOptions options,
+    const jsg::TypeHandler<CachePurgeOptions>& optionsHandler,
+    const jsg::TypeHandler<CachePurgeResult>& resultHandler,
+    const jsg::TypeHandler<jsg::Ref<JsRpcProperty>>& rpcPropHandler) {
+  JSG_FAIL_REQUIRE(Error, "Cache purge is not available in this context.");
 }
 
 void ExecutionContext::abort(jsg::Lock& js, jsg::Optional<jsg::Value> reason) {

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -30,6 +30,7 @@ namespace workerd::api {
 class TailEvent;
 class Cache;
 class CacheStorage;
+class JsRpcProperty;
 class Crypto;
 class CryptoKey;
 class ErrorEvent;
@@ -191,6 +192,46 @@ class TestController: public jsg::Object {
   JSG_RESOURCE_TYPE(TestController) {}
 };
 
+// Structured types for the cache purge API (ctx.cache.purge()).
+// These match the coreless-purge-ingest WorkersCachePurgeEntrypoint types.
+struct CachePurgeError {
+  int code;
+  kj::String message;
+  JSG_STRUCT(code, message);
+};
+
+struct CachePurgeResult {
+  bool success;
+  kj::String zoneTag;
+  kj::Array<CachePurgeError> errors;
+  JSG_STRUCT(success, zoneTag, errors);
+};
+
+struct CachePurgeOptions {
+  jsg::Optional<kj::Array<kj::String>> tags;
+  jsg::Optional<kj::Array<kj::String>> pathPrefixes;
+  jsg::Optional<bool> purgeEverything;
+  JSG_STRUCT(tags, pathPrefixes, purgeEverything);
+};
+
+// Base class for the ctx.cache object on cache enabled Workers.
+// Subclass when embedding to provide an implementation.
+class CacheContext: public jsg::Object {
+ public:
+  // Purge cached content.
+  //
+  // The default implementation throws without an overriding IoContext.
+  virtual jsg::Promise<CachePurgeResult> purge(jsg::Lock& js,
+      CachePurgeOptions options,
+      const jsg::TypeHandler<CachePurgeOptions>& optionsHandler,
+      const jsg::TypeHandler<CachePurgeResult>& resultHandler,
+      const jsg::TypeHandler<jsg::Ref<JsRpcProperty>>& rpcPropHandler);
+
+  JSG_RESOURCE_TYPE(CacheContext) {
+    JSG_METHOD(purge);
+  }
+};
+
 class ExecutionContext: public jsg::Object {
  public:
   ExecutionContext(jsg::Lock& js, jsg::JsValue exports)
@@ -228,6 +269,11 @@ class ExecutionContext: public jsg::Object {
     return props.getHandle(js);
   }
 
+  // Returns a CacheContext for cache-enabled workers, or empty jsg::Optional otherwise.
+  // However, by default this always returns undefined unless the embedding application overrides
+  // the IoContext.
+  jsg::Optional<jsg::Ref<CacheContext>> getCache(jsg::Lock& js);
+
   jsg::JsValue getVersion(jsg::Lock& js) {
     // TODO(soon): We should be able to assert for `version != kj::none` in the constructor when the
     //   `enable_version_api` compat flag is enabled, but currently dynamic workers and "reusable
@@ -246,6 +292,7 @@ class ExecutionContext: public jsg::Object {
       JSG_LAZY_INSTANCE_PROPERTY(exports, getExports);
     }
     JSG_LAZY_INSTANCE_PROPERTY(props, getProps);
+    JSG_LAZY_INSTANCE_PROPERTY(cache, getCache);
     if (flags.getEnableVersionApi()) {
       JSG_LAZY_INSTANCE_PROPERTY(version, getVersion);
     }
@@ -1024,6 +1071,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
   api::WorkerGlobalScope, api::ServiceWorkerGlobalScope, api::TestController,                      \
       api::ExecutionContext, api::ExportedHandler,                                                 \
       api::ServiceWorkerGlobalScope::StructuredCloneOptions, api::Navigator,                       \
-      api::AlarmInvocationInfo, api::Immediate, api::Cloudflare
+      api::AlarmInvocationInfo, api::Immediate, api::Cloudflare, api::CachePurgeError,             \
+      api::CachePurgeResult, api::CachePurgeOptions, api::CacheContext
 // The list of global-scope.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -520,6 +520,10 @@ kj::Maybe<const Worker::Api&> Worker::Api::tryCurrent() {
   return kj::none;
 }
 
+jsg::Optional<jsg::Ref<api::CacheContext>> Worker::Api::getCtxCacheProperty(jsg::Lock& js) const {
+  return kj::none;
+}
+
 struct Worker::Impl {
   kj::Maybe<jsg::JsContext<api::ServiceWorkerGlobalScope>> context;
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -46,6 +46,7 @@ struct CryptoAlgorithm;
 struct QueueExportedHandler;
 class WebSocket;
 class WebSocketRequestResponsePair;
+class CacheContext;
 class ExecutionContext;
 namespace pyodide {
 struct ArtifactBundler_State;
@@ -662,6 +663,10 @@ class Worker::Api {
   // params.
   virtual jsg::JsObject wrapExecutionContext(
       jsg::Lock& lock, jsg::Ref<api::ExecutionContext> ref) const = 0;
+
+  // Hook for the embedding application to provide a CacheContext for the ctx.cache property.
+  // The default implementation returns kj::none (undefined).
+  virtual jsg::Optional<jsg::Ref<api::CacheContext>> getCtxCacheProperty(jsg::Lock& js) const;
 
   virtual const jsg::IsolateObserver& getObserver() const = 0;
   virtual void setIsolateObserver(IsolateObserver&) = 0;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -492,6 +492,7 @@ interface ExecutionContext<Props = unknown> {
   passThroughOnException(): void;
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
+  cache?: CacheContext;
   readonly version?: {
     readonly metadata?: {
       readonly id: string;
@@ -584,6 +585,23 @@ interface AlarmInvocationInfo {
 }
 interface Cloudflare {
   readonly compatibilityFlags: Record<string, boolean>;
+}
+interface CachePurgeError {
+  code: number;
+  message: string;
+}
+interface CachePurgeResult {
+  success: boolean;
+  zoneTag: string;
+  errors: CachePurgeError[];
+}
+interface CachePurgeOptions {
+  tags?: string[];
+  pathPrefixes?: string[];
+  purgeEverything?: boolean;
+}
+interface CacheContext {
+  purge(options: CachePurgeOptions): Promise<CachePurgeResult>;
 }
 declare abstract class ColoLocalActorNamespace {
   get(actorId: string): Fetcher;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -494,6 +494,7 @@ export interface ExecutionContext<Props = unknown> {
   passThroughOnException(): void;
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
+  cache?: CacheContext;
   readonly version?: {
     readonly metadata?: {
       readonly id: string;
@@ -586,6 +587,23 @@ export interface AlarmInvocationInfo {
 }
 export interface Cloudflare {
   readonly compatibilityFlags: Record<string, boolean>;
+}
+export interface CachePurgeError {
+  code: number;
+  message: string;
+}
+export interface CachePurgeResult {
+  success: boolean;
+  zoneTag: string;
+  errors: CachePurgeError[];
+}
+export interface CachePurgeOptions {
+  tags?: string[];
+  pathPrefixes?: string[];
+  purgeEverything?: boolean;
+}
+export interface CacheContext {
+  purge(options: CachePurgeOptions): Promise<CachePurgeResult>;
 }
 export declare abstract class ColoLocalActorNamespace {
   get(actorId: string): Fetcher;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -479,6 +479,7 @@ interface ExecutionContext<Props = unknown> {
   passThroughOnException(): void;
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
+  cache?: CacheContext;
 }
 type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -561,6 +562,23 @@ interface AlarmInvocationInfo {
 }
 interface Cloudflare {
   readonly compatibilityFlags: Record<string, boolean>;
+}
+interface CachePurgeError {
+  code: number;
+  message: string;
+}
+interface CachePurgeResult {
+  success: boolean;
+  zoneTag: string;
+  errors: CachePurgeError[];
+}
+interface CachePurgeOptions {
+  tags?: string[];
+  pathPrefixes?: string[];
+  purgeEverything?: boolean;
+}
+interface CacheContext {
+  purge(options: CachePurgeOptions): Promise<CachePurgeResult>;
 }
 declare abstract class ColoLocalActorNamespace {
   get(actorId: string): Fetcher;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -481,6 +481,7 @@ export interface ExecutionContext<Props = unknown> {
   passThroughOnException(): void;
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
+  cache?: CacheContext;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -563,6 +564,23 @@ export interface AlarmInvocationInfo {
 }
 export interface Cloudflare {
   readonly compatibilityFlags: Record<string, boolean>;
+}
+export interface CachePurgeError {
+  code: number;
+  message: string;
+}
+export interface CachePurgeResult {
+  success: boolean;
+  zoneTag: string;
+  errors: CachePurgeError[];
+}
+export interface CachePurgeOptions {
+  tags?: string[];
+  pathPrefixes?: string[];
+  purgeEverything?: boolean;
+}
+export interface CacheContext {
+  purge(options: CachePurgeOptions): Promise<CachePurgeResult>;
 }
 export declare abstract class ColoLocalActorNamespace {
   get(actorId: string): Fetcher;


### PR DESCRIPTION
Creates a ctx.cache object with a purge function.

This allows Cache-enabled workers to purge their own cache.
We expose ctx.cache as JSG_RESOURCE_TYPE with the purge function defined
on it, and the types for that function as separate classes. By default
when an IoContext is not present this field is undefined. However it is
designed to be overridden when embedding workerd for actual use with the
provided types.