### PR TITLE
STREAM-6735: change input types on watermarks and captions to ReadableStream

### DIFF
--- a/types/defines/stream.d.ts
+++ b/types/defines/stream.d.ts
@@ -375,14 +375,13 @@ interface StreamScopedCaptions {
    * Uploads the caption or subtitle file to the endpoint for a specific BCP47 language.
    * One caption or subtitle file per language is allowed.
    * @param language The BCP 47 language tag for the caption or subtitle.
-   * @param file The caption or subtitle file to upload.
+   * @param input The caption or subtitle stream to upload.
    * @returns The created caption entry.
    * @throws {NotFoundError} if the video is not found
    * @throws {BadRequestError} if the language or file is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {InternalError} if an unexpected error occurs
    */
-  upload(language: string, file: File): Promise<StreamCaption>;
+  upload(language: string, input: ReadableStream): Promise<StreamCaption>;
   /**
    * Generate captions or subtitles for the provided language via AI.
    * @param language The BCP 47 language tag to generate.
@@ -461,17 +460,16 @@ interface StreamVideos {
 interface StreamWatermarks {
   /**
    * Generate a new watermark profile
-   * @param file The image file to upload
+   * @param input The image stream to upload
    * @param params The watermark creation parameters.
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */
   generate(
-    file: File,
+    input: ReadableStream,
     params: StreamWatermarkCreateParams
   ): Promise<StreamWatermark>;
   /**
@@ -481,7 +479,6 @@ interface StreamWatermarks {
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14037,14 +14037,13 @@ interface StreamScopedCaptions {
    * Uploads the caption or subtitle file to the endpoint for a specific BCP47 language.
    * One caption or subtitle file per language is allowed.
    * @param language The BCP 47 language tag for the caption or subtitle.
-   * @param file The caption or subtitle file to upload.
+   * @param input The caption or subtitle stream to upload.
    * @returns The created caption entry.
    * @throws {NotFoundError} if the video is not found
    * @throws {BadRequestError} if the language or file is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {InternalError} if an unexpected error occurs
    */
-  upload(language: string, file: File): Promise<StreamCaption>;
+  upload(language: string, input: ReadableStream): Promise<StreamCaption>;
   /**
    * Generate captions or subtitles for the provided language via AI.
    * @param language The BCP 47 language tag to generate.
@@ -14120,17 +14119,16 @@ interface StreamVideos {
 interface StreamWatermarks {
   /**
    * Generate a new watermark profile
-   * @param file The image file to upload
+   * @param input The image stream to upload
    * @param params The watermark creation parameters.
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */
   generate(
-    file: File,
+    input: ReadableStream,
     params: StreamWatermarkCreateParams,
   ): Promise<StreamWatermark>;
   /**
@@ -14140,7 +14138,6 @@ interface StreamWatermarks {
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -13994,14 +13994,13 @@ export interface StreamScopedCaptions {
    * Uploads the caption or subtitle file to the endpoint for a specific BCP47 language.
    * One caption or subtitle file per language is allowed.
    * @param language The BCP 47 language tag for the caption or subtitle.
-   * @param file The caption or subtitle file to upload.
+   * @param input The caption or subtitle stream to upload.
    * @returns The created caption entry.
    * @throws {NotFoundError} if the video is not found
    * @throws {BadRequestError} if the language or file is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {InternalError} if an unexpected error occurs
    */
-  upload(language: string, file: File): Promise<StreamCaption>;
+  upload(language: string, input: ReadableStream): Promise<StreamCaption>;
   /**
    * Generate captions or subtitles for the provided language via AI.
    * @param language The BCP 47 language tag to generate.
@@ -14077,17 +14076,16 @@ export interface StreamVideos {
 export interface StreamWatermarks {
   /**
    * Generate a new watermark profile
-   * @param file The image file to upload
+   * @param input The image stream to upload
    * @param params The watermark creation parameters.
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */
   generate(
-    file: File,
+    input: ReadableStream,
     params: StreamWatermarkCreateParams,
   ): Promise<StreamWatermark>;
   /**
@@ -14097,7 +14095,6 @@ export interface StreamWatermarks {
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -13312,14 +13312,13 @@ interface StreamScopedCaptions {
    * Uploads the caption or subtitle file to the endpoint for a specific BCP47 language.
    * One caption or subtitle file per language is allowed.
    * @param language The BCP 47 language tag for the caption or subtitle.
-   * @param file The caption or subtitle file to upload.
+   * @param input The caption or subtitle stream to upload.
    * @returns The created caption entry.
    * @throws {NotFoundError} if the video is not found
    * @throws {BadRequestError} if the language or file is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {InternalError} if an unexpected error occurs
    */
-  upload(language: string, file: File): Promise<StreamCaption>;
+  upload(language: string, input: ReadableStream): Promise<StreamCaption>;
   /**
    * Generate captions or subtitles for the provided language via AI.
    * @param language The BCP 47 language tag to generate.
@@ -13395,17 +13394,16 @@ interface StreamVideos {
 interface StreamWatermarks {
   /**
    * Generate a new watermark profile
-   * @param file The image file to upload
+   * @param input The image stream to upload
    * @param params The watermark creation parameters.
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */
   generate(
-    file: File,
+    input: ReadableStream,
     params: StreamWatermarkCreateParams,
   ): Promise<StreamWatermark>;
   /**
@@ -13415,7 +13413,6 @@ interface StreamWatermarks {
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -13269,14 +13269,13 @@ export interface StreamScopedCaptions {
    * Uploads the caption or subtitle file to the endpoint for a specific BCP47 language.
    * One caption or subtitle file per language is allowed.
    * @param language The BCP 47 language tag for the caption or subtitle.
-   * @param file The caption or subtitle file to upload.
+   * @param input The caption or subtitle stream to upload.
    * @returns The created caption entry.
    * @throws {NotFoundError} if the video is not found
    * @throws {BadRequestError} if the language or file is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {InternalError} if an unexpected error occurs
    */
-  upload(language: string, file: File): Promise<StreamCaption>;
+  upload(language: string, input: ReadableStream): Promise<StreamCaption>;
   /**
    * Generate captions or subtitles for the provided language via AI.
    * @param language The BCP 47 language tag to generate.
@@ -13352,17 +13351,16 @@ export interface StreamVideos {
 export interface StreamWatermarks {
   /**
    * Generate a new watermark profile
-   * @param file The image file to upload
+   * @param input The image stream to upload
    * @param params The watermark creation parameters.
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */
   generate(
-    file: File,
+    input: ReadableStream,
     params: StreamWatermarkCreateParams,
   ): Promise<StreamWatermark>;
   /**
@@ -13372,7 +13370,6 @@ export interface StreamWatermarks {
    * @returns The created watermark profile.
    * @throws {BadRequestError} if the parameters are invalid
    * @throws {InvalidURLError} if the URL is invalid
-   * @throws {MaxFileSizeError} if the file size is too large
    * @throws {TooManyWatermarksError} if the number of allowed watermarks is reached
    * @throws {InternalError} if an unexpected error occurs
    */


### PR DESCRIPTION
This updates watermarks and caption upload types to take in a `ReadableStream` instead of a `File` 
Note that this binding is not publically available yet and thus this breaking change will not impact customers