### PR TITLE
Account for deprecated GetPrototypeV2() and HolderV2() in v8 14.7

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -2153,8 +2153,14 @@ void Worker::handleLog(jsg::Lock& js,
 
           // Determine whether `obj` is constructed using `{}` or `new Object()`. This ensures
           // we don't serialise values like Promises to JSON.
+#if V8_MAJOR_VERSION >= 15 || (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION >= 7)
+          if (obj->GetPrototype()->SameValue(freshObj->GetPrototype()) ||
+              obj->GetPrototype()->IsNull()) {
+#else
+          // TODO(cleanup): Remove when unnecessary.
           if (obj->GetPrototypeV2()->SameValue(freshObj->GetPrototypeV2()) ||
               obj->GetPrototypeV2()->IsNull()) {
+#endif
             shouldSerialiseToJson = true;
           }
 

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -135,7 +135,7 @@ JsObject JsObject::jsonClone(Lock& js) {
 
 JsValue JsObject::getPrototype(Lock& js) {
   if (inner->IsProxy()) {
-    // Here we emulate the behavior of v8's GetPrototypeV2() function for proxies.
+    // Here we emulate the behavior of v8's GetPrototype() function for proxies.
     // If the proxy has a getPrototypeOf trap, we call it and return the result.
     // Otherwise we return the prototype of the target object.
     // Note that we do not check if the target object is extensible or not, or
@@ -168,7 +168,12 @@ JsValue JsObject::getPrototype(Lock& js) {
     // given how we are currently using this function.
     return ret;
   }
+#if V8_MAJOR_VERSION >= 15 || (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION >= 7)
+  return JsValue(inner->GetPrototype());
+#else
+  // TODO(cleanup): Remove when unnecessary.
   return JsValue(inner->GetPrototypeV2());
+#endif
 }
 
 kj::String JsSymbol::description(Lock& js) const {

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -29,6 +29,11 @@
 #include <type_traits>
 #include <typeindex>
 
+// TODO(cleanup): Remove when unnecessary.
+#if V8_MAJOR_VERSION >= 15 || (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION >= 7)
+#define HolderV2 Holder
+#endif
+
 namespace std {
 inline auto KJ_HASHCODE(const std::type_index& idx) {
   // Make std::type_index (which points to std::type_info) usable as a kj::HashMap key.

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -230,7 +230,12 @@ v8::Maybe<bool> Serializer::IsHostObject(v8::Isolate* isolate, v8::Local<v8::Obj
   // to be serialized normally. Otherwise, it is a class instance, which we should treat as a host
   // object. Inside `WriteHostObject()` we will throw DataCloneError due to the object not having
   // internal fields.
+#if V8_MAJOR_VERSION >= 15 || (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION >= 7)
+  return v8::Just(object->GetPrototype() != prototypeOfObject);
+#else
+  // TODO(cleanup): Remove when unnecessary.
   return v8::Just(object->GetPrototypeV2() != prototypeOfObject);
+#endif
 }
 
 v8::Maybe<bool> Serializer::WriteHostObject(v8::Isolate* isolate, v8::Local<v8::Object> object) {


### PR DESCRIPTION
Relevant v8 change: https://chromium-review.googlesource.com/c/v8/v8/+/7624359