### PR TITLE
Document async FFI and error handling patterns in Rust AGENTS.md

### DIFF
--- a/src/rust/AGENTS.md
+++ b/src/rust/AGENTS.md
@@ -36,3 +36,45 @@
 - **FFI naming**: instance methods on an existing handle use a `local_<type>_<method>` prefix (e.g. `local_array_buffer_byte_length`). Static constructors that create a new value do **not** use the `local_` prefix — name them `<type>_<method>` (e.g. `array_buffer_new_with_mode`, `array_buffer_maybe_new`, `backing_store_new_resizable`).
 - **FFI groups**: `v8.rs` `mod ffi`, `ffi.h`, and `ffi.c++` all use matching comment groups (e.g. `// Local<T>`, `// Local<Array>`, `// Local<TypedArray>`, `// Local<ArrayBuffer>`, `// Local<ArrayBufferView>`, `// Local<SharedArrayBuffer>`, `// BackingStore`, `// Unwrappers`, `// Global<T>`, `// FunctionCallbackInfo`). When adding new FFI functions, place them in the correct group in **all three files**. Do not scatter related functions across groups.
 - **Feature flags**: `Lock::feature_flags()` returns a capnp `compatibility_flags::Reader` for the current worker. Use `lock.feature_flags().get_node_js_compat()`. Flags are parsed once and stored in the `Realm` at construction; C++ passes canonical capnp bytes to `realm_create()`. Schema: `src/workerd/io/compatibility-date.capnp`, generated Rust bindings: `compatibility_date_capnp` crate.
+
+## CXX BRIDGE: ASYNC AND ERROR HANDLING
+
+### C++ calling async Rust (`extern "Rust"`)
+
+Mark an `extern "Rust"` function `async` to generate a C++ function returning `kj::Promise<T>`. If the function borrows any references (including `&self`), it needs an explicit lifetime annotation, which in turn requires `unsafe`:
+
+```rust
+extern "Rust" {
+    // Borrows &self — needs explicit lifetime + unsafe.
+    async unsafe fn do_work<'a>(self: &'a MyType, arg: i32) -> Result<u64>;
+
+    // Only owned parameters — no lifetime or unsafe needed.
+    async fn do_work_owned(arg: i32) -> Result<u64>;
+}
+```
+
+Without the explicit lifetime, the CXX macro requires the future to be `'static`, which fails if the async body references borrowed parameters.
+
+### Rust calling async C++ (`extern "C++"`)
+
+Mark an `extern "C++"` function `async` to wrap a C++ function returning `kj::Promise<T>` as a Rust `Future`. The Rust caller can `.await` it:
+
+```rust
+unsafe extern "C++" {
+    async fn request(
+        this_: Pin<&mut HttpService>,
+        method: HttpMethod,
+        url: &[u8],
+    ) -> Result<()>;
+}
+```
+
+Note: `this_` is used instead of `self` because CXX's `self` receiver syntax doesn't support `Pin<&mut T>`. This is needed for C++ types with virtual methods where the Rust side calls into a pinned C++ object.
+
+### Error handling across FFI
+
+Functions returning `Result<T>` in `extern "Rust"` blocks translate to C++ functions that throw `kj::Exception` on error. The error type must implement `std::error::Error` (which provides `IntoKjException`). Recommended patterns:
+
+- **`thiserror` enums**: Define a crate-level `Error` enum for structured errors. This is the preferred pattern for crates with multiple error cases.
+- **`std::io::Error`**: Acceptable for purely I/O-related errors.
+- **`cxx::KjError`**: Use `KjError::new(KjExceptionType::Failed, message)` when you need direct control over the KJ exception type.


### PR DESCRIPTION
I had trouble coaxing Claude to implement an async, Result-returning cxxbridged Rust function, because it doesn't know that our cxx-rs fork supports async interoperability, or KJ exceptions. I'm not sure where's best to put this, but this file seems reasonable.

---

Add guidance on how to declare async functions in extern "Rust" CXX bridge blocks (explicit lifetime + unsafe required), and how to handle errors across the FFI boundary (thiserror, std::io::Error, or cxx::KjError).

Assisted-by: Claude