### PR TITLE
make exception copy explicit or completely avoid it

### DIFF
--- a/src/workerd/api/streams/identity-transform-stream.c++
+++ b/src/workerd/api/streams/identity-transform-stream.c++
@@ -107,12 +107,12 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
         if (amount > l) {
           auto exception = JSG_KJ_EXCEPTION(
               FAILED, TypeError, "Attempt to write too many bytes through a FixedLengthStream.");
-          cancel(exception);
+          cancel(kj::cp(exception));
           return kj::mv(exception);
         } else if (amount == 0 && l != 0) {
           auto exception = JSG_KJ_EXCEPTION(FAILED, TypeError,
               "FixedLengthStream did not see all expected bytes before close().");
-          cancel(exception);
+          cancel(kj::cp(exception));
           return kj::mv(exception);
         }
         l -= amount;

--- a/src/workerd/api/streams/writable-sink-adapter-test.c++
+++ b/src/workerd/api/streams/writable-sink-adapter-test.c++
@@ -202,7 +202,7 @@ KJ_TEST("Basic abort() operation") {
 
     KJ_ASSERT(adapter->isClosed() == false, "Adapter should not be closed after abort()");
     KJ_ASSERT(adapter->isClosing() == false, "Adapter should not be closing after abort()");
-    auto exception =
+    auto& exception =
         KJ_ASSERT_NONNULL(adapter->isErrored(), "Adapter should be in errored state after abort()");
     KJ_ASSERT(exception.getDescription().contains("Abort reason"),
         "Adapter should be in errored state after abort()");
@@ -223,7 +223,7 @@ KJ_TEST("Basic abort() operation") {
         "End after abort() call should be rejected");
 
     adapter->abort(env.js, env.js.str("Abort reason 2"_kj));
-    auto exception2 = KJ_ASSERT_NONNULL(
+    auto& exception2 = KJ_ASSERT_NONNULL(
         adapter->isErrored(), "Adapter should still be in errored state after second abort()");
     KJ_ASSERT(exception2.getDescription().contains("Abort reason 2"),
         "Adapter should reflect reason from second abort() call");
@@ -248,7 +248,7 @@ KJ_TEST("Abort from closing state supersedes close") {
 
     KJ_ASSERT(adapter->isClosed() == false, "Adapter should not be closed after abort()");
     KJ_ASSERT(adapter->isClosing() == false, "Adapter should not be closing after abort()");
-    auto exception =
+    auto& exception =
         KJ_ASSERT_NONNULL(adapter->isErrored(), "Adapter should be in errored state after abort()");
     KJ_ASSERT(exception.getDescription().contains("Abort reason"),
         "Adapter should be in errored state after abort()");

--- a/src/workerd/jsg/exception.h
+++ b/src/workerd/jsg/exception.h
@@ -83,9 +83,9 @@ namespace workerd::jsg {
   do {                                                                                             \
     try {                                                                                          \
       KJ_REQUIRE(cond, jsErrorType ": Cloudflare internal error.");                                \
-    } catch (const kj::Exception& e) {                                                             \
+    } catch (kj::Exception & e) {                                                                  \
       KJ_LOG(ERROR, e, ##__VA_ARGS__);                                                             \
-      throw e;                                                                                     \
+      throw kj::mv(e);                                                                             \
     }                                                                                              \
   } while (0)
 
@@ -93,9 +93,9 @@ namespace workerd::jsg {
   ([&]() -> decltype(auto) {                                                                       \
     try {                                                                                          \
       return KJ_REQUIRE_NONNULL(value, jsErrorType ": Cloudflare internal error.");                \
-    } catch (const kj::Exception& e) {                                                             \
+    } catch (kj::Exception & e) {                                                                  \
       KJ_LOG(ERROR, e, ##__VA_ARGS__);                                                             \
-      throw e;                                                                                     \
+      throw kj::mv(e);                                                                             \
     }                                                                                              \
   }())
 
@@ -103,9 +103,9 @@ namespace workerd::jsg {
   do {                                                                                             \
     try {                                                                                          \
       KJ_FAIL_REQUIRE(jsErrorType ": Cloudflare internal error.");                                 \
-    } catch (const kj::Exception& e) {                                                             \
+    } catch (kj::Exception & e) {                                                                  \
       KJ_LOG(ERROR, e, ##__VA_ARGS__);                                                             \
-      throw e;                                                                                     \
+      throw kj::mv(e);                                                                             \
     }                                                                                              \
   } while (0)
 

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -454,7 +454,7 @@ void TestFixture::runInIoContext(kj::Function<kj::Promise<void>(const Environmen
     });
   } catch (kj::Exception& e) {
     if (!ignoreDescription(e.getDescription())) {
-      throw e;
+      throw kj::mv(e);
     }
   }
 }

--- a/src/workerd/util/test.h
+++ b/src/workerd/util/test.h
@@ -14,7 +14,7 @@ namespace workerd {
 #define WD_EXPECT_THROW(expException, code, ...)                                                   \
   do {                                                                                             \
     /* NOLINTNEXTLINE(performance-unnecessary-copy-initialization) */                              \
-    auto expExcObj = expException;                                                                 \
+    auto expExcObj = kj::cp(expException);                                                         \
     KJ_IF_SOME(e, ::kj::runCatchingExceptions([&]() { (void)({ code; }); })) {                     \
       KJ_EXPECT(e.getType() == expExcObj.getType(), "code threw wrong exception type: " #code, e,  \
           ##__VA_ARGS__);                                                                          \


### PR DESCRIPTION
I am making Exception copy constructor explicit in capnp and it uncovered these cases