### PR TITLE
Migrate R2Bucket hash properties from jsg::BufferSource

### DIFF
--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -671,7 +671,8 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
       KJ_IF_SOME(md5, o.md5) {
         verifyHashNotSpecified();
         KJ_SWITCH_ONEOF(md5) {
-          KJ_CASE_ONEOF(bin, jsg::BufferSource) {
+          KJ_CASE_ONEOF(binRef, jsg::JsRef<jsg::JsBufferSource>) {
+            auto bin = binRef.getHandle(js);
             JSG_REQUIRE(bin.size() == 16, TypeError, "MD5 is 16 bytes, not ", bin.size());
             putBuilder.setMd5(bin.asArrayPtr());
             traceContext.setTag("cloudflare.r2.request.checksum.type"_kjc, "md5"_kjc);
@@ -692,7 +693,8 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
       KJ_IF_SOME(sha1, o.sha1) {
         verifyHashNotSpecified();
         KJ_SWITCH_ONEOF(sha1) {
-          KJ_CASE_ONEOF(bin, jsg::BufferSource) {
+          KJ_CASE_ONEOF(binRef, jsg::JsRef<jsg::JsBufferSource>) {
+            auto bin = binRef.getHandle(js);
             JSG_REQUIRE(bin.size() == 20, TypeError, "SHA-1 is 20 bytes, not ", bin.size());
             putBuilder.setSha1(bin.asArrayPtr());
             traceContext.setTag("cloudflare.r2.request.checksum.type"_kjc, "sha1"_kjc);
@@ -713,7 +715,8 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
       KJ_IF_SOME(sha256, o.sha256) {
         verifyHashNotSpecified();
         KJ_SWITCH_ONEOF(sha256) {
-          KJ_CASE_ONEOF(bin, jsg::BufferSource) {
+          KJ_CASE_ONEOF(binRef, jsg::JsRef<jsg::JsBufferSource>) {
+            auto bin = binRef.getHandle(js);
             JSG_REQUIRE(bin.size() == 32, TypeError, "SHA-256 is 32 bytes, not ", bin.size());
             putBuilder.setSha256(bin.asArrayPtr());
             traceContext.setTag("cloudflare.r2.request.checksum.type"_kjc, "sha256"_kjc);
@@ -735,7 +738,8 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
       KJ_IF_SOME(sha384, o.sha384) {
         verifyHashNotSpecified();
         KJ_SWITCH_ONEOF(sha384) {
-          KJ_CASE_ONEOF(bin, jsg::BufferSource) {
+          KJ_CASE_ONEOF(binRef, jsg::JsRef<jsg::JsBufferSource>) {
+            auto bin = binRef.getHandle(js);
             JSG_REQUIRE(bin.size() == 48, TypeError, "SHA-384 is 48 bytes, not ", bin.size());
             putBuilder.setSha384(bin.asArrayPtr());
             traceContext.setTag("cloudflare.r2.request.checksum.type"_kjc, "sha384"_kjc);
@@ -757,7 +761,8 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
       KJ_IF_SOME(sha512, o.sha512) {
         verifyHashNotSpecified();
         KJ_SWITCH_ONEOF(sha512) {
-          KJ_CASE_ONEOF(bin, jsg::BufferSource) {
+          KJ_CASE_ONEOF(binRef, jsg::JsRef<jsg::JsBufferSource>) {
+            auto bin = binRef.getHandle(js);
             JSG_REQUIRE(bin.size() == 64, TypeError, "SHA-512 is 64 bytes, not ", bin.size());
             putBuilder.setSha512(bin.asArrayPtr());
             traceContext.setTag("cloudflare.r2.request.checksum.type"_kjc, "sha512"_kjc);
@@ -1436,30 +1441,26 @@ R2Bucket::StringChecksums R2Bucket::Checksums::toJSON() {
 }
 
 namespace {
-jsg::Optional<jsg::BufferSource> copyHash(
+jsg::Optional<jsg::JsArrayBuffer> copyHash(
     jsg::Lock& js, const jsg::Optional<kj::Array<kj::byte>>& maybeHash) {
-  KJ_IF_SOME(hash, maybeHash) {
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, hash.size());
-    backing.asArrayPtr().copyFrom(hash);
-    return jsg::BufferSource(js, kj::mv(backing));
-  }
-  return kj::none;
+  return maybeHash.map(
+      [&](const kj::Array<kj::byte>& hash) { return jsg::JsArrayBuffer::create(js, hash); });
 }
 }  // namespace
 
-jsg::Optional<jsg::BufferSource> R2Bucket::Checksums::getMd5(jsg::Lock& js) {
+jsg::Optional<jsg::JsArrayBuffer> R2Bucket::Checksums::getMd5(jsg::Lock& js) {
   return copyHash(js, md5);
 }
-jsg::Optional<jsg::BufferSource> R2Bucket::Checksums::getSha1(jsg::Lock& js) {
+jsg::Optional<jsg::JsArrayBuffer> R2Bucket::Checksums::getSha1(jsg::Lock& js) {
   return copyHash(js, sha1);
 }
-jsg::Optional<jsg::BufferSource> R2Bucket::Checksums::getSha256(jsg::Lock& js) {
+jsg::Optional<jsg::JsArrayBuffer> R2Bucket::Checksums::getSha256(jsg::Lock& js) {
   return copyHash(js, sha256);
 }
-jsg::Optional<jsg::BufferSource> R2Bucket::Checksums::getSha384(jsg::Lock& js) {
+jsg::Optional<jsg::JsArrayBuffer> R2Bucket::Checksums::getSha384(jsg::Lock& js) {
   return copyHash(js, sha384);
 }
-jsg::Optional<jsg::BufferSource> R2Bucket::Checksums::getSha512(jsg::Lock& js) {
+jsg::Optional<jsg::JsArrayBuffer> R2Bucket::Checksums::getSha512(jsg::Lock& js) {
   return copyHash(js, sha512);
 }
 

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -132,11 +132,11 @@ class R2Bucket: public jsg::Object {
           sha384(kj::mv(sha384)),
           sha512(kj::mv(sha512)) {}
 
-    jsg::Optional<jsg::BufferSource> getMd5(jsg::Lock& js);
-    jsg::Optional<jsg::BufferSource> getSha1(jsg::Lock& js);
-    jsg::Optional<jsg::BufferSource> getSha256(jsg::Lock& js);
-    jsg::Optional<jsg::BufferSource> getSha384(jsg::Lock& js);
-    jsg::Optional<jsg::BufferSource> getSha512(jsg::Lock& js);
+    jsg::Optional<jsg::JsArrayBuffer> getMd5(jsg::Lock& js);
+    jsg::Optional<jsg::JsArrayBuffer> getSha1(jsg::Lock& js);
+    jsg::Optional<jsg::JsArrayBuffer> getSha256(jsg::Lock& js);
+    jsg::Optional<jsg::JsArrayBuffer> getSha384(jsg::Lock& js);
+    jsg::Optional<jsg::JsArrayBuffer> getSha512(jsg::Lock& js);
 
     StringChecksums toJSON();
 
@@ -204,11 +204,11 @@ class R2Bucket: public jsg::Object {
     jsg::Optional<kj::OneOf<Conditional, jsg::Ref<Headers>>> onlyIf;
     jsg::Optional<kj::OneOf<HttpMetadata, jsg::Ref<Headers>>> httpMetadata;
     jsg::Optional<jsg::Dict<kj::String>> customMetadata;
-    jsg::Optional<kj::OneOf<jsg::BufferSource, jsg::NonCoercible<kj::String>>> md5;
-    jsg::Optional<kj::OneOf<jsg::BufferSource, jsg::NonCoercible<kj::String>>> sha1;
-    jsg::Optional<kj::OneOf<jsg::BufferSource, jsg::NonCoercible<kj::String>>> sha256;
-    jsg::Optional<kj::OneOf<jsg::BufferSource, jsg::NonCoercible<kj::String>>> sha384;
-    jsg::Optional<kj::OneOf<jsg::BufferSource, jsg::NonCoercible<kj::String>>> sha512;
+    jsg::Optional<kj::OneOf<jsg::JsRef<jsg::JsBufferSource>, jsg::NonCoercible<kj::String>>> md5;
+    jsg::Optional<kj::OneOf<jsg::JsRef<jsg::JsBufferSource>, jsg::NonCoercible<kj::String>>> sha1;
+    jsg::Optional<kj::OneOf<jsg::JsRef<jsg::JsBufferSource>, jsg::NonCoercible<kj::String>>> sha256;
+    jsg::Optional<kj::OneOf<jsg::JsRef<jsg::JsBufferSource>, jsg::NonCoercible<kj::String>>> sha384;
+    jsg::Optional<kj::OneOf<jsg::JsRef<jsg::JsBufferSource>, jsg::NonCoercible<kj::String>>> sha512;
     jsg::Optional<kj::String> storageClass;
     jsg::Optional<kj::OneOf<kj::Array<byte>, kj::String>> ssecKey;
 


### PR DESCRIPTION
Use the lighterweight/faster jsg::Js* types instead.