### PR TITLE
Allow DurationExceededLogger to build its log message lazily

### DIFF
--- a/src/workerd/util/duration-exceeded-logger-test.c++
+++ b/src/workerd/util/duration-exceeded-logger-test.c++
@@ -22,5 +22,48 @@ KJ_TEST("Duration alert triggers when time is exceeded") {
   }
 }
 
+KJ_TEST("DURATION_EXCEEDED_LOG with extra params triggers when time is exceeded") {
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+
+  int requestId = 42;
+  kj::StringPtr operation = "doSomething";
+
+  KJ_EXPECT_LOG(WARNING,
+      "test message; requestId = 42; operation = doSomething; warningDuration = 10s; "
+      "actualDuration = ");
+  {
+    DURATION_EXCEEDED_LOG(duration, timer, 10 * kj::SECONDS, "test message", requestId, operation);
+    timer.advanceTo(timer.now() + 100 * kj::SECONDS);
+  }
+}
+
+KJ_TEST("DURATION_EXCEEDED_LOG without extra params triggers when time is exceeded") {
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+
+  KJ_EXPECT_LOG(WARNING, "no extras test; warningDuration = 10s; actualDuration = ");
+  {
+    DURATION_EXCEEDED_LOG(duration, timer, 10 * kj::SECONDS, "no extras test");
+    timer.advanceTo(timer.now() + 100 * kj::SECONDS);
+  }
+}
+
+KJ_TEST("DURATION_EXCEEDED_LOG extra params are lazily evaluated") {
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+
+  // This test verifies that the extra params lambda is NOT called when the duration
+  // threshold is not exceeded. We use a counter to track whether stringification occurred.
+  int stringifyCount = 0;
+  auto makeExpensiveString = [&]() -> kj::StringPtr {
+    ++stringifyCount;
+    return "expensive"_kj;
+  };
+
+  {
+    DURATION_EXCEEDED_LOG(duration, timer, 10 * kj::SECONDS, "lazy test", makeExpensiveString());
+    timer.advanceTo(timer.now() + 1 * kj::SECONDS);
+  }
+  KJ_EXPECT(stringifyCount == 0, "extra params should not be evaluated when duration not exceeded");
+}
+
 }  // namespace
 }  // namespace workerd::util

--- a/src/workerd/util/duration-exceeded-logger.h
+++ b/src/workerd/util/duration-exceeded-logger.h
@@ -10,11 +10,24 @@
 
 namespace workerd::util {
 
-// This is a utility class for instantiating a timer, which will log if it's destructed after a specified time
-// This works by relying on RAII (Scope-Bound Resource Management) to check how much time has elapsed
-// when the object is destructed. This ensures that the time is checked when the timer object goes out of scope
-// thereby timing everything after the initialization of the timer, until the end of the scope where it was
-// instantiated.
+// This is a utility class for instantiating a timer, which will log if it's destructed after a
+// specified time. This works by relying on RAII (Scope-Bound Resource Management) to check how
+// much time has elapsed when the object is destructed. This ensures that the time is checked when
+// the timer object goes out of scope, thereby timing everything after the initialization of the
+// timer until the end of the scope where it was instantiated.
+//
+// For the simple case (no extra parameters), construct directly:
+//
+//   DurationExceededLogger logger(clock, 5 * kj::SECONDS, "operation slow");
+//
+// To include lazily-evaluated extra parameters (avoiding heap allocation when the duration
+// threshold is not exceeded), use the DURATION_EXCEEDED_LOG macro instead:
+//
+//   DURATION_EXCEEDED_LOG(logger, clock, 5 * kj::SECONDS, "operation slow", requestId, size);
+//
+// The extra parameters are formatted in the same style as KJ_LOG (name = value), and are only
+// stringified if the duration threshold is actually exceeded.
+
 class DurationExceededLogger {
  public:
   DurationExceededLogger(
@@ -39,5 +52,74 @@ class DurationExceededLogger {
   kj::TimePoint start;
   const kj::MonotonicClock& clock;
 };
+
+// Template variant of DurationExceededLogger that supports lazily-evaluated extra parameters.
+// Do not use this class directly; use the DURATION_EXCEEDED_LOG macro which creates the
+// appropriate lambda and template instantiation.
+template <typename ExtraArgsFunc>
+class DurationExceededLoggerWithExtras {
+ public:
+  DurationExceededLoggerWithExtras(const kj::MonotonicClock& clock,
+      kj::Duration warningDuration,
+      kj::StringPtr logMessage,
+      ExtraArgsFunc& extraArgsFunc)
+      : warningDuration(warningDuration),
+        logMessage(logMessage),
+        start(clock.now()),
+        clock(clock),
+        extraArgsFunc(extraArgsFunc) {}
+
+  KJ_DISALLOW_COPY_AND_MOVE(DurationExceededLoggerWithExtras);
+
+  ~DurationExceededLoggerWithExtras() noexcept(false) {
+    kj::Duration actualDuration = clock.now() - start;
+    if (actualDuration >= warningDuration) {
+      auto extra = extraArgsFunc();
+      if (extra.size() > 0) {
+        KJ_LOG(WARNING, kj::str("NOSENTRY ", logMessage, "; ", extra), warningDuration,
+            actualDuration);
+      } else {
+        KJ_LOG(WARNING, kj::str("NOSENTRY ", logMessage), warningDuration, actualDuration);
+      }
+    }
+  }
+
+ private:
+  kj::Duration warningDuration;
+  kj::StringPtr logMessage;
+  kj::TimePoint start;
+  const kj::MonotonicClock& clock;
+  ExtraArgsFunc& extraArgsFunc;
+};
+
+// Macro for creating a DurationExceededLogger with lazily-evaluated extra parameters.
+// Extra parameters are only stringified if the duration threshold is actually exceeded,
+// avoiding unnecessary heap allocations in the common case where the operation completes quickly.
+//
+// Parameters are formatted in the same style as KJ_LOG: name = value; name2 = value2
+//
+// Example:
+//   DURATION_EXCEEDED_LOG(logger, clock, 5 * kj::SECONDS, "operation slow", requestId, size);
+//
+// If triggered, logs something like:
+//   NOSENTRY operation slow; requestId = abc; size = 4096; warningDuration = 5s; actualDuration = 12s
+//
+// The macro also works without extra parameters, behaving identically to DurationExceededLogger:
+//   DURATION_EXCEEDED_LOG(logger, clock, 5 * kj::SECONDS, "operation slow");
+#if KJ_MSVC_TRADITIONAL_CPP
+#define DURATION_EXCEEDED_LOG(name, clock, warningDuration, logMessage, ...)                       \
+  auto KJ_UNIQUE_NAME(_delExtraArgsFunc) = [&]() -> kj::String {                                   \
+    return ::kj::_::Debug::makeDescription("" #__VA_ARGS__, __VA_ARGS__);                          \
+  };                                                                                               \
+  ::workerd::util::DurationExceededLoggerWithExtras<decltype(KJ_UNIQUE_NAME(_delExtraArgsFunc))>   \
+  name(clock, warningDuration, logMessage, KJ_UNIQUE_NAME(_delExtraArgsFunc))
+#else
+#define DURATION_EXCEEDED_LOG(name, clock, warningDuration, logMessage, ...)                       \
+  auto KJ_UNIQUE_NAME(_delExtraArgsFunc) = [&]() -> kj::String {                                   \
+    return ::kj::_::Debug::makeDescription(#__VA_ARGS__, ##__VA_ARGS__);                           \
+  };                                                                                               \
+  ::workerd::util::DurationExceededLoggerWithExtras<decltype(KJ_UNIQUE_NAME(_delExtraArgsFunc))>   \
+  name(clock, warningDuration, logMessage, KJ_UNIQUE_NAME(_delExtraArgsFunc))
+#endif
 
 }  // namespace workerd::util


### PR DESCRIPTION
There have been a couple places in the code recently where we've wanted to use DurationExceededLogger but to add additional fields into the log message. Before this change, that required heap-allocating a string before constructing the DurationExceededLogger and passing in a StringPtr to it, but that's very wasteful given that most of the time the log message is never even used.

This change adds a new DURATION_EXCEEDED_LOG macro that lazily constructs the message to be logged only when it's needed.

---

Adding the NOSENTRY tag via `kj::str()` in the implementation annoys me a bit too, but at least that's only in the path where we're already going to the trouble of emitting the log, so it's more arguably worth it (vs needing to make all callers include NOSENTRY in their messages).

In addition to my PR a few days ago, this also came up in one of @shrima-cf 's changes yesterday, motivating me to make this change.

The macros were written by Claude, cribbed largely from the existing KJ logging macros.