### PR TITLE
node: replace nbytes with simdutf for base64 decoding

### DIFF
--- a/src/workerd/api/node/buffer.c++
+++ b/src/workerd/api/node/buffer.c++
@@ -161,17 +161,26 @@ jsg::JsUint8Array decodeStringImpl(
     case Encoding::BASE64:
       // Fall-through
     case Encoding::BASE64URL: {
-      // TODO(soon): Use simdutf for faster decoding for BASE64 and BASE64URL.
       // We do not use the kj::String conversion here because inline null-characters
       // need to be ignored.
       KJ_STACK_ARRAY(kj::byte, buf, length, 1024, 536870888);
       auto result = string.writeInto(js, buf, options);
       auto len = result.written;
-      auto dest = jsg::JsUint8Array::create(js, nbytes::Base64DecodedSize(buf.begin(), len));
-      len = nbytes::Base64Decode(
-          dest.asArrayPtr<char>().begin(), dest.size(), buf.begin(), buf.size());
-      if (len < dest.size()) {
-        return dest.slice(js, len);
+      // Node.js quirk: Base64 and Base64URL decoders accept both alphabets mixed together.
+      // simdutf strictly adheres to one or the other. We must normalize the url-safe
+      // characters into standard Base64 characters before passing to the decoder.
+      for (size_t i = 0; i < len; ++i) {
+        if (buf[i] == '-')
+          buf[i] = '+';
+        else if (buf[i] == '_')
+          buf[i] = '/';
+      }
+      auto dest = jsg::JsUint8Array::create(
+          js, simdutf::maximal_binary_length_from_base64(buf.asChars().begin(), len));
+      auto dec_result = simdutf::base64_to_binary(buf.asChars().begin(), len,
+          dest.asArrayPtr().asChars().begin(), simdutf::base64_default_accept_garbage);
+      if (dec_result.count < dest.size()) {
+        return dest.slice(js, dec_result.count);
       }
       return dest;
     }

--- a/src/workerd/api/node/buffer.c++
+++ b/src/workerd/api/node/buffer.c++
@@ -166,19 +166,10 @@ jsg::JsUint8Array decodeStringImpl(
       KJ_STACK_ARRAY(kj::byte, buf, length, 1024, 536870888);
       auto result = string.writeInto(js, buf, options);
       auto len = result.written;
-      // Node.js quirk: Base64 and Base64URL decoders accept both alphabets mixed together.
-      // simdutf strictly adheres to one or the other. We must normalize the url-safe
-      // characters into standard Base64 characters before passing to the decoder.
-      for (size_t i = 0; i < len; ++i) {
-        if (buf[i] == '-')
-          buf[i] = '+';
-        else if (buf[i] == '_')
-          buf[i] = '/';
-      }
       auto dest = jsg::JsUint8Array::create(
           js, simdutf::maximal_binary_length_from_base64(buf.asChars().begin(), len));
       auto dec_result = simdutf::base64_to_binary(buf.asChars().begin(), len,
-          dest.asArrayPtr().asChars().begin(), simdutf::base64_default_accept_garbage);
+          dest.asArrayPtr().asChars().begin(), simdutf::base64_default_or_url_accept_garbage);
       if (dec_result.count < dest.size()) {
         return dest.slice(js, dec_result.count);
       }


### PR DESCRIPTION
This implementation aims to implement using simdutf for decoding base64 in the Node Buffer api which has been a TODO for a while.

I use the option "base64_default_or_url_accept_garbage" which behaves exactly like Nodejs. All tests for the buffer api pass successfully.

I also wrote a simple micro-benchmark to avoid regressions. The benchmark is only a sanity check and is unlikely to represent actual base64 strings in use. The results are below:

Original implementation using nbytes
| Name | Iterations | Time |
|------|------------|------|
| Small String | 10,000 | 6 ms |
| Mixed URL-Safe | 10,000 | 48 ms |
| Large String | 10,000 | 322 ms |


simdutf implementation
| Name | Iterations | Time |
|------|------------|------|
| Small String | 10,000 | 7 ms |
| Mixed URL-Safe | 10,000 | 26 ms |
| Large String | 10,000 | 323 ms |


We get a tiny regression in decoding strings with non mixed alphabets but a huge speedup in decoding strings with mixed alphabets. It is useful to note that the time shown here is the total for all runs. In this case (where we run 10,000 iterations) a ~1ms regression is actually 0.0001ms for every individual run. The benchmark code and the config are included below

```js
import { Buffer } from 'node:buffer';

export default {
  async test() {
    const smallStr = 'SGVsbG8gV29ybGQ=';
    const mixedStr = 'SGVsbG8_SGVsbG8-'.repeat(1000);
    const largeStr = 'SGVsbG8gV29ybGQ='.repeat(100000);

    function runBench(name, fn, iters) {
      // Warmup runs. (also helps V8 optimize this path)
      for (let i = 0; i < 1000; i++) fn();

      const start = Date.now();
      for (let i = 0; i < iters; i++) fn();
      const end = Date.now();

      console.log(
        `${name.padEnd(20)} | ${iters.toLocaleString().padStart(10)} iters | ${end - start} ms`
      );
    }

    console.log('Running Base64 Benchmarks');
    runBench('Small String', () => Buffer.from(smallStr, 'base64'), 10_000);
    runBench('Mixed URL-Safe', () => Buffer.from(mixedStr, 'base64'), 10_000);
    runBench('Large String', () => Buffer.from(largeStr, 'base64'), 10_000);
  },
};
```

```capnp
using Workerd = import "/workerd/workerd.capnp";

const config :Workerd.Config = (
  services = [
    (name = "test", worker = .testWorker)
  ]
);

const testWorker :Workerd.Worker = (
  modules = [
    (name = "bench-buffer.js", esModule = embed "bench-buffer.js")
  ],
  compatibilityDate = "2024-04-03",
  compatibilityFlags = ["nodejs_compat"],
);

```