### PR TITLE
Revert "Add compat flag to prevent creating Blob with resizable Array…

### DIFF
--- a/src/workerd/api/blob.c++
+++ b/src/workerd/api/blob.c++
@@ -6,7 +6,6 @@
 
 #include <workerd/api/streams/readable-source.h>
 #include <workerd/api/streams/readable.h>
-#include <workerd/io/features.h>
 #include <workerd/io/observer.h>
 #include <workerd/util/mimetype.h>
 #include <workerd/util/stream-utils.h>
@@ -21,21 +20,14 @@ kj::Maybe<jsg::JsBufferSource> concat(jsg::Lock& js, jsg::Optional<Blob::Bits> m
     return kj::none;
   }
 
-  auto rejectResizable = FeatureFlags::get(js).getNoResizableArrayBufferInBlob();
   auto maxBlobSize = Worker::Isolate::from(js).getLimitEnforcer().getBlobSizeLimit();
   static constexpr int kMaxInt KJ_UNUSED = kj::maxValue;
   KJ_DASSERT(maxBlobSize <= kMaxInt, "Blob size limit exceeds int range");
   size_t size = 0;
-  kj::SmallArray<size_t, 8> cachedPartSizes(bits.size());
-  int index = 0;
   for (auto& part: bits) {
     size_t partSize = 0;
     KJ_SWITCH_ONEOF(part) {
-      KJ_CASE_ONEOF(bytes, jsg::JsBufferSource) {
-        if (rejectResizable) {
-          JSG_REQUIRE(
-              !bytes.isResizable(), TypeError, "Cannot create a Blob with a resizable ArrayBuffer");
-        }
+      KJ_CASE_ONEOF(bytes, kj::Array<const byte>) {
         partSize = bytes.size();
       }
       KJ_CASE_ONEOF(text, kj::String) {
@@ -45,7 +37,6 @@ kj::Maybe<jsg::JsBufferSource> concat(jsg::Lock& js, jsg::Optional<Blob::Bits> m
         partSize = blob->getData().size();
       }
     }
-    cachedPartSizes[index++] = partSize;
 
     // We can skip the remaining checks if the part is empty.
     if (partSize == 0) continue;
@@ -75,26 +66,18 @@ kj::Maybe<jsg::JsBufferSource> concat(jsg::Lock& js, jsg::Optional<Blob::Bits> m
 
   auto view = u8.asArrayPtr();
 
-  index = 0;
   for (auto& part: bits) {
     KJ_SWITCH_ONEOF(part) {
-      KJ_CASE_ONEOF(bytes, jsg::JsBufferSource) {
-        size_t cachedSize = cachedPartSizes[index++];
-        // If the ArrayBuffer was resized larger, we'll ignore the additional bytes.
-        // If the ArrayBuffer was resized smaller, we'll copy up the current size
-        // and the remaining bytes for this chunk will be left as zeros.
-        size_t toCopy = kj::min(bytes.size(), cachedSize);
-        if (toCopy > 0) {
-          KJ_ASSERT(view.size() >= toCopy);
-          view.first(toCopy).copyFrom(bytes.asArrayPtr().first(toCopy));
-        }
-        view = view.slice(cachedSize);
+      KJ_CASE_ONEOF(bytes, kj::Array<const byte>) {
+        if (bytes.size() == 0) continue;
+        KJ_ASSERT(view.size() >= bytes.size());
+        view.first(bytes.size()).copyFrom(bytes);
+        view = view.slice(bytes.size());
       }
       KJ_CASE_ONEOF(text, kj::String) {
         auto byteLength = text.asBytes().size();
         if (byteLength == 0) continue;
         KJ_ASSERT(view.size() >= byteLength);
-        KJ_ASSERT(byteLength == cachedPartSizes[index++]);
         view.first(byteLength).copyFrom(text.asBytes());
         view = view.slice(byteLength);
       }
@@ -102,7 +85,6 @@ kj::Maybe<jsg::JsBufferSource> concat(jsg::Lock& js, jsg::Optional<Blob::Bits> m
         auto data = blob->getData();
         if (data.size() == 0) continue;
         KJ_ASSERT(view.size() >= data.size());
-        KJ_ASSERT(data.size() == cachedPartSizes[index++]);
         view.first(data.size()).copyFrom(data);
         view = view.slice(data.size());
       }
@@ -147,12 +129,7 @@ Blob::Blob(kj::Array<byte> data, kj::String type)
 Blob::Blob(jsg::Lock& js, jsg::JsBufferSource data, kj::String type)
     : ownData(data.addRef(js)),
       data(data.asArrayPtr()),
-      type(kj::mv(type)) {
-  if (FeatureFlags::get(js).getNoResizableArrayBufferInBlob()) {
-    JSG_REQUIRE(
-        !data.isResizable(), TypeError, "Cannot create a Blob with a resizable ArrayBuffer");
-  }
-}
+      type(kj::mv(type)) {}
 
 Blob::Blob(jsg::Ref<Blob> parent, kj::ArrayPtr<const byte> data, kj::String type)
     : ownData(kj::mv(parent)),

--- a/src/workerd/api/blob.h
+++ b/src/workerd/api/blob.h
@@ -32,7 +32,7 @@ class Blob: public jsg::Object {
     JSG_STRUCT(type, endings);
   };
 
-  using BitsValue = kj::OneOf<jsg::JsBufferSource, kj::String, jsg::Ref<Blob>>;
+  using BitsValue = kj::OneOf<kj::Array<const byte>, kj::String, jsg::Ref<Blob>>;
   using Bits = kj::Array<BitsValue>;
 
   static jsg::Ref<Blob> constructor(

--- a/src/workerd/api/tests/blob-test.wd-test
+++ b/src/workerd/api/tests/blob-test.wd-test
@@ -8,11 +8,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "blob-test.js")
         ],
-        compatibilityFlags = [
-          "nodejs_compat",
-          "set_tostring_tag",
-          "workers_api_getters_setters_on_prototype",
-          "resizable_array_buffer_in_blob"],
+        compatibilityFlags = ["nodejs_compat", "set_tostring_tag", "workers_api_getters_setters_on_prototype"],
         bindings = [
           (name = "request-blob", service = "blob-test")
         ]

--- a/src/workerd/api/tests/blob2-test.js
+++ b/src/workerd/api/tests/blob2-test.js
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { ok, strictEqual, deepStrictEqual, throws } from 'node:assert';
+import { ok, strictEqual, deepStrictEqual } from 'node:assert';
 
 export const test = {
   async test() {
@@ -34,15 +34,5 @@ export const bytes = {
     const u8_2 = await res.bytes();
     deepStrictEqual(u8_2, check);
     ok(u8_2 instanceof Uint8Array);
-  },
-};
-
-export const noResizable = {
-  test() {
-    const ab = new ArrayBuffer(8, { maxByteLength: 16 });
-    throws(() => new Blob([ab]), {
-      name: 'TypeError',
-      message: 'Cannot create a Blob with a resizable ArrayBuffer',
-    });
   },
 };

--- a/src/workerd/api/tests/blob2-test.wd-test
+++ b/src/workerd/api/tests/blob2-test.wd-test
@@ -7,11 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "blob2-test.js")
         ],
-        compatibilityFlags = [
-          "nodejs_compat",
-          "blob_standard_mime_type",
-          "no_resizable_array_buffer_in_blob",
-        ],
+        compatibilityFlags = ["nodejs_compat", "blob_standard_mime_type"],
       )
     ),
   ],

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1505,7 +1505,8 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
 
   noResizableArrayBufferInBlob @173 :Bool
     $compatEnableFlag("no_resizable_array_buffer_in_blob")
-    $compatDisableFlag("resizable_array_buffer_in_blob");
+    $compatDisableFlag("resizable_array_buffer_in_blob")
+    $experimental;
   # When enabled, creating a Blob with a resizable ArrayBuffer will throw a TypeError, matching
   # expected spec behavior.
 }


### PR DESCRIPTION
…Buffer"

This partially reverts commit 50417a4800f207eacdcd882a4ff20f54e66b2997.