### PR TITLE
Fix experimental queue metrics hanging with missing body size

### DIFF
--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -463,7 +463,8 @@ jsg::Promise<WorkerQueue::Metrics> WorkerQueue::metrics(
   auto headers = kj::HttpHeaders(context.getHeaderTable());
 
   auto client = context.getHttpClient(subrequestChannel, true, kj::none, "queue_metrics"_kjc);
-  auto req = client->request(kj::HttpMethod::GET, "https://fake-host/metrics"_kjc, headers);
+  auto req = client->request(
+      kj::HttpMethod::GET, "https://fake-host/metrics"_kjc, headers, static_cast<uint64_t>(0));
   const auto& headerIds = context.getHeaderIds();
 
   static constexpr auto handleMetrics = [](auto req, auto client,

--- a/src/workerd/api/tests/queue-metrics-test.js
+++ b/src/workerd/api/tests/queue-metrics-test.js
@@ -9,6 +9,10 @@ export default {
     const { pathname } = new URL(request.url);
     if (pathname === '/metrics') {
       assert.strictEqual(request.method, 'GET');
+      // Regression test: read the request body before responding, matching
+      // production behavior. If we omit expectedBodySize on the GET request,
+      // the body pipe is never closed and this arrayBuffer() call deadlocks
+      await request.arrayBuffer();
       return Response.json({
         backlogCount: 100,
         backlogBytes: 2048,


### PR DESCRIPTION
## Summary

One-line fix for the experimental `metrics()` method on the queues binding. 

In production, the upstream service calls `arrayBuffer()` on the request body. This was hanging as the body pipe was never closed.

## Testing
Added regression test, verified that it times out without the fix.
- [x] bazel test //src/workerd/api/tests:queue-metrics-test@