### PR TITLE
Set broken.ignored no such actor class is IS_USER_ERROR

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3855,7 +3855,9 @@ Worker::Actor::Actor(const Worker& worker,
       // const_cast OK because we're just storing the pointer and will only use this under lock.
       impl->classInstance = const_cast<ActorClassInfo*>(&cls);
     } else {
-      kj::throwFatalException(KJ_EXCEPTION(FAILED, "broken.ignored; no such actor class", c));
+      auto e = KJ_EXCEPTION(FAILED, "broken.ignored; no such actor class", c);
+      e.setDetail(jsg::EXCEPTION_IS_USER_ERROR, kj::heapArray<kj::byte>(0));
+      kj::throwFatalException(kj::mv(e));
     }
   } else {
     impl->classInstance = Impl::NoClass();


### PR DESCRIPTION
This error "no such actor class" represents a permanent, irrecoverable failure caused by an actor class that was renamed/removed but alarm persists in storage. We should mark is as user error.