### PR TITLE
Save and restore user span context on hibernation.

### DIFF
--- a/src/workerd/api/tests/tail-worker-test.js
+++ b/src/workerd/api/tests/tail-worker-test.js
@@ -284,9 +284,9 @@ const expectedWithPropagation = [
 
   // websocket/hibernation: independent roots
   n(E.wsUpgrade),
-  n(E.wsHibernation),
-  n(E.wsMessage),
-  n(E.wsClose),
+  // wsMessage and wsClose are children of wsHibernation because the trace context
+  // was captured at acceptWebSocket() time and restored when the DO was woken up.
+  n(E.wsHibernation, [n(E.wsMessage), n(E.wsClose)]),
 
   // cacheMode: standalone
   n(E.cacheMode),

--- a/src/workerd/io/hibernation-manager.c++
+++ b/src/workerd/io/hibernation-manager.c++
@@ -5,7 +5,9 @@
 #include "hibernation-manager.h"
 
 #include "io-channels.h"
+#include "io-context.h"
 
+#include <workerd/util/autogate.h>
 #include <workerd/util/uuid.h>
 
 namespace workerd {
@@ -110,6 +112,15 @@ void HibernationManagerImpl::acceptWebSocket(
 
   auto hib = kj::heap<HibernatableWebSocket>(kj::mv(ws), tags, *this);
   HibernatableWebSocket& refToHibernatable = *hib.get();
+
+  // TODO(mar): Improve accept span context capturing — route snapshotted user span context
+  // to serialization point instead of capturing only the invocation root span here.
+  if (util::Autogate::isEnabled(util::AutogateKey::USER_SPAN_CONTEXT_PROPAGATION)) {
+    auto& invCtx = IoContext::current().getInvocationSpanContext();
+    refToHibernatable.userSpanContext =
+        tracing::SpanContext(invCtx.getTraceId(), invCtx.getSpanId());
+  }
+
   allWs.push_front(kj::mv(hib));
   refToHibernatable.node = allWs.begin();
 
@@ -266,8 +277,14 @@ kj::Promise<void> HibernationManagerImpl::handleSocketTermination(
     }
 
     KJ_REQUIRE_NONNULL(params).setTimeout(eventTimeoutMs);
-    // Dispatch the event.
-    auto workerInterface = loopback->getWorker(IoChannelFactory::SubrequestMetadata{});
+    // Dispatch the event, restoring the trace context captured at acceptWebSocket time.
+    SpanParent userSpanParent = SpanParent(nullptr);
+    KJ_IF_SOME(ctx, hib.userSpanContext) {
+      userSpanParent = SpanParent::fromSpanContext(tracing::SpanContext::clone(ctx));
+    }
+    auto workerInterface = loopback->getWorker({
+      .userSpanParent = kj::mv(userSpanParent),
+    });
     event = workerInterface
                 ->customEvent(kj::heap<api::HibernatableWebSocketCustomEvent>(
                     hibernationEventType, kj::mv(KJ_REQUIRE_NONNULL(params)), *this))
@@ -372,8 +389,14 @@ kj::Promise<void> HibernationManagerImpl::readLoop(HibernatableWebSocket& hib) {
     auto params = kj::mv(KJ_REQUIRE_NONNULL(maybeParams));
     params.setTimeout(eventTimeoutMs);
     auto isClose = params.isCloseEvent();
-    // Dispatch the event.
-    auto workerInterface = loopback->getWorker(IoChannelFactory::SubrequestMetadata{});
+    // Dispatch the event, restoring the trace context captured at acceptWebSocket time.
+    SpanParent userSpanParent = SpanParent(nullptr);
+    KJ_IF_SOME(ctx, hib.userSpanContext) {
+      userSpanParent = SpanParent::fromSpanContext(tracing::SpanContext::clone(ctx));
+    }
+    auto workerInterface = loopback->getWorker({
+      .userSpanParent = kj::mv(userSpanParent),
+    });
     co_await workerInterface->customEvent(kj::heap<api::HibernatableWebSocketCustomEvent>(
         hibernationEventType, kj::mv(params), *this));
     if (isClose) {

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -7,6 +7,7 @@
 #include <workerd/api/actor-state.h>
 #include <workerd/api/hibernatable-web-socket.h>
 #include <workerd/api/web-socket.h>
+#include <workerd/io/trace.h>
 #include <workerd/jsg/jsg.h>
 
 #include <kj/exception.h>
@@ -129,6 +130,10 @@ class HibernationManagerImpl final: public Worker::Actor::HibernationManager {
     // True once we have dispatched the close event.
     // This prevents us from dispatching it if we have already done so.
     bool hasDispatchedClose = false;
+
+    // Trace context captured at acceptWebSocket() time, restored when the DO is woken up
+    // so that hibernation events are linked to the original trace.
+    kj::Maybe<tracing::SpanContext> userSpanContext;
 
     // Stores the last received autoResponseRequest timestamp.
     kj::Maybe<kj::Date> autoResponseTimestamp;

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -1051,6 +1051,10 @@ class SpanParent {
   // Return the serializable identity of this span for cross-boundary propagation.
   kj::Maybe<tracing::SpanContext> toSpanContext();
 
+  // Create a SpanParent from a pre-serialized SpanContext. The resulting SpanParent
+  // carries identity for toSpanContext() but does not record spans.
+  static SpanParent fromSpanContext(tracing::SpanContext context);
+
  private:
   kj::Maybe<kj::Own<SpanObserver>> observer;
 };
@@ -1188,11 +1192,35 @@ class SpanObserver: public kj::Refcounted {
   }
 };
 
+// A non-recording SpanObserver that carries a pre-serialized SpanContext for propagation.
+// Used to create a SpanParent from stored identity when no live observer exists
+// (e.g. rehydrating trace context after hibernation).
+class NonRecordingSpanObserver final: public SpanObserver {
+ public:
+  explicit NonRecordingSpanObserver(tracing::SpanContext context): context(kj::mv(context)) {}
+
+  kj::Own<SpanObserver> newChild() override {
+    return {};
+  }
+  void onOpen(kj::ConstString, kj::Date) override {}
+  void onClose(kj::Date, Span::TagMap&&, kj::Vector<Span::Log>&&) override {}
+  kj::Maybe<tracing::SpanContext> toSpanContext() override {
+    return tracing::SpanContext::clone(context);
+  }
+
+ private:
+  tracing::SpanContext context;
+};
+
 inline kj::Maybe<tracing::SpanContext> SpanParent::toSpanContext() {
   KJ_IF_SOME(obs, observer) {
     return obs->toSpanContext();
   }
   return kj::none;
+}
+
+inline SpanParent SpanParent::fromSpanContext(tracing::SpanContext context) {
+  return SpanParent(kj::refcounted<NonRecordingSpanObserver>(kj::mv(context)));
 }
 
 inline SpanParent::SpanParent(SpanBuilder& builder): observer(mapAddRef(builder.observer)) {}


### PR DESCRIPTION
Serialize user span context captured at acceptWebSocket time and restore on wake.