### PR TITLE
node: tls: accept ALPNProtocols for undici compatibility

### DIFF
--- a/src/node/internal/internal_tls_wrap.ts
+++ b/src/node/internal/internal_tls_wrap.ts
@@ -32,7 +32,10 @@ import {
   tryReadStart,
 } from 'node-internal:internal_net';
 import { JSStreamSocket } from 'node-internal:internal_tls_jsstream';
-import { checkServerIdentity } from 'node-internal:internal_tls';
+import {
+  checkServerIdentity,
+  convertALPNProtocols,
+} from 'node-internal:internal_tls';
 import type {
   ConnectionOptions,
   TlsOptions,
@@ -194,8 +197,12 @@ export function TLSSocket(
   }
 
   if (tlsOptions.ALPNProtocols !== undefined) {
-    // Does not apply to Cloudflare Workers.
-    throw new ERR_OPTION_NOT_IMPLEMENTED('options.ALPNProtocols');
+    // connect()/startTls() does not expose ALPN selection yet.
+    // Undici's buildConnector always passes ALPNProtocols for TLS connections,
+    // so rejecting it breaks clients like @elastic/elasticsearch. Accept the
+    // option and preserve Node.js input validation behavior.
+    const normalizedAlpn = { ALPNProtocols: Buffer.alloc(0) };
+    convertALPNProtocols(tlsOptions.ALPNProtocols, normalizedAlpn);
   }
 
   if (tlsOptions.SNICallback !== undefined) {

--- a/src/workerd/api/node/tests/tls-nodejs-test.js
+++ b/src/workerd/api/node/tests/tls-nodejs-test.js
@@ -753,6 +753,34 @@ export const testConvertALPNProtocols = {
   },
 };
 
+export const testConnectAcceptsAlpnProtocols = {
+  async test(_ctrl, env) {
+    const socket = tls.connect({
+      port: env.ECHO_SERVER_PORT,
+      ALPNProtocols: ['http/1.1'],
+    });
+
+    await once(socket, 'secureConnect');
+    socket.destroy();
+  },
+};
+
+export const testConnectRejectsInvalidAlpnProtocolLength = {
+  async test() {
+    throws(
+      () =>
+        tls.connect({
+          port: 42,
+          lookup() {},
+          ALPNProtocols: [new String('a').repeat(500)],
+        }),
+      {
+        code: 'ERR_OUT_OF_RANGE',
+      }
+    );
+  },
+};
+
 export const testStartTlsBehaviorOnUpgrade = {
   async test(ctrl, env) {
     const { promise, resolve, reject } = Promise.withResolvers();


### PR DESCRIPTION
Fixes #6527

This change fixes a Node.js compatibility issue where TLS connections failed with:
The options.ALPNProtocols option is not implemented

In practice, this was breaking @elastic/elasticsearch usage on Workers because Undici passes ALPNProtocols by default on HTTPS connections.

## Root cause
The TLS compatibility layer in internal_tls_wrap.ts explicitly rejected options.ALPNProtocols, even though this option is commonly set by upstream clients and connectors.

## What changed
- Accept ALPNProtocols in TLSSocket options instead of throwing.
- Keep Node-like input validation by normalizing ALPNProtocols via convertALPNProtocols.
- Add regression coverage in tls-nodejs-test.js:
- handshake succeeds when ALPNProtocols is provided
- invalid ALPN protocol length still throws ERR_OUT_OF_RANGE

## Why this is safe
- This PR removes an unnecessary compatibility rejection, but does not claim full ALPN feature exposure through the public sockets API.
- Existing validation behavior is preserved.
- Scope is intentionally minimal and focused on ecosystem compatibility.

## Validation
- npx -y @bazel/bazelisk test //src/workerd/api/node/tests:tls-nodejs-test@ --test_output=errors
- npx -y @bazel/bazelisk test //src/workerd/api/node/tests:tls-nodejs-test@all-compat-flags //src/workerd/api/node/tests:tls-nodejs-test@all-autogates --test_output=errors
