### PR TITLE
ensure worker stub subrequest channel is kept alive until internal startRequest call

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4250,9 +4250,9 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
       kj::Own<WorkerInterface> startRequest(
           IoChannelFactory::SubrequestMetadata metadata) override {
         if (isolate->service == kj::none) {
-          return newPromisedWorkerInterface(
-              isolate->startupTask.addBranch().then([this, metadata = kj::mv(metadata)]() mutable {
-            return startRequestImpl(kj::mv(metadata));
+          return newPromisedWorkerInterface(isolate->startupTask.addBranch().then(
+              [self = kj::addRef(*this), metadata = kj::mv(metadata)]() mutable {
+            return self->startRequestImpl(kj::mv(metadata));
           }));
         } else {
           return startRequestImpl(kj::mv(metadata));


### PR DESCRIPTION
When using `newPromisedWorkerInterface`, by the time the `.then()` callback is executed, it is possible for the subrequest channel itself to have gone out of scope due to GC kicking in, causing a crash when `startRequestImpl` tries to access the worker service

```js
// This pattern triggers the bug (fetcher can get GC'd)
const result = await dynamicWorker.getEntrypoint().foo(...);

// This doesn't (Fetcher is kept in scope, keeping the subrequest channel alive)
const e = dynamicWorker.getEntrypoint();
const result = await e.foo(...);
```

Closes #6441