### PR TITLE
Fix use-after-free segfault in dynamic worker loading (worker_loaders)

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4250,9 +4250,12 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
       kj::Own<WorkerInterface> startRequest(
           IoChannelFactory::SubrequestMetadata metadata) override {
         if (isolate->service == kj::none) {
-          return newPromisedWorkerInterface(
-              isolate->startupTask.addBranch().then([this, metadata = kj::mv(metadata)]() mutable {
-            return startRequestImpl(kj::mv(metadata));
+          // Capture a refcounted reference rather than a raw `this` pointer so that the
+          // SubrequestChannelImpl is kept alive until the startup task resolves, even if the
+          // owning Fetcher is garbage-collected while the deferred promise is pending.
+          return newPromisedWorkerInterface(isolate->startupTask.addBranch().then(
+              [self = kj::addRef(*this), metadata = kj::mv(metadata)]() mutable {
+            return self->startRequestImpl(kj::mv(metadata));
           }));
         } else {
           return startRequestImpl(kj::mv(metadata));
@@ -4276,7 +4279,17 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
           entrypointService = service->getEntrypoint(entrypointName, kj::mv(props));
         }
         KJ_IF_SOME(ep, entrypointService) {
-          return ep->startRequest(kj::mv(metadata));
+          // Attach a refcounted reference to `this` (SubrequestChannelImpl) to the returned
+          // WorkerInterface. This keeps the SubrequestChannelImpl alive for the duration of
+          // the request, which in turn keeps the WorkerStubImpl alive (via Rc), preventing
+          // WorkerStubImpl::unlink() from destroying the WorkerService's I/O channels while
+          // the request's IoContext still holds raw pointers to the WorkerService.
+          //
+          // Without this, if the JS Fetcher object is garbage-collected mid-request (e.g.
+          // because it was a temporary expression), the SubrequestChannelImpl is destroyed,
+          // the WorkerStubImpl refcount drops to zero, unlink() clears the WorkerService's
+          // LinkedIoChannels, and the child worker's IoContext crashes accessing them.
+          return ep->startRequest(kj::mv(metadata)).attach(kj::addRef(*this));
         } else {
           KJ_IF_SOME(en, entrypointName) {
             JSG_FAIL_REQUIRE(Error, "Worker has no such entrypoint: ", en);
@@ -4307,11 +4320,13 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
           return kj::none;
         }
 
-        // Have to wait for the isolate to start up.
-        return isolate->startupTask.addBranch().then([this]() {
-          if (inner == kj::none) {
-            inner =
-                KJ_ASSERT_NONNULL(isolate->service)->getActorClass(entrypointName, kj::mv(props));
+        // Have to wait for the isolate to start up. Capture a refcounted reference rather than
+        // a raw `this` pointer so that the ActorClassImpl stays alive until the startup task
+        // resolves, even if the owning object is garbage-collected while waiting.
+        return isolate->startupTask.addBranch().then([self = kj::addRef(*this)]() mutable {
+          if (self->inner == kj::none) {
+            self->inner = KJ_ASSERT_NONNULL(self->isolate->service)
+                              ->getActorClass(self->entrypointName, kj::mv(self->props));
           }
         });
       }


### PR DESCRIPTION
Fixes #6441.

When JS code uses dynamic worker loading with temporary objects, e.g.:

    loader.get(name, getCode).getEntrypoint().evaluate(args)

the WorkerStub and Fetcher JS objects are temporaries that V8's garbage collector can destroy mid-request. This triggers a chain of destruction:

1. Fetcher GC'd → IoOwn<SubrequestChannelImpl> destroyed
2. SubrequestChannelImpl destroyed → Rc<WorkerStubImpl> released
3. WorkerStubImpl refcount hits zero → destructor calls unlink()
4. unlink() calls WorkerService::unlink() which clears LinkedIoChannels
5. The child worker's IoContext still holds raw pointers (via NullDisposer) to the WorkerService as its IoChannelFactory
6. Child worker tries to use I/O channels (e.g. RPC callback to parent) → accesses freed/cleared memory → SIGSEGV or SIGBUS

This was 100% reproducible using @cloudflare/codemode's DynamicWorkerExecutor, which chains loader.get().getEntrypoint().evaluate() as a single expression with no intermediate variable assignments.

Three fixes applied to SubrequestChannelImpl and ActorClassImpl in WorkerLoaderNamespace:

- startRequestImpl(): Attach kj::addRef(*this) to the returned WorkerInterface, keeping the SubrequestChannelImpl (and thus the WorkerStubImpl and WorkerService) alive for the full request duration.

- startRequest() deferred path: Replace raw `[this, ...]` capture in the .then() lambda with `[self = kj::addRef(*this), ...]` to prevent use-after-free when the Fetcher is GC'd before async startup completes.

- ActorClassImpl::whenReady(): Same refcounted capture pattern for the actor class deferred startup path.

## Reproduction

Requires `@cloudflare/codemode` and `wrangler`:

```json
// package.json
{ "dependencies": { "@cloudflare/codemode": "^0.3.2", "wrangler": "^4.77.0" } }
```

```jsonc
// wrangler.jsonc
{
  "name": "repro",
  "main": "src/index.ts",
  "compatibility_date": "2025-06-01",
  "compatibility_flags": ["nodejs_compat"],
  "worker_loaders": [{ "binding": "LOADER" }]
}
```

```ts
// src/index.ts
import { DynamicWorkerExecutor, resolveProvider } from '@cloudflare/codemode';
interface Env {
  LOADER: ConstructorParameters<typeof DynamicWorkerExecutor>[0]['loader'];
}
export default {
  async fetch(request: Request, env: Env) {
    const executor = new DynamicWorkerExecutor({ loader: env.LOADER, timeout: 30_000 });
    const tools = {
      get_items: async () =>
        Array.from({ length: 112 }, (_, i) => ({
          id: `item_${i}`, name: `Item ${i}`, memo: 'x'.repeat(220),
        })),
    };
    for (let i = 0; i < 6; i++) {
      const result = await executor.execute(
        `async () => { return await codemode.get_items(); }`,
        [resolveProvider({ name: 'codemode', tools })]
      );
      if (result.error) return Response.json({ round: i, error: result.error }, { status: 500 });
    }
    return Response.json({ ok: true });
  },
};
```

Then: `wrangler dev` and `curl http://localhost:8787` → segfault every time.

To test a local workerd build against this reproduction:

    MINIFLARE_WORKERD_PATH=bazel-bin/src/workerd/server/workerd wrangler dev