### PR TITLE
Fix remaining use-after-free in dynamic worker loading (worker_loaders)

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4257,6 +4257,9 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
       kj::Own<WorkerInterface> startRequest(
           IoChannelFactory::SubrequestMetadata metadata) override {
         if (isolate->service == kj::none) {
+          // Capture a refcounted reference rather than a raw `this` pointer so that the
+          // SubrequestChannelImpl is kept alive until the startup task resolves, even if the
+          // owning Fetcher is garbage-collected while the deferred promise is pending.
           return newPromisedWorkerInterface(isolate->startupTask.addBranch().then(
               [self = kj::addRef(*this), metadata = kj::mv(metadata)]() mutable {
             return self->startRequestImpl(kj::mv(metadata));
@@ -4283,7 +4286,17 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
           entrypointService = service->getEntrypoint(entrypointName, kj::mv(props));
         }
         KJ_IF_SOME(ep, entrypointService) {
-          return ep->startRequest(kj::mv(metadata));
+          // Attach a refcounted reference to `this` (SubrequestChannelImpl) to the returned
+          // WorkerInterface. This keeps the SubrequestChannelImpl alive for the duration of
+          // the request, which in turn keeps the WorkerStubImpl alive (via Rc), preventing
+          // WorkerStubImpl::unlink() from destroying the WorkerService's I/O channels while
+          // the request's IoContext still holds raw pointers to the WorkerService.
+          //
+          // Without this, if the JS Fetcher object is garbage-collected mid-request (e.g.
+          // because it was a temporary expression), the SubrequestChannelImpl is destroyed,
+          // the WorkerStubImpl refcount drops to zero, unlink() clears the WorkerService's
+          // LinkedIoChannels, and the child worker's IoContext crashes accessing them.
+          return ep->startRequest(kj::mv(metadata)).attach(kj::addRef(*this));
         } else {
           KJ_IF_SOME(en, entrypointName) {
             JSG_FAIL_REQUIRE(Error, "Worker has no such entrypoint: ", en);
@@ -4314,11 +4327,13 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
           return kj::none;
         }
 
-        // Have to wait for the isolate to start up.
-        return isolate->startupTask.addBranch().then([this]() {
-          if (inner == kj::none) {
-            inner =
-                KJ_ASSERT_NONNULL(isolate->service)->getActorClass(entrypointName, kj::mv(props));
+        // Have to wait for the isolate to start up. Capture a refcounted reference rather than
+        // a raw `this` pointer so that the ActorClassImpl stays alive until the startup task
+        // resolves, even if the owning object is garbage-collected while waiting.
+        return isolate->startupTask.addBranch().then([self = kj::addRef(*this)]() mutable {
+          if (self->inner == kj::none) {
+            self->inner = KJ_ASSERT_NONNULL(self->isolate->service)
+                              ->getActorClass(self->entrypointName, kj::mv(self->props));
           }
         });
       }


### PR DESCRIPTION
Follow-up to #6547, which fixed the deferred startup path but missed two additional crash vectors for the same root cause (#6441).

#6547 fixed the `[this, ...]` capture in `SubrequestChannelImpl:: startRequest()` for the case where `isolate->service == kj::none` (async startup not yet complete). However, the crash reported in #6441 also reproduces on the synchronous startup path, and with the same pattern on `ActorClassImpl::whenReady()`.

The core problem: when JS code chains temporary objects like

    loader.get(name, getCode).getEntrypoint().evaluate(args)

V8 can GC the Fetcher mid-request. This destroys the SubrequestChannelImpl, which releases its Rc<WorkerStubImpl>, which triggers WorkerStubImpl::unlink() → WorkerService::unlink(), clearing the LinkedIoChannels. The child worker's IoContext still holds raw pointers (via NullDisposer) to the WorkerService as its IoChannelFactory and LimitEnforcer, so the next I/O operation (e.g. an RPC callback to the parent) dereferences freed memory → SIGSEGV or SIGBUS.

This remains 100% reproducible on current main using the reproduction from #6441 (@cloudflare/codemode DynamicWorkerExecutor).

Two additional fixes, both in WorkerLoaderNamespace:

- SubrequestChannelImpl::startRequestImpl(): Attach kj::addRef(*this) to the returned WorkerInterface, keeping the SubrequestChannelImpl (and thus WorkerStubImpl and WorkerService) alive for the full request duration. This is the fix for the synchronous startup path that #6547 did not address.

- ActorClassImpl::whenReady(): Replace raw `[this]` capture with `[self = kj::addRef(*this)]` — same pattern as the SubrequestChannelImpl fix from #6547, applied to the actor class deferred startup path.

## Reproduction

Requires `@cloudflare/codemode` and `wrangler`:

```json
// package.json
{ "dependencies": { "@cloudflare/codemode": "^0.3.2", "wrangler": "^4.77.0" } }
```

```jsonc
// wrangler.jsonc
{
  "name": "repro",
  "main": "src/index.ts",
  "compatibility_date": "2025-06-01",
  "compatibility_flags": ["nodejs_compat"],
  "worker_loaders": [{ "binding": "LOADER" }]
}
```

```ts
// src/index.ts
import { DynamicWorkerExecutor, resolveProvider } from '@cloudflare/codemode';
interface Env {
  LOADER: ConstructorParameters<typeof DynamicWorkerExecutor>[0]['loader'];
}
export default {
  async fetch(request: Request, env: Env) {
    const executor = new DynamicWorkerExecutor({ loader: env.LOADER, timeout: 30_000 });
    const tools = {
      get_items: async () =>
        Array.from({ length: 112 }, (_, i) => ({
          id: `item_${i}`, name: `Item ${i}`, memo: 'x'.repeat(220),
        })),
    };
    for (let i = 0; i < 6; i++) {
      const result = await executor.execute(
        `async () => { return await codemode.get_items(); }`,
        [resolveProvider({ name: 'codemode', tools })]
      );
      if (result.error) return Response.json({ round: i, error: result.error }, { status: 500 });
    }
    return Response.json({ ok: true });
  },
};
```

Then: `wrangler dev` and `curl http://localhost:8787` → segfault every time.

To test a local workerd build against this reproduction:

    MINIFLARE_WORKERD_PATH=bazel-bin/src/workerd/server/workerd wrangler dev