### PR TITLE
[build] Fix clangd under macOS, speed up CI slightly

### DIFF
--- a/build/ci.bazelrc
+++ b/build/ci.bazelrc
@@ -4,12 +4,11 @@
 build:ci --keep_going
 build:ci --verbose_failures
 # Use a higher jobs level to effectively fetch from CPU and and use the remote cache at the same
-# time, see https://github.com/bazelbuild/bazel/issues/6394. 32 is still a fairly small number here
-# and should work for the small CI runners we use, if we switch to a bigger runner consider
-# increasing this closer towards the suggested value of 200. Note the number of maximum build jobs
-# is controlled by the --local_resources=cpu flag and still limited to the number of cores by
-# default.
-build:ci --jobs=32
+# time, see https://github.com/bazelbuild/bazel/issues/6394. This is still a relatively small number
+# and should work for the CI runners we use, if we switch to bigger runners consider increasing this
+# closer towards the suggested value of 200. Note the number of maximum build jobs is controlled by
+# the --local_resources=cpu flag and still limited to the number of cores by default.
+build:ci --jobs=64
 # Do not check for changes in external repository files, should speed up bazel invocations after the first one
 build:ci --noexperimental_check_external_repository_files
 # Only build runfile trees when needed. Runfile trees are useful for directly invoking bazel-built

--- a/build/tools/clang_tidy/clang_tidy.bazelrc
+++ b/build/tools/clang_tidy/clang_tidy.bazelrc
@@ -1,5 +1,6 @@
 # enable clang tidy checks with default configuration
 build:clang-tidy --aspects //build/tools/clang_tidy:clang_tidy.bzl%clang_tidy_aspect --output_groups=+clang_tidy_checks
+build:clang-tidy-only --aspects //build/tools/clang_tidy:clang_tidy.bzl%clang_tidy_aspect --output_groups=clang_tidy_checks
 
 # enable clang tidy check with all issues reported as warnings
 build:clang-tidy-warnings --config=clang-tidy --aspects_parameters=clang_tidy_args=--warnings-as-errors=-*

--- a/build/tools/clang_tidy/clang_tidy.bzl
+++ b/build/tools/clang_tidy/clang_tidy.bzl
@@ -154,6 +154,9 @@ def _clang_tidy_aspect_impl(target, ctx):
 
         # macOS includes
         args.add("-isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1")
+
+        # Xcode 26.4 bumps the Apple Clang version from 17 to 21, support both for now
+        args.add("-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/include")
         args.add("-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include")
         args.add("-isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include")
 

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -27,6 +27,7 @@
 -isystem/usr/include/aarch64-linux-gnu
 -isystem/usr/include
 -isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1
+-isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/include
 -isystem/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include
 -isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
 -isystem/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/Current/Headers


### PR DESCRIPTION
- Xcode 26.4 bumped the AppleClang version, add the new path for that
- Increase number of concurrent jobs to speed up downloading/fetching from cache now that we have larger runners
- Add new clang-tidy-only action, we may use this in the lint CI job in the future (would have to make sure header parsing and Rust linting are still active though)