### PR TITLE
Remove experimental gate from Queues metrics APIs

### DIFF
--- a/src/workerd/api/queue.h
+++ b/src/workerd/api/queue.h
@@ -138,32 +138,18 @@ class WorkerQueue: public jsg::Object {
   jsg::Promise<Metrics> metrics(jsg::Lock& js, const jsg::TypeHandler<Metrics>& metricsHandler);
 
   JSG_RESOURCE_TYPE(WorkerQueue, CompatibilityFlags::Reader flags) {
-    if (flags.getWorkerdExperimental()) {
-      JSG_METHOD_NAMED(send, sendWithResponse);
-      JSG_METHOD_NAMED(sendBatch, sendBatchWithResponse);
-      JSG_METHOD(metrics);
-    } else {
-      JSG_METHOD(send);
-      JSG_METHOD(sendBatch);
-    }
+    JSG_METHOD(metrics);
+    JSG_METHOD_NAMED(send, sendWithResponse);
+    JSG_METHOD_NAMED(sendBatch, sendBatchWithResponse);
 
     JSG_TS_ROOT();
-    if (flags.getWorkerdExperimental()) {
-      JSG_TS_OVERRIDE(Queue<Body = unknown> {
-        send(message: Body, options?: QueueSendOptions): Promise<QueueSendResponse>;
-        sendBatch(messages
-                  : Iterable<MessageSendRequest<Body>>, options ?: QueueSendBatchOptions)
-            : Promise<QueueSendBatchResponse>;
-        metrics(): Promise<QueueMetrics>;
-      });
-    } else {
-      JSG_TS_OVERRIDE(Queue<Body = unknown> {
-        send(message: Body, options?: QueueSendOptions): Promise<void>;
-        sendBatch(messages
-                  : Iterable<MessageSendRequest<Body>>, options ?: QueueSendBatchOptions)
-            : Promise<void>;
-      });
-    }
+    JSG_TS_OVERRIDE(Queue<Body = unknown> {
+      send(message: Body, options?: QueueSendOptions): Promise<QueueSendResponse>;
+      sendBatch(messages
+                : Iterable<MessageSendRequest<Body>>, options ?: QueueSendBatchOptions)
+          : Promise<QueueSendBatchResponse>;
+      metrics(): Promise<QueueMetrics>;
+    });
     JSG_TS_DEFINE(type QueueContentType = "text" | "bytes" | "json" | "v8");
   }
 
@@ -339,24 +325,16 @@ class QueueEvent final: public ExtendableEvent {
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(messages, getMessages);
     JSG_READONLY_INSTANCE_PROPERTY(queue, getQueueName);
 
-    if (flags.getWorkerdExperimental()) {
-      JSG_READONLY_INSTANCE_PROPERTY(metadata, getMetadata);
-    }
+    JSG_READONLY_INSTANCE_PROPERTY(metadata, getMetadata);
 
     JSG_METHOD(retryAll);
     JSG_METHOD(ackAll);
 
     JSG_TS_ROOT();
-    if (flags.getWorkerdExperimental()) {
-      JSG_TS_OVERRIDE(QueueEvent<Body = unknown> {
-          readonly messages: readonly Message<Body>[];
-          readonly metadata: MessageBatchMetadata;
-      });
-    } else {
-      JSG_TS_OVERRIDE(QueueEvent<Body = unknown> {
-          readonly messages: readonly Message<Body>[];
-      });
-    }
+    JSG_TS_OVERRIDE(QueueEvent<Body = unknown> {
+        readonly messages: readonly Message<Body>[];
+        readonly metadata: MessageBatchMetadata;
+    });
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
@@ -422,24 +400,16 @@ class QueueController final: public jsg::Object {
     JSG_READONLY_INSTANCE_PROPERTY(messages, getMessages);
     JSG_READONLY_INSTANCE_PROPERTY(queue, getQueueName);
 
-    if (flags.getWorkerdExperimental()) {
-      JSG_READONLY_INSTANCE_PROPERTY(metadata, getMetadata);
-    }
+    JSG_READONLY_INSTANCE_PROPERTY(metadata, getMetadata);
 
     JSG_METHOD(retryAll);
     JSG_METHOD(ackAll);
 
     JSG_TS_ROOT();
-    if (flags.getWorkerdExperimental()) {
-      JSG_TS_OVERRIDE(MessageBatch<Body = unknown> {
-        readonly messages: readonly Message<Body>[];
-        readonly metadata: MessageBatchMetadata;
-      });
-    } else {
-      JSG_TS_OVERRIDE(MessageBatch<Body = unknown> {
-        readonly messages: readonly Message<Body>[];
-      });
-    }
+    JSG_TS_OVERRIDE(MessageBatch<Body = unknown> {
+      readonly messages: readonly Message<Body>[];
+      readonly metadata: MessageBatchMetadata;
+    });
   }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {

--- a/src/workerd/api/tests/queue-metadata-test.js
+++ b/src/workerd/api/tests/queue-metadata-test.js
@@ -6,16 +6,6 @@ import assert from 'node:assert';
 
 export default {
   async queue(batch, env, ctx) {
-    const flagEnabled = env.METADATA_FLAG;
-
-    if (!flagEnabled) {
-      // Flag disabled → metadata property should not exist
-      assert.strictEqual(batch.metadata, undefined);
-      batch.ackAll();
-      return;
-    }
-
-    // Flag enabled → metadata should always be present
     assert.ok(batch.metadata, 'Expected batch.metadata to be defined');
     assert.ok(
       batch.metadata.metrics,
@@ -47,37 +37,27 @@ export default {
   },
 
   async test(ctrl, env, ctx) {
-    const flagEnabled = env.METADATA_FLAG;
     const timestamp = new Date();
 
-    if (flagEnabled) {
-      const response1 = await env.SERVICE.queue(
-        'test-queue',
-        [{ id: '0', timestamp, body: 'hello', attempts: 1 }],
-        {
-          metrics: {
-            backlogCount: 100,
-            backlogBytes: 2048,
-            oldestMessageTimestamp: 1000000,
-          },
-        }
-      );
-      assert.strictEqual(response1.outcome, 'ok');
-      assert(response1.ackAll);
+    const response1 = await env.SERVICE.queue(
+      'test-queue',
+      [{ id: '0', timestamp, body: 'hello', attempts: 1 }],
+      {
+        metrics: {
+          backlogCount: 100,
+          backlogBytes: 2048,
+          oldestMessageTimestamp: 1000000,
+        },
+      }
+    );
+    assert.strictEqual(response1.outcome, 'ok');
+    assert(response1.ackAll);
 
-      // Test with omitted metadata
-      const response2 = await env.SERVICE.queue('test-queue', [
-        { id: '1', timestamp, body: 'world', attempts: 1 },
-      ]);
-      assert.strictEqual(response2.outcome, 'ok');
-      assert(response2.ackAll);
-    } else {
-      // Flag disabled → handler still works, metadata not visible
-      const response = await env.SERVICE.queue('test-queue', [
-        { id: '0', timestamp, body: 'foobar', attempts: 1 },
-      ]);
-      assert.strictEqual(response.outcome, 'ok');
-      assert(response.ackAll);
-    }
+    // Test with omitted metadata
+    const response2 = await env.SERVICE.queue('test-queue', [
+      { id: '1', timestamp, body: 'world', attempts: 1 },
+    ]);
+    assert.strictEqual(response2.outcome, 'ok');
+    assert(response2.ackAll);
   },
 };

--- a/src/workerd/api/tests/queue-metadata-test.wd-test
+++ b/src/workerd/api/tests/queue-metadata-test.wd-test
@@ -9,19 +9,6 @@ const unitTests :Workerd.Config = (
         ],
         bindings = [
           ( name = "SERVICE", service = "queue-metadata-test" ),
-          ( name = "METADATA_FLAG", json = "true" ),
-        ],
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "experimental"],
-      )
-    ),
-    ( name = "queue-metadata-disabled-test",
-      worker = (
-        modules = [
-          ( name = "worker-disabled", esModule = embed "queue-metadata-test.js" )
-        ],
-        bindings = [
-          ( name = "SERVICE", service = "queue-metadata-disabled-test" ),
-          ( name = "METADATA_FLAG", json = "false" ),
         ],
         compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers"],
       )

--- a/src/workerd/api/tests/queue-metrics-sentinel-test.wd-test
+++ b/src/workerd/api/tests/queue-metrics-sentinel-test.wd-test
@@ -10,7 +10,7 @@ const unitTests :Workerd.Config = (
         bindings = [
           ( name = "QUEUE", queue = "queue-metrics-sentinel-test" ),
         ],
-        compatibilityFlags = ["nodejs_compat", "queues_json_messages", "experimental", "capture_async_api_throws"],
+        compatibilityFlags = ["nodejs_compat", "queues_json_messages", "capture_async_api_throws"],
       )
     ),
   ],

--- a/src/workerd/api/tests/queue-metrics-test.js
+++ b/src/workerd/api/tests/queue-metrics-test.js
@@ -23,21 +23,14 @@ export default {
   },
 
   async test(ctrl, env, ctx) {
-    const metricsEnabled = env.METRICS_FLAG;
-    if (metricsEnabled) {
-      // Flag ON → metrics() should exist and return data
-      assert.strictEqual(typeof env.QUEUE.metrics, 'function');
-      const metrics = await env.QUEUE.metrics();
-      assert.strictEqual(metrics.backlogCount, 100);
-      assert.strictEqual(metrics.backlogBytes, 2048);
-      assert.ok(
-        metrics.oldestMessageTimestamp instanceof Date,
-        'Expected oldestMessageTimestamp to be a Date'
-      );
-      assert.strictEqual(metrics.oldestMessageTimestamp.getTime(), 1000000);
-    } else {
-      // Flag OFF → metrics() should not be exposed on the binding
-      assert.strictEqual(typeof env.QUEUE.metrics, 'undefined');
-    }
+    assert.strictEqual(typeof env.QUEUE.metrics, 'function');
+    const metrics = await env.QUEUE.metrics();
+    assert.strictEqual(metrics.backlogCount, 100);
+    assert.strictEqual(metrics.backlogBytes, 2048);
+    assert.ok(
+      metrics.oldestMessageTimestamp instanceof Date,
+      'Expected oldestMessageTimestamp to be a Date'
+    );
+    assert.strictEqual(metrics.oldestMessageTimestamp.getTime(), 1000000);
   },
 };

--- a/src/workerd/api/tests/queue-metrics-test.wd-test
+++ b/src/workerd/api/tests/queue-metrics-test.wd-test
@@ -2,26 +2,13 @@ using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
   services = [
-    ( name = "queue-metrics-enabled",
+    ( name = "queue-metrics-test",
       worker = (
         modules = [
-          ( name = "worker-metrics-enabled", esModule = embed "queue-metrics-test.js" )
+          ( name = "worker-metrics-test", esModule = embed "queue-metrics-test.js" )
         ],
         bindings = [
-          ( name = "QUEUE", queue = "queue-metrics-enabled" ),
-          ( name = "METRICS_FLAG", json = "true" ),
-        ],
-        compatibilityFlags = ["nodejs_compat", "experimental", "capture_async_api_throws"],
-      )
-    ),
-    ( name = "queue-metrics-disabled",
-      worker = (
-        modules = [
-          ( name = "worker-metrics-disabled", esModule = embed "queue-metrics-test.js" )
-        ],
-        bindings = [
-          ( name = "QUEUE", queue = "queue-metrics-disabled" ),
-          ( name = "METRICS_FLAG", json = "false" ),
+          ( name = "QUEUE", queue = "queue-metrics-test" ),
         ],
         compatibilityFlags = ["nodejs_compat", "capture_async_api_throws"],
       )

--- a/src/workerd/api/tests/queue-producer-metadata-test.js
+++ b/src/workerd/api/tests/queue-producer-metadata-test.js
@@ -46,38 +46,31 @@ export default {
   },
 
   async test(ctrl, env) {
-    const responseBodyEnabled = env.RESPONSE_BODY_FLAG;
-
     const sendResult = await env.QUEUE.send('abc', { contentType: 'text' });
     const sendBatchResult = await env.QUEUE.sendBatch([
       { body: 'def', contentType: 'text' },
     ]);
 
-    if (responseBodyEnabled) {
-      assert.strictEqual(sendResult.metadata.metrics.backlogCount, 100);
-      assert.strictEqual(sendResult.metadata.metrics.backlogBytes, 2048);
-      assert.ok(
-        sendResult.metadata.metrics.oldestMessageTimestamp instanceof Date,
-        'Expected oldestMessageTimestamp to be a Date'
-      );
-      assert.strictEqual(
-        sendResult.metadata.metrics.oldestMessageTimestamp.getTime(),
-        1000000
-      );
+    assert.strictEqual(sendResult.metadata.metrics.backlogCount, 100);
+    assert.strictEqual(sendResult.metadata.metrics.backlogBytes, 2048);
+    assert.ok(
+      sendResult.metadata.metrics.oldestMessageTimestamp instanceof Date,
+      'Expected oldestMessageTimestamp to be a Date'
+    );
+    assert.strictEqual(
+      sendResult.metadata.metrics.oldestMessageTimestamp.getTime(),
+      1000000
+    );
 
-      assert.strictEqual(sendBatchResult.metadata.metrics.backlogCount, 200);
-      assert.strictEqual(sendBatchResult.metadata.metrics.backlogBytes, 4096);
-      assert.ok(
-        sendBatchResult.metadata.metrics.oldestMessageTimestamp instanceof Date,
-        'Expected oldestMessageTimestamp to be a Date'
-      );
-      assert.strictEqual(
-        sendBatchResult.metadata.metrics.oldestMessageTimestamp.getTime(),
-        2000000
-      );
-    } else {
-      assert.strictEqual(sendResult, undefined);
-      assert.strictEqual(sendBatchResult, undefined);
-    }
+    assert.strictEqual(sendBatchResult.metadata.metrics.backlogCount, 200);
+    assert.strictEqual(sendBatchResult.metadata.metrics.backlogBytes, 4096);
+    assert.ok(
+      sendBatchResult.metadata.metrics.oldestMessageTimestamp instanceof Date,
+      'Expected oldestMessageTimestamp to be a Date'
+    );
+    assert.strictEqual(
+      sendBatchResult.metadata.metrics.oldestMessageTimestamp.getTime(),
+      2000000
+    );
   },
 };

--- a/src/workerd/api/tests/queue-producer-metadata-test.wd-test
+++ b/src/workerd/api/tests/queue-producer-metadata-test.wd-test
@@ -2,26 +2,13 @@ using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
   services = [
-    ( name = "queue-producer-metadata-enabled",
+    ( name = "queue-producer-metadata-test",
       worker = (
         modules = [
-          ( name = "worker-producer-metadata-enabled", esModule = embed "queue-producer-metadata-test.js" )
+          ( name = "worker-producer-metadata-test", esModule = embed "queue-producer-metadata-test.js" )
         ],
         bindings = [
-          ( name = "QUEUE", queue = "queue-producer-metadata-enabled" ),
-          ( name = "RESPONSE_BODY_FLAG", json = "true" ),
-        ],
-        compatibilityFlags = ["nodejs_compat", "queues_json_messages", "experimental", "capture_async_api_throws"],
-      )
-    ),
-    ( name = "queue-producer-metadata-disabled",
-      worker = (
-        modules = [
-          ( name = "worker-producer-metadata-disabled", esModule = embed "queue-producer-metadata-test.js" )
-        ],
-        bindings = [
-          ( name = "QUEUE", queue = "queue-producer-metadata-disabled" ),
-          ( name = "RESPONSE_BODY_FLAG", json = "false" ),
+          ( name = "QUEUE", queue = "queue-producer-metadata-test" ),
         ],
         compatibilityFlags = ["nodejs_compat", "queues_json_messages", "capture_async_api_throws"],
       )

--- a/src/workerd/api/tests/queue-test.js
+++ b/src/workerd/api/tests/queue-test.js
@@ -65,7 +65,15 @@ export default {
     } else {
       assert.fail(`Unexpected pathname: ${JSON.stringify(pathname)}`);
     }
-    return new Response();
+    return Response.json({
+      metadata: {
+        metrics: {
+          backlogCount: 0,
+          backlogBytes: 0,
+          oldestMessageTimestamp: 0,
+        },
+      },
+    });
   },
 
   // Consumer receiver (from `env.SERVICE`)

--- a/src/workerd/api/tests/queue-test.wd-test
+++ b/src/workerd/api/tests/queue-test.wd-test
@@ -23,7 +23,7 @@ const unitTests :Workerd.Config = (
           ( name = "QUEUE", queue = "queue-error-codes-enabled" ),
           ( name = "ERROR_CODES_FLAG", json = "true" ),
         ],
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "queues_json_messages", "queue_expose_error_codes", "experimental", "rpc", "capture_async_api_throws", "disable_fast_jsg_struct"],
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "queues_json_messages", "queue_expose_error_codes", "rpc", "capture_async_api_throws", "disable_fast_jsg_struct"],
       )
     ),
     ( name = "queue-error-codes-disabled",
@@ -35,7 +35,7 @@ const unitTests :Workerd.Config = (
           ( name = "QUEUE", queue = "queue-error-codes-disabled" ),
           ( name = "ERROR_CODES_FLAG", json = "false" ),
         ],
-        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "queues_json_messages", "no_queue_expose_error_codes", "experimental", "rpc", "capture_async_api_throws", "disable_fast_jsg_struct"],
+        compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "queues_json_messages", "no_queue_expose_error_codes", "rpc", "capture_async_api_throws", "disable_fast_jsg_struct"],
       )
     ),
   ],

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1462,9 +1462,10 @@ KJ_TEST("Server: capability bindings") {
       .+hello)"_blockquote);
     subreq.send(R"(
       HTTP/1.1 200 OK
-      Content-Length: 2
+      Content-Type: application/json
+      Content-Length: 27
 
-      OK
+      {"metadata":{"metrics":{}}}
     )"_blockquote);
   }
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -2417,12 +2417,12 @@ interface KVNamespaceGetWithMetadataResult<Value, Metadata> {
 }
 type QueueContentType = "text" | "bytes" | "json" | "v8";
 interface Queue<Body = unknown> {
+  metrics(): Promise<QueueMetrics>;
   send(message: Body, options?: QueueSendOptions): Promise<QueueSendResponse>;
   sendBatch(
     messages: Iterable<MessageSendRequest<Body>>,
     options?: QueueSendBatchOptions,
   ): Promise<QueueSendBatchResponse>;
-  metrics(): Promise<QueueMetrics>;
 }
 interface QueueSendMetrics {
   backlogCount: number;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -2420,12 +2420,12 @@ export interface KVNamespaceGetWithMetadataResult<Value, Metadata> {
 }
 export type QueueContentType = "text" | "bytes" | "json" | "v8";
 export interface Queue<Body = unknown> {
+  metrics(): Promise<QueueMetrics>;
   send(message: Body, options?: QueueSendOptions): Promise<QueueSendResponse>;
   sendBatch(
     messages: Iterable<MessageSendRequest<Body>>,
     options?: QueueSendBatchOptions,
   ): Promise<QueueSendBatchResponse>;
-  metrics(): Promise<QueueMetrics>;
 }
 export interface QueueSendMetrics {
   backlogCount: number;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -2342,11 +2342,34 @@ interface KVNamespaceGetWithMetadataResult<Value, Metadata> {
 }
 type QueueContentType = "text" | "bytes" | "json" | "v8";
 interface Queue<Body = unknown> {
-  send(message: Body, options?: QueueSendOptions): Promise<void>;
+  metrics(): Promise<QueueMetrics>;
+  send(message: Body, options?: QueueSendOptions): Promise<QueueSendResponse>;
   sendBatch(
     messages: Iterable<MessageSendRequest<Body>>,
     options?: QueueSendBatchOptions,
-  ): Promise<void>;
+  ): Promise<QueueSendBatchResponse>;
+}
+interface QueueSendMetrics {
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+}
+interface QueueSendMetadata {
+  metrics: QueueSendMetrics;
+}
+interface QueueSendResponse {
+  metadata: QueueSendMetadata;
+}
+interface QueueSendBatchMetrics {
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+}
+interface QueueSendBatchMetadata {
+  metrics: QueueSendBatchMetrics;
+}
+interface QueueSendBatchResponse {
+  metadata: QueueSendBatchMetadata;
 }
 interface QueueSendOptions {
   contentType?: QueueContentType;
@@ -2359,6 +2382,19 @@ interface MessageSendRequest<Body = unknown> {
   body: Body;
   contentType?: QueueContentType;
   delaySeconds?: number;
+}
+interface QueueMetrics {
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+}
+interface MessageBatchMetrics {
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+}
+interface MessageBatchMetadata {
+  metrics: MessageBatchMetrics;
 }
 interface QueueRetryOptions {
   delaySeconds?: number;
@@ -2374,12 +2410,14 @@ interface Message<Body = unknown> {
 interface QueueEvent<Body = unknown> extends ExtendableEvent {
   readonly messages: readonly Message<Body>[];
   readonly queue: string;
+  readonly metadata: MessageBatchMetadata;
   retryAll(options?: QueueRetryOptions): void;
   ackAll(): void;
 }
 interface MessageBatch<Body = unknown> {
   readonly messages: readonly Message<Body>[];
   readonly queue: string;
+  readonly metadata: MessageBatchMetadata;
   retryAll(options?: QueueRetryOptions): void;
   ackAll(): void;
 }

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -2345,11 +2345,34 @@ export interface KVNamespaceGetWithMetadataResult<Value, Metadata> {
 }
 export type QueueContentType = "text" | "bytes" | "json" | "v8";
 export interface Queue<Body = unknown> {
-  send(message: Body, options?: QueueSendOptions): Promise<void>;
+  metrics(): Promise<QueueMetrics>;
+  send(message: Body, options?: QueueSendOptions): Promise<QueueSendResponse>;
   sendBatch(
     messages: Iterable<MessageSendRequest<Body>>,
     options?: QueueSendBatchOptions,
-  ): Promise<void>;
+  ): Promise<QueueSendBatchResponse>;
+}
+export interface QueueSendMetrics {
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+}
+export interface QueueSendMetadata {
+  metrics: QueueSendMetrics;
+}
+export interface QueueSendResponse {
+  metadata: QueueSendMetadata;
+}
+export interface QueueSendBatchMetrics {
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+}
+export interface QueueSendBatchMetadata {
+  metrics: QueueSendBatchMetrics;
+}
+export interface QueueSendBatchResponse {
+  metadata: QueueSendBatchMetadata;
 }
 export interface QueueSendOptions {
   contentType?: QueueContentType;
@@ -2362,6 +2385,19 @@ export interface MessageSendRequest<Body = unknown> {
   body: Body;
   contentType?: QueueContentType;
   delaySeconds?: number;
+}
+export interface QueueMetrics {
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+}
+export interface MessageBatchMetrics {
+  backlogCount: number;
+  backlogBytes: number;
+  oldestMessageTimestamp?: Date;
+}
+export interface MessageBatchMetadata {
+  metrics: MessageBatchMetrics;
 }
 export interface QueueRetryOptions {
   delaySeconds?: number;
@@ -2377,12 +2413,14 @@ export interface Message<Body = unknown> {
 export interface QueueEvent<Body = unknown> extends ExtendableEvent {
   readonly messages: readonly Message<Body>[];
   readonly queue: string;
+  readonly metadata: MessageBatchMetadata;
   retryAll(options?: QueueRetryOptions): void;
   ackAll(): void;
 }
 export interface MessageBatch<Body = unknown> {
   readonly messages: readonly Message<Body>[];
   readonly queue: string;
+  readonly metadata: MessageBatchMetadata;
   retryAll(options?: QueueRetryOptions): void;
   ackAll(): void;
 }


### PR DESCRIPTION
## Summary

This PR removes the experimental gate from the Queue metrics APIs. 

It ungates the three features: 
- Add `env.QUEUE.metrics()` method [MQ-1154](https://github.com/cloudflare/workerd/pull/6246)
- Add response body with metrics to `env.QUEUE.send()` and `env.QUEUE.sendBody()` [MQ-1200](https://github.com/cloudflare/workerd/pull/6354)
- Add metrics to `queue()` handler [MQ-1202](https://github.com/cloudflare/workerd/pull/6339)

The upstream services that call `workerd` have been updated:
- [PR in queue-broker-worker](https://gitlab.cfdata.org/cloudflare/mq/queue-broker-worker/-/merge_requests/1783)
- [PR in miniflare](https://github.com/cloudflare/workers-sdk/pull/13335)

## Changes
1. The Javascript API for `send()` and `sendBatch()` now call `WorkerQueue::sendWithResponse` and `WorkerQueue::sendBatchWithResponse` respectively. 

2. `metrics(): Promise<QueueMetrics>` definition on queue binding is no longer gated behind experimental flag

3. `readonly metadata: MessageBatchMetadata` definition on `queue()` handler is no longer gated behind experimental flag

4. Removed reference to `METADATA_FLAG` and the flag disabled cases in tests.

5. Types regenerated using `just generate-types`


## Testing
- [x] `bazel test //src/workerd/api/tests:queue-test@ //src/workerd/api/tests:queue-metrics-test@ //src/workerd/api/tests:queue-metadata-test@ //src/workerd/api/tests:queue-metrics-sentinel-test@ //src/workerd/api/tests:queue-producer-metadata-test@`
- [x] `bazel test //src/workerd/api/tests:queue-test@all-compat-flags //src/workerd/api/tests:queue-metrics-test@all-compat-flags //src/workerd/api/tests:queue-metadata-test@all-compat-flags //src/workerd/api/tests:queue-metrics-sentinel-test@all-compat-flags //src/workerd/api/tests:queue-producer-metadata-test@all-compat-flags`
- [x] Tested experimental workers locally with Miniflare and in production queues