### PR TITLE
[o11y] Avoid tail stream cancellation warning with empty handler

### DIFF
--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -64,6 +64,7 @@ wd_test(
         "tail-worker-test-receiver.js",
         "tail-worker-test-dummy.js",
         "tail-worker-test-invalid.js",
+        "tail-worker-test-no-op.js",
         "tail-worker-test-jsrpc.js",
         "websocket-hibernation.js",
         "connect-handler-test.js",

--- a/src/workerd/api/tests/tail-worker-test-no-op.js
+++ b/src/workerd/api/tests/tail-worker-test-no-op.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2023 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+export default {
+  // https://developers.cloudflare.com/workers/observability/logs/tail-workers/
+  tailStream(event, env, ctx) {
+    // Return a handler object that does not include any handler functions for individual tail
+    // events – serves as a regression test for a bug where a handler that did not have handler
+    // functions for any events in the final tail stream RPC call caused stream cancellation
+    // warnings.
+    return {};
+  },
+};

--- a/src/workerd/api/tests/tail-worker-test.wd-test
+++ b/src/workerd/api/tests/tail-worker-test.wd-test
@@ -13,7 +13,7 @@ const unitTests :Workerd.Config = (
           ( name = "CACHE_ENABLED", json = "false" ),
         ],
         compatibilityFlags = ["nodejs_compat", "service_binding_extra_handlers", "cache_option_disabled", "queues_json_messages", "url_standard", "workers_api_getters_setters_on_prototype", "fetch_legacy_url", "web_socket_auto_reply_to_close"],
-        streamingTails = ["log", "log-invalid"],
+        streamingTails = ["log", "log-invalid", "log-no-op"],
       ),
     ),
     ( name = "queue-test",
@@ -72,6 +72,15 @@ const unitTests :Workerd.Config = (
       worker = (
         modules = [
           (name = "worker", esModule = embed "tail-worker-test-invalid.js")
+        ],
+      ),
+    ),
+    # tail worker with a handler object that doesn't handle any of the individual tail event types,
+    # used to confirm that this does not cause warnings
+    ( name = "log-no-op",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "tail-worker-test-no-op.js")
         ],
       ),
     )

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -934,6 +934,12 @@ class TailStreamTarget final: public rpc::TailStreamTarget::Server {
         });
       }
       return ioContext.awaitJs(js, kj::mv(p));
+    } else if (doFulfill) {
+      // If we have no promises, but doFulfill is true, then none of the events we have had a
+      // handler available, but we still need to indicate that we are done since we got the outcome
+      // event – do this by calling fulfill right away.
+      doneReceiving = true;
+      doneFulfiller->fulfill();
     }
     return kj::READY_NOW;
   }


### PR DESCRIPTION
We were not marking the TailStreamTarget fulfiller as done if the RPC call with the outcome event did not result in any calls to the tail handler (which can happen if the tail handler is an empty object). This resulted in cumbersome "Streaming tail session canceled" warnings.

Test: When making tailStream() in src/workerd/api/tests/tail-worker-test-invalid.js return {} instead of an invalid value, we no longer get cancellation warnings.