### PR TITLE
Fix Durable Object ordering when mixing RPC and fetch calls

### DIFF
--- a/src/workerd/api/tests/js-rpc-socket-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-socket-test.wd-test
@@ -29,6 +29,7 @@ const unitTests :Workerd.Config = (
           (name = "MyServiceProxy", service = "MyServiceProxy-loop"),
           (name = "MyActor", durableObjectNamespace = "MyActor"),
           (name = "ActorNoExtends", durableObjectNamespace = "ActorNoExtends"),
+          (name = "OrderingActor", durableObjectNamespace = "OrderingActor"),
           (name = "defaultExport", service = "default-loop"),
           (name = "twelve", json = "12"),
           (name = "GreeterFactory", service = "GreeterFactory-loop"),
@@ -37,6 +38,7 @@ const unitTests :Workerd.Config = (
         durableObjectNamespaces = [
           (className = "MyActor", uniqueKey = "foo"),
           (className = "ActorNoExtends", uniqueKey = "bar"),
+          (className = "OrderingActor", uniqueKey = "ordering"),
         ],
 
         durableObjectStorage = (inMemory = void),

--- a/src/workerd/api/tests/js-rpc-test.js
+++ b/src/workerd/api/tests/js-rpc-test.js
@@ -586,6 +586,25 @@ export class ActorNoExtends {
   }
 }
 
+// DO used to test that mixed RPC+fetch calls preserve send order.
+export class OrderingActor extends DurableObject {
+  #log = [];
+
+  record(input) {
+    this.#log.push(input);
+  }
+
+  async fetch(request) {
+    let url = new URL(request.url);
+    this.#log.push(url.pathname);
+    return new Response('ok');
+  }
+
+  getLog() {
+    return this.#log;
+  }
+}
+
 export default class DefaultService extends WorkerEntrypoint {
   async fetch(req) {
     // Test this.env here just to prove omitting the constructor entirely works.
@@ -2115,5 +2134,69 @@ export let eOrderTest = {
     let results = await Promise.all(promises);
 
     assert.deepEqual(results, [1, 2, 3, 4, 5, 6]);
+  },
+};
+
+// Verify that interleaved RPC and fetch calls on a DO stub are delivered in send order.
+export let mixedRpcFetchOrdering = {
+  async test(controller, env, ctx) {
+    let id = env.OrderingActor.idFromName('mixed');
+    let stub = env.OrderingActor.get(id);
+
+    let promises = [];
+    let expected = [];
+    for (let i = 0; i < 20; i++) {
+      if (i % 2 === 0) {
+        promises.push(stub.record(`rpc-${i}`));
+        expected.push(`rpc-${i}`);
+      } else {
+        promises.push(stub.fetch(`http://x/fetch-${i}`));
+        expected.push(`/fetch-${i}`);
+      }
+    }
+    await Promise.all(promises);
+
+    let log = await stub.getLog();
+    assert.deepEqual(log, expected);
+  },
+};
+
+// Verify that pure RPC calls on a DO stub preserve send order.
+export let pureRpcOrdering = {
+  async test(controller, env, ctx) {
+    let id = env.OrderingActor.idFromName('pure-rpc');
+    let stub = env.OrderingActor.get(id);
+
+    let promises = [];
+    for (let i = 0; i < 20; i++) {
+      promises.push(stub.record(`call-${i}`));
+    }
+    await Promise.all(promises);
+
+    let log = await stub.getLog();
+    assert.deepEqual(
+      log,
+      Array.from({ length: 20 }, (_, i) => `call-${i}`)
+    );
+  },
+};
+
+// Verify that pure fetch calls on a DO stub preserve send order.
+export let pureFetchOrdering = {
+  async test(controller, env, ctx) {
+    let id = env.OrderingActor.idFromName('pure-fetch');
+    let stub = env.OrderingActor.get(id);
+
+    let promises = [];
+    for (let i = 0; i < 20; i++) {
+      promises.push(stub.fetch(`http://x/${i}`));
+    }
+    await Promise.all(promises);
+
+    let log = await stub.getLog();
+    assert.deepEqual(
+      log,
+      Array.from({ length: 20 }, (_, i) => `/${i}`)
+    );
   },
 };

--- a/src/workerd/api/tests/js-rpc-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-test.wd-test
@@ -25,6 +25,7 @@ const unitTests :Workerd.Config = (
           (name = "MyServiceProxy", service = (name = "js-rpc-test", entrypoint = "MyServiceProxy")),
           (name = "MyActor", durableObjectNamespace = "MyActor"),
           (name = "ActorNoExtends", durableObjectNamespace = "ActorNoExtends"),
+          (name = "OrderingActor", durableObjectNamespace = "OrderingActor"),
           (name = "defaultExport", service = "js-rpc-test"),
           (name = "twelve", json = "12"),
           (name = "GreeterFactory", service = (name = "js-rpc-test", entrypoint = "GreeterFactory")),
@@ -33,6 +34,7 @@ const unitTests :Workerd.Config = (
         durableObjectNamespaces = [
           (className = "MyActor", uniqueKey = "foo"),
           (className = "ActorNoExtends", uniqueKey = "bar"),
+          (className = "OrderingActor", uniqueKey = "ordering"),
         ],
 
         durableObjectStorage = (inMemory = void),

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1000,9 +1000,14 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       : enterIsolateAndCall([this, &ctx](CallContext callContext) {
           // Note: No need to topUpActor() since this is the start of a top-level request, so the
           // actor will already have been topped up by IncomingRequest::delivered().
+          //
+          // If a pre-acquired InputGate lock is available (set by JsRpcSessionCustomEvent::run()
+          // to preserve ordering with other event types like fetch), consume it here so that
+          // ctx.run() skips InputGate::wait() and uses the already-reserved position.
+          auto inputLock = kj::mv(preAcquiredInputLock);
           return ctx.run([this, &ctx, callContext](Worker::Lock& lock) mutable {
             return callImpl(lock, ctx, callContext);
-          });
+          }, kj::mv(inputLock));
         }),
         externalPusher(ctx.getExternalPusher()) {}
 
@@ -1056,6 +1061,12 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
   kj::Promise<void> pushAbortSignal(PushAbortSignalContext context) override {
     return externalPusher->pushAbortSignal(context);
   }
+
+  // Pre-acquired InputGate lock for the first RPC call in a session. When set by
+  // JsRpcSessionCustomEvent::run(), this ensures the RPC call's position in the InputGate
+  // FIFO matches its arrival order relative to other event types (fetch, connect, etc.).
+  // Consumed on first use by enterIsolateAndCall; subsequent calls acquire normally.
+  kj::Maybe<InputGate::Lock> preAcquiredInputLock;
 
   KJ_DISALLOW_COPY_AND_MOVE(JsRpcTargetBase);
 
@@ -2174,6 +2185,19 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::run(
 
   incomingRequest->delivered();
 
+  // For actors, eagerly reserve our position in the InputGate FIFO. Without this, fetch calls
+  // reach the InputGate in ~1 async hop (via WorkerEntrypoint::request() -> context.run()) while
+  // RPC takes ~4+ hops (session setup, Cap'n Proto dispatch, kj::yield()). By acquiring the lock
+  // here — at the same level as request() — we ensure mixed RPC+fetch calls are ordered by
+  // arrival time, not by how many async hops each code path takes.
+  //
+  // The lock is passed to EntrypointJsRpcTarget and consumed by the first ctx.run() call,
+  // so it is NOT held for the session lifetime.
+  kj::Maybe<InputGate::Lock> inputLock;
+  KJ_IF_SOME(a, ioctx.getActor()) {
+    inputLock = co_await a.getInputGate().wait(ioctx.getCurrentTraceSpan());
+  }
+
   KJ_DEFER({
     // waitUntil() should allow extending execution on the server side even when the client
     // disconnects.
@@ -2182,6 +2206,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::run(
 
   EntrypointJsRpcTarget target(ioctx, entrypointName, kj::mv(versionInfo), kj::mv(props),
       kj::mv(wrapperModule), mapAddRef(incomingRequest->getWorkerTracer()), isDynamicDispatch);
+  target.preAcquiredInputLock = kj::mv(inputLock);
   capnp::RevocableServer<rpc::JsRpcTarget> revcableTarget(target);
 
   try {


### PR DESCRIPTION
## Summary

Fixes #6561.

When a caller fires interleaved `stub.rpc()` and `stub.fetch()` calls on the same Durable Object stub without awaiting, all fetch calls were processed before all RPC calls, regardless of send order. This violated the expected E-order guarantee.

```js
// Caller sends: rpc-0, fetch-1, rpc-2, fetch-3, rpc-4, fetch-5, ...
//
// Before fix:   fetch-1, fetch-3, fetch-5, ..., rpc-0, rpc-2, rpc-4, ...
// After fix:    rpc-0, fetch-1, rpc-2, fetch-3, rpc-4, fetch-5, ...
```

Same-type ordering (pure RPC or pure fetch) was already correct. This fix addresses the cross-type ordering.

## Root Cause

`stub.fetch()` and `stub.rpc()` both create a `WorkerInterface` via `ActorChannel::startRequest()`, but they call different methods on it — `request()` for fetch, `customEvent()` for RPC. These two paths reach the DO's `InputGate` through a very different number of async hops:

**fetch path** (~1 hop to InputGate):
```
WorkerEntrypoint::request()
  → context.run()
    → InputGate::wait()      ← queued here
```

**RPC path** (~4+ hops to InputGate):
```
WorkerEntrypoint::customEvent()
  → JsRpcSessionCustomEvent::run()
    → delivered()
    → Cap'n Proto session setup + capability fulfillment
       → JsRpcTargetBase::call()
         → co_await kj::yield()
         → ctx.run()
           → InputGate::wait()   ← queued here
```

Since all operations originate from the same synchronous JS execution, fetch calls (fewer hops) always enqueued at the InputGate before any RPC calls (more hops).

## Fix

Eagerly acquire the InputGate position in `JsRpcSessionCustomEvent::run()`, right after `delivered()` — the same level where `WorkerEntrypoint::request()` acquires it via `context.run()`. The lock is stored on `EntrypointJsRpcTarget` and consumed by the first `ctx.run()` call via the existing `IoContext::run(func, Maybe<InputGate::Lock>)` overload (the same pattern used by `ensureConstructedImpl`).

Key properties:
- The lock is **consumed on first use** — it is NOT held for the RPC session lifetime
- The `kj::yield()` in `JsRpcTargetBase::call()` still runs (InputGate position is already reserved, so ExternalPusher ordering is preserved)
- Non-actor RPC is unaffected (guarded by `KJ_IF_SOME(a, ioctx.getActor())`)
- `TransientJsRpcTarget` (within-session stubs) is unaffected — only `EntrypointJsRpcTarget` uses the pre-acquired lock
- The `ServerTopLevelMembrane` ensures exactly one call per `getClientForOneCall()` session, so the lock always matches the single call

## Performance

The InputGate lock is acquired a few event loop turns earlier than before — during the Cap'n Proto session setup and `kj::yield()` period (microseconds). ExternalPusher calls (`pushByteStream`, `pushAbortSignal`) don't need the InputGate, so they are unaffected. Other events wait one extra turn at most. For single-caller latency, the gate is free and `wait()` returns immediately.

## Changes

- **`worker-rpc.c++`**: 27 lines — early InputGate acquisition in `JsRpcSessionCustomEvent::run()`, lock threading through `JsRpcTargetBase` to `ctx.run()`
- **`js-rpc-test.js`**: New `OrderingActor` DO class + 3 test cases (`mixedRpcFetchOrdering`, `pureRpcOrdering`, `pureFetchOrdering`)
- **`js-rpc-test.wd-test`**: Register `OrderingActor` binding and namespace

## Test plan

- [x] `mixedRpcFetchOrdering` — interleaves 20 RPC and fetch calls, asserts send-order delivery (the primary bug)
- [x] `pureRpcOrdering` — 20 fire-and-forget RPC calls preserve order (regression)
- [x] `pureFetchOrdering` — 20 fire-and-forget fetch calls preserve order (regression)
- [x] Existing `eOrderTest` passes (ExternalPusher + e-order regression)
- [x] Existing `receiveStubOverRpc` passes (service stub RPC ordering regression)
- [x] Existing `namedActorBinding` passes (DO RPC regression)
- [x] Full `js-rpc-test@` suite passes locally

## Reproduction

Repro repo: https://github.com/threepointone/test-do-rpc-fetch-ordering
Live demo: `curl https://test-ordering.threepointone.workers.dev/test-all?n=20`

---

*Root cause analysis, fix design, and implementation developed in collaboration with Cursor.*

Made with [Cursor](https://cursor.com)