### PR TITLE
chore: Harden pnpm usage in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,10 +243,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
       - name: Use Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Cache
         id: cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - name: Use Node
         uses: actions/setup-node@v6

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -16,15 +16,7 @@ COPY . .
 
 RUN echo "build:linux --repo_env=CC=/usr/lib/llvm-19/bin/clang" >> .bazelrc
 COPY .bazel-cache /bazel-disk-cache
-# pnpm version will be different depending on the value of `packageManager` field in package.json
-RUN npm install -g pnpm@$(node -e " \
-  const pm = require('./package.json').packageManager; \
-  if (!pm || !pm.startsWith('pnpm@')) { \
-    console.error('Expected packageManager to start with pnpm@, got:', pm); \
-    process.exit(1); \
-  } \
-  console.log(pm.split('@')[1]); \
-")
+RUN corepack enable
 RUN pnpm install
 
 RUN pnpm exec bazel build --disk_cache=/bazel-disk-cache --config=release_linux //src/workerd/server:workerd

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -16,6 +16,7 @@ COPY . .
 
 RUN echo "build:linux --repo_env=CC=/usr/lib/llvm-19/bin/clang" >> .bazelrc
 COPY .bazel-cache /bazel-disk-cache
+RUN npm install -g --force corepack
 RUN corepack enable
 RUN pnpm install
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -16,8 +16,8 @@ COPY . .
 
 RUN echo "build:linux --repo_env=CC=/usr/lib/llvm-19/bin/clang" >> .bazelrc
 COPY .bazel-cache /bazel-disk-cache
-RUN npm install -g --force corepack
-RUN corepack enable
+# pnpm version will be different depending on the value of `packageManager` field in package.json
+RUN npm install -g pnpm@latest
 RUN pnpm install
 
 RUN pnpm exec bazel build --disk_cache=/bazel-disk-cache --config=release_linux //src/workerd/server:workerd

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -17,7 +17,14 @@ COPY . .
 RUN echo "build:linux --repo_env=CC=/usr/lib/llvm-19/bin/clang" >> .bazelrc
 COPY .bazel-cache /bazel-disk-cache
 # pnpm version will be different depending on the value of `packageManager` field in package.json
-RUN npm install -g pnpm@latest
+RUN npm install -g pnpm@$(node -e " \
+  const pm = require('./package.json').packageManager; \
+  if (!pm || !pm.startsWith('pnpm@')) { \
+    console.error('Expected packageManager to start with pnpm@, got:', pm); \
+    process.exit(1); \
+  } \
+  console.log(pm.split('@')[1]); \
+")
 RUN pnpm install
 
 RUN pnpm exec bazel build --disk_cache=/bazel-disk-cache --config=release_linux //src/workerd/server:workerd


### PR DESCRIPTION
Ensure esbuild resolves from the lockfile in the publish-wrapper job by installing dependencies with pnpm before running `npx esbuild`.