### PR TITLE
chore: Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/_bazel.yml
+++ b/.github/workflows/_bazel.yml
@@ -156,7 +156,7 @@ jobs:
           bazel coverage --remote_cache=https://bazel:${{ secrets.BAZEL_CACHE_KEY }}@bazel-remote-cache.devprod.cloudflare.dev --config=ci ${{ inputs.extra_bazel_args }} ${{ inputs.test_target }}
       - name: Upload coverage to Codecov
         if: inputs.run_coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           # Use bazel info to get the actual output path, avoiding symlink issues
           files: ${{ github.workspace }}/bazel-out/_coverage/_coverage_report.dat

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           # CLA Action uses this in-built GitHub token to make the API calls for interacting with GitHub.
           # It is built into Github Actions and does not need to be manually specified in your secrets store.

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -60,7 +60,7 @@ jobs:
           chmod +x run_benchmarks.sh
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@db35df748deb45fdef0960669f57d627c1956c30 # v4.13.1
         with:
           mode: simulation
           run: ./run_benchmarks.sh

--- a/.github/workflows/deps-updater.yml
+++ b/.github/workflows/deps-updater.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./tools/cross/format.py git
       - name: Open pull request
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "update dependencies to latest version"
           branch: "automatic-update-deps"

--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -8,5 +8,5 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Block Fixup Commit Merge
-      uses: 13rac1/block-fixup-merge-action@v2.0.0
+      uses: 13rac1/block-fixup-merge-action@bd5504fb9ca0253e109d98eb86b7debc01970cdc # v2.0.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: mukunku/tag-exists-action@v1.7.0
+      - uses: mukunku/tag-exists-action@5c39604fe8aef7e65acb6fbcf96ec580f7680313 # v1.7.0
         id: check_tag
         with:
           tag: v${{ needs.version.outputs.version }}
@@ -64,7 +64,7 @@ jobs:
         with:
           fetch-depth: 0
       - run: git tag v${{ needs.version.outputs.version }} && git push origin v${{ needs.version.outputs.version }}
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         id: create_release
         with:
           generateReleaseNotes: true
@@ -208,7 +208,7 @@ jobs:
           repository: cloudflare/workers-sdk
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
           repository: cloudflare/workers-sdk
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
Pin all third-party (non-`actions/*`, non-Cloudflare-owned) GitHub Actions to full 40-character commit SHAs to mitigate supply chain attacks via compromised tags.

## Changes
| Action | Version | Files |
|--------|---------|-------|
| `codecov/codecov-action` | v5.5.4 | `_bazel.yml` |
| `contributor-assistant/github-action` | v2.6.1 | `cla.yml` |
| `CodSpeedHQ/action` | v4.13.1 | `codspeed.yml` |
| `peter-evans/create-pull-request` | v8.1.1 | `deps-updater.yml` |
| `13rac1/block-fixup-merge-action` | v2.0.0 | `fixup.yml` |
| `mukunku/tag-exists-action` | v1.7.0 | `release.yml` |
| `ncipollo/release-action` | v1.21.0 | `release.yml` |
| `pnpm/action-setup` | v4.3.0 | `release.yml`, `test.yml` |

## Test plan
- [x] Verify CI workflows pass with SHA-pinned actions