### PR TITLE
Add optional traceFlags to SpanContext for upstream sampling propagation

### DIFF
--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -269,10 +269,11 @@ void IoContext::IncomingRequest::delivered(kj::SourceLocation location) {
   // BaseTracer::WeakRef, so they cannot extend tracer lifetime.
   KJ_IF_SOME(workerTracer, workerTracer) {
     if (util::Autogate::isEnabled(util::AutogateKey::USER_SPAN_CONTEXT_PROPAGATION)) {
-      auto traceId = getInvocationSpanContext().getTraceId();
-      rootUserTraceSpan = workerTracer->makeUserRequestSpan(kj::mv(traceId));
+      auto& invCtx = getInvocationSpanContext();
+      rootUserTraceSpan =
+          workerTracer->makeUserRequestSpan(invCtx.getTraceId(), invCtx.getTraceFlags());
     } else {
-      rootUserTraceSpan = workerTracer->makeUserRequestSpan(tracing::TraceId(nullptr));
+      rootUserTraceSpan = workerTracer->makeUserRequestSpan(tracing::TraceId(nullptr), kj::none);
     }
   }
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -264,10 +264,11 @@ void IoContext::IncomingRequest::delivered(kj::SourceLocation location) {
 
   KJ_IF_SOME(workerTracer, workerTracer) {
     if (util::Autogate::isEnabled(util::AutogateKey::USER_SPAN_CONTEXT_PROPAGATION)) {
-      auto traceId = getInvocationSpanContext().getTraceId();
-      currentUserTraceSpan = workerTracer->makeUserRequestSpan(kj::mv(traceId));
+      auto& invCtx = getInvocationSpanContext();
+      currentUserTraceSpan =
+          workerTracer->makeUserRequestSpan(invCtx.getTraceId(), invCtx.getTraceFlags());
     } else {
-      currentUserTraceSpan = workerTracer->makeUserRequestSpan(tracing::TraceId(nullptr));
+      currentUserTraceSpan = workerTracer->makeUserRequestSpan(tracing::TraceId(nullptr), kj::none);
     }
   }
 

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -917,7 +917,8 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
     auto& base = getCurrentIncomingRequest().getInvocationSpanContext();
     tracing::SpanId sid = getCurrentUserTraceSpan().getSpanId();
     if (sid != tracing::SpanId::nullId) {
-      return tracing::InvocationSpanContext(base.getTraceId(), base.getInvocationId(), sid);
+      return tracing::InvocationSpanContext(
+          base.getTraceId(), base.getInvocationId(), sid, base.getTraceFlags());
     }
     return base.clone();
   }

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -80,6 +80,7 @@ namespace {
   V(SPANCLOSE, "spanClose")                                                                        \
   V(SPANCONTEXT, "spanContext")                                                                    \
   V(SPANID, "spanId")                                                                              \
+  V(TRACEFLAGS, "traceFlags")                                                                      \
   V(SPANOPEN, "spanOpen")                                                                          \
   V(STACK, "stack")                                                                                \
   V(STATUSCODE, "statusCode")                                                                      \
@@ -549,6 +550,9 @@ jsg::JsValue ToJs(jsg::Lock& js, const TailEvent& event, StringCache& cache) {
   sCObj.set(js, TRACEID_STR, js.str(event.spanContext.getTraceId().toGoString()));
   KJ_IF_SOME(spanId, event.spanContext.getSpanId()) {
     sCObj.set(js, SPANID_STR, js.str(spanId.toGoString()));
+  }
+  KJ_IF_SOME(flags, event.spanContext.getTraceFlags()) {
+    sCObj.set(js, TRACEFLAGS_STR, js.num(flags));
   }
   obj.set(js, SPANCONTEXT_STR, kj::mv(sCObj));
 
@@ -1251,7 +1255,7 @@ void TailStreamWriter::report(const InvocationSpanContext& context,
   // chance (see SpanId::fromEntropy()), so this should be safe.
   TailEvent tailEvent(context.getTraceId(), context.getInvocationId(),
       context.getSpanId() == SpanId::nullId ? kj::none : kj::Maybe(context.getSpanId()), timestamp,
-      sequence++, kj::mv(event));
+      sequence++, kj::mv(event), context.getTraceFlags());
 
   KJ_SWITCH_ONEOF(inner) {
     KJ_CASE_ONEOF(closed, Closed) {

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -79,6 +79,7 @@ namespace {
   V(SPANCLOSE, "spanClose")                                                                        \
   V(SPANCONTEXT, "spanContext")                                                                    \
   V(SPANID, "spanId")                                                                              \
+  V(TRACEFLAGS, "traceFlags")                                                                      \
   V(SPANOPEN, "spanOpen")                                                                          \
   V(STACK, "stack")                                                                                \
   V(STATUSCODE, "statusCode")                                                                      \
@@ -542,6 +543,9 @@ jsg::JsValue ToJs(jsg::Lock& js, const TailEvent& event, StringCache& cache) {
   sCObj.set(js, TRACEID_STR, js.str(event.spanContext.getTraceId().toGoString()));
   KJ_IF_SOME(spanId, event.spanContext.getSpanId()) {
     sCObj.set(js, SPANID_STR, js.str(spanId.toGoString()));
+  }
+  KJ_IF_SOME(flags, event.spanContext.getTraceFlags()) {
+    sCObj.set(js, TRACEFLAGS_STR, js.num(flags));
   }
   obj.set(js, SPANCONTEXT_STR, kj::mv(sCObj));
 
@@ -1244,7 +1248,7 @@ void TailStreamWriter::report(const InvocationSpanContext& context,
   // chance (see SpanId::fromEntropy()), so this should be safe.
   TailEvent tailEvent(context.getTraceId(), context.getInvocationId(),
       context.getSpanId() == SpanId::nullId ? kj::none : kj::Maybe(context.getSpanId()), timestamp,
-      sequence++, kj::mv(event));
+      sequence++, kj::mv(event), context.getTraceFlags());
 
   KJ_SWITCH_ONEOF(inner) {
     KJ_CASE_ONEOF(closed, Closed) {

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -133,26 +133,108 @@ KJ_TEST("InvocationSpanContext") {
   KJ_EXPECT(sc5.isTrigger());
 }
 
+KJ_TEST("InvocationSpanContext propagates traceFlags from trigger") {
+  setPredictableModeForTest();
+  FakeEntropySource fakeEntropySource;
+
+  // Trigger with traceFlags set — propagates to new invocation
+  auto trigger =
+      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x01));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(trigger.getTraceFlags()) == 0x01);
+
+  auto sc = InvocationSpanContext::newForInvocation(trigger, fakeEntropySource);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc.getTraceFlags()) == 0x01);
+
+  // No trigger — traceFlags is absent
+  auto sc2 = InvocationSpanContext::newForInvocation(kj::none, fakeEntropySource);
+  KJ_EXPECT(sc2.getTraceFlags() == kj::none);
+
+  // newChild() propagates traceFlags
+  auto child = sc.newChild();
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child.getTraceFlags()) == 0x01);
+
+  auto child2 = sc2.newChild();
+  KJ_EXPECT(child2.getTraceFlags() == kj::none);
+}
+
+KJ_TEST("InvocationSpanContext traceFlags capnp round-trip and newChild propagation") {
+  setPredictableModeForTest();
+  FakeEntropySource fakeEntropySource;
+
+  // traceFlags=0x01 (sampled) survives round-trip and propagates through newChild
+  auto sampled =
+      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x01));
+  capnp::MallocMessageBuilder b1;
+  sampled.toCapnp(b1.initRoot<rpc::InvocationSpanContext>());
+  auto rt1 =
+      KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(b1.getRoot<rpc::InvocationSpanContext>()));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(rt1.getTraceFlags()) == 0x01);
+  auto child1 = InvocationSpanContext::newForInvocation(rt1, fakeEntropySource);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child1.newChild().getTraceFlags()) == 0x01);
+
+  // traceFlags=0x00 (unsampled) is distinct from absent
+  auto unsampled =
+      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x00));
+  capnp::MallocMessageBuilder b2;
+  unsampled.toCapnp(b2.initRoot<rpc::InvocationSpanContext>());
+  auto rt2 =
+      KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(b2.getRoot<rpc::InvocationSpanContext>()));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(rt2.getTraceFlags()) == 0x00);
+  auto child2 = InvocationSpanContext::newForInvocation(rt2, fakeEntropySource);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child2.newChild().getTraceFlags()) == 0x00);
+
+  // traceFlags absent stays absent
+  auto absent = InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), kj::none);
+  capnp::MallocMessageBuilder b3;
+  absent.toCapnp(b3.initRoot<rpc::InvocationSpanContext>());
+  auto rt3 =
+      KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(b3.getRoot<rpc::InvocationSpanContext>()));
+  KJ_EXPECT(rt3.getTraceFlags() == kj::none);
+  auto child3 = InvocationSpanContext::newForInvocation(rt3, fakeEntropySource);
+  KJ_EXPECT(child3.newChild().getTraceFlags() == kj::none);
+}
+
 KJ_TEST("SpanContext") {
   setPredictableModeForTest();
   FakeEntropySource fakeEntropySource;
   auto sc =
       SpanContext(TraceId::fromEntropy(fakeEntropySource), SpanId::fromEntropy(fakeEntropySource));
 
-  // We can create a SpanContext...
   static constexpr auto kCheck = TraceId(0x2a2a2a2a2a2a2a2a, 0x2a2a2a2a2a2a2a2a);
   KJ_EXPECT(sc.getTraceId() == kCheck);
   KJ_EXPECT(sc.getSpanId() == SpanId(1));
+  KJ_EXPECT(sc.getTraceFlags() == kj::none);
 
-  // And serialize that to a capnp struct...
   capnp::MallocMessageBuilder builder;
   auto root = builder.initRoot<rpc::SpanContext>();
   sc.toCapnp(root);
 
-  // Then back again...
   auto sc2 = SpanContext::fromCapnp(root.asReader());
   KJ_EXPECT(sc2.getTraceId() == kCheck);
   KJ_EXPECT(sc2.getSpanId() == SpanId(1));
+  KJ_EXPECT(sc2.getTraceFlags() == kj::none);
+}
+
+KJ_TEST("SpanContext traceFlags preserved through capnp when set, absent when unset") {
+  auto sc = SpanContext(TraceId(1, 2), SpanId(3), static_cast<uint8_t>(0x01));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc.getTraceFlags()) == 0x01);
+
+  capnp::MallocMessageBuilder builder;
+  auto root = builder.initRoot<rpc::SpanContext>();
+  sc.toCapnp(root);
+
+  auto sc2 = SpanContext::fromCapnp(root.asReader());
+  KJ_EXPECT(sc2.getTraceId() == TraceId(1, 2));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc2.getSpanId()) == SpanId(3));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc2.getTraceFlags()) == 0x01);
+
+  auto sc3 = SpanContext(TraceId(4, 5), SpanId(6));
+  capnp::MallocMessageBuilder builder2;
+  auto root2 = builder2.initRoot<rpc::SpanContext>();
+  sc3.toCapnp(root2);
+
+  auto sc4 = SpanContext::fromCapnp(root2.asReader());
+  KJ_EXPECT(sc4.getTraceFlags() == kj::none);
 }
 
 KJ_TEST("Read/Write FetchEventInfo works") {
@@ -629,6 +711,7 @@ KJ_TEST("SpanContext::tryFromTraceparent valid") {
       "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01"_kj));
   KJ_EXPECT(result.getTraceId() == TraceId(0x9900aabbccddeeff, 0x1122334455667788));
   KJ_EXPECT(KJ_ASSERT_NONNULL(result.getSpanId()) == SpanId(0xa1b2c3d4e5f60718));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result.getTraceFlags()) == 0x01);
 }
 
 KJ_TEST("SpanContext::tryFromTraceparent sampled with extra flags") {
@@ -636,6 +719,7 @@ KJ_TEST("SpanContext::tryFromTraceparent sampled with extra flags") {
       "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-03"_kj));
   KJ_EXPECT(result.getTraceId() == TraceId(0x9900aabbccddeeff, 0x1122334455667788));
   KJ_EXPECT(KJ_ASSERT_NONNULL(result.getSpanId()) == SpanId(0xa1b2c3d4e5f60718));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result.getTraceFlags()) == 0x03);
 }
 
 KJ_TEST("SpanContext::tryFromTraceparent rejects invalid inputs") {
@@ -694,8 +778,11 @@ KJ_TEST("SpanContext::tryFromTraceparent rejects invalid inputs") {
                 "00-11223344556677889900aabbccddeeff-0000000000000000-01"_kj) == kj::none);
 
   // Unsampled
-  KJ_EXPECT(SpanContext::tryFromTraceparent(
-                "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-00"_kj) == kj::none);
+  auto unsampled = KJ_ASSERT_NONNULL(SpanContext::tryFromTraceparent(
+      "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-00"_kj));
+  KJ_EXPECT(unsampled.getTraceId() == TraceId(0x9900aabbccddeeff, 0x1122334455667788));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(unsampled.getSpanId()) == SpanId(0xa1b2c3d4e5f60718));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(unsampled.getTraceFlags()) == 0x00);
 }
 
 }  // namespace

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -138,12 +138,11 @@ KJ_TEST("InvocationSpanContext propagates traceFlags from trigger") {
   FakeEntropySource fakeEntropySource;
 
   // Trigger with traceFlags set — propagates to new invocation
-  auto trigger =
-      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x01));
-  KJ_EXPECT(KJ_ASSERT_NONNULL(trigger.getTraceFlags()) == 0x01);
+  auto trigger = InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), TraceFlags(0x01));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(trigger.getTraceFlags()) == TraceFlags(0x01));
 
   auto sc = InvocationSpanContext::newForInvocation(trigger, fakeEntropySource);
-  KJ_EXPECT(KJ_ASSERT_NONNULL(sc.getTraceFlags()) == 0x01);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc.getTraceFlags()) == TraceFlags(0x01));
 
   // No trigger — traceFlags is absent
   auto sc2 = InvocationSpanContext::newForInvocation(kj::none, fakeEntropySource);
@@ -151,7 +150,7 @@ KJ_TEST("InvocationSpanContext propagates traceFlags from trigger") {
 
   // newChild() propagates traceFlags
   auto child = sc.newChild();
-  KJ_EXPECT(KJ_ASSERT_NONNULL(child.getTraceFlags()) == 0x01);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child.getTraceFlags()) == TraceFlags(0x01));
 
   auto child2 = sc2.newChild();
   KJ_EXPECT(child2.getTraceFlags() == kj::none);
@@ -162,26 +161,24 @@ KJ_TEST("InvocationSpanContext traceFlags capnp round-trip and newChild propagat
   FakeEntropySource fakeEntropySource;
 
   // traceFlags=0x01 (sampled) survives round-trip and propagates through newChild
-  auto sampled =
-      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x01));
+  auto sampled = InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), TraceFlags(0x01));
   capnp::MallocMessageBuilder b1;
   sampled.toCapnp(b1.initRoot<rpc::InvocationSpanContext>());
   auto rt1 =
       KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(b1.getRoot<rpc::InvocationSpanContext>()));
-  KJ_EXPECT(KJ_ASSERT_NONNULL(rt1.getTraceFlags()) == 0x01);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(rt1.getTraceFlags()) == TraceFlags(0x01));
   auto child1 = InvocationSpanContext::newForInvocation(rt1, fakeEntropySource);
-  KJ_EXPECT(KJ_ASSERT_NONNULL(child1.newChild().getTraceFlags()) == 0x01);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child1.newChild().getTraceFlags()) == TraceFlags(0x01));
 
   // traceFlags=0x00 (unsampled) is distinct from absent
-  auto unsampled =
-      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x00));
+  auto unsampled = InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), TraceFlags(0x00));
   capnp::MallocMessageBuilder b2;
   unsampled.toCapnp(b2.initRoot<rpc::InvocationSpanContext>());
   auto rt2 =
       KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(b2.getRoot<rpc::InvocationSpanContext>()));
-  KJ_EXPECT(KJ_ASSERT_NONNULL(rt2.getTraceFlags()) == 0x00);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(rt2.getTraceFlags()) == TraceFlags(0x00));
   auto child2 = InvocationSpanContext::newForInvocation(rt2, fakeEntropySource);
-  KJ_EXPECT(KJ_ASSERT_NONNULL(child2.newChild().getTraceFlags()) == 0x00);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child2.newChild().getTraceFlags()) == TraceFlags(0x00));
 
   // traceFlags absent stays absent
   auto absent = InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), kj::none);
@@ -216,8 +213,8 @@ KJ_TEST("SpanContext") {
 }
 
 KJ_TEST("SpanContext traceFlags preserved through capnp when set, absent when unset") {
-  auto sc = SpanContext(TraceId(1, 2), SpanId(3), static_cast<uint8_t>(0x01));
-  KJ_EXPECT(KJ_ASSERT_NONNULL(sc.getTraceFlags()) == 0x01);
+  auto sc = SpanContext(TraceId(1, 2), SpanId(3), TraceFlags(0x01));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc.getTraceFlags()) == TraceFlags(0x01));
 
   capnp::MallocMessageBuilder builder;
   auto root = builder.initRoot<rpc::SpanContext>();
@@ -226,7 +223,7 @@ KJ_TEST("SpanContext traceFlags preserved through capnp when set, absent when un
   auto sc2 = SpanContext::fromCapnp(root.asReader());
   KJ_EXPECT(sc2.getTraceId() == TraceId(1, 2));
   KJ_EXPECT(KJ_ASSERT_NONNULL(sc2.getSpanId()) == SpanId(3));
-  KJ_EXPECT(KJ_ASSERT_NONNULL(sc2.getTraceFlags()) == 0x01);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc2.getTraceFlags()) == TraceFlags(0x01));
 
   auto sc3 = SpanContext(TraceId(4, 5), SpanId(6));
   capnp::MallocMessageBuilder builder2;

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -133,26 +133,64 @@ KJ_TEST("InvocationSpanContext") {
   KJ_EXPECT(sc5.isTrigger());
 }
 
+KJ_TEST("InvocationSpanContext propagates traceFlags from trigger") {
+  setPredictableModeForTest();
+  FakeEntropySource fakeEntropySource;
+
+  // Trigger with traceFlags set — propagates to new invocation
+  auto trigger =
+      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x01));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(trigger.getTraceFlags()) == 0x01);
+
+  auto sc = InvocationSpanContext::newForInvocation(trigger, fakeEntropySource);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc.getTraceFlags()) == 0x01);
+
+  // No trigger — traceFlags is absent
+  auto sc2 = InvocationSpanContext::newForInvocation(kj::none, fakeEntropySource);
+  KJ_EXPECT(sc2.getTraceFlags() == kj::none);
+}
+
 KJ_TEST("SpanContext") {
   setPredictableModeForTest();
   FakeEntropySource fakeEntropySource;
   auto sc =
       SpanContext(TraceId::fromEntropy(fakeEntropySource), SpanId::fromEntropy(fakeEntropySource));
 
-  // We can create a SpanContext...
   static constexpr auto kCheck = TraceId(0x2a2a2a2a2a2a2a2a, 0x2a2a2a2a2a2a2a2a);
   KJ_EXPECT(sc.getTraceId() == kCheck);
   KJ_EXPECT(sc.getSpanId() == SpanId(1));
+  KJ_EXPECT(sc.getTraceFlags() == kj::none);
 
-  // And serialize that to a capnp struct...
   capnp::MallocMessageBuilder builder;
   auto root = builder.initRoot<rpc::SpanContext>();
   sc.toCapnp(root);
 
-  // Then back again...
   auto sc2 = SpanContext::fromCapnp(root.asReader());
   KJ_EXPECT(sc2.getTraceId() == kCheck);
   KJ_EXPECT(sc2.getSpanId() == SpanId(1));
+  KJ_EXPECT(sc2.getTraceFlags() == kj::none);
+}
+
+KJ_TEST("SpanContext traceFlags preserved through capnp when set, absent when unset") {
+  auto sc = SpanContext(TraceId(1, 2), SpanId(3), static_cast<uint8_t>(0x01));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc.getTraceFlags()) == 0x01);
+
+  capnp::MallocMessageBuilder builder;
+  auto root = builder.initRoot<rpc::SpanContext>();
+  sc.toCapnp(root);
+
+  auto sc2 = SpanContext::fromCapnp(root.asReader());
+  KJ_EXPECT(sc2.getTraceId() == TraceId(1, 2));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc2.getSpanId()) == SpanId(3));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(sc2.getTraceFlags()) == 0x01);
+
+  auto sc3 = SpanContext(TraceId(4, 5), SpanId(6));
+  capnp::MallocMessageBuilder builder2;
+  auto root2 = builder2.initRoot<rpc::SpanContext>();
+  sc3.toCapnp(root2);
+
+  auto sc4 = SpanContext::fromCapnp(root2.asReader());
+  KJ_EXPECT(sc4.getTraceFlags() == kj::none);
 }
 
 KJ_TEST("Read/Write FetchEventInfo works") {
@@ -629,6 +667,7 @@ KJ_TEST("SpanContext::tryFromTraceparent valid") {
       "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01"_kj));
   KJ_EXPECT(result.getTraceId() == TraceId(0x9900aabbccddeeff, 0x1122334455667788));
   KJ_EXPECT(KJ_ASSERT_NONNULL(result.getSpanId()) == SpanId(0xa1b2c3d4e5f60718));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result.getTraceFlags()) == 0x01);
 }
 
 KJ_TEST("SpanContext::tryFromTraceparent sampled with extra flags") {
@@ -636,6 +675,7 @@ KJ_TEST("SpanContext::tryFromTraceparent sampled with extra flags") {
       "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-03"_kj));
   KJ_EXPECT(result.getTraceId() == TraceId(0x9900aabbccddeeff, 0x1122334455667788));
   KJ_EXPECT(KJ_ASSERT_NONNULL(result.getSpanId()) == SpanId(0xa1b2c3d4e5f60718));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(result.getTraceFlags()) == 0x03);
 }
 
 KJ_TEST("SpanContext::tryFromTraceparent rejects invalid inputs") {
@@ -694,8 +734,11 @@ KJ_TEST("SpanContext::tryFromTraceparent rejects invalid inputs") {
                 "00-11223344556677889900aabbccddeeff-0000000000000000-01"_kj) == kj::none);
 
   // Unsampled
-  KJ_EXPECT(SpanContext::tryFromTraceparent(
-                "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-00"_kj) == kj::none);
+  auto unsampled = KJ_ASSERT_NONNULL(SpanContext::tryFromTraceparent(
+      "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-00"_kj));
+  KJ_EXPECT(unsampled.getTraceId() == TraceId(0x9900aabbccddeeff, 0x1122334455667788));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(unsampled.getSpanId()) == SpanId(0xa1b2c3d4e5f60718));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(unsampled.getTraceFlags()) == 0x00);
 }
 
 }  // namespace

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -148,6 +148,50 @@ KJ_TEST("InvocationSpanContext propagates traceFlags from trigger") {
   // No trigger — traceFlags is absent
   auto sc2 = InvocationSpanContext::newForInvocation(kj::none, fakeEntropySource);
   KJ_EXPECT(sc2.getTraceFlags() == kj::none);
+
+  // newChild() propagates traceFlags
+  auto child = sc.newChild();
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child.getTraceFlags()) == 0x01);
+
+  auto child2 = sc2.newChild();
+  KJ_EXPECT(child2.getTraceFlags() == kj::none);
+}
+
+KJ_TEST("InvocationSpanContext traceFlags capnp round-trip and newChild propagation") {
+  setPredictableModeForTest();
+  FakeEntropySource fakeEntropySource;
+
+  // traceFlags=0x01 (sampled) survives round-trip and propagates through newChild
+  auto sampled =
+      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x01));
+  capnp::MallocMessageBuilder b1;
+  sampled.toCapnp(b1.initRoot<rpc::InvocationSpanContext>());
+  auto rt1 =
+      KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(b1.getRoot<rpc::InvocationSpanContext>()));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(rt1.getTraceFlags()) == 0x01);
+  auto child1 = InvocationSpanContext::newForInvocation(rt1, fakeEntropySource);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child1.newChild().getTraceFlags()) == 0x01);
+
+  // traceFlags=0x00 (unsampled) is distinct from absent
+  auto unsampled =
+      InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), static_cast<uint8_t>(0x00));
+  capnp::MallocMessageBuilder b2;
+  unsampled.toCapnp(b2.initRoot<rpc::InvocationSpanContext>());
+  auto rt2 =
+      KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(b2.getRoot<rpc::InvocationSpanContext>()));
+  KJ_EXPECT(KJ_ASSERT_NONNULL(rt2.getTraceFlags()) == 0x00);
+  auto child2 = InvocationSpanContext::newForInvocation(rt2, fakeEntropySource);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(child2.newChild().getTraceFlags()) == 0x00);
+
+  // traceFlags absent stays absent
+  auto absent = InvocationSpanContext(TraceId(1, 2), TraceId(3, 4), SpanId(5), kj::none);
+  capnp::MallocMessageBuilder b3;
+  absent.toCapnp(b3.initRoot<rpc::InvocationSpanContext>());
+  auto rt3 =
+      KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(b3.getRoot<rpc::InvocationSpanContext>()));
+  KJ_EXPECT(rt3.getTraceFlags() == kj::none);
+  auto child3 = InvocationSpanContext::newForInvocation(rt3, fakeEntropySource);
+  KJ_EXPECT(child3.newChild().getTraceFlags() == kj::none);
 }
 
 KJ_TEST("SpanContext") {

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -230,8 +230,8 @@ kj::Maybe<InvocationSpanContext> InvocationSpanContext::fromCapnp(
   }
 
   kj::Maybe<TraceFlags> flags;
-  if (reader.getTraceFlags().isValue()) {
-    flags = TraceFlags(reader.getTraceFlags().getValue());
+  if (reader.hasTraceFlags() && reader.getTraceFlags().getValue().isSet()) {
+    flags = TraceFlags(reader.getTraceFlags().getValue().getSet());
   }
 
   auto sc = InvocationSpanContext(kj::Badge<InvocationSpanContext>(), kj::none,
@@ -247,7 +247,7 @@ void InvocationSpanContext::toCapnp(rpc::InvocationSpanContext::Builder writer) 
   invocationId.toCapnp(writer.initInvocationId());
   writer.setSpanId(spanId);
   KJ_IF_SOME(flags, traceFlags) {
-    writer.getTraceFlags().setValue(flags);
+    writer.initTraceFlags().getValue().setSet(flags);
   }
 }
 
@@ -313,8 +313,8 @@ SpanContext SpanContext::fromCapnp(rpc::SpanContext::Reader reader) {
   }
 
   kj::Maybe<TraceFlags> flags;
-  if (reader.getTraceFlags().isValue()) {
-    flags = TraceFlags(reader.getTraceFlags().getValue());
+  if (reader.hasTraceFlags() && reader.getTraceFlags().getValue().isSet()) {
+    flags = TraceFlags(reader.getTraceFlags().getValue().getSet());
   }
 
   return SpanContext(TraceId::fromCapnp(reader.getTraceId()), spanId, flags);
@@ -327,7 +327,7 @@ void SpanContext::toCapnp(rpc::SpanContext::Builder writer) const {
     info.setSpanId(s);
   }
   KJ_IF_SOME(flags, traceFlags) {
-    writer.getTraceFlags().setValue(flags);
+    writer.initTraceFlags().getValue().setSet(flags);
   }
 }
 

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -177,34 +177,39 @@ InvocationSpanContext::InvocationSpanContext(kj::Badge<InvocationSpanContext>,
     TraceId traceId,
     TraceId invocationId,
     SpanId spanId,
-    kj::Maybe<const InvocationSpanContext&> parentSpanContext)
+    kj::Maybe<const InvocationSpanContext&> parentSpanContext,
+    kj::Maybe<uint8_t> traceFlags)
     : entropySource(entropySource),
       traceId(kj::mv(traceId)),
       invocationId(kj::mv(invocationId)),
       spanId(kj::mv(spanId)),
       parentSpanContext(parentSpanContext.map([](const InvocationSpanContext& ctx) {
         return kj::heap<InvocationSpanContext>(ctx.clone());
-      })) {}
+      })),
+      traceFlags(kj::mv(traceFlags)) {}
 
 InvocationSpanContext InvocationSpanContext::newChild() const {
   KJ_ASSERT(!isTrigger(), "unable to create child spans on this context");
   kj::Maybe<kj::EntropySource&> otherEntropySource = entropySource.map(
       [](auto& es) -> kj::EntropySource& { return const_cast<kj::EntropySource&>(es); });
   return InvocationSpanContext(kj::Badge<InvocationSpanContext>(), otherEntropySource, traceId,
-      invocationId, SpanId::fromEntropy(otherEntropySource), *this);
+      invocationId, SpanId::fromEntropy(otherEntropySource), *this, traceFlags);
 }
 
 InvocationSpanContext InvocationSpanContext::newForInvocation(
     kj::Maybe<const InvocationSpanContext&> triggerContext,
     kj::Maybe<kj::EntropySource&> entropySource) {
   kj::Maybe<const InvocationSpanContext&> parent;
+  kj::Maybe<uint8_t> flags;
   auto traceId = triggerContext
                      .map([&](auto& ctx) mutable {
     parent = ctx;
+    flags = ctx.traceFlags;
     return ctx.traceId;
   }).orDefault([&] { return TraceId::fromEntropy(entropySource); });
   return InvocationSpanContext(kj::Badge<InvocationSpanContext>(), entropySource, kj::mv(traceId),
-      TraceId::fromEntropy(entropySource), SpanId::fromEntropy(entropySource), kj::mv(parent));
+      TraceId::fromEntropy(entropySource), SpanId::fromEntropy(entropySource), kj::mv(parent),
+      kj::mv(flags));
 }
 
 TraceId TraceId::fromCapnp(rpc::TraceId::Reader reader) {
@@ -224,9 +229,14 @@ kj::Maybe<InvocationSpanContext> InvocationSpanContext::fromCapnp(
     return kj::none;
   }
 
+  kj::Maybe<uint8_t> flags;
+  if (reader.getTraceFlags().isValue()) {
+    flags = reader.getTraceFlags().getValue();
+  }
+
   auto sc = InvocationSpanContext(kj::Badge<InvocationSpanContext>(), kj::none,
       TraceId::fromCapnp(reader.getTraceId()), TraceId::fromCapnp(reader.getInvocationId()),
-      reader.getSpanId());
+      reader.getSpanId(), kj::none, flags);
   // If the traceId or invocationId are invalid, then we'll ignore them.
   if (!sc.getTraceId() || !sc.getInvocationId()) return kj::none;
   return kj::mv(sc);
@@ -236,6 +246,9 @@ void InvocationSpanContext::toCapnp(rpc::InvocationSpanContext::Builder writer) 
   traceId.toCapnp(writer.initTraceId());
   invocationId.toCapnp(writer.initInvocationId());
   writer.setSpanId(spanId);
+  KJ_IF_SOME(flags, traceFlags) {
+    writer.getTraceFlags().setValue(flags);
+  }
 }
 
 InvocationSpanContext InvocationSpanContext::clone() const {
@@ -243,7 +256,8 @@ InvocationSpanContext InvocationSpanContext::clone() const {
       [](auto& es) -> kj::EntropySource& { return const_cast<kj::EntropySource&>(es); });
   return InvocationSpanContext(kj::Badge<InvocationSpanContext>(), otherEntropySource, traceId,
       invocationId, spanId,
-      parentSpanContext.map([](auto& ctx) -> const InvocationSpanContext& { return *ctx.get(); }));
+      parentSpanContext.map([](auto& ctx) -> const InvocationSpanContext& { return *ctx.get(); }),
+      traceFlags);
 }
 
 kj::String KJ_STRINGIFY(const InvocationSpanContext& context) {
@@ -298,7 +312,12 @@ SpanContext SpanContext::fromCapnp(rpc::SpanContext::Reader reader) {
     spanId = info.getSpanId();
   }
 
-  return SpanContext(TraceId::fromCapnp(reader.getTraceId()), spanId);
+  kj::Maybe<uint8_t> flags;
+  if (reader.getTraceFlags().isValue()) {
+    flags = reader.getTraceFlags().getValue();
+  }
+
+  return SpanContext(TraceId::fromCapnp(reader.getTraceId()), spanId, flags);
 }
 
 void SpanContext::toCapnp(rpc::SpanContext::Builder writer) const {
@@ -306,6 +325,9 @@ void SpanContext::toCapnp(rpc::SpanContext::Builder writer) const {
   auto info = writer.initInfo();
   KJ_IF_SOME(s, spanId) {
     info.setSpanId(s);
+  }
+  KJ_IF_SOME(flags, traceFlags) {
+    writer.getTraceFlags().setValue(flags);
   }
 }
 
@@ -342,10 +364,8 @@ kj::Maybe<SpanContext> SpanContext::tryFromTraceparent(kj::StringPtr tp) {
   uint8_t flags = KJ_UNWRAP_OR_RETURN(hexToUint64(tp.slice(kFlagsStart, kFlagsEnd)), kj::none);
 
   if (version != 0 || (traceHigh == 0 && traceLow == 0) || parentId == 0) return kj::none;
-  constexpr uint8_t kSampledFlag = 0x01;
-  if ((flags & kSampledFlag) == 0) return kj::none;
 
-  return SpanContext(TraceId(traceLow, traceHigh), SpanId(parentId));
+  return SpanContext(TraceId(traceLow, traceHigh), SpanId(parentId), flags);
 }
 
 kj::String KJ_STRINGIFY(const SpanContext& context) {
@@ -1459,8 +1479,9 @@ TailEvent::TailEvent(TraceId traceId,
     kj::Maybe<SpanId> spanId,
     kj::Date timestamp,
     kj::uint sequence,
-    Event&& event)
-    : spanContext(kj::mv(traceId), kj::mv(spanId)),
+    Event&& event,
+    kj::Maybe<uint8_t> traceFlags)
+    : spanContext(kj::mv(traceId), kj::mv(spanId), kj::mv(traceFlags)),
       invocationId(kj::mv(invocationId)),
       timestamp(timestamp),
       sequence(sequence),
@@ -1598,7 +1619,7 @@ TailEvent TailEvent::clone() const {
     KJ_UNREACHABLE;
   };
   return TailEvent(spanContext.getTraceId(), invocationId, spanContext.getSpanId(), timestamp,
-      sequence, cloneEvent(event));
+      sequence, cloneEvent(event), spanContext.getTraceFlags());
 }
 
 SpanOpenData::SpanOpenData(rpc::SpanOpenData::Reader reader)

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -178,7 +178,7 @@ InvocationSpanContext::InvocationSpanContext(kj::Badge<InvocationSpanContext>,
     TraceId invocationId,
     SpanId spanId,
     kj::Maybe<const InvocationSpanContext&> parentSpanContext,
-    kj::Maybe<uint8_t> traceFlags)
+    kj::Maybe<TraceFlags> traceFlags)
     : entropySource(entropySource),
       traceId(kj::mv(traceId)),
       invocationId(kj::mv(invocationId)),
@@ -200,7 +200,7 @@ InvocationSpanContext InvocationSpanContext::newForInvocation(
     kj::Maybe<const InvocationSpanContext&> triggerContext,
     kj::Maybe<kj::EntropySource&> entropySource) {
   kj::Maybe<const InvocationSpanContext&> parent;
-  kj::Maybe<uint8_t> flags;
+  kj::Maybe<TraceFlags> flags;
   auto traceId = triggerContext
                      .map([&](auto& ctx) mutable {
     parent = ctx;
@@ -229,9 +229,9 @@ kj::Maybe<InvocationSpanContext> InvocationSpanContext::fromCapnp(
     return kj::none;
   }
 
-  kj::Maybe<uint8_t> flags;
+  kj::Maybe<TraceFlags> flags;
   if (reader.getTraceFlags().isValue()) {
-    flags = reader.getTraceFlags().getValue();
+    flags = TraceFlags(reader.getTraceFlags().getValue());
   }
 
   auto sc = InvocationSpanContext(kj::Badge<InvocationSpanContext>(), kj::none,
@@ -312,9 +312,9 @@ SpanContext SpanContext::fromCapnp(rpc::SpanContext::Reader reader) {
     spanId = info.getSpanId();
   }
 
-  kj::Maybe<uint8_t> flags;
+  kj::Maybe<TraceFlags> flags;
   if (reader.getTraceFlags().isValue()) {
-    flags = reader.getTraceFlags().getValue();
+    flags = TraceFlags(reader.getTraceFlags().getValue());
   }
 
   return SpanContext(TraceId::fromCapnp(reader.getTraceId()), spanId, flags);
@@ -365,7 +365,7 @@ kj::Maybe<SpanContext> SpanContext::tryFromTraceparent(kj::StringPtr tp) {
 
   if (version != 0 || (traceHigh == 0 && traceLow == 0) || parentId == 0) return kj::none;
 
-  return SpanContext(TraceId(traceLow, traceHigh), SpanId(parentId), flags);
+  return SpanContext(TraceId(traceLow, traceHigh), SpanId(parentId), TraceFlags(flags));
 }
 
 kj::String KJ_STRINGIFY(const SpanContext& context) {
@@ -1480,7 +1480,7 @@ TailEvent::TailEvent(TraceId traceId,
     kj::Date timestamp,
     kj::uint sequence,
     Event&& event,
-    kj::Maybe<uint8_t> traceFlags)
+    kj::Maybe<TraceFlags> traceFlags)
     : spanContext(kj::mv(traceId), kj::mv(spanId), kj::mv(traceFlags)),
       invocationId(kj::mv(invocationId)),
       timestamp(timestamp),

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -177,34 +177,39 @@ InvocationSpanContext::InvocationSpanContext(kj::Badge<InvocationSpanContext>,
     TraceId traceId,
     TraceId invocationId,
     SpanId spanId,
-    kj::Maybe<const InvocationSpanContext&> parentSpanContext)
+    kj::Maybe<const InvocationSpanContext&> parentSpanContext,
+    kj::Maybe<uint8_t> traceFlags)
     : entropySource(entropySource),
       traceId(kj::mv(traceId)),
       invocationId(kj::mv(invocationId)),
       spanId(kj::mv(spanId)),
       parentSpanContext(parentSpanContext.map([](const InvocationSpanContext& ctx) {
         return kj::heap<InvocationSpanContext>(ctx.clone());
-      })) {}
+      })),
+      traceFlags(kj::mv(traceFlags)) {}
 
 InvocationSpanContext InvocationSpanContext::newChild() const {
   KJ_ASSERT(!isTrigger(), "unable to create child spans on this context");
   kj::Maybe<kj::EntropySource&> otherEntropySource = entropySource.map(
       [](auto& es) -> kj::EntropySource& { return const_cast<kj::EntropySource&>(es); });
   return InvocationSpanContext(kj::Badge<InvocationSpanContext>(), otherEntropySource, traceId,
-      invocationId, SpanId::fromEntropy(otherEntropySource), *this);
+      invocationId, SpanId::fromEntropy(otherEntropySource), *this, traceFlags);
 }
 
 InvocationSpanContext InvocationSpanContext::newForInvocation(
     kj::Maybe<const InvocationSpanContext&> triggerContext,
     kj::Maybe<kj::EntropySource&> entropySource) {
   kj::Maybe<const InvocationSpanContext&> parent;
+  kj::Maybe<uint8_t> flags;
   auto traceId = triggerContext
                      .map([&](auto& ctx) mutable {
     parent = ctx;
+    flags = ctx.traceFlags;
     return ctx.traceId;
   }).orDefault([&] { return TraceId::fromEntropy(entropySource); });
   return InvocationSpanContext(kj::Badge<InvocationSpanContext>(), entropySource, kj::mv(traceId),
-      TraceId::fromEntropy(entropySource), SpanId::fromEntropy(entropySource), kj::mv(parent));
+      TraceId::fromEntropy(entropySource), SpanId::fromEntropy(entropySource), kj::mv(parent),
+      kj::mv(flags));
 }
 
 TraceId TraceId::fromCapnp(rpc::TraceId::Reader reader) {
@@ -224,9 +229,14 @@ kj::Maybe<InvocationSpanContext> InvocationSpanContext::fromCapnp(
     return kj::none;
   }
 
+  kj::Maybe<uint8_t> flags;
+  if (reader.getTraceFlags().isValue()) {
+    flags = reader.getTraceFlags().getValue();
+  }
+
   auto sc = InvocationSpanContext(kj::Badge<InvocationSpanContext>(), kj::none,
       TraceId::fromCapnp(reader.getTraceId()), TraceId::fromCapnp(reader.getInvocationId()),
-      reader.getSpanId());
+      reader.getSpanId(), kj::none, flags);
   // If the traceId or invocationId are invalid, then we'll ignore them.
   if (!sc.getTraceId() || !sc.getInvocationId()) return kj::none;
   return kj::mv(sc);
@@ -236,6 +246,9 @@ void InvocationSpanContext::toCapnp(rpc::InvocationSpanContext::Builder writer) 
   traceId.toCapnp(writer.initTraceId());
   invocationId.toCapnp(writer.initInvocationId());
   writer.setSpanId(spanId);
+  KJ_IF_SOME(flags, traceFlags) {
+    writer.getTraceFlags().setValue(flags);
+  }
 }
 
 InvocationSpanContext InvocationSpanContext::clone() const {
@@ -243,7 +256,8 @@ InvocationSpanContext InvocationSpanContext::clone() const {
       [](auto& es) -> kj::EntropySource& { return const_cast<kj::EntropySource&>(es); });
   return InvocationSpanContext(kj::Badge<InvocationSpanContext>(), otherEntropySource, traceId,
       invocationId, spanId,
-      parentSpanContext.map([](auto& ctx) -> const InvocationSpanContext& { return *ctx.get(); }));
+      parentSpanContext.map([](auto& ctx) -> const InvocationSpanContext& { return *ctx.get(); }),
+      traceFlags);
 }
 
 kj::String KJ_STRINGIFY(const InvocationSpanContext& context) {
@@ -298,7 +312,12 @@ SpanContext SpanContext::fromCapnp(rpc::SpanContext::Reader reader) {
     spanId = info.getSpanId();
   }
 
-  return SpanContext(TraceId::fromCapnp(reader.getTraceId()), spanId);
+  kj::Maybe<uint8_t> flags;
+  if (reader.getTraceFlags().isValue()) {
+    flags = reader.getTraceFlags().getValue();
+  }
+
+  return SpanContext(TraceId::fromCapnp(reader.getTraceId()), spanId, flags);
 }
 
 void SpanContext::toCapnp(rpc::SpanContext::Builder writer) const {
@@ -306,6 +325,9 @@ void SpanContext::toCapnp(rpc::SpanContext::Builder writer) const {
   auto info = writer.initInfo();
   KJ_IF_SOME(s, spanId) {
     info.setSpanId(s);
+  }
+  KJ_IF_SOME(flags, traceFlags) {
+    writer.getTraceFlags().setValue(flags);
   }
 }
 
@@ -342,10 +364,8 @@ kj::Maybe<SpanContext> SpanContext::tryFromTraceparent(kj::StringPtr tp) {
   uint8_t flags = KJ_UNWRAP_OR_RETURN(hexToUint64(tp.slice(kFlagsStart, kFlagsEnd)), kj::none);
 
   if (version != 0 || (traceHigh == 0 && traceLow == 0) || parentId == 0) return kj::none;
-  constexpr uint8_t kSampledFlag = 0x01;
-  if ((flags & kSampledFlag) == 0) return kj::none;
 
-  return SpanContext(TraceId(traceLow, traceHigh), SpanId(parentId));
+  return SpanContext(TraceId(traceLow, traceHigh), SpanId(parentId), flags);
 }
 
 kj::String KJ_STRINGIFY(const SpanContext& context) {
@@ -1459,8 +1479,9 @@ TailEvent::TailEvent(TraceId traceId,
     kj::Maybe<SpanId> spanId,
     kj::Date timestamp,
     kj::uint sequence,
-    Event&& event)
-    : spanContext(kj::mv(traceId), kj::mv(spanId)),
+    Event&& event,
+    kj::Maybe<uint8_t> traceFlags)
+    : spanContext(kj::mv(traceId), kj::mv(spanId), kj::mv(traceFlags)),
       invocationId(kj::mv(invocationId)),
       timestamp(timestamp),
       sequence(sequence),
@@ -1598,7 +1619,7 @@ TailEvent TailEvent::clone() const {
     KJ_UNREACHABLE;
   };
   return TailEvent(spanContext.getTraceId(), invocationId, spanContext.getSpanId(), timestamp,
-      sequence, cloneEvent(event));
+      sequence, cloneEvent(event), spanContext.getTraceFlags());
 }
 
 void CompleteSpan::copyTo(rpc::UserSpanData::Builder builder) const {

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -189,13 +189,16 @@ class InvocationSpanContext final {
       TraceId traceId,
       TraceId invocationId,
       SpanId spanId,
-      kj::Maybe<const InvocationSpanContext&> parentSpanContext = kj::none);
+      kj::Maybe<const InvocationSpanContext&> parentSpanContext,
+      kj::Maybe<uint8_t> traceFlags);
   // Still need a constructor to be available as long as span context is not propagated everywhere
   // we need it.
-  InvocationSpanContext(TraceId traceId, TraceId invocationId, SpanId spanId)
+  InvocationSpanContext(
+      TraceId traceId, TraceId invocationId, SpanId spanId, kj::Maybe<uint8_t> traceFlags)
       : traceId(traceId),
         invocationId(invocationId),
-        spanId(spanId) {};
+        spanId(spanId),
+        traceFlags(traceFlags) {};
 
   KJ_DISALLOW_COPY(InvocationSpanContext);
 
@@ -223,6 +226,12 @@ class InvocationSpanContext final {
       return *p;
     }
     return kj::none;
+  }
+
+  // W3C trace flags propagated from an upstream traceparent. kj::none when
+  // no upstream sampling decision exists.
+  inline kj::Maybe<uint8_t> getTraceFlags() const {
+    return traceFlags;
   }
 
   // Creates a new child span. If the current context does not have an entropy
@@ -266,12 +275,19 @@ class InvocationSpanContext final {
   // traceId but a different invocationId (unless predictable mode for
   // testing is enabled). The isTrigger() should also return true.
   kj::Maybe<kj::Own<InvocationSpanContext>> parentSpanContext;
+
+  // W3C trace flags from an upstream traceparent, propagated through the
+  // invocation chain. kj::none when no upstream sampling decision was made.
+  kj::Maybe<uint8_t> traceFlags;
 };
 
 // SpanContext as used for streaming tail worker tail events. spanId is always set except for Onset
 // events that don't inherit context from another invocation.
 struct SpanContext {
-  SpanContext(TraceId traceId, kj::Maybe<SpanId> spanId): traceId(traceId), spanId(spanId) {};
+  SpanContext(TraceId traceId, kj::Maybe<SpanId> spanId, kj::Maybe<uint8_t> traceFlags = kj::none)
+      : traceId(traceId),
+        spanId(spanId),
+        traceFlags(traceFlags) {};
   KJ_DISALLOW_COPY(SpanContext);
   SpanContext(SpanContext&& other) = default;
   SpanContext& operator=(SpanContext&& other) = default;
@@ -288,10 +304,17 @@ struct SpanContext {
     return spanId;
   }
 
+  // W3C trace flags from an upstream traceparent. kj::none when no upstream
+  // sampling decision was made (e.g. subrequest propagation without a
+  // worker_tracing header). Bit 0 = sampled.
+  inline kj::Maybe<uint8_t> getTraceFlags() const {
+    return traceFlags;
+  }
+
   static SpanContext fromCapnp(rpc::SpanContext::Reader reader);
   void toCapnp(rpc::SpanContext::Builder writer) const;
   static SpanContext clone(const SpanContext& ctx) {
-    return SpanContext(ctx.traceId, ctx.spanId);
+    return SpanContext(ctx.traceId, ctx.spanId, ctx.traceFlags);
   }
 
   // Parse a W3C traceparent string into a SpanContext.
@@ -301,6 +324,7 @@ struct SpanContext {
  private:
   TraceId traceId;
   kj::Maybe<SpanId> spanId;
+  kj::Maybe<uint8_t> traceFlags;
 };
 
 kj::String KJ_STRINGIFY(const SpanId& id);
@@ -835,7 +859,8 @@ struct TailEvent final {
       kj::Maybe<SpanId> spanId,
       kj::Date timestamp,
       kj::uint sequence,
-      Event&& event);
+      Event&& event,
+      kj::Maybe<uint8_t> traceFlags = kj::none);
   TailEvent(rpc::Trace::TailEvent::Reader reader);
   TailEvent(TailEvent&&) = default;
   TailEvent& operator=(TailEvent&&) = default;

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -174,6 +174,31 @@ constexpr SpanId SpanId::nullId = nullptr;
 // Fixed spanId value to be used for tests
 constexpr uint64_t staticSpanId = 0x2a2a2a2a2a2a2a2aULL;
 
+// W3C trace flags propagated from an upstream traceparent. Wrapped in kj::Maybe
+// at usage sites: kj::none means no upstream decision was made.
+class TraceFlags final {
+ public:
+  explicit constexpr TraceFlags(uint8_t flags): flags(flags) {}
+
+  constexpr bool isSampled() const {
+    return flags & SAMPLED;
+  }
+
+  constexpr operator uint8_t() const {
+    return flags;
+  }
+
+  constexpr bool operator==(const TraceFlags& other) const {
+    return flags == other.flags;
+  }
+
+ private:
+  // W3C trace-flags bit: the caller requested this trace be recorded.
+  static constexpr uint8_t SAMPLED = 0x01;
+
+  uint8_t flags;
+};
+
 // The InvocationSpanContext is a tuple of a trace id, invocation id, and span id.
 // The trace id represents a top-level request and should be shared across all
 // invocation spans and events within those spans. The invocation id identifies
@@ -190,11 +215,11 @@ class InvocationSpanContext final {
       TraceId invocationId,
       SpanId spanId,
       kj::Maybe<const InvocationSpanContext&> parentSpanContext,
-      kj::Maybe<uint8_t> traceFlags);
+      kj::Maybe<TraceFlags> traceFlags);
   // Still need a constructor to be available as long as span context is not propagated everywhere
   // we need it.
   InvocationSpanContext(
-      TraceId traceId, TraceId invocationId, SpanId spanId, kj::Maybe<uint8_t> traceFlags)
+      TraceId traceId, TraceId invocationId, SpanId spanId, kj::Maybe<TraceFlags> traceFlags)
       : traceId(traceId),
         invocationId(invocationId),
         spanId(spanId),
@@ -230,7 +255,7 @@ class InvocationSpanContext final {
 
   // W3C trace flags propagated from an upstream traceparent. kj::none when
   // no upstream sampling decision exists.
-  inline kj::Maybe<uint8_t> getTraceFlags() const {
+  inline kj::Maybe<TraceFlags> getTraceFlags() const {
     return traceFlags;
   }
 
@@ -278,13 +303,14 @@ class InvocationSpanContext final {
 
   // W3C trace flags from an upstream traceparent, propagated through the
   // invocation chain. kj::none when no upstream sampling decision was made.
-  kj::Maybe<uint8_t> traceFlags;
+  kj::Maybe<TraceFlags> traceFlags;
 };
 
 // SpanContext as used for streaming tail worker tail events. spanId is always set except for Onset
 // events that don't inherit context from another invocation.
 struct SpanContext {
-  SpanContext(TraceId traceId, kj::Maybe<SpanId> spanId, kj::Maybe<uint8_t> traceFlags = kj::none)
+  SpanContext(
+      TraceId traceId, kj::Maybe<SpanId> spanId, kj::Maybe<TraceFlags> traceFlags = kj::none)
       : traceId(traceId),
         spanId(spanId),
         traceFlags(traceFlags) {};
@@ -306,8 +332,8 @@ struct SpanContext {
 
   // W3C trace flags from an upstream traceparent. kj::none when no upstream
   // sampling decision was made (e.g. subrequest propagation without a
-  // worker_tracing header). Bit 0 = sampled.
-  inline kj::Maybe<uint8_t> getTraceFlags() const {
+  // worker_tracing header).
+  inline kj::Maybe<TraceFlags> getTraceFlags() const {
     return traceFlags;
   }
 
@@ -324,7 +350,7 @@ struct SpanContext {
  private:
   TraceId traceId;
   kj::Maybe<SpanId> spanId;
-  kj::Maybe<uint8_t> traceFlags;
+  kj::Maybe<TraceFlags> traceFlags;
 };
 
 kj::String KJ_STRINGIFY(const SpanId& id);
@@ -860,7 +886,7 @@ struct TailEvent final {
       kj::Date timestamp,
       kj::uint sequence,
       Event&& event,
-      kj::Maybe<uint8_t> traceFlags = kj::none);
+      kj::Maybe<TraceFlags> traceFlags = kj::none);
   TailEvent(rpc::Trace::TailEvent::Reader reader);
   TailEvent(TailEvent&&) = default;
   TailEvent& operator=(TailEvent&&) = default;

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -293,7 +293,7 @@ struct SpanContext {
   SpanContext& operator=(SpanContext&& other) = default;
 
   inline bool operator==(const SpanContext& other) const {
-    return traceId == other.traceId && spanId == other.spanId && traceFlags == other.traceFlags;
+    return traceId == other.traceId && spanId == other.spanId;
   }
 
   inline const TraceId& getTraceId() const {

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -189,13 +189,16 @@ class InvocationSpanContext final {
       TraceId traceId,
       TraceId invocationId,
       SpanId spanId,
-      kj::Maybe<const InvocationSpanContext&> parentSpanContext = kj::none);
+      kj::Maybe<const InvocationSpanContext&> parentSpanContext,
+      kj::Maybe<uint8_t> traceFlags);
   // Still need a constructor to be available as long as span context is not propagated everywhere
   // we need it.
-  InvocationSpanContext(TraceId traceId, TraceId invocationId, SpanId spanId)
+  InvocationSpanContext(
+      TraceId traceId, TraceId invocationId, SpanId spanId, kj::Maybe<uint8_t> traceFlags)
       : traceId(traceId),
         invocationId(invocationId),
-        spanId(spanId) {};
+        spanId(spanId),
+        traceFlags(traceFlags) {};
 
   KJ_DISALLOW_COPY(InvocationSpanContext);
 
@@ -223,6 +226,12 @@ class InvocationSpanContext final {
       return *p;
     }
     return kj::none;
+  }
+
+  // W3C trace flags propagated from an upstream traceparent. kj::none when
+  // no upstream sampling decision exists.
+  inline kj::Maybe<uint8_t> getTraceFlags() const {
+    return traceFlags;
   }
 
   // Creates a new child span. If the current context does not have an entropy
@@ -266,18 +275,25 @@ class InvocationSpanContext final {
   // traceId but a different invocationId (unless predictable mode for
   // testing is enabled). The isTrigger() should also return true.
   kj::Maybe<kj::Own<InvocationSpanContext>> parentSpanContext;
+
+  // W3C trace flags from an upstream traceparent, propagated through the
+  // invocation chain. kj::none when no upstream sampling decision was made.
+  kj::Maybe<uint8_t> traceFlags;
 };
 
 // SpanContext as used for streaming tail worker tail events. spanId is always set except for Onset
 // events that don't inherit context from another invocation.
 struct SpanContext {
-  SpanContext(TraceId traceId, kj::Maybe<SpanId> spanId): traceId(traceId), spanId(spanId) {};
+  SpanContext(TraceId traceId, kj::Maybe<SpanId> spanId, kj::Maybe<uint8_t> traceFlags = kj::none)
+      : traceId(traceId),
+        spanId(spanId),
+        traceFlags(traceFlags) {};
   KJ_DISALLOW_COPY(SpanContext);
   SpanContext(SpanContext&& other) = default;
   SpanContext& operator=(SpanContext&& other) = default;
 
   inline bool operator==(const SpanContext& other) const {
-    return traceId == other.traceId && spanId == other.spanId;
+    return traceId == other.traceId && spanId == other.spanId && traceFlags == other.traceFlags;
   }
 
   inline const TraceId& getTraceId() const {
@@ -288,10 +304,17 @@ struct SpanContext {
     return spanId;
   }
 
+  // W3C trace flags from an upstream traceparent. kj::none when no upstream
+  // sampling decision was made (e.g. subrequest propagation without a
+  // worker_tracing header). Bit 0 = sampled.
+  inline kj::Maybe<uint8_t> getTraceFlags() const {
+    return traceFlags;
+  }
+
   static SpanContext fromCapnp(rpc::SpanContext::Reader reader);
   void toCapnp(rpc::SpanContext::Builder writer) const;
   static SpanContext clone(const SpanContext& ctx) {
-    return SpanContext(ctx.traceId, ctx.spanId);
+    return SpanContext(ctx.traceId, ctx.spanId, ctx.traceFlags);
   }
 
   // Parse a W3C traceparent string into a SpanContext.
@@ -301,6 +324,7 @@ struct SpanContext {
  private:
   TraceId traceId;
   kj::Maybe<SpanId> spanId;
+  kj::Maybe<uint8_t> traceFlags;
 };
 
 kj::String KJ_STRINGIFY(const SpanId& id);
@@ -863,7 +887,8 @@ struct TailEvent final {
       kj::Maybe<SpanId> spanId,
       kj::Date timestamp,
       kj::uint sequence,
-      Event&& event);
+      Event&& event,
+      kj::Maybe<uint8_t> traceFlags = kj::none);
   TailEvent(rpc::Trace::TailEvent::Reader reader);
   TailEvent(TailEvent&&) = default;
   TailEvent& operator=(TailEvent&&) = default;

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -171,8 +171,8 @@ void WorkerTracer::addSpanOpen(tracing::SpanId spanId,
     parentSpanId = topLevelContext.getSpanId();
   }
   size_t spanNameSize = operationName.size();
-  auto spanOpenContext = tracing::InvocationSpanContext(
-      topLevelContext.getTraceId(), topLevelContext.getInvocationId(), parentSpanId);
+  auto spanOpenContext = tracing::InvocationSpanContext(topLevelContext.getTraceId(),
+      topLevelContext.getInvocationId(), parentSpanId, topLevelContext.getTraceFlags());
   tailStreamWriter->report(
       spanOpenContext, tracing::SpanOpen(spanId, kj::mv(operationName)), startTime, spanNameSize);
 }
@@ -208,8 +208,8 @@ void WorkerTracer::addSpanClose(tracing::SpanEndData&& span, kj::Maybe<kj::Date>
   // Compose Attributes and SpanClose, which are available at span completion time and transmitted
   // together.
   auto& topLevelContext = KJ_ASSERT_NONNULL(topLevelInvocationSpanContext);
-  auto spanComponentContext = tracing::InvocationSpanContext(
-      topLevelContext.getTraceId(), topLevelContext.getInvocationId(), span.spanId);
+  auto spanComponentContext = tracing::InvocationSpanContext(topLevelContext.getTraceId(),
+      topLevelContext.getInvocationId(), span.spanId, topLevelContext.getTraceFlags());
 
   if (span.tags.size() && spanTagsSize <= MAX_TRACE_BYTES) {
     tracing::CustomInfo attr = KJ_MAP(tag, span.tags) {
@@ -372,7 +372,7 @@ void WorkerTracer::setEventInfoInternal(
     // as its parent span ID, except for recursive SpanOpens (which have the parent span instead)
     // and Attribute/SpanClose events (which have the spanId opened in the corresponding SpanOpen).
     auto onsetContext = tracing::InvocationSpanContext(
-        context.getTraceId(), context.getInvocationId(), parentSpanId);
+        context.getTraceId(), context.getInvocationId(), parentSpanId, context.getTraceFlags());
 
     // Not applying size accounting for Onset since it is sent separately
     writer->report(onsetContext,
@@ -524,9 +524,10 @@ void WorkerTracer::setWorkerAttribute(kj::ConstString key, Span::TagValue value)
   attributes.add(tracing::Attribute{kj::mv(key), kj::mv(value)});
 }
 
-SpanParent BaseTracer::makeUserRequestSpan(tracing::TraceId traceId) {
+SpanParent BaseTracer::makeUserRequestSpan(
+    tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags) {
   KJ_IF_SOME(func, makeUserRequestSpanFunc) {
-    return func(kj::mv(traceId));
+    return func(kj::mv(traceId), traceFlags);
   } else {
     return SpanParent(nullptr);
   }
@@ -556,19 +557,19 @@ void WorkerTracer::setJsRpcInfo(const tracing::InvocationSpanContext& context,
 }
 
 kj::Own<SpanObserver> UserSpanObserver::newChild() {
-  return kj::refcounted<UserSpanObserver>(kj::addRef(*submitter), spanId, traceId);
+  return kj::refcounted<UserSpanObserver>(kj::addRef(*submitter), spanId, traceId, traceFlags);
 }
 
 kj::Own<SpanObserver> UserSpanObserver::newChildFromUserCode() {
   return kj::refcounted<UserSpanObserver>(
-      kj::addRef(*submitter), spanId, traceId, /*fromUserCode=*/true);
+      kj::addRef(*submitter), spanId, traceId, traceFlags, /*fromUserCode=*/true);
 }
 
 kj::Maybe<tracing::SpanContext> UserSpanObserver::toSpanContext() {
   if (traceId == nullptr) {
     return kj::none;
   }
-  return tracing::SpanContext(traceId, spanId);
+  return tracing::SpanContext(traceId, spanId, traceFlags);
 }
 
 void UserSpanObserver::onClose(

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -525,7 +525,7 @@ void WorkerTracer::setWorkerAttribute(kj::ConstString key, Span::TagValue value)
 }
 
 SpanParent BaseTracer::makeUserRequestSpan(
-    tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags) {
+    tracing::TraceId traceId, kj::Maybe<tracing::TraceFlags> traceFlags) {
   KJ_IF_SOME(func, makeUserRequestSpanFunc) {
     return func(kj::mv(traceId), traceFlags);
   } else {

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -179,8 +179,8 @@ void WorkerTracer::addSpanOpen(tracing::SpanId spanId,
     parentSpanId = topLevelContext.getSpanId();
   }
   size_t spanNameSize = operationName.size();
-  auto spanOpenContext = tracing::InvocationSpanContext(
-      topLevelContext.getTraceId(), topLevelContext.getInvocationId(), parentSpanId);
+  auto spanOpenContext = tracing::InvocationSpanContext(topLevelContext.getTraceId(),
+      topLevelContext.getInvocationId(), parentSpanId, topLevelContext.getTraceFlags());
   tailStreamWriter->report(
       spanOpenContext, tracing::SpanOpen(spanId, kj::mv(operationName)), startTime, spanNameSize);
 }
@@ -216,8 +216,8 @@ void WorkerTracer::addSpanEnd(tracing::SpanEndData&& span, kj::Maybe<kj::Date> m
   // Compose Attributes and SpanClose, which are available at span completion time and transmitted
   // together.
   auto& topLevelContext = KJ_ASSERT_NONNULL(topLevelInvocationSpanContext);
-  auto spanComponentContext = tracing::InvocationSpanContext(
-      topLevelContext.getTraceId(), topLevelContext.getInvocationId(), span.spanId);
+  auto spanComponentContext = tracing::InvocationSpanContext(topLevelContext.getTraceId(),
+      topLevelContext.getInvocationId(), span.spanId, topLevelContext.getTraceFlags());
 
   if (span.tags.size() && spanTagsSize <= MAX_TRACE_BYTES) {
     tracing::CustomInfo attr = KJ_MAP(tag, span.tags) {
@@ -380,7 +380,7 @@ void WorkerTracer::setEventInfoInternal(
     // as its parent span ID, except for recursive SpanOpens (which have the parent span instead)
     // and Attribute/SpanClose events (which have the spanId opened in the corresponding SpanOpen).
     auto onsetContext = tracing::InvocationSpanContext(
-        context.getTraceId(), context.getInvocationId(), parentSpanId);
+        context.getTraceId(), context.getInvocationId(), parentSpanId, context.getTraceFlags());
 
     // Not applying size accounting for Onset since it is sent separately
     writer->report(onsetContext,
@@ -584,9 +584,10 @@ void WorkerTracer::setWorkerAttribute(kj::ConstString key, Span::TagValue value)
   attributes.add(tracing::Attribute{kj::mv(key), kj::mv(value)});
 }
 
-SpanParent BaseTracer::makeUserRequestSpan(tracing::TraceId traceId) {
+SpanParent BaseTracer::makeUserRequestSpan(
+    tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags) {
   KJ_IF_SOME(func, makeUserRequestSpanFunc) {
-    return func(kj::mv(traceId));
+    return func(kj::mv(traceId), traceFlags);
   } else {
     return SpanParent(nullptr);
   }
@@ -616,14 +617,14 @@ void WorkerTracer::setJsRpcInfo(const tracing::InvocationSpanContext& context,
 }
 
 kj::Own<SpanObserver> UserSpanObserver::newChild() {
-  return kj::refcounted<UserSpanObserver>(kj::addRef(*submitter), spanId, traceId);
+  return kj::refcounted<UserSpanObserver>(kj::addRef(*submitter), spanId, traceId, traceFlags);
 }
 
 kj::Maybe<tracing::SpanContext> UserSpanObserver::toSpanContext() {
   if (traceId == nullptr) {
     return kj::none;
   }
-  return tracing::SpanContext(traceId, spanId);
+  return tracing::SpanContext(traceId, spanId, traceFlags);
 }
 
 void UserSpanObserver::report(const Span& span) {

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -79,9 +79,9 @@ class BaseTracer: public kj::Refcounted {
   // be available afterwards.
   virtual void recordTimestamp(kj::Date timestamp) = 0;
 
-  SpanParent makeUserRequestSpan(tracing::TraceId traceId);
+  SpanParent makeUserRequestSpan(tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags);
 
-  using MakeUserRequestSpanFunc = kj::Function<SpanParent(tracing::TraceId)>;
+  using MakeUserRequestSpanFunc = kj::Function<SpanParent(tracing::TraceId, kj::Maybe<uint8_t>)>;
 
   // Allow setting the user request span after the tracer has been created so its observer can
   // reference the tracer. This can only be set once.
@@ -237,23 +237,28 @@ class UserSpanObserver final: public SpanObserver {
         spanId(tracing::SpanId::nullId),
         parentSpanId(tracing::SpanId::nullId),
         traceId(nullptr) {}
-  // constructor for top-level observer with trace ID
-  UserSpanObserver(kj::Own<SpanSubmitter> submitter, tracing::TraceId traceId)
+  // constructor for top-level observer with trace ID and optional trace flags
+  UserSpanObserver(kj::Own<SpanSubmitter> submitter,
+      tracing::TraceId traceId,
+      kj::Maybe<uint8_t> traceFlags = kj::none)
       : submitter(kj::mv(submitter)),
         spanId(tracing::SpanId::nullId),
         parentSpanId(tracing::SpanId::nullId),
-        traceId(kj::mv(traceId)) {}
+        traceId(kj::mv(traceId)),
+        traceFlags(traceFlags) {}
   // constructor for subsequent observers attached to a span. `fromUserCode` is true for
   // spans created directly via `ctx.tracing.enterSpan`; this routes onOpen() through
   // submitUserSpanOpen() so submitters can apply different policies than for runtime spans.
   UserSpanObserver(kj::Own<SpanSubmitter> submitter,
       tracing::SpanId parentSpanId,
       tracing::TraceId traceId,
+      kj::Maybe<uint8_t> traceFlags,
       bool fromUserCode = false)
       : submitter(kj::mv(submitter)),
         spanId(this->submitter->makeSpanId()),
         parentSpanId(parentSpanId),
         traceId(kj::mv(traceId)),
+        traceFlags(traceFlags),
         fromUserCode(fromUserCode) {}
   KJ_DISALLOW_COPY(UserSpanObserver);
 
@@ -275,6 +280,7 @@ class UserSpanObserver final: public SpanObserver {
   kj::Date startTime = kj::UNIX_EPOCH;
   // Allow the submitter to reject spans, causing them to not be reported.
   bool wasAccepted = true;
+  kj::Maybe<uint8_t> traceFlags;
   // True only for spans created directly via `ctx.tracing.enterSpan`. Not inherited by
   // children created via `newChild()` — runtime sub-operations nested inside an enterSpan
   // callback (e.g. `kv_get`) should remain subject to runtime-span policies.

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -79,9 +79,11 @@ class BaseTracer: public kj::Refcounted {
   // be available afterwards.
   virtual void recordTimestamp(kj::Date timestamp) = 0;
 
-  SpanParent makeUserRequestSpan(tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags);
+  SpanParent makeUserRequestSpan(
+      tracing::TraceId traceId, kj::Maybe<tracing::TraceFlags> traceFlags);
 
-  using MakeUserRequestSpanFunc = kj::Function<SpanParent(tracing::TraceId, kj::Maybe<uint8_t>)>;
+  using MakeUserRequestSpanFunc =
+      kj::Function<SpanParent(tracing::TraceId, kj::Maybe<tracing::TraceFlags>)>;
 
   // Allow setting the user request span after the tracer has been created so its observer can
   // reference the tracer. This can only be set once.
@@ -240,7 +242,7 @@ class UserSpanObserver final: public SpanObserver {
   // constructor for top-level observer with trace ID and optional trace flags
   UserSpanObserver(kj::Own<SpanSubmitter> submitter,
       tracing::TraceId traceId,
-      kj::Maybe<uint8_t> traceFlags = kj::none)
+      kj::Maybe<tracing::TraceFlags> traceFlags = kj::none)
       : submitter(kj::mv(submitter)),
         spanId(tracing::SpanId::nullId),
         parentSpanId(tracing::SpanId::nullId),
@@ -252,7 +254,7 @@ class UserSpanObserver final: public SpanObserver {
   UserSpanObserver(kj::Own<SpanSubmitter> submitter,
       tracing::SpanId parentSpanId,
       tracing::TraceId traceId,
-      kj::Maybe<uint8_t> traceFlags,
+      kj::Maybe<tracing::TraceFlags> traceFlags,
       bool fromUserCode = false)
       : submitter(kj::mv(submitter)),
         spanId(this->submitter->makeSpanId()),
@@ -280,7 +282,7 @@ class UserSpanObserver final: public SpanObserver {
   kj::Date startTime = kj::UNIX_EPOCH;
   // Allow the submitter to reject spans, causing them to not be reported.
   bool wasAccepted = true;
-  kj::Maybe<uint8_t> traceFlags;
+  kj::Maybe<tracing::TraceFlags> traceFlags;
   // True only for spans created directly via `ctx.tracing.enterSpan`. Not inherited by
   // children created via `newChild()` — runtime sub-operations nested inside an enterSpan
   // callback (e.g. `kv_get`) should remain subject to runtime-span policies.

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -71,9 +71,9 @@ class BaseTracer: public kj::Refcounted {
   // be available afterwards.
   virtual void recordTimestamp(kj::Date timestamp) = 0;
 
-  SpanParent makeUserRequestSpan(tracing::TraceId traceId);
+  SpanParent makeUserRequestSpan(tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags);
 
-  using MakeUserRequestSpanFunc = kj::Function<SpanParent(tracing::TraceId)>;
+  using MakeUserRequestSpanFunc = kj::Function<SpanParent(tracing::TraceId, kj::Maybe<uint8_t>)>;
 
   // Allow setting the user request span after the tracer has been created so its observer can
   // reference the tracer. This can only be set once.
@@ -213,19 +213,25 @@ class UserSpanObserver final: public SpanObserver {
         spanId(tracing::SpanId::nullId),
         parentSpanId(tracing::SpanId::nullId),
         traceId(nullptr) {}
-  // constructor for top-level observer with trace ID
-  UserSpanObserver(kj::Own<SpanSubmitter> submitter, tracing::TraceId traceId)
+  // constructor for top-level observer with trace ID and optional trace flags
+  UserSpanObserver(kj::Own<SpanSubmitter> submitter,
+      tracing::TraceId traceId,
+      kj::Maybe<uint8_t> traceFlags = kj::none)
       : submitter(kj::mv(submitter)),
         spanId(tracing::SpanId::nullId),
         parentSpanId(tracing::SpanId::nullId),
-        traceId(kj::mv(traceId)) {}
+        traceId(kj::mv(traceId)),
+        traceFlags(traceFlags) {}
   // constructor for subsequent observers attached to a span
-  UserSpanObserver(
-      kj::Own<SpanSubmitter> submitter, tracing::SpanId parentSpanId, tracing::TraceId traceId)
+  UserSpanObserver(kj::Own<SpanSubmitter> submitter,
+      tracing::SpanId parentSpanId,
+      tracing::TraceId traceId,
+      kj::Maybe<uint8_t> traceFlags)
       : submitter(kj::mv(submitter)),
         spanId(this->submitter->makeSpanId()),
         parentSpanId(parentSpanId),
-        traceId(kj::mv(traceId)) {}
+        traceId(kj::mv(traceId)),
+        traceFlags(traceFlags) {}
   KJ_DISALLOW_COPY(UserSpanObserver);
 
   kj::Own<SpanObserver> newChild() override;
@@ -240,6 +246,7 @@ class UserSpanObserver final: public SpanObserver {
   tracing::SpanId spanId;
   tracing::SpanId parentSpanId;
   tracing::TraceId traceId;
+  kj::Maybe<uint8_t> traceFlags;
 };
 
 }  // namespace workerd

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -24,6 +24,17 @@ struct TraceId {
   low @1 :UInt64;
 }
 
+# W3C trace flags from an upstream traceparent.
+# Bit 0 = sampled. Only meaningful when set to a value.
+# When the field is missing or the union is unset, no upstream sampling decision
+# was made and the tail worker should make its own sampling decision.
+struct TraceFlags {
+  value :union {
+    unset @0 :Void;
+    set @1 :UInt8;
+  }
+}
+
 # InvocationSpanContext used to identify the current tracing context. Only used internally so far.
 struct InvocationSpanContext {
   # The 128-bit ID uniquely identifying a trace.
@@ -32,13 +43,8 @@ struct InvocationSpanContext {
   invocationId @1 :TraceId;
   # The 64-bit span ID identifying an individual span within a worker stage invocation.
   spanId @2 :UInt64;
-
-  # W3C trace flags from an upstream traceparent, propagated through the
-  # invocation chain. When unset, no upstream sampling decision was made.
-  traceFlags :union {
-    unset @3 :Void;
-    value @4 :UInt8;
-  }
+  # W3C trace flags.
+  traceFlags @3 :TraceFlags;
 }
 
 # Span context for a tail event – this is provided for each tail event.
@@ -56,15 +62,8 @@ struct SpanContext {
     empty @1 :Void;
     spanId @2 :UInt64;
   }
-
-  # W3C trace flags
-  # Bit 0 = sampled. Only meaningful when set to a value.
-  # When unset, no upstream sampling decision was made and the tail worker should
-  # make its own sampling decision.
-  traceFlags :union {
-    unset @3 :Void;
-    value @4 :UInt8;
-  }
+  # W3C trace flags.
+  traceFlags @3 :TraceFlags;
 }
 
 struct Trace @0x8e8d911203762d34 {

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -32,6 +32,13 @@ struct InvocationSpanContext {
   invocationId @1 :TraceId;
   # The 64-bit span ID identifying an individual span within a worker stage invocation.
   spanId @2 :UInt64;
+
+  # W3C trace flags from an upstream traceparent, propagated through the
+  # invocation chain. When unset, no upstream sampling decision was made.
+  traceFlags :union {
+    unset @3 :Void;
+    value @4 :UInt8;
+  }
 }
 
 # Span context for a tail event – this is provided for each tail event.
@@ -48,6 +55,15 @@ struct SpanContext {
   info :union {
     empty @1 :Void;
     spanId @2 :UInt64;
+  }
+
+  # W3C trace flags
+  # Bit 0 = sampled. Only meaningful when set to a value.
+  # When unset, no upstream sampling decision was made and the tail worker should
+  # make its own sampling decision.
+  traceFlags :union {
+    unset @3 :Void;
+    value @4 :UInt8;
   }
 }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2210,9 +2210,10 @@ class Server::WorkerService final: public Service,
     }
 
     KJ_IF_SOME(w, workerTracer) {
-      w->setMakeUserRequestSpanFunc([&w = *w](tracing::TraceId traceId) {
+      w->setMakeUserRequestSpanFunc(
+          [&w = *w](tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags) {
         return SpanParent(kj::refcounted<UserSpanObserver>(
-            kj::refcounted<SequentialSpanSubmitter>(w.getWeakRef()), kj::mv(traceId)));
+            kj::refcounted<SequentialSpanSubmitter>(w.getWeakRef()), kj::mv(traceId), traceFlags));
       });
     }
     kj::Own<RequestObserver> observer =
@@ -2221,8 +2222,8 @@ class Server::WorkerService final: public Service,
     kj::Maybe<tracing::InvocationSpanContext> triggerContext;
     KJ_IF_SOME(ctx, metadata.userSpanParent.toSpanContext()) {
       KJ_IF_SOME(spanId, ctx.getSpanId()) {
-        triggerContext =
-            tracing::InvocationSpanContext(ctx.getTraceId(), tracing::TraceId::nullId, spanId);
+        triggerContext = tracing::InvocationSpanContext(
+            ctx.getTraceId(), tracing::TraceId::nullId, spanId, ctx.getTraceFlags());
       }
     }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2211,7 +2211,7 @@ class Server::WorkerService final: public Service,
 
     KJ_IF_SOME(w, workerTracer) {
       w->setMakeUserRequestSpanFunc(
-          [&w = *w](tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags) {
+          [&w = *w](tracing::TraceId traceId, kj::Maybe<tracing::TraceFlags> traceFlags) {
         return SpanParent(kj::refcounted<UserSpanObserver>(
             kj::refcounted<SequentialSpanSubmitter>(w.getWeakRef()), kj::mv(traceId), traceFlags));
       });

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2214,9 +2214,10 @@ class Server::WorkerService final: public Service,
     }
 
     KJ_IF_SOME(w, workerTracer) {
-      w->setMakeUserRequestSpanFunc([&w = *w](tracing::TraceId traceId) {
+      w->setMakeUserRequestSpanFunc(
+          [&w = *w](tracing::TraceId traceId, kj::Maybe<uint8_t> traceFlags) {
         return SpanParent(kj::refcounted<UserSpanObserver>(
-            kj::refcounted<SequentialSpanSubmitter>(kj::addRef(w)), kj::mv(traceId)));
+            kj::refcounted<SequentialSpanSubmitter>(kj::addRef(w)), kj::mv(traceId), traceFlags));
       });
     }
     kj::Own<RequestObserver> observer =
@@ -2225,8 +2226,8 @@ class Server::WorkerService final: public Service,
     kj::Maybe<tracing::InvocationSpanContext> triggerContext;
     KJ_IF_SOME(ctx, metadata.userSpanParent.toSpanContext()) {
       KJ_IF_SOME(spanId, ctx.getSpanId()) {
-        triggerContext =
-            tracing::InvocationSpanContext(ctx.getTraceId(), tracing::TraceId::nullId, spanId);
+        triggerContext = tracing::InvocationSpanContext(
+            ctx.getTraceId(), tracing::TraceId::nullId, spanId, ctx.getTraceFlags());
       }
     }
 


### PR DESCRIPTION
- Adds traceFlags to SpanContext and tryFromTraceparent parsing
- Propagates through InvocationSpanContext and UserSpanObserver
- Exposes on tail worker onset event