### PR TITLE
Make wpt:encoding a large test

### DIFF
--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -73,6 +73,7 @@ wpt_test(
 
 wpt_test(
     name = "encoding",
+    size = "large",
     compat_flags = [
         "encoder_stream_spec_compliant_backpressure",
         "fixup-transform-stream-backpressure",


### PR DESCRIPTION
This one is just on the edge and often times
out in internal builds, causing reruns.