### PR TITLE
Revert "Fixup consumer ref in backpressure update"

### DIFF
--- a/src/workerd/api/streams/queue.h
+++ b/src/workerd/api/streams/queue.h
@@ -349,17 +349,15 @@ class ConsumerImpl final {
 
   // A simple utility to be allocated on any stack where consumer buffer data maybe consumed
   // or expanded. When the stack is unwound, it ensures the backpressure is appropriately
-  // updated. Captures the weakref to the consumer as there's a chance it'll be destroyed
-  // while the scope is pending.
+  // updated. Captures the queue at construction time since the consumer may be
+  // destroyed before the scope ends (e.g., via onConsumerError -> owner.doError()).
   struct UpdateBackpressureScope final {
-    kj::Rc<WeakRef<ConsumerImpl<Self>>> consumer;
-    UpdateBackpressureScope(ConsumerImpl& consumer): consumer(consumer.selfRef.addRef()) {}
+    kj::Maybe<QueueImpl&> queue;
+    UpdateBackpressureScope(ConsumerImpl& consumer): queue(consumer.queue) {}
     ~UpdateBackpressureScope() noexcept(false) {
-      consumer->runIfAlive([](ConsumerImpl& consumer) {
-        KJ_IF_SOME(q, consumer.queue) {
-          q.maybeUpdateBackpressure();
-        }
-      });
+      KJ_IF_SOME(q, queue) {
+        q.maybeUpdateBackpressure();
+      }
     }
     KJ_DISALLOW_COPY_AND_MOVE(UpdateBackpressureScope);
   };


### PR DESCRIPTION
Reverts cloudflare/workerd#6482

This reverts the change to `UpdateBackpressureScope` that switched from capturing the `QueueImpl&` directly to capturing a `WeakRef<ConsumerImpl>` and using `runIfAlive`. The original approach of capturing the queue at construction time is restored.