### PR TITLE
refactor: rename Flags type to Flagship and prefix exported types

### DIFF
--- a/types/defines/flagship.d.ts
+++ b/types/defines/flagship.d.ts
@@ -2,9 +2,12 @@
  * Evaluation context for targeting rules.
  * Keys are attribute names (e.g. "userId", "country"), values are the attribute values.
  */
-export type EvaluationContext = Record<string, string | number | boolean>;
+export type FlagshipEvaluationContext = Record<
+  string,
+  string | number | boolean
+>;
 
-export interface EvaluationDetails<T> {
+export interface FlagshipEvaluationDetails<T> {
   flagKey: string;
   value: T;
   variant?: string | undefined;
@@ -13,7 +16,7 @@ export interface EvaluationDetails<T> {
   errorMessage?: string | undefined;
 }
 
-export interface FlagEvaluationError extends Error {}
+export interface FlagshipEvaluationError extends Error {}
 
 /**
  * Feature flags binding for evaluating feature flags from a Cloudflare Workers script.
@@ -34,7 +37,7 @@ export interface FlagEvaluationError extends Error {}
  * console.log(details.variant, details.reason);
  * ```
  */
-export declare abstract class Flags {
+export declare abstract class Flagship {
   /**
    * Get a flag value without type checking.
    * @param flagKey The key of the flag to evaluate.
@@ -44,7 +47,7 @@ export declare abstract class Flags {
   get(
     flagKey: string,
     defaultValue?: unknown,
-    context?: EvaluationContext
+    context?: FlagshipEvaluationContext
   ): Promise<unknown>;
 
   /**
@@ -56,7 +59,7 @@ export declare abstract class Flags {
   getBooleanValue(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext
+    context?: FlagshipEvaluationContext
   ): Promise<boolean>;
 
   /**
@@ -68,7 +71,7 @@ export declare abstract class Flags {
   getStringValue(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext
+    context?: FlagshipEvaluationContext
   ): Promise<string>;
 
   /**
@@ -80,7 +83,7 @@ export declare abstract class Flags {
   getNumberValue(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext
+    context?: FlagshipEvaluationContext
   ): Promise<number>;
 
   /**
@@ -92,7 +95,7 @@ export declare abstract class Flags {
   getObjectValue<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext
+    context?: FlagshipEvaluationContext
   ): Promise<T>;
 
   /**
@@ -104,8 +107,8 @@ export declare abstract class Flags {
   getBooleanDetails(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext
-  ): Promise<EvaluationDetails<boolean>>;
+    context?: FlagshipEvaluationContext
+  ): Promise<FlagshipEvaluationDetails<boolean>>;
 
   /**
    * Get a string flag value with full evaluation details.
@@ -116,8 +119,8 @@ export declare abstract class Flags {
   getStringDetails(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext
-  ): Promise<EvaluationDetails<string>>;
+    context?: FlagshipEvaluationContext
+  ): Promise<FlagshipEvaluationDetails<string>>;
 
   /**
    * Get a number flag value with full evaluation details.
@@ -128,8 +131,8 @@ export declare abstract class Flags {
   getNumberDetails(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext
-  ): Promise<EvaluationDetails<number>>;
+    context?: FlagshipEvaluationContext
+  ): Promise<FlagshipEvaluationDetails<number>>;
 
   /**
    * Get an object flag value with full evaluation details.
@@ -140,6 +143,6 @@ export declare abstract class Flags {
   getObjectDetails<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext
-  ): Promise<EvaluationDetails<T>>;
+    context?: FlagshipEvaluationContext
+  ): Promise<FlagshipEvaluationDetails<T>>;
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3955,28 +3955,23 @@ interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
-  readonly __stdoutp: ArrayBuffer;
-  readonly __stderrp: ArrayBuffer;
 }
 interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  __stdinp?: ReadableStream | "pipe";
-  __stdoutp?: "pipe" | "ignore";
-  __stderrp?: "pipe" | "ignore" | "combined";
+  stdin?: ReadableStream | "pipe";
+  stdout?: "pipe" | "ignore";
+  stderr?: "pipe" | "ignore" | "combined";
 }
 interface ExecProcess {
-  get stdin(): WritableStream | undefined;
-  get stdout(): ReadableStream | undefined;
-  get stderr(): ReadableStream | undefined;
+  readonly stdin: WritableStream | null;
+  readonly stdout: ReadableStream | null;
+  readonly stderr: ReadableStream | null;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
-  readonly __stdinp: WritableStream | null;
-  readonly __stdoutp: ReadableStream | null;
-  readonly __stderrp: ReadableStream | null;
 }
 interface Container {
   get running(): boolean;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3955,23 +3955,28 @@ interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
+  readonly __stdoutp: ArrayBuffer;
+  readonly __stderrp: ArrayBuffer;
 }
 interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  stdin?: ReadableStream | "pipe";
-  stdout?: "pipe" | "ignore";
-  stderr?: "pipe" | "ignore" | "combined";
+  __stdinp?: ReadableStream | "pipe";
+  __stdoutp?: "pipe" | "ignore";
+  __stderrp?: "pipe" | "ignore" | "combined";
 }
 interface ExecProcess {
-  readonly stdin: WritableStream | null;
-  readonly stdout: ReadableStream | null;
-  readonly stderr: ReadableStream | null;
+  get stdin(): WritableStream | undefined;
+  get stdout(): ReadableStream | undefined;
+  get stderr(): ReadableStream | undefined;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
+  readonly __stdinp: WritableStream | null;
+  readonly __stdoutp: ReadableStream | null;
+  readonly __stderrp: ReadableStream | null;
 }
 interface Container {
   get running(): boolean;
@@ -12816,8 +12821,8 @@ declare module "cloudflare:email" {
  * Evaluation context for targeting rules.
  * Keys are attribute names (e.g. "userId", "country"), values are the attribute values.
  */
-type EvaluationContext = Record<string, string | number | boolean>;
-interface EvaluationDetails<T> {
+type FlagshipEvaluationContext = Record<string, string | number | boolean>;
+interface FlagshipEvaluationDetails<T> {
   flagKey: string;
   value: T;
   variant?: string | undefined;
@@ -12825,7 +12830,7 @@ interface EvaluationDetails<T> {
   errorCode?: string | undefined;
   errorMessage?: string | undefined;
 }
-interface FlagEvaluationError extends Error {}
+interface FlagshipEvaluationError extends Error {}
 /**
  * Feature flags binding for evaluating feature flags from a Cloudflare Workers script.
  *
@@ -12845,7 +12850,7 @@ interface FlagEvaluationError extends Error {}
  * console.log(details.variant, details.reason);
  * ```
  */
-declare abstract class Flags {
+declare abstract class Flagship {
   /**
    * Get a flag value without type checking.
    * @param flagKey The key of the flag to evaluate.
@@ -12855,7 +12860,7 @@ declare abstract class Flags {
   get(
     flagKey: string,
     defaultValue?: unknown,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<unknown>;
   /**
    * Get a boolean flag value.
@@ -12866,7 +12871,7 @@ declare abstract class Flags {
   getBooleanValue(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<boolean>;
   /**
    * Get a string flag value.
@@ -12877,7 +12882,7 @@ declare abstract class Flags {
   getStringValue(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<string>;
   /**
    * Get a number flag value.
@@ -12888,7 +12893,7 @@ declare abstract class Flags {
   getNumberValue(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<number>;
   /**
    * Get an object flag value.
@@ -12899,7 +12904,7 @@ declare abstract class Flags {
   getObjectValue<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<T>;
   /**
    * Get a boolean flag value with full evaluation details.
@@ -12910,8 +12915,8 @@ declare abstract class Flags {
   getBooleanDetails(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<boolean>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<boolean>>;
   /**
    * Get a string flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12921,8 +12926,8 @@ declare abstract class Flags {
   getStringDetails(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<string>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<string>>;
   /**
    * Get a number flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12932,8 +12937,8 @@ declare abstract class Flags {
   getNumberDetails(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<number>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<number>>;
   /**
    * Get an object flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12943,8 +12948,8 @@ declare abstract class Flags {
   getObjectDetails<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<T>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<T>>;
 }
 /**
  * Hello World binding to serve as an explanatory example. DO NOT USE

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3961,23 +3961,28 @@ export interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
+  readonly __stdoutp: ArrayBuffer;
+  readonly __stderrp: ArrayBuffer;
 }
 export interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  stdin?: ReadableStream | "pipe";
-  stdout?: "pipe" | "ignore";
-  stderr?: "pipe" | "ignore" | "combined";
+  __stdinp?: ReadableStream | "pipe";
+  __stdoutp?: "pipe" | "ignore";
+  __stderrp?: "pipe" | "ignore" | "combined";
 }
 export interface ExecProcess {
-  readonly stdin: WritableStream | null;
-  readonly stdout: ReadableStream | null;
-  readonly stderr: ReadableStream | null;
+  get stdin(): WritableStream | undefined;
+  get stdout(): ReadableStream | undefined;
+  get stderr(): ReadableStream | undefined;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
+  readonly __stdinp: WritableStream | null;
+  readonly __stdoutp: ReadableStream | null;
+  readonly __stderrp: ReadableStream | null;
 }
 export interface Container {
   get running(): boolean;
@@ -12832,8 +12837,11 @@ export declare type EmailExportedHandler<Env = unknown, Props = unknown> = (
  * Evaluation context for targeting rules.
  * Keys are attribute names (e.g. "userId", "country"), values are the attribute values.
  */
-export type EvaluationContext = Record<string, string | number | boolean>;
-export interface EvaluationDetails<T> {
+export type FlagshipEvaluationContext = Record<
+  string,
+  string | number | boolean
+>;
+export interface FlagshipEvaluationDetails<T> {
   flagKey: string;
   value: T;
   variant?: string | undefined;
@@ -12841,7 +12849,7 @@ export interface EvaluationDetails<T> {
   errorCode?: string | undefined;
   errorMessage?: string | undefined;
 }
-export interface FlagEvaluationError extends Error {}
+export interface FlagshipEvaluationError extends Error {}
 /**
  * Feature flags binding for evaluating feature flags from a Cloudflare Workers script.
  *
@@ -12861,7 +12869,7 @@ export interface FlagEvaluationError extends Error {}
  * console.log(details.variant, details.reason);
  * ```
  */
-export declare abstract class Flags {
+export declare abstract class Flagship {
   /**
    * Get a flag value without type checking.
    * @param flagKey The key of the flag to evaluate.
@@ -12871,7 +12879,7 @@ export declare abstract class Flags {
   get(
     flagKey: string,
     defaultValue?: unknown,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<unknown>;
   /**
    * Get a boolean flag value.
@@ -12882,7 +12890,7 @@ export declare abstract class Flags {
   getBooleanValue(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<boolean>;
   /**
    * Get a string flag value.
@@ -12893,7 +12901,7 @@ export declare abstract class Flags {
   getStringValue(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<string>;
   /**
    * Get a number flag value.
@@ -12904,7 +12912,7 @@ export declare abstract class Flags {
   getNumberValue(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<number>;
   /**
    * Get an object flag value.
@@ -12915,7 +12923,7 @@ export declare abstract class Flags {
   getObjectValue<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<T>;
   /**
    * Get a boolean flag value with full evaluation details.
@@ -12926,8 +12934,8 @@ export declare abstract class Flags {
   getBooleanDetails(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<boolean>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<boolean>>;
   /**
    * Get a string flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12937,8 +12945,8 @@ export declare abstract class Flags {
   getStringDetails(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<string>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<string>>;
   /**
    * Get a number flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12948,8 +12956,8 @@ export declare abstract class Flags {
   getNumberDetails(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<number>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<number>>;
   /**
    * Get an object flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12959,8 +12967,8 @@ export declare abstract class Flags {
   getObjectDetails<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<T>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<T>>;
 }
 /**
  * Hello World binding to serve as an explanatory example. DO NOT USE

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3961,28 +3961,23 @@ export interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
-  readonly __stdoutp: ArrayBuffer;
-  readonly __stderrp: ArrayBuffer;
 }
 export interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  __stdinp?: ReadableStream | "pipe";
-  __stdoutp?: "pipe" | "ignore";
-  __stderrp?: "pipe" | "ignore" | "combined";
+  stdin?: ReadableStream | "pipe";
+  stdout?: "pipe" | "ignore";
+  stderr?: "pipe" | "ignore" | "combined";
 }
 export interface ExecProcess {
-  get stdin(): WritableStream | undefined;
-  get stdout(): ReadableStream | undefined;
-  get stderr(): ReadableStream | undefined;
+  readonly stdin: WritableStream | null;
+  readonly stdout: ReadableStream | null;
+  readonly stderr: ReadableStream | null;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
-  readonly __stdinp: WritableStream | null;
-  readonly __stdoutp: ReadableStream | null;
-  readonly __stderrp: ReadableStream | null;
 }
 export interface Container {
   get running(): boolean;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12124,8 +12124,8 @@ declare module "cloudflare:email" {
  * Evaluation context for targeting rules.
  * Keys are attribute names (e.g. "userId", "country"), values are the attribute values.
  */
-type EvaluationContext = Record<string, string | number | boolean>;
-interface EvaluationDetails<T> {
+type FlagshipEvaluationContext = Record<string, string | number | boolean>;
+interface FlagshipEvaluationDetails<T> {
   flagKey: string;
   value: T;
   variant?: string | undefined;
@@ -12133,7 +12133,7 @@ interface EvaluationDetails<T> {
   errorCode?: string | undefined;
   errorMessage?: string | undefined;
 }
-interface FlagEvaluationError extends Error {}
+interface FlagshipEvaluationError extends Error {}
 /**
  * Feature flags binding for evaluating feature flags from a Cloudflare Workers script.
  *
@@ -12153,7 +12153,7 @@ interface FlagEvaluationError extends Error {}
  * console.log(details.variant, details.reason);
  * ```
  */
-declare abstract class Flags {
+declare abstract class Flagship {
   /**
    * Get a flag value without type checking.
    * @param flagKey The key of the flag to evaluate.
@@ -12163,7 +12163,7 @@ declare abstract class Flags {
   get(
     flagKey: string,
     defaultValue?: unknown,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<unknown>;
   /**
    * Get a boolean flag value.
@@ -12174,7 +12174,7 @@ declare abstract class Flags {
   getBooleanValue(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<boolean>;
   /**
    * Get a string flag value.
@@ -12185,7 +12185,7 @@ declare abstract class Flags {
   getStringValue(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<string>;
   /**
    * Get a number flag value.
@@ -12196,7 +12196,7 @@ declare abstract class Flags {
   getNumberValue(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<number>;
   /**
    * Get an object flag value.
@@ -12207,7 +12207,7 @@ declare abstract class Flags {
   getObjectValue<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<T>;
   /**
    * Get a boolean flag value with full evaluation details.
@@ -12218,8 +12218,8 @@ declare abstract class Flags {
   getBooleanDetails(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<boolean>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<boolean>>;
   /**
    * Get a string flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12229,8 +12229,8 @@ declare abstract class Flags {
   getStringDetails(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<string>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<string>>;
   /**
    * Get a number flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12240,8 +12240,8 @@ declare abstract class Flags {
   getNumberDetails(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<number>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<number>>;
   /**
    * Get an object flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12251,8 +12251,8 @@ declare abstract class Flags {
   getObjectDetails<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<T>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<T>>;
 }
 /**
  * Hello World binding to serve as an explanatory example. DO NOT USE

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12140,8 +12140,11 @@ export declare type EmailExportedHandler<Env = unknown, Props = unknown> = (
  * Evaluation context for targeting rules.
  * Keys are attribute names (e.g. "userId", "country"), values are the attribute values.
  */
-export type EvaluationContext = Record<string, string | number | boolean>;
-export interface EvaluationDetails<T> {
+export type FlagshipEvaluationContext = Record<
+  string,
+  string | number | boolean
+>;
+export interface FlagshipEvaluationDetails<T> {
   flagKey: string;
   value: T;
   variant?: string | undefined;
@@ -12149,7 +12152,7 @@ export interface EvaluationDetails<T> {
   errorCode?: string | undefined;
   errorMessage?: string | undefined;
 }
-export interface FlagEvaluationError extends Error {}
+export interface FlagshipEvaluationError extends Error {}
 /**
  * Feature flags binding for evaluating feature flags from a Cloudflare Workers script.
  *
@@ -12169,7 +12172,7 @@ export interface FlagEvaluationError extends Error {}
  * console.log(details.variant, details.reason);
  * ```
  */
-export declare abstract class Flags {
+export declare abstract class Flagship {
   /**
    * Get a flag value without type checking.
    * @param flagKey The key of the flag to evaluate.
@@ -12179,7 +12182,7 @@ export declare abstract class Flags {
   get(
     flagKey: string,
     defaultValue?: unknown,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<unknown>;
   /**
    * Get a boolean flag value.
@@ -12190,7 +12193,7 @@ export declare abstract class Flags {
   getBooleanValue(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<boolean>;
   /**
    * Get a string flag value.
@@ -12201,7 +12204,7 @@ export declare abstract class Flags {
   getStringValue(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<string>;
   /**
    * Get a number flag value.
@@ -12212,7 +12215,7 @@ export declare abstract class Flags {
   getNumberValue(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<number>;
   /**
    * Get an object flag value.
@@ -12223,7 +12226,7 @@ export declare abstract class Flags {
   getObjectValue<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext,
+    context?: FlagshipEvaluationContext,
   ): Promise<T>;
   /**
    * Get a boolean flag value with full evaluation details.
@@ -12234,8 +12237,8 @@ export declare abstract class Flags {
   getBooleanDetails(
     flagKey: string,
     defaultValue: boolean,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<boolean>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<boolean>>;
   /**
    * Get a string flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12245,8 +12248,8 @@ export declare abstract class Flags {
   getStringDetails(
     flagKey: string,
     defaultValue: string,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<string>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<string>>;
   /**
    * Get a number flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12256,8 +12259,8 @@ export declare abstract class Flags {
   getNumberDetails(
     flagKey: string,
     defaultValue: number,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<number>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<number>>;
   /**
    * Get an object flag value with full evaluation details.
    * @param flagKey The key of the flag to evaluate.
@@ -12267,8 +12270,8 @@ export declare abstract class Flags {
   getObjectDetails<T extends object>(
     flagKey: string,
     defaultValue: T,
-    context?: EvaluationContext,
-  ): Promise<EvaluationDetails<T>>;
+    context?: FlagshipEvaluationContext,
+  ): Promise<FlagshipEvaluationDetails<T>>;
 }
 /**
  * Hello World binding to serve as an explanatory example. DO NOT USE


### PR DESCRIPTION
## Summary

- Renames `types/defines/flags.d.ts` to `types/defines/flagship.d.ts`
- Renames all exported types to use the `Flagship` prefix:
  - `Flags` -> `Flagship`
  - `EvaluationContext` -> `FlagshipEvaluationContext`
  - `EvaluationDetails` -> `FlagshipEvaluationDetails`
  - `FlagEvaluationError` -> `FlagshipEvaluationError`
- Regenerates `types/generated-snapshot/` to reflect the new names

## Motivation

Wrangler's type generation already references this binding type as [`Flagship`](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/type-generation/index.ts#L2815). This change aligns the workerd type definitions to match, preventing type mismatches for users.