### PR TITLE
ByobBuffer, rename minBytes to minElements

### DIFF
--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -392,9 +392,10 @@ class ReadableStreamController {
     size_t byteOffset = 0;
     size_t byteLength;
 
-    // The minimum number of bytes that should be read. When not specified, the default
+    // The minimum number of elements that should be read. When not specified, the default
     // is DEFAULT_AT_LEAST. This is a non-standard, Workers-specific extension to
     // support the readAtLeast method on the ReadableStreamBYOBReader object.
+    // ReaderImpl::read() converts this to bytes by multiplying by element size.
     kj::Maybe<size_t> atLeast = DEFAULT_AT_LEAST;
 
     // True if the given buffer should be detached. Per the spec, we should always be

--- a/src/workerd/api/streams/internal-test.c++
+++ b/src/workerd/api/streams/internal-test.c++
@@ -819,6 +819,110 @@ KJ_TEST("ReadableStreamBYOBReader rejects read when atLeast exceeds buffer size"
   });
 }
 
+KJ_TEST("ReadableStreamBYOBReader readAtLeast with element count within capacity succeeds") {
+  // readAtLeast() treats its first argument as an element count.
+  // readAtLeast(10, Uint32Array(10)) → 10 elements * 4 bytes = 40 bytes, buffer is 40 → OK.
+  auto fixture = makeStreamTestFixture();
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    auto rs = makeByteStream(env.js);
+    auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
+
+    // Uint32Array: element size 4, byteLength 40, length 10
+    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 40);
+    auto view = v8::Uint32Array::New(buffer, 0, 10);
+
+    bool rejected = false;
+    reader->readAtLeast(env.js, 10, view)
+        .catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
+      rejected = true;
+      auto ex = js.exceptionToKj(kj::mv(reason));
+      KJ_FAIL_ASSERT("readAtLeast(10) on 10-element Uint32Array should not reject", ex);
+      return {.done = true};
+    });
+    env.js.runMicrotasks();
+    KJ_ASSERT(!rejected);
+  });
+}
+
+KJ_TEST("ReadableStreamBYOBReader readAtLeast rejects when element count exceeds capacity") {
+  // Regression test for the bug: before the fix, validation compared
+  // the raw element count against byteLength (mixed units), so large element
+  // counts slipped through and produced an impossible (minBytes > maxBytes) pair
+  // that caused stack overflow in decoders like brotli.
+  // readAtLeast(11, Uint32Array(10)) → 11 * 4 = 44 bytes > 40 byte buffer → reject.
+  auto fixture = makeStreamTestFixture();
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    auto rs = makeByteStream(env.js);
+    auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
+
+    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 40);
+    auto view = v8::Uint32Array::New(buffer, 0, 10);
+
+    bool rejected = false;
+    reader->readAtLeast(env.js, 11, view)
+        .catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
+      rejected = true;
+      auto ex = js.exceptionToKj(kj::mv(reason));
+      KJ_ASSERT(ex.getDescription().contains("exceeds size of buffer"), ex);
+      return {.done = true};
+    });
+    env.js.runMicrotasks();
+    KJ_ASSERT(rejected, "readAtLeast(11) on 10-element Uint32Array should reject");
+  });
+}
+
+KJ_TEST("ReadableStreamBYOBReader readAtLeast rejects byteLength as element count") {
+  // readAtLeast(view.byteLength, view) with a Uint32Array.
+  // byteLength=4096, element count interpretation → 4096 * 4 = 16384 > 4096 → must reject.
+  auto fixture = makeStreamTestFixture();
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    auto rs = makeByteStream(env.js);
+    auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
+
+    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 4096);
+    auto view = v8::Uint32Array::New(buffer, 0, 1024);
+
+    bool rejected = false;
+    reader->readAtLeast(env.js, 4096, view)
+        .catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
+      rejected = true;
+      auto ex = js.exceptionToKj(kj::mv(reason));
+      KJ_ASSERT(ex.getDescription().contains("exceeds size of buffer"), ex);
+      return {.done = true};
+    });
+    env.js.runMicrotasks();
+    KJ_ASSERT(rejected, "readAtLeast(4096) on 1024-element Uint32Array must reject");
+  });
+}
+
+KJ_TEST("ReadableStreamBYOBReader read() with min exceeding element capacity rejects") {
+  // read(view, {min: N}) where N is in elements. Before the fix, validation
+  // compared element count against byte length (mixed units), so large values
+  // slipped through.
+  // min=11 elements on Uint32Array(10) → 44 bytes > 40 → reject.
+  auto fixture = makeStreamTestFixture();
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    auto rs = makeByteStream(env.js);
+    auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
+
+    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 40);
+    auto view = v8::Uint32Array::New(buffer, 0, 10);
+
+    ReadableStreamBYOBReader::ReadableStreamBYOBReaderReadOptions opts;
+    opts.min = 11;
+    bool rejected = false;
+    reader->read(env.js, view, kj::mv(opts))
+        .catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
+      rejected = true;
+      auto ex = js.exceptionToKj(kj::mv(reason));
+      KJ_ASSERT(ex.getDescription().contains("exceeds size of buffer"), ex);
+      return {.done = true};
+    });
+    env.js.runMicrotasks();
+    KJ_ASSERT(rejected, "read() with min=11 on 10-element Uint32Array should reject");
+  });
+}
+
 KJ_TEST("ReadableStreamBYOBReader rejects read after releaseLock") {
   auto fixture = makeStreamTestFixture();
   fixture.runInIoContext([&](const TestFixture::Environment& env) {

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -563,6 +563,8 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
       }
       auto bytes = kj::arrayPtr(readPtr, byteLength);
 
+      KJ_ASSERT(atLeast <= bytes.size(), "minBytes must not exceed maxBytes in tryRead");
+
       auto promise = kj::evalNow([&] {
         return readable->tryRead(bytes.begin(), atLeast, bytes.size()).attach(kj::mv(backing));
       });

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -94,13 +94,19 @@ jsg::Promise<ReadResult> ReaderImpl::read(
       return js.rejectedPromise<ReadResult>(js.v8TypeError(
           kj::str("Requested invalid minimum number of bytes to read (", atLeast, ").")));
     }
+
+    // Both read() and readAtLeast() pass atLeast in element count.
+    // Convert to bytes before validation and forwarding to the controller.
+    jsg::BufferSource source(js, options.bufferView.getHandle(js));
+    auto elementSize = source.getElementSize();
+    atLeast = atLeast * elementSize;
+
     if (atLeast > options.byteLength) {
       return js.rejectedPromise<ReadResult>(js.v8TypeError(kj::str("Minimum bytes to read (",
           atLeast, ") exceeds size of buffer (", options.byteLength, ").")));
     }
 
-    jsg::BufferSource source(js, options.bufferView.getHandle(js));
-    options.atLeast = atLeast * source.getElementSize();
+    options.atLeast = atLeast;
   }
 
   return KJ_ASSERT_NONNULL(attached.stream->getController().read(js, kj::mv(byobOptions)));
@@ -232,12 +238,12 @@ jsg::Promise<ReadResult> ReadableStreamBYOBReader::read(jsg::Lock& js,
 }
 
 jsg::Promise<ReadResult> ReadableStreamBYOBReader::readAtLeast(
-    jsg::Lock& js, int minBytes, v8::Local<v8::ArrayBufferView> byobBuffer) {
+    jsg::Lock& js, int minElements, v8::Local<v8::ArrayBufferView> byobBuffer) {
   auto options = ReadableStreamController::ByobOptions{
     .bufferView = js.v8Ref(byobBuffer),
     .byteOffset = byobBuffer->ByteOffset(),
     .byteLength = byobBuffer->ByteLength(),
-    .atLeast = minBytes,
+    .atLeast = minElements,
     .detachBuffer = true,
   };
   return impl.read(js, kj::mv(options));

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -166,15 +166,15 @@ public:
   jsg::Promise<ReadResult> read(jsg::Lock& js, v8::Local<v8::ArrayBufferView> byobBuffer,
       jsg::Optional<ReadableStreamBYOBReaderReadOptions> options = kj::none);
 
-  // Non-standard extension so that reads can specify a minimum number of bytes to read. It's a
+  // Non-standard extension so that reads can specify a minimum number of elements to read. It's a
   // struct so that we could eventually add things like timeouts if we need to. Since there's no
   // existing spec that's a leading contender, this is behind a different method name to avoid
-  // conflicts with any changes to `read`. Fewer than `minBytes` may be returned if EOF is hit or
-  // the underlying stream is closed/errors out. In all cases the read result is either
+  // conflicts with any changes to `read`. Fewer than `minElements` may be returned if EOF is hit
+  // or the underlying stream is closed/errors out. In all cases the read result is either
   // {value: theChunk, done: false} or {value: undefined, done: true} as with read.
   // TODO(soon): Like fetch() and Cache.match(), readAtLeast() returns a promise for a V8 object.
   jsg::Promise<ReadResult> readAtLeast(jsg::Lock& js,
-                                        int minBytes,
+                                        int minElements,
                                         v8::Local<v8::ArrayBufferView> byobBuffer);
 
   void releaseLock(jsg::Lock& js);


### PR DESCRIPTION
This was the semantics all along.  Tighten up code that handles it.