### PR TITLE
Improve ctx.cache ergonomics

### DIFF
--- a/src/cloudflare/internal/workers.d.ts
+++ b/src/cloudflare/internal/workers.d.ts
@@ -36,3 +36,28 @@ export class RpcTarget {}
 export class ServiceStub {}
 
 export function waitUntil(promise: Promise<unknown>): void;
+
+// Stubs for the C++ CacheContext types (see src/workerd/api/global-scope.h).
+// The full interface is also generated in types/generated-snapshot/ from C++ RTTI.
+// If you change the C++ types, update these to match.
+export interface CachePurgeError {
+  code: number;
+  message: string;
+}
+
+export interface CachePurgeResult {
+  success: boolean;
+  errors: CachePurgeError[];
+}
+
+export interface CachePurgeOptions {
+  tags?: string[];
+  pathPrefixes?: string[];
+  purgeEverything?: boolean;
+}
+
+export interface CacheContext {
+  purge(options: CachePurgeOptions): Promise<CachePurgeResult>;
+}
+
+export function getCtxCache(): CacheContext | undefined;

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -151,3 +151,54 @@ export const exports = new Proxy(
 );
 
 export const waitUntil = entrypoints.waitUntil.bind(entrypoints);
+
+// A proxy for the worker's cache context (ctx.cache). Since cache is imported as a module-level
+// reference, the object identity cannot be changed. The proxy provides indirection, delegating
+// to the current request's CacheContext. This ensures that cache remains entrypoint specific
+// ensuring that the runtime always delegates the right host to clear.
+export const cache = new Proxy(
+  {},
+  {
+    get(_: unknown, prop: string | symbol): unknown {
+      const inner = entrypoints.getCtxCache();
+      if (inner) {
+        const value: unknown = Reflect.get(inner, prop);
+        // Bind methods to the underlying CacheContext so that `this` is correct
+        // when calling e.g. cache.purge() through the proxy.
+        if (typeof value === 'function') {
+          return Function.prototype.bind.call(value, inner);
+        }
+        return value;
+      }
+      // Used to enable safe no-op access outside module init.
+      return undefined;
+    },
+
+    has(_: unknown, prop: string | symbol): boolean {
+      const inner = entrypoints.getCtxCache();
+      if (inner) {
+        return Reflect.has(inner, prop);
+      }
+      return false;
+    },
+
+    ownKeys(_: unknown): ArrayLike<string | symbol> {
+      const inner = entrypoints.getCtxCache();
+      if (inner) {
+        return Reflect.ownKeys(inner);
+      }
+      return [];
+    },
+
+    getOwnPropertyDescriptor(
+      _: unknown,
+      prop: string | symbol
+    ): PropertyDescriptor | undefined {
+      const inner = entrypoints.getCtxCache();
+      if (inner) {
+        return Reflect.getOwnPropertyDescriptor(inner, prop);
+      }
+      return undefined;
+    },
+  }
+);

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -199,6 +199,9 @@ class TestController: public jsg::Object {
 
 // Structured types for the cache purge API (ctx.cache.purge()).
 // These match the coreless-purge-ingest WorkersCachePurgeEntrypoint types.
+// NOTE: TypeScript stubs for CachePurgeError, CachePurgeResult, CachePurgeOptions, and
+// CacheContext are manually maintained in src/cloudflare/internal/workers.d.ts. If you change
+// these types, update that file to match.
 struct CachePurgeError {
   int code;
   kj::String message;

--- a/src/workerd/api/tests/new-module-registry-test.js
+++ b/src/workerd/api/tests/new-module-registry-test.js
@@ -29,6 +29,7 @@ strictEqual(typeof workers.WorkflowEntrypoint, 'function');
 strictEqual(typeof workers.waitUntil, 'function');
 strictEqual(typeof workers.withEnv, 'function');
 strictEqual(typeof workers.env, 'object');
+strictEqual(typeof workers.cache, 'object');
 
 await rejects(import('cloudflare-internal:env'), {
   message: /Module not found/,

--- a/src/workerd/api/workers-module.c++
+++ b/src/workerd/api/workers-module.c++
@@ -58,4 +58,14 @@ void EntrypointsModule::waitUntil(kj::Promise<void> promise) {
   IoContext::current().addWaitUntil(kj::mv(promise));
 }
 
+jsg::Optional<jsg::Ref<CacheContext>> EntrypointsModule::getCtxCache(jsg::Lock& js) {
+  // Delegate to the embedding application's getCtxCacheProperty() hook, which returns a
+  // CacheContext (e.g. CachePurge in edgeworker) when cache is enabled for this pipeline.
+  // Returns kj::none when there is no active request or cache is not available.
+  if (IoContext::hasCurrent()) {
+    return Worker::Isolate::from(js).getApi().getCtxCacheProperty(js);
+  }
+  return kj::none;
+}
+
 }  // namespace workerd::api

--- a/src/workerd/api/workers-module.h
+++ b/src/workerd/api/workers-module.h
@@ -9,6 +9,8 @@
 
 namespace workerd::api {
 
+class CacheContext;
+
 // Base class for exported RPC services.
 //
 // When the worker's top-level module exports a class that extends this class, it means that it
@@ -79,6 +81,11 @@ class EntrypointsModule: public jsg::Object {
 
   void waitUntil(kj::Promise<void> promise);
 
+  // Returns the current request's CacheContext (ctx.cache), or kj::none if there is no active
+  // IoContext or cache is not available. Used by the cloudflare:workers TypeScript wrapper to
+  // expose an importable `cache` proxy.
+  jsg::Optional<jsg::Ref<CacheContext>> getCtxCache(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(EntrypointsModule) {
     JSG_NESTED_TYPE(WorkerEntrypoint);
     JSG_NESTED_TYPE(WorkflowEntrypoint);
@@ -90,6 +97,7 @@ class EntrypointsModule: public jsg::Object {
     JSG_NESTED_TYPE_NAMED(Fetcher, ServiceStub);
 
     JSG_METHOD(waitUntil);
+    JSG_METHOD(getCtxCache);
   }
 };
 

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -391,6 +391,7 @@ declare namespace CloudflareWorkersModule {
 
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const cache: CacheContext;
 }
 
 declare module 'cloudflare:workers' {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14393,6 +14393,7 @@ declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const cache: CacheContext;
 }
 declare module "cloudflare:workers" {
   export = CloudflareWorkersModule;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14364,6 +14364,7 @@ export declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const cache: CacheContext;
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -13733,6 +13733,7 @@ declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const cache: CacheContext;
 }
 declare module "cloudflare:workers" {
   export = CloudflareWorkersModule;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -13704,6 +13704,7 @@ export declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const cache: CacheContext;
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -3,12 +3,19 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import {
+  cache,
   DurableObject,
   RpcStub,
   RpcTarget,
   WorkerEntrypoint,
 } from 'cloudflare:workers';
 import { expectTypeOf } from 'expect-type';
+
+// Check `cache` export from `cloudflare:workers` has the expected type.
+expectTypeOf(cache).toEqualTypeOf<CacheContext>();
+expectTypeOf(cache.purge).toEqualTypeOf<
+  (options: CachePurgeOptions) => Promise<CachePurgeResult>
+>();
 
 type TestType = {
   fieldString: string;


### PR DESCRIPTION
Allow `cache` to be imported from `cloudflare:workers`.