### PR TITLE
[o11y] Add internalError event outcome

### DIFF
--- a/src/workerd/io/outcome.capnp
+++ b/src/workerd/io/outcome.capnp
@@ -27,4 +27,5 @@ enum EventOutcome {
   exceededMemory @8;
   loadShed @9;
   responseStreamDisconnected @10;
+  internalError @11;
 }

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -49,6 +49,7 @@ namespace {
   V(HIBERNATABLEWEBSOCKET, "hibernatableWebSocket")                                                \
   V(ID, "id")                                                                                      \
   V(INFO, "info")                                                                                  \
+  V(INTERNALERROR, "internalError")                                                                \
   V(INVOCATIONID, "invocationId")                                                                  \
   V(JSRPC, "jsrpc")                                                                                \
   V(KILLSWITCH, "killSwitch")                                                                      \
@@ -329,6 +330,8 @@ jsg::JsValue ToJs(jsg::Lock& js, const EventOutcome& outcome, StringCache& cache
       return cache.get(js, RESPONSESTREAMDISCONNECTED_STR);
     case EventOutcome::SCRIPT_NOT_FOUND:
       return cache.get(js, SCRIPTNOTFOUND_STR);
+    case EventOutcome::INTERNAL_ERROR:
+      return cache.get(js, INTERNALERROR_STR);
     case EventOutcome::UNKNOWN:
       return cache.get(js, UNKNOWN_STR);
   }

--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -80,7 +80,7 @@ interface ConnectEventInfo {
 
 type EventOutcome = "ok" | "canceled" | "exception" | "unknown" | "killSwitch" |
                     "daemonDown" | "exceededCpu" | "exceededMemory" | "loadShed" |
-                    "responseStreamDisconnected" | "scriptNotFound";
+                    "responseStreamDisconnected" | "scriptNotFound" | "internalError";
 
 interface ScriptVersion {
   readonly id: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -15315,7 +15315,8 @@ declare namespace TailStream {
     | "exceededMemory"
     | "loadShed"
     | "responseStreamDisconnected"
-    | "scriptNotFound";
+    | "scriptNotFound"
+    | "internalError";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -15111,7 +15111,8 @@ declare namespace TailStream {
     | "exceededMemory"
     | "loadShed"
     | "responseStreamDisconnected"
-    | "scriptNotFound";
+    | "scriptNotFound"
+    | "internalError";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -15276,7 +15276,8 @@ export declare namespace TailStream {
     | "exceededMemory"
     | "loadShed"
     | "responseStreamDisconnected"
-    | "scriptNotFound";
+    | "scriptNotFound"
+    | "internalError";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -15072,7 +15072,8 @@ export declare namespace TailStream {
     | "exceededMemory"
     | "loadShed"
     | "responseStreamDisconnected"
-    | "scriptNotFound";
+    | "scriptNotFound"
+    | "internalError";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14655,7 +14655,8 @@ declare namespace TailStream {
     | "exceededMemory"
     | "loadShed"
     | "responseStreamDisconnected"
-    | "scriptNotFound";
+    | "scriptNotFound"
+    | "internalError";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14457,7 +14457,8 @@ declare namespace TailStream {
     | "exceededMemory"
     | "loadShed"
     | "responseStreamDisconnected"
-    | "scriptNotFound";
+    | "scriptNotFound"
+    | "internalError";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14616,7 +14616,8 @@ export declare namespace TailStream {
     | "exceededMemory"
     | "loadShed"
     | "responseStreamDisconnected"
-    | "scriptNotFound";
+    | "scriptNotFound"
+    | "internalError";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14418,7 +14418,8 @@ export declare namespace TailStream {
     | "exceededMemory"
     | "loadShed"
     | "responseStreamDisconnected"
-    | "scriptNotFound";
+    | "scriptNotFound"
+    | "internalError";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;


### PR DESCRIPTION
See internal discussion as for the rationale for this.
As noted in outcome.capnp, the authoritative version of EventOutcome is defined internally and needs to be updated first – this has already been done.
Note that internalError is not being used in workerd at present – we likely will use it in server.c++'s RequestObserverWithTracer::reportFailure(), but we should only start using it there once we've finalized how it will be used in the edge runtime.

Also see the internal PR.