### PR TITLE
fix(artifacts): remove tokenExpiresAt from ArtifactsCreateRepoResult

### DIFF
--- a/types/defines/artifacts.d.ts
+++ b/types/defines/artifacts.d.ts
@@ -51,8 +51,8 @@ interface ArtifactsCreateRepoResult {
 
 /** Paginated list of repositories. */
 interface ArtifactsRepoListResult {
-  /** Repositories in this page (without the `remote` field). */
-  repos: Omit<ArtifactsRepoInfo, 'remote'>[];
+  /** Repositories in this page. */
+  repos: ArtifactsRepoInfo[];
   /** Total number of repositories in the namespace. */
   total: number;
   /** Cursor for the next page, if there are more results. */

--- a/types/defines/artifacts.d.ts
+++ b/types/defines/artifacts.d.ts
@@ -45,10 +45,8 @@ interface ArtifactsCreateRepoResult {
   defaultBranch: string;
   /** HTTPS git remote URL. */
   remote: string;
-  /** Plaintext access token (only returned at creation time). */
+  /** Plaintext access token (only returned at creation time). The token encodes its expiry as `art_v1_<secret>?expires=<unix_seconds>`. */
   token: string;
-  /** ISO 8601 token expiry timestamp. */
-  tokenExpiresAt: string;
 }
 
 /** Paginated list of repositories. */

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -11786,10 +11786,8 @@ interface ArtifactsCreateRepoResult {
   defaultBranch: string;
   /** HTTPS git remote URL. */
   remote: string;
-  /** Plaintext access token (only returned at creation time). */
+  /** Plaintext access token (only returned at creation time). The token encodes its expiry as `art_v1_<secret>?expires=<unix_seconds>`. */
   token: string;
-  /** ISO 8601 token expiry timestamp. */
-  tokenExpiresAt: string;
 }
 /** Paginated list of repositories. */
 interface ArtifactsRepoListResult {
@@ -11808,7 +11806,6 @@ interface ArtifactsCreateTokenResult {
   plaintext: string;
   /** Token scope: "read" or "write". */
   scope: "read" | "write";
-  /** ISO 8601 token expiry timestamp. */
   expiresAt: string;
 }
 /** Token metadata (no plaintext). */

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -11791,8 +11791,8 @@ interface ArtifactsCreateRepoResult {
 }
 /** Paginated list of repositories. */
 interface ArtifactsRepoListResult {
-  /** Repositories in this page (without the `remote` field). */
-  repos: Omit<ArtifactsRepoInfo, "remote">[];
+  /** Repositories in this page. */
+  repos: ArtifactsRepoInfo[];
   /** Total number of repositories in the namespace. */
   total: number;
   /** Cursor for the next page, if there are more results. */

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -11798,10 +11798,8 @@ export interface ArtifactsCreateRepoResult {
   defaultBranch: string;
   /** HTTPS git remote URL. */
   remote: string;
-  /** Plaintext access token (only returned at creation time). */
+  /** Plaintext access token (only returned at creation time). The token encodes its expiry as `art_v1_<secret>?expires=<unix_seconds>`. */
   token: string;
-  /** ISO 8601 token expiry timestamp. */
-  tokenExpiresAt: string;
 }
 /** Paginated list of repositories. */
 export interface ArtifactsRepoListResult {
@@ -11820,7 +11818,6 @@ export interface ArtifactsCreateTokenResult {
   plaintext: string;
   /** Token scope: "read" or "write". */
   scope: "read" | "write";
-  /** ISO 8601 token expiry timestamp. */
   expiresAt: string;
 }
 /** Token metadata (no plaintext). */

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -11803,8 +11803,8 @@ export interface ArtifactsCreateRepoResult {
 }
 /** Paginated list of repositories. */
 export interface ArtifactsRepoListResult {
-  /** Repositories in this page (without the `remote` field). */
-  repos: Omit<ArtifactsRepoInfo, "remote">[];
+  /** Repositories in this page. */
+  repos: ArtifactsRepoInfo[];
   /** Total number of repositories in the namespace. */
   total: number;
   /** Cursor for the next page, if there are more results. */

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -11126,10 +11126,8 @@ interface ArtifactsCreateRepoResult {
   defaultBranch: string;
   /** HTTPS git remote URL. */
   remote: string;
-  /** Plaintext access token (only returned at creation time). */
+  /** Plaintext access token (only returned at creation time). The token encodes its expiry as `art_v1_<secret>?expires=<unix_seconds>`. */
   token: string;
-  /** ISO 8601 token expiry timestamp. */
-  tokenExpiresAt: string;
 }
 /** Paginated list of repositories. */
 interface ArtifactsRepoListResult {
@@ -11148,7 +11146,6 @@ interface ArtifactsCreateTokenResult {
   plaintext: string;
   /** Token scope: "read" or "write". */
   scope: "read" | "write";
-  /** ISO 8601 token expiry timestamp. */
   expiresAt: string;
 }
 /** Token metadata (no plaintext). */

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -11131,8 +11131,8 @@ interface ArtifactsCreateRepoResult {
 }
 /** Paginated list of repositories. */
 interface ArtifactsRepoListResult {
-  /** Repositories in this page (without the `remote` field). */
-  repos: Omit<ArtifactsRepoInfo, "remote">[];
+  /** Repositories in this page. */
+  repos: ArtifactsRepoInfo[];
   /** Total number of repositories in the namespace. */
   total: number;
   /** Cursor for the next page, if there are more results. */

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -11143,8 +11143,8 @@ export interface ArtifactsCreateRepoResult {
 }
 /** Paginated list of repositories. */
 export interface ArtifactsRepoListResult {
-  /** Repositories in this page (without the `remote` field). */
-  repos: Omit<ArtifactsRepoInfo, "remote">[];
+  /** Repositories in this page. */
+  repos: ArtifactsRepoInfo[];
   /** Total number of repositories in the namespace. */
   total: number;
   /** Cursor for the next page, if there are more results. */

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -11138,10 +11138,8 @@ export interface ArtifactsCreateRepoResult {
   defaultBranch: string;
   /** HTTPS git remote URL. */
   remote: string;
-  /** Plaintext access token (only returned at creation time). */
+  /** Plaintext access token (only returned at creation time). The token encodes its expiry as `art_v1_<secret>?expires=<unix_seconds>`. */
   token: string;
-  /** ISO 8601 token expiry timestamp. */
-  tokenExpiresAt: string;
 }
 /** Paginated list of repositories. */
 export interface ArtifactsRepoListResult {
@@ -11160,7 +11158,6 @@ export interface ArtifactsCreateTokenResult {
   plaintext: string;
   /** Token scope: "read" or "write". */
   scope: "read" | "write";
-  /** ISO 8601 token expiry timestamp. */
   expiresAt: string;
 }
 /** Token metadata (no plaintext). */


### PR DESCRIPTION
Remove the `tokenExpiresAt` field from `ArtifactsCreateRepoResult`. The token itself encodes its expiry as `art_v1_<secret>?expires=<unix_seconds>`, making the separate field redundant.

Companion PRs:
- cloudflare-docs: https://github.com/cloudflare/cloudflare-docs/pull/30030
- artifacts: (pending)