### PR TITLE
EW-6888 Improve finishScheduled() outcome reporting

### DIFF
--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -726,9 +726,9 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEvent::run(
       // It'd be nicer if we could fall through to the code below for the non-compat-flag logic in
       // this case, but we don't even know if the worker uses service worker syntax until after
       // runProm resolves, so we just copy the bare essentials here.
-      auto result = co_await incomingRequest->finishScheduled();
-      bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
-      outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU;
+      auto scheduledResult = co_await incomingRequest->finishScheduled();
+      bool completed = scheduledResult == EventOutcome::OK;
+      outcome = completed ? context.waitUntilStatus() : scheduledResult;
     } else {
       // We're responsible for calling drain() on the incomingRequest to ensure that waitUntil tasks
       // can continue to run in the backgound for a while even after we return a result to the
@@ -750,55 +750,11 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEvent::run(
 
     // We reuse the finishScheduled() method for convenience, since queues use the same wall clock
     // timeout as scheduled workers.
-    auto result = co_await incomingRequest->finishScheduled();
-    bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
-
-    // Log some debug info if the request timed out or was aborted, to aid in debugging situations
-    // where consumer workers appear to get stuck and repeatedly take 15 minutes.
-    // In particular, detect whether or not the users queue() handler function completed
-    // and include info about other waitUntil tasks that may have caused the request to timeout.
-    if (!completed) {
-      kj::String status;
-      if (queueEventHolder->event.get() == nullptr) {
-        status = kj::str("Empty");
-      } else {
-        KJ_SWITCH_ONEOF(queueEventHolder->event->getCompletionStatus()) {
-          KJ_CASE_ONEOF(i, QueueEvent::Incomplete) {
-            status = kj::str("Incomplete");
-            break;
-          }
-          KJ_CASE_ONEOF(s, QueueEvent::CompletedSuccessfully) {
-            status = kj::str("Completed Succesfully");
-            break;
-          }
-          KJ_CASE_ONEOF(e, QueueEvent::CompletedWithError) {
-            status = kj::str("Completed with error:", e.error);
-            break;
-          }
-        }
-      }
-      auto& ioContext = incomingRequest->getContext();
-      auto scriptId = ioContext.getWorker().getScript().getId();
-      auto tasks = ioContext.getWaitUntilTasks().trace();
-      if (result == IoContext_IncomingRequest::FinishScheduledResult::TIMEOUT) {
-        KJ_LOG(WARNING, "NOSENTRY queue event hit timeout", scriptId, status, tasks);
-      } else if (result == IoContext_IncomingRequest::FinishScheduledResult::ABORTED) {
-        // Attempt to grab the error message to understand the reason for the abort.
-        // Include a timeout just in case for some unexpected reason the onAbort promise hasn't
-        // already rejected.
-        kj::String abortError;
-        co_await ioContext.onAbort()
-            .catch_([&abortError](kj::Exception&& e) {
-          abortError = kj::str(e);
-        }).exclusiveJoin(ioContext.afterLimitTimeout(1 * kj::MICROSECONDS).then([&abortError]() {
-          abortError = kj::str("onAbort() promise has unexpectedly not yet been rejected");
-        }));
-        KJ_LOG(WARNING, "NOSENTRY queue event aborted", abortError, scriptId, status, tasks);
-      }
-    }
+    auto scheduledResult = co_await incomingRequest->finishScheduled();
+    bool completed = scheduledResult == EventOutcome::OK;
 
     co_return WorkerInterface::CustomEvent::Result{
-      .outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU,
+      .outcome = completed ? context.waitUntilStatus() : scheduledResult,
     };
   }
 }

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -908,9 +908,9 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEvent::run(
       // It'd be nicer if we could fall through to the code below for the non-compat-flag logic in
       // this case, but we don't even know if the worker uses service worker syntax until after
       // runProm resolves, so we just copy the bare essentials here.
-      auto result = co_await incomingRequest->finishScheduled();
-      bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
-      outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU;
+      auto scheduledResult = co_await incomingRequest->finishScheduled();
+      bool completed = scheduledResult == EventOutcome::OK;
+      outcome = completed ? context.waitUntilStatus() : scheduledResult;
     } else {
       // We're responsible for calling drain() on the incomingRequest to ensure that waitUntil tasks
       // can continue to run in the backgound for a while even after we return a result to the
@@ -932,8 +932,8 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEvent::run(
 
     // We reuse the finishScheduled() method for convenience, since queues use the same wall clock
     // timeout as scheduled workers.
-    auto result = co_await incomingRequest->finishScheduled();
-    bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
+    auto scheduledResult = co_await incomingRequest->finishScheduled();
+    bool completed = scheduledResult == EventOutcome::OK;
 
     // Log some debug info if the request timed out or was aborted, to aid in debugging situations
     // where consumer workers appear to get stuck and repeatedly take 15 minutes.
@@ -962,9 +962,11 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEvent::run(
       auto& ioContext = incomingRequest->getContext();
       auto scriptId = ioContext.getWorker().getScript().getId();
       auto tasks = ioContext.getWaitUntilTasks().trace();
-      if (result == IoContext_IncomingRequest::FinishScheduledResult::TIMEOUT) {
+      // TODO
+      if (scheduledResult == EventOutcome::EXCEEDED_CPU) {
+        // if (result == IoContext_IncomingRequest::FinishScheduledResult::TIMEOUT) {
         KJ_LOG(WARNING, "NOSENTRY queue event hit timeout", scriptId, status, tasks);
-      } else if (result == IoContext_IncomingRequest::FinishScheduledResult::ABORTED) {
+      } else if (scheduledResult == EventOutcome::EXCEPTION) {
         // Attempt to grab the error message to understand the reason for the abort.
         // Include a timeout just in case for some unexpected reason the onAbort promise hasn't
         // already rejected.
@@ -980,7 +982,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> QueueCustomEvent::run(
     }
 
     co_return WorkerInterface::CustomEvent::Result{
-      .outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU,
+      .outcome = completed ? context.waitUntilStatus() : scheduledResult,
     };
   }
 }

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -251,6 +251,7 @@ wd_cc_library(
     hdrs = ["observer.h"],
     implementation_deps = [
         ":worker-interface",
+        "//src/workerd/util:exception",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -578,8 +578,7 @@ kj::Promise<void> IoContext::IncomingRequest::drain() {
       .exclusiveJoin(context->onAbort().catch_([](kj::Exception&&) {}));
 }
 
-kj::Promise<IoContext_IncomingRequest::FinishScheduledResult> IoContext::IncomingRequest::
-    finishScheduled() {
+kj::Promise<EventOutcome> IoContext::IncomingRequest::finishScheduled() {
   // TODO(someday): In principle we should be able to support delivering the "scheduled" event type
   //   to an actor, and this may be important if we open up the whole of WorkerInterface to be
   //   callable from any stub. However, the logic around async tasks would have to be different. We
@@ -593,14 +592,19 @@ kj::Promise<IoContext_IncomingRequest::FinishScheduledResult> IoContext::Incomin
   KJ_ASSERT(context->incomingRequests.size() == 1);
   context->incomingRequests.front().waitedForWaitUntil = true;
 
-  auto timeoutPromise = context->limitEnforcer->limitScheduled().then(
-      [] { return IoContext_IncomingRequest::FinishScheduledResult::TIMEOUT; });
+  auto timeoutPromise = context->limitEnforcer->limitScheduled().then([] {
+    // TODO(soon): The limit being hit here is a wall time limit. Can we report an
+    // "exceededWallTime" outcome instead?
+    return EventOutcome::EXCEEDED_CPU;
+  });
   return context->waitUntilTasks.onEmpty()
-      .then([]() { return IoContext_IncomingRequest::FinishScheduledResult::COMPLETED; })
+      .then([]() { return EventOutcome::OK; })
       .exclusiveJoin(kj::mv(timeoutPromise))
       .exclusiveJoin(context->onAbort().then([] {
-    return IoContext_IncomingRequest::FinishScheduledResult::ABORTED;
-  }, [](kj::Exception&&) { return IoContext_IncomingRequest::FinishScheduledResult::ABORTED; }));
+    // abortFulfiller should only ever be rejected instead of being fulfilled, return an
+    // internalError outcome if it does happen
+    return EventOutcome::INTERNAL_ERROR;
+  }, [](kj::Exception&& e) { return RequestObserver::outcomeFromException(e); }));
 }
 
 class IoContext::PendingEvent: public kj::Refcounted {
@@ -1162,7 +1166,7 @@ void IoContext::taskFailed(kj::Exception&& exception) {
     KJ_IF_SOME(status, limitEnforcer->getLimitsExceeded()) {
       waitUntilStatusValue = status;
     } else {
-      waitUntilStatusValue = EventOutcome::EXCEPTION;
+      waitUntilStatusValue = RequestObserver::outcomeFromException(exception);
     }
   }
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -564,8 +564,35 @@ kj::Promise<void> IoContext::IncomingRequest::drain() {
       .exclusiveJoin(context->onAbort().catch_([](kj::Exception&&) {}));
 }
 
-kj::Promise<IoContext_IncomingRequest::FinishScheduledResult> IoContext::IncomingRequest::
-    finishScheduled() {
+// TODO
+constexpr kj::Exception::DetailTypeId SCRIPT_KILLED_DETAIL_ID = 0x0ull;
+constexpr kj::Exception::DetailTypeId INACTIVE_WEBSOCKETS_DETAIL_ID = 0x0ull;
+constexpr kj::Exception::DetailTypeId SCRIPT_NOT_FOUND_DETAIL_ID = 0x0ull;
+
+// TODO: Try to generalize this. Are all outcomes needed here?
+EventOutcome outcomeFromException(kj::Exception& e) {
+  if (e.getType() == kj::Exception::Type::OVERLOADED) {
+    if (e.getDetail(SCRIPT_KILLED_DETAIL_ID) != kj::none) {
+      return EventOutcome::KILL_SWITCH;
+    } else if (e.getDetail(MEMORY_LIMIT_DETAIL_ID) != kj::none) {
+      return EventOutcome::EXCEEDED_MEMORY;
+    } else if (e.getDetail(CPU_LIMIT_DETAIL_ID) != kj::none) {
+      return EventOutcome::EXCEEDED_CPU;
+    } else if (e.getDetail(INACTIVE_WEBSOCKETS_DETAIL_ID) != kj::none) {
+      return EventOutcome::LOAD_SHED;
+    } else {
+      // TODO(later): We have many overloaded exceptions that can't be described as killSwitch,
+      // exceededCpu or exceededMemory. Should there be a new outcome type for them?
+      return EventOutcome::EXCEPTION;
+    }
+  } else if (e.getDetail(SCRIPT_NOT_FOUND_DETAIL_ID) != kj::none) {
+    return EventOutcome::SCRIPT_NOT_FOUND;
+  } else {
+    return EventOutcome::EXCEPTION;
+  }
+}
+
+kj::Promise<EventOutcome> IoContext::IncomingRequest::finishScheduled() {
   // TODO(someday): In principle we should be able to support delivering the "scheduled" event type
   //   to an actor, and this may be important if we open up the whole of WorkerInterface to be
   //   callable from any stub. However, the logic around async tasks would have to be different. We
@@ -580,13 +607,22 @@ kj::Promise<IoContext_IncomingRequest::FinishScheduledResult> IoContext::Incomin
   context->incomingRequests.front().waitedForWaitUntil = true;
 
   auto timeoutPromise = context->limitEnforcer->limitScheduled().then(
-      [] { return IoContext_IncomingRequest::FinishScheduledResult::TIMEOUT; });
+      // TODO: I think there is a material difference between the scheduled limit being hit and
+      // actually hitting the CPU limit, we emit a NOSENTRY log for this case for queue events. How
+      // do we handle this best?
+      [] { return EventOutcome::EXCEEDED_CPU; });
   return context->waitUntilTasks.onEmpty()
-      .then([]() { return IoContext_IncomingRequest::FinishScheduledResult::COMPLETED; })
+      .then([]() { return EventOutcome::OK; })
       .exclusiveJoin(kj::mv(timeoutPromise))
       .exclusiveJoin(context->onAbort().then([] {
-    return IoContext_IncomingRequest::FinishScheduledResult::ABORTED;
-  }, [](kj::Exception&&) { return IoContext_IncomingRequest::FinishScheduledResult::ABORTED; }));
+    // abortFulfiller should only ever be rejected instead of being fulfilled, but return an
+    // exception outcome if it does happen
+    return EventOutcome::EXCEPTION;
+  }, [](kj::Exception&& e) {
+    // TODO: If we end up returning exception here, that's still a case that's hard to make sense of
+    return outcomeFromException(e);
+    // TODO: Just call reportFailure() here?
+  }));
 }
 
 class IoContext::PendingEvent: public kj::Refcounted {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -99,8 +99,8 @@ class IoContext_IncomingRequest final {
   kj::Promise<void> drain();
 
   // Waits for all "waitUntil" tasks to finish, up to the time limit for scheduled events, as
-  // defined by `scheduledTimeoutMs` in `WorkerLimits`. Returns an enum indicating if the
-  // event completed successfully, hit a timeout, or was aborted.
+  // defined by `scheduledTimeoutMs` in `WorkerLimits`. Returns an enum indicating the event outcome
+  // based on whether the given tasks completed successfully, hit a timeout, or were aborted.
   //
   // Note that, while this is similar in some ways to `drain()`, `finishScheduled()` is intended
   // to be called synchronously during request handling, i.e. where a client is waiting for the
@@ -110,8 +110,7 @@ class IoContext_IncomingRequest final {
   // This method is also used by some custom event handlers (see WorkerInterface::CustomEvent) that
   // need similar behavior, as well as the test handler. TODO(cleanup): Rename to something more
   // generic?
-  enum class FinishScheduledResult { COMPLETED, ABORTED, TIMEOUT };
-  kj::Promise<FinishScheduledResult> finishScheduled();
+  kj::Promise<EventOutcome> finishScheduled();
 
   // Access the event loop's current time point. This will remain constant between ticks. This is
   // used to implement IoContext::now(), which should be preferred so that time can be adjusted

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -110,8 +110,7 @@ class IoContext_IncomingRequest final {
   // This method is also used by some custom event handlers (see WorkerInterface::CustomEvent) that
   // need similar behavior, as well as the test handler. TODO(cleanup): Rename to something more
   // generic?
-  enum class FinishScheduledResult { COMPLETED, ABORTED, TIMEOUT };
-  kj::Promise<FinishScheduledResult> finishScheduled();
+  kj::Promise<EventOutcome> finishScheduled();
 
   // Access the event loop's current time point. This will remain constant between ticks. This is
   // used to implement IoContext::now(), which should be preferred so that time can be adjusted

--- a/src/workerd/io/observer.c++
+++ b/src/workerd/io/observer.c++
@@ -2,6 +2,8 @@
 
 #include "worker-interface.h"
 
+#include <workerd/util/exception.h>
+
 #include <kj/common.h>
 #include <kj/debug.h>
 #include <kj/map.h>
@@ -47,4 +49,24 @@ kj::Maybe<FeatureObserver&> FeatureObserver::get() {
   }
   return kj::none;
 }
+
+EventOutcome RequestObserver::outcomeFromException(const kj::Exception& e, FailureSource source) {
+  if (e.getDetail(MEMORY_LIMIT_DETAIL_ID) != kj::none) {
+    return EventOutcome::EXCEEDED_MEMORY;
+  } else if (e.getDetail(CPU_LIMIT_DETAIL_ID) != kj::none) {
+    return EventOutcome::EXCEEDED_CPU;
+  } else if (e.getDetail(SCRIPT_KILLED_DETAIL_ID) != kj::none) {
+    return EventOutcome::KILL_SWITCH;
+  } else if (source == RequestObserver::FailureSource::DEFERRED_PROXY &&
+      e.getType() == kj::Exception::Type::DISCONNECTED) {
+    return EventOutcome::RESPONSE_STREAM_DISCONNECTED;
+  } else if (e.getType() == kj::Exception::Type::OVERLOADED) {
+    // We use exception details to describe some overloaded exceptions more accurately, if no such
+    // detail is present report internalError.
+    return EventOutcome::INTERNAL_ERROR;
+  } else {
+    return EventOutcome::EXCEPTION;
+  }
+}
+
 };  // namespace workerd

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -99,6 +99,9 @@ class RequestObserver: public kj::Refcounted {
   // occurred asynchronously.
   virtual void reportFailure(const kj::Exception& e, FailureSource source = FailureSource::OTHER) {}
 
+  static EventOutcome outcomeFromException(
+      const kj::Exception& e, FailureSource source = FailureSource::OTHER);
+
   // Called when an internal exception is observed during this request. Used to track which
   // internal exception types occurred during a request, for metrics purposes. The same exception
   // type may be reported multiple times during a single request; implementations should deduplicate.

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -721,10 +721,10 @@ kj::Promise<WorkerInterface::ScheduledResult> WorkerEntrypoint::runScheduled(
                                               kj::Own<IoContext::IncomingRequest> request)
       -> kj::Promise<WorkerInterface::ScheduledResult> {
     TRACE_EVENT("workerd", "WorkerEntrypoint::runScheduled() waitForFinished()");
-    auto result = co_await request->finishScheduled();
-    bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
+    auto scheduledResult = co_await request->finishScheduled();
+    bool completed = scheduledResult == EventOutcome::OK;
     co_return WorkerInterface::ScheduledResult{.retry = context.shouldRetryScheduled(),
-      .outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU};
+      .outcome = completed ? context.waitUntilStatus() : scheduledResult};
   };
 
   auto promise = waitForFinished(context, kj::mv(incomingRequest));
@@ -899,9 +899,9 @@ kj::Promise<bool> WorkerEntrypoint::test() {
   static auto constexpr waitForFinished =
       [](IoContext& context, kj::Own<IoContext::IncomingRequest> request) -> kj::Promise<bool> {
     TRACE_EVENT("workerd", "WorkerEntrypoint::test() waitForFinished()");
-    auto result = co_await request->finishScheduled();
+    auto scheduledResult = co_await request->finishScheduled();
 
-    if (result == IoContext_IncomingRequest::FinishScheduledResult::ABORTED) {
+    if (scheduledResult == EventOutcome::EXCEPTION) {
       // If the test handler throws an exception (without aborting - just a regular exception),
       // then `outcome` ends up being EventOutcome::EXCEPTION, which causes us to return false.
       // But in that case we are separately relying on the exception being logged as an uncaught
@@ -919,8 +919,8 @@ kj::Promise<bool> WorkerEntrypoint::test() {
     // (enough so that we can get logs/spans from them in wd-tests), so this is not needed in
     // practice.
 
-    bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
-    auto outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU;
+    bool completed = scheduledResult == EventOutcome::OK;
+    auto outcome = completed ? context.waitUntilStatus() : scheduledResult;
     co_return outcome == EventOutcome::OK;
   };
 

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -718,10 +718,10 @@ kj::Promise<WorkerInterface::ScheduledResult> WorkerEntrypoint::runScheduled(
                                               kj::Own<IoContext::IncomingRequest> request)
       -> kj::Promise<WorkerInterface::ScheduledResult> {
     TRACE_EVENT("workerd", "WorkerEntrypoint::runScheduled() waitForFinished()");
-    auto result = co_await request->finishScheduled();
-    bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
+    auto scheduledResult = co_await request->finishScheduled();
+    bool completed = scheduledResult == EventOutcome::OK;
     co_return WorkerInterface::ScheduledResult{.retry = context.shouldRetryScheduled(),
-      .outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU};
+      .outcome = completed ? context.waitUntilStatus() : scheduledResult};
   };
 
   auto promise = waitForFinished(context, kj::mv(incomingRequest));
@@ -893,9 +893,9 @@ kj::Promise<bool> WorkerEntrypoint::test() {
   static auto constexpr waitForFinished =
       [](IoContext& context, kj::Own<IoContext::IncomingRequest> request) -> kj::Promise<bool> {
     TRACE_EVENT("workerd", "WorkerEntrypoint::test() waitForFinished()");
-    auto result = co_await request->finishScheduled();
+    auto scheduledResult = co_await request->finishScheduled();
 
-    if (result == IoContext_IncomingRequest::FinishScheduledResult::ABORTED) {
+    if (scheduledResult == EventOutcome::EXCEPTION) {
       // If the test handler throws an exception (without aborting - just a regular exception),
       // then `outcome` ends up being EventOutcome::EXCEPTION, which causes us to return false.
       // But in that case we are separately relying on the exception being logged as an uncaught
@@ -913,8 +913,8 @@ kj::Promise<bool> WorkerEntrypoint::test() {
     // (enough so that we can get logs/spans from them in wd-tests), so this is not needed in
     // practice.
 
-    bool completed = result == IoContext_IncomingRequest::FinishScheduledResult::COMPLETED;
-    auto outcome = completed ? context.waitUntilStatus() : EventOutcome::EXCEEDED_CPU;
+    bool completed = scheduledResult == EventOutcome::OK;
+    auto outcome = completed ? context.waitUntilStatus() : scheduledResult;
     co_return outcome == EventOutcome::OK;
   };
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1605,21 +1605,7 @@ class RequestObserverWithTracer final: public RequestObserver, public WorkerInte
 
   void reportFailure(
       const kj::Exception& exception, FailureSource source = FailureSource::OTHER) override {
-    // Handle all exception based outcomes that can appear in workerd.
-    if (exception.getDetail(CPU_LIMIT_DETAIL_ID) != kj::none) {
-      outcome = EventOutcome::EXCEEDED_CPU;
-    } else if (exception.getDetail(MEMORY_LIMIT_DETAIL_ID) != kj::none) {
-      outcome = EventOutcome::EXCEEDED_MEMORY;
-    } else if (source == RequestObserver::FailureSource::DEFERRED_PROXY &&
-        exception.getType() == kj::Exception::Type::DISCONNECTED) {
-      outcome = EventOutcome::RESPONSE_STREAM_DISCONNECTED;
-    } else if (exception.getType() == kj::Exception::Type::OVERLOADED) {
-      // We use exception details to describe some overloaded exceptions accurately, if no such
-      // detail is present report internalError.
-      outcome = EventOutcome::INTERNAL_ERROR;
-    } else {
-      outcome = EventOutcome::EXCEPTION;
-    }
+    outcome = RequestObserver::outcomeFromException(exception, source);
   }
 
   void setOutcome(EventOutcome newOutcome) override {


### PR DESCRIPTION
Fixes a number of footguns that could lead to misleading event outcomes being reported for all events that use finishScheduled() (scheduled, queue, test etc.):
- Exception outcomes in finishScheduled() could be converted into exceededCpu
- Exception details were not being checked in finishScheduled()
- IoContext::taskFailed() now properly handles exception details
- Consolidate code used to get outcome from exception detail 
- Add a TODO for improving outcome reporting when the scheduled time limit is hit

For context, see the recent outcome related changes (#6668, #6589, #6542) as well as the corresponding downstream PRs.