### PR TITLE
Fix `ExternalPusherImpl` so it doesn't care about ordering.

### DIFF
--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -572,20 +572,9 @@ JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
       // here, which is filled in later on to point at the JsRpcPromise, if and when one is created.
       auto weakRef = kj::atomicRefcounted<JsRpcPromise::WeakRef>();
 
-      // HACK: Make sure that any calls to the ExternalPusher get to us before we try to
-      // deserialize the result. A weird quirk of Cap'n Proto is that return values arrive faster
-      // than calls by 1 turn of the event loop, so if we just insert a turn here we should be OK.
-      //
-      // Note that key to this working is the fact that the continuation returns a Promise, even
-      // though it is initialized with an immediate value. This forces the extra turn.
-      auto promise = callResult.then(
-          [](auto resp) -> kj::Promise<capnp::Response<rpc::JsRpcTarget::CallResults>> {
-        return kj::mv(resp);
-      });
-
       // RemotePromise lets us consume its pipeline and promise portions independently; we consume
       // the promise here and we consume the pipeline below, both via kj::mv().
-      auto jsPromise = ioContext.awaitIo(js, kj::mv(promise),
+      auto jsPromise = ioContext.awaitIo(js, kj::mv(callResult),
           [weakRef = kj::atomicAddRef(*weakRef), resultStreamSink = kj::mv(resultStreamSink)](
               jsg::Lock& js,
               capnp::Response<rpc::JsRpcTarget::CallResults> response) mutable -> jsg::Value {

--- a/src/workerd/io/external-pusher.c++
+++ b/src/workerd/io/external-pusher.c++
@@ -132,10 +132,15 @@ kj::Promise<void> ExternalPusherImpl::pushByteStream(PushByteStreamContext conte
 
 kj::Own<kj::AsyncInputStream> ExternalPusherImpl::unwrapStream(
     ExternalPusher::InputStream::Client cap) {
-  auto& unwrapped = KJ_REQUIRE_NONNULL(
-      inputStreamSet.tryGetLocalServerSync(cap), "pushed external is not a byte stream");
+  return kj::newPromisedStream(unwrapStreamImpl(kj::mv(cap)));
+}
 
-  return KJ_REQUIRE_NONNULL(kj::mv(kj::downcast<InputStreamImpl>(unwrapped).stream),
+kj::Promise<kj::Own<kj::AsyncInputStream>> ExternalPusherImpl::unwrapStreamImpl(
+    ExternalPusher::InputStream::Client cap) {
+  auto& unwrapped = KJ_REQUIRE_NONNULL(
+      co_await inputStreamSet.getLocalServer(cap), "pushed external is not a byte stream");
+
+  co_return KJ_REQUIRE_NONNULL(kj::mv(kj::downcast<InputStreamImpl>(unwrapped).stream),
       "pushed byte stream has already been consumed");
 }
 
@@ -146,7 +151,7 @@ namespace {
 
 // The jsrpc handler that receives aborts from the remote and triggers them locally
 //
-// TODO(cleanup): This class has been copied from external-pusher.c++. The copy there can be
+// TODO(cleanup): This class has been copied from basics.c++. The copy there can be
 //   deleted as soon as we've switched from StreamSink to ExternalPusher and can delete all the
 //   StreamSink-related code. For now I'm not trying to avoid duplication.
 class AbortTriggerRpcServer final: public rpc::AbortTrigger::Server {
@@ -196,32 +201,62 @@ class AbortTriggerRpcServer final: public rpc::AbortTrigger::Server {
 
 class ExternalPusherImpl::AbortSignalImpl final: public ExternalPusher::AbortSignal::Server {
  public:
-  AbortSignalImpl(AbortSignal content): content(kj::mv(content)) {}
+  AbortSignalImpl(kj::Own<kj::PromiseFulfiller<rpc::AbortTrigger::Client>> triggerFulfiller)
+      : triggerFulfiller(kj::mv(triggerFulfiller)) {}
 
-  kj::Maybe<AbortSignal> content;
+  kj::Maybe<kj::Own<kj::PromiseFulfiller<rpc::AbortTrigger::Client>>> triggerFulfiller;
 };
 
 kj::Promise<void> ExternalPusherImpl::pushAbortSignal(PushAbortSignalContext context) {
-  auto paf = kj::newPromiseAndFulfiller<void>();
-  auto pendingReason = kj::refcounted<PendingAbortReason>();
+  // We can't allocate the `AbortTriggerRpcServer` yet because we don't have the
+  // `PendingAbortReason` box, because that MUST be allocated inside unwrapAbortSignal() so it
+  // can be returned synchronously. So, we'll return a promise for a future `AbortTrigger`, and
+  // we'll put the fulfiller into the `AbortSignalImpl` where `unwrapAbortSignalImpl()` can find
+  // and fulfill it.
+  auto triggerPaf = kj::newPromiseAndFulfiller<rpc::AbortTrigger::Client>();
 
   auto results = context.initResults(capnp::MessageSize{4, 2});
-
-  results.setTrigger(
-      kj::heap<AbortTriggerRpcServer>(kj::mv(paf.fulfiller), kj::addRef(*pendingReason)));
-  results.setSignal(abortSignalSet.add(
-      kj::heap<AbortSignalImpl>(AbortSignal{kj::mv(paf.promise), kj::mv(pendingReason)})));
+  results.setTrigger(kj::mv(triggerPaf.promise));
+  results.setSignal(abortSignalSet.add(kj::heap<AbortSignalImpl>(kj::mv(triggerPaf.fulfiller))));
 
   return kj::READY_NOW;
 }
 
 ExternalPusherImpl::AbortSignal ExternalPusherImpl::unwrapAbortSignal(
     ExternalPusher::AbortSignal::Client cap) {
-  auto& unwrapped = KJ_REQUIRE_NONNULL(
-      abortSignalSet.tryGetLocalServerSync(cap), "pushed external is not an AbortSignal");
+  // We need to return a result synchronously, including the PendingAbortReason box. But,
+  // pushAbortSignal() might not have been received yet. So, we have to allocate the box here, so
+  // we can return it. Then we can try to wire it up to the right trigger later, in
+  // unwrapAbortSignalImpl().
+  auto pendingReason = kj::refcounted<PendingAbortReason>();
+  auto promise = unwrapAbortSignalImpl(kj::mv(cap), kj::addRef(*pendingReason));
 
-  return KJ_REQUIRE_NONNULL(kj::mv(kj::downcast<AbortSignalImpl>(unwrapped).content),
-      "pushed AbortSignal has already been consumed");
+  return {
+    .signal = kj::mv(promise),
+    .reason = kj::mv(pendingReason),
+  };
+}
+
+kj::Promise<void> ExternalPusherImpl::unwrapAbortSignalImpl(
+    ExternalPusher::AbortSignal::Client cap, kj::Own<PendingAbortReason> pendingReason) {
+  auto paf = kj::newPromiseAndFulfiller<void>();
+
+  {
+    auto& unwrapped = KJ_REQUIRE_NONNULL(
+        co_await abortSignalSet.getLocalServer(cap), "pushed external is not an AbortSignal");
+
+    auto triggerFulfiller =
+        KJ_REQUIRE_NONNULL(kj::mv(kj::downcast<AbortSignalImpl>(unwrapped).triggerFulfiller),
+            "pushed AbortSignal has already been consumed");
+
+    triggerFulfiller->fulfill(
+        kj::heap<AbortTriggerRpcServer>(kj::mv(paf.fulfiller), kj::mv(pendingReason)));
+
+    // We don't need `cap` anymore.
+    auto drop = kj::mv(cap);
+  }
+
+  co_await paf.promise;
 }
 
 }  // namespace workerd

--- a/src/workerd/io/external-pusher.h
+++ b/src/workerd/io/external-pusher.h
@@ -50,6 +50,12 @@ class ExternalPusherImpl: public rpc::JsValue::ExternalPusher::Server, public kj
   capnp::CapabilityServerSet<ExternalPusher::InputStream> inputStreamSet;
   capnp::CapabilityServerSet<ExternalPusher::AbortSignal> abortSignalSet;
 
+  kj::Promise<kj::Own<kj::AsyncInputStream>> unwrapStreamImpl(
+      ExternalPusher::InputStream::Client cap);
+
+  kj::Promise<void> unwrapAbortSignalImpl(
+      ExternalPusher::AbortSignal::Client cap, kj::Own<PendingAbortReason> pendingReason);
+
   class InputStreamImpl;
   class AbortSignalImpl;
 };

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -623,7 +623,6 @@ struct JsValue {
     }
 
     # TODO(soon):
-    # - AbortTrigger
     # - Promises
   }
 }

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -593,8 +593,14 @@ struct JsValue {
     # unwrapped to obtain the underlying local object, which the recipient then uses to back the
     # external value delivered to the application.
     #
-    # Note that externals must be pushed BEFORE the JsValue that uses them is sent, so that they
-    # can be unwrapped immediately when deserializing the value.
+    # Typically, externals are pushed before the JsValue that uses them is sent. However, this
+    # is not strictly required, as all pushable externals deserialize into an object that can wait
+    # for the push as a first step. For example, if a ReadableStream is received in a JsValue
+    # before pushByteStream() has been called, the resulting stream will simply wait for the push
+    # as part of its first read() call. This is important as Cap'n Proto doesn't strictly guarantee
+    # call ordering between calls on different capabilities, or a call vs. a return, so it's
+    # difficult for the sender to guarantee that a push arrives before the JsValue that refers
+    # to it.
 
     pushByteStream @0 (lengthPlusOne :UInt64 = 0) -> (source :InputStream, sink :ByteStream);
     # Creates a readable stream within the remote's memory space. `source` should be placed in a


### PR DESCRIPTION
Previously, `ExternalPusherImpl` _assumed_ that the `push` RPC would always be received before the corresponding `unwrap` method was called during deserialization.

We seem to have cases in production where this assumption isn't holding.

It turns out, though, we don't have to make the assumption. We can actually deal with the push coming after the unwrap just fine, if we are clever.

Honestly, I had a feeling I'd burn myself trying to create `tryGetLocalServerSync()`...