### PR TITLE
Replace startSpan with auto-ending enterSpan in user tracing

### DIFF
--- a/src/cloudflare/internal/test/instrumentation-test-helper.js
+++ b/src/cloudflare/internal/test/instrumentation-test-helper.js
@@ -72,6 +72,98 @@ export function createTailStreamHandler(state) {
 }
 
 /**
+ * Creates a tail-stream handler that records span parent/child relationships in addition
+ * to the span attributes. Use this when your test needs to assert on hierarchy (e.g.,
+ * "the fetch span's parent is the enterSpan I just opened").
+ *
+ * The returned state shape is:
+ *   state.spans: Map<spanKey, {
+ *     name, spanId, parentSpanId, invocationId, closed, ...attributes
+ *   }>
+ *   state.topLevelSpans: Map<invocationId, topLevelSpanId>
+ *     (the span ID from the onset event, i.e. the implicit request root)
+ *
+ * @returns {{state: Object, tailStream: Function, waitForCompletion: Function}}
+ */
+export function createHierarchyAwareCollector() {
+  const state = {
+    invocationPromises: [],
+    spans: new Map(),
+    topLevelSpans: new Map(),
+  };
+
+  const tailStream = (event, env, ctx) => {
+    // Record the onset event's spanId as the top-level span for this invocation.
+    state.topLevelSpans.set(event.invocationId, event.event.spanId);
+
+    let resolveFn;
+    state.invocationPromises.push(
+      new Promise((resolve) => {
+        resolveFn = resolve;
+      })
+    );
+
+    return (event) => {
+      const spanKey = `${event.invocationId}#${event.event.spanId || event.spanContext.spanId}`;
+      switch (event.event.type) {
+        case 'spanOpen':
+          // event.event.spanId is the new span's id; event.spanContext.spanId is the
+          // span that was active when this one was opened (i.e., its parent).
+          state.spans.set(spanKey, {
+            name: event.event.name,
+            spanId: event.event.spanId,
+            parentSpanId: event.spanContext.spanId,
+            invocationId: event.invocationId,
+          });
+          break;
+        case 'attributes': {
+          const span = state.spans.get(spanKey);
+          if (!span) break;
+          for (const { name, value } of event.event.info) {
+            span[name] = value;
+          }
+          break;
+        }
+        case 'spanClose': {
+          const span = state.spans.get(spanKey);
+          if (!span) break;
+          span.closed = true;
+          break;
+        }
+        case 'outcome':
+          resolveFn();
+          break;
+      }
+    };
+  };
+
+  const waitForCompletion = () => Promise.allSettled(state.invocationPromises);
+
+  return { state, tailStream, waitForCompletion };
+}
+
+/**
+ * Find a span whose `name` field matches (after an optional filter function).
+ * Throws if there is not exactly one such span in the collector's state.
+ */
+export function findSpanByName(state, name, filterFn = () => true) {
+  const matches = [];
+  for (const span of state.spans.values()) {
+    if (span.name === name && filterFn(span)) matches.push(span);
+  }
+  if (matches.length === 0) {
+    throw new Error(`No span found with name='${name}'`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Expected exactly one span with name='${name}', found ${matches.length}: ` +
+        JSON.stringify(matches, null, 2)
+    );
+  }
+  return matches[0];
+}
+
+/**
  * Runs instrumentation test assertions.
  * This mirrors the original test logic exactly.
  * @param {Object} state - The state object from createInstrumentationState

--- a/src/cloudflare/internal/test/tracing/BUILD.bazel
+++ b/src/cloudflare/internal/test/tracing/BUILD.bazel
@@ -5,3 +5,9 @@ wd_test(
     args = ["--experimental"],
     data = glob(["*.js"]) + ["//src/cloudflare/internal/test:instrumentation-test-helper.js"],
 )
+
+wd_test(
+    src = "tracing-hierarchy-test.wd-test",
+    args = ["--experimental"],
+    data = glob(["*.js"]) + ["//src/cloudflare/internal/test:instrumentation-test-helper.js"],
+)

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
@@ -34,6 +34,8 @@ export const validateSpans = {
         test: 'setAttributeUndefined',
         expectedSpan: 'undefined-attr-op',
       },
+      { test: 'publicImportTracing', expectedSpan: 'public-import-op' },
+      { test: 'ctxTracing', expectedSpan: 'ctx-tracing-op' },
     ];
 
     for (const { test, expectedSpan } of testValidations) {

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
@@ -22,21 +22,62 @@ export const validateSpans = {
     const allSpans = collector.spans.values();
     const spansByTest = groupSpansBy(allSpans, 'test');
 
-    // Define the core tests that validate withSpan behavior
+    // Core tests that validate withSpan produces a correctly-closed span of the given name.
     const testValidations = [
       { test: 'syncFunction', expectedSpan: 'sync-op' },
       { test: 'asyncFunction', expectedSpan: 'async-op' },
       { test: 'syncError', expectedSpan: 'sync-error-op' },
       { test: 'asyncError', expectedSpan: 'async-error-op' },
+      { test: 'spanClassName', expectedSpan: 'class-name-op' },
+      { test: 'isTraced', expectedSpan: 'is-traced-op' },
+      {
+        test: 'setAttributeUndefined',
+        expectedSpan: 'undefined-attr-op',
+      },
     ];
 
-    // Validate each test's span
     for (const { test, expectedSpan } of testValidations) {
       const testSpans = spansByTest.get(test) || [];
       const span = testSpans.find((s) => s.name === expectedSpan);
 
       assert(span, `${test}: Should have created span '${expectedSpan}'`);
       assert(span.closed, `${test}: Span '${expectedSpan}' should be closed`);
+    }
+
+    // setAttributeUndefined should NOT have a 'skipped' attribute recorded.
+    {
+      const span = (spansByTest.get('setAttributeUndefined') || []).find(
+        (s) => s.name === 'undefined-attr-op'
+      );
+      assert(span, 'setAttributeUndefined: span present');
+      assert(
+        !('skipped' in span),
+        'setAttribute(key, undefined) should not record the attribute'
+      );
+    }
+
+    // Nested spans: verify both outer and inner spans exist and both are closed.
+    // This exercises the AsyncContextFrame push path used by enterSpan for nesting.
+    for (const testName of ['nestedSyncSpans', 'nestedAsyncSpans']) {
+      const testSpans = spansByTest.get(testName) || [];
+      const outerName =
+        testName === 'nestedSyncSpans'
+          ? 'nested-outer-op'
+          : 'nested-async-outer-op';
+      const innerName =
+        testName === 'nestedSyncSpans'
+          ? 'nested-inner-op'
+          : 'nested-async-inner-op';
+
+      const outer = testSpans.find((s) => s.name === outerName);
+      const inner = testSpans.find((s) => s.name === innerName);
+
+      assert(outer, `${testName}: outer span '${outerName}' should exist`);
+      assert(inner, `${testName}: inner span '${innerName}' should exist`);
+      assert(outer.closed, `${testName}: outer span should be closed`);
+      assert(inner.closed, `${testName}: inner span should be closed`);
+      assert.strictEqual(outer.level, 'outer');
+      assert.strictEqual(inner.level, 'inner');
     }
 
     console.log('All tracing-helpers tests passed!');

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import assert from 'node:assert';
+import { tracing as publicTracing } from 'cloudflare:workers';
 
 export const syncFunction = {
   async test(ctrl, env, ctx) {
@@ -179,5 +180,39 @@ export const nestedAsyncSpans = {
     );
 
     assert.strictEqual(result, 'nested-async-value');
+  },
+};
+
+// Verify the public import path: `import { tracing } from 'cloudflare:workers'`.
+// Hitting enterSpan via the public import should behave identically to the internal path.
+export const publicImportTracing = {
+  async test(ctrl, env, ctx) {
+    const result = publicTracing.enterSpan('public-import-op', (span) => {
+      span.setAttribute('test', 'publicImportTracing');
+      span.setAttribute('path', 'import-from-cloudflare-workers');
+      assert.strictEqual(span.isTraced, true);
+      return 'public-import-value';
+    });
+    assert.strictEqual(result, 'public-import-value');
+  },
+};
+
+// Verify ctx.tracing: same Tracing instance should be reachable off the execution context.
+export const ctxTracing = {
+  async test(ctrl, env, ctx) {
+    assert.ok(ctx.tracing, 'ctx.tracing should be defined');
+    assert.strictEqual(
+      typeof ctx.tracing.enterSpan,
+      'function',
+      'ctx.tracing.enterSpan should be a function'
+    );
+
+    const result = ctx.tracing.enterSpan('ctx-tracing-op', (span) => {
+      span.setAttribute('test', 'ctxTracing');
+      span.setAttribute('path', 'ctx.tracing');
+      assert.strictEqual(span.isTraced, true);
+      return 'ctx-tracing-value';
+    });
+    assert.strictEqual(result, 'ctx-tracing-value');
   },
 };

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
@@ -75,3 +75,109 @@ export const asyncError = {
     assert(errorCaught, 'Async error should have been caught');
   },
 };
+
+// Verify the JS-visible class name is exactly "Span" - no internal-implementation names
+// should leak into JavaScript.
+export const spanClassName = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+
+    withSpan('class-name-op', (span) => {
+      span.setAttribute('test', 'spanClassName');
+      assert.strictEqual(span.constructor.name, 'Span');
+    });
+  },
+};
+
+// Verify isTraced reflects the state of the span: true while the span is live, false
+// after it has been auto-ended by withSpan.
+export const isTraced = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+
+    let capturedSpan = null;
+    withSpan('is-traced-op', (span) => {
+      capturedSpan = span;
+      // While inside the callback, the span should be traced (we're inside a tailed
+      // request - the streamingTails binding is configured for this worker).
+      assert.strictEqual(
+        span.isTraced,
+        true,
+        'Span should be traced inside withSpan callback'
+      );
+      span.setAttribute('test', 'isTraced');
+    });
+
+    // After withSpan returns, the span has been auto-ended -> isTraced should be false.
+    assert.strictEqual(
+      capturedSpan.isTraced,
+      false,
+      'Span should no longer be traced after auto-end'
+    );
+  },
+};
+
+// Verify that setAttribute with undefined is a no-op (the attribute is simply not set),
+// which is the idiomatic pattern for optional attributes.
+export const setAttributeUndefined = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+
+    const result = withSpan('undefined-attr-op', (span) => {
+      span.setAttribute('test', 'setAttributeUndefined');
+      // Passing undefined should not throw and should not record the attribute.
+      span.setAttribute('skipped', undefined);
+      return 'undefined-attr-value';
+    });
+
+    assert.strictEqual(result, 'undefined-attr-value');
+  },
+};
+
+// Verify that nested withSpan calls produce correctly nested spans. This exercises the
+// AsyncContextFrame push path in enterSpan: the inner span should be parented on the
+// outer span.
+export const nestedSyncSpans = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+
+    const result = withSpan('nested-outer-op', (outerSpan) => {
+      outerSpan.setAttribute('test', 'nestedSyncSpans');
+      outerSpan.setAttribute('level', 'outer');
+      return withSpan('nested-inner-op', (innerSpan) => {
+        innerSpan.setAttribute('test', 'nestedSyncSpans');
+        innerSpan.setAttribute('level', 'inner');
+        return 'nested-value';
+      });
+    });
+
+    assert.strictEqual(result, 'nested-value');
+  },
+};
+
+// Async analog of the nested test: inner span lives inside an await that spans a
+// microtask boundary, so the inner span's parent is preserved only if the
+// AsyncContextFrame push correctly follows the async continuation.
+export const nestedAsyncSpans = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+
+    const result = await withSpan(
+      'nested-async-outer-op',
+      async (outerSpan) => {
+        outerSpan.setAttribute('test', 'nestedAsyncSpans');
+        outerSpan.setAttribute('level', 'outer');
+        // Crossing a microtask boundary before creating the inner span.
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return await withSpan('nested-async-inner-op', async (innerSpan) => {
+          innerSpan.setAttribute('test', 'nestedAsyncSpans');
+          innerSpan.setAttribute('level', 'inner');
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return 'nested-async-value';
+        });
+      }
+    );
+
+    assert.strictEqual(result, 'nested-async-value');
+  },
+};

--- a/src/cloudflare/internal/test/tracing/tracing-hierarchy-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-hierarchy-instrumentation-test.js
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import assert from 'node:assert';
+import {
+  createHierarchyAwareCollector,
+  findSpanByName,
+} from 'instrumentation-test-helper';
+
+const collector = createHierarchyAwareCollector();
+export default { tailStream: collector.tailStream };
+
+// After all test cases above have run (triggering tailStream invocations per-request),
+// validate the parent/child relationships encoded in the streaming-tail events.
+export const validateHierarchy = {
+  async test() {
+    await collector.waitForCompletion();
+    const { state } = collector;
+    const allSpans = Array.from(state.spans.values());
+
+    // Assert an edge in the span tree: `child` is a direct child of `parent`.
+    const assertParent = (child, parent, label) => {
+      assert.strictEqual(
+        child.parentSpanId,
+        parent.spanId,
+        `${label}: expected span "${child.name}" (id=${child.spanId}) to have ` +
+          `parent "${parent.name}" (id=${parent.spanId}), but got parentSpanId=${child.parentSpanId}`
+      );
+      assert.strictEqual(
+        child.invocationId,
+        parent.invocationId,
+        `${label}: child and parent should share invocationId`
+      );
+    };
+
+    // Assert `span` is a direct child of the top-level (onset) span for its invocation.
+    const assertTopLevelParent = (span, label) => {
+      const topLevelSpanId = state.topLevelSpans.get(span.invocationId);
+      assert.ok(
+        topLevelSpanId,
+        `${label}: missing topLevelSpanId for invocation ${span.invocationId}`
+      );
+      assert.strictEqual(
+        span.parentSpanId,
+        topLevelSpanId,
+        `${label}: expected span "${span.name}" to be a direct child of the onset ` +
+          `span (id=${topLevelSpanId}), but parentSpanId=${span.parentSpanId}`
+      );
+    };
+
+    // ---------- Case 1: nestedEnterSpan (sync) ----------
+    {
+      const outer = findSpanByName(state, 'hierarchy-outer');
+      const inner = findSpanByName(state, 'hierarchy-inner');
+      assert.strictEqual(outer.role, 'outer');
+      assert.strictEqual(inner.role, 'inner');
+      assert.ok(outer.closed, 'outer sync span should be closed');
+      assert.ok(inner.closed, 'inner sync span should be closed');
+      assertParent(inner, outer, 'nestedEnterSpan');
+      assertTopLevelParent(outer, 'nestedEnterSpan');
+    }
+
+    // ---------- Case 2: nestedEnterSpanAsync ----------
+    // The important assertion here: the inner span is created AFTER an `await`, so its
+    // parent is only correctly reported if the AsyncContextFrame push propagates through
+    // the microtask boundary.
+    {
+      const outer = findSpanByName(state, 'hierarchy-async-outer');
+      const inner = findSpanByName(state, 'hierarchy-async-inner');
+      assert.strictEqual(outer.role, 'outer');
+      assert.strictEqual(inner.role, 'inner');
+      assert.ok(outer.closed);
+      assert.ok(inner.closed);
+      assertParent(inner, outer, 'nestedEnterSpanAsync');
+      assertTopLevelParent(outer, 'nestedEnterSpanAsync');
+    }
+
+    // ---------- Case 3: fetchInsideEnterSpan ----------
+    // The runtime-created "fetch" span must be nested under our enterSpan. This test
+    // is the key proof that enterSpan's AsyncContextFrame push is observed by lower-level
+    // runtime tracing paths (IoContext::makeUserTraceSpan -> getCurrentUserTraceSpan).
+    {
+      const outer = findSpanByName(state, 'hierarchy-fetch-outer');
+      assert.strictEqual(outer.case, 'fetchInsideEnterSpan');
+      assert.ok(outer.closed);
+      // Find the fetch span that belongs to this invocation (there are other fetch
+      // spans in other test invocations).
+      const fetchSpan = findSpanByName(
+        state,
+        'fetch',
+        (s) => s.invocationId === outer.invocationId
+      );
+      assertParent(fetchSpan, outer, 'fetchInsideEnterSpan');
+      assertTopLevelParent(outer, 'fetchInsideEnterSpan');
+    }
+
+    // ---------- Case 4: fetchInsideNestedEnterSpan ----------
+    // Three-level chain: onset -> outer -> inner -> fetch.
+    {
+      const outer = findSpanByName(state, 'hierarchy-deep-outer');
+      const inner = findSpanByName(state, 'hierarchy-deep-inner');
+      assert.strictEqual(outer.role, 'outer');
+      assert.strictEqual(inner.role, 'inner');
+      assert.ok(outer.closed);
+      assert.ok(inner.closed);
+      const fetchSpan = findSpanByName(
+        state,
+        'fetch',
+        (s) => s.invocationId === outer.invocationId
+      );
+      assertParent(inner, outer, 'fetchInsideNestedEnterSpan (inner->outer)');
+      assertParent(
+        fetchSpan,
+        inner,
+        'fetchInsideNestedEnterSpan (fetch->inner)'
+      );
+      assertTopLevelParent(outer, 'fetchInsideNestedEnterSpan');
+    }
+
+    // ---------- Case 5: siblingEnterSpans ----------
+    // Sequential (non-nested) spans should each hang directly off the onset, not off
+    // each other - the first span's AsyncContextFrame push must be fully popped before
+    // the second span opens.
+    {
+      const a = findSpanByName(state, 'hierarchy-sibling-a');
+      const b = findSpanByName(state, 'hierarchy-sibling-b');
+      assert.strictEqual(a.role, 'sibling-a');
+      assert.strictEqual(b.role, 'sibling-b');
+      assert.ok(a.closed);
+      assert.ok(b.closed);
+      assert.strictEqual(
+        a.invocationId,
+        b.invocationId,
+        'siblingEnterSpans: both should share the same invocation'
+      );
+      assertTopLevelParent(a, 'siblingEnterSpans (a)');
+      assertTopLevelParent(b, 'siblingEnterSpans (b)');
+    }
+
+    console.log('All tracing-hierarchy tests passed!');
+  },
+};

--- a/src/cloudflare/internal/test/tracing/tracing-hierarchy-mock.js
+++ b/src/cloudflare/internal/test/tracing/tracing-hierarchy-mock.js
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Minimal fetch target used by tracing-hierarchy-test. Just echoes the request path so
+// the runtime-generated "fetch" span has something to observe.
+export default {
+  async fetch(request) {
+    return new Response('ok', { status: 200 });
+  },
+};

--- a/src/cloudflare/internal/test/tracing/tracing-hierarchy-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-hierarchy-test.js
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Tests that verify the tracing hierarchy produced by enterSpan is correct. Each test
+// case below runs a specific scenario (nested enterSpan, fetch inside enterSpan, etc.);
+// the tail worker in tracing-hierarchy-instrumentation-test.js receives the streaming
+// tail events and validates the parent/child relationships in a followup validation test.
+
+import assert from 'node:assert';
+
+export const nestedEnterSpan = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // Two nested synchronous enterSpan calls. The inner span's parent must be the outer
+    // span, and the outer span's parent must be the top-level request span (onset).
+    const result = withSpan('hierarchy-outer', (outer) => {
+      outer.setAttribute('case', 'nestedEnterSpan');
+      outer.setAttribute('role', 'outer');
+      return withSpan('hierarchy-inner', (inner) => {
+        inner.setAttribute('case', 'nestedEnterSpan');
+        inner.setAttribute('role', 'inner');
+        return 'ok';
+      });
+    });
+    assert.strictEqual(result, 'ok');
+  },
+};
+
+export const nestedEnterSpanAsync = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // Async variant: the inner span is created after the outer span has awaited once,
+    // so the correct parent is only reported if the AsyncContextFrame push propagates
+    // through the microtask boundary.
+    const result = await withSpan('hierarchy-async-outer', async (outer) => {
+      outer.setAttribute('case', 'nestedEnterSpanAsync');
+      outer.setAttribute('role', 'outer');
+      await new Promise((r) => setTimeout(r, 5));
+      return await withSpan('hierarchy-async-inner', async (inner) => {
+        inner.setAttribute('case', 'nestedEnterSpanAsync');
+        inner.setAttribute('role', 'inner');
+        await new Promise((r) => setTimeout(r, 5));
+        return 'ok';
+      });
+    });
+    assert.strictEqual(result, 'ok');
+  },
+};
+
+export const fetchInsideEnterSpan = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // fetch() automatically creates a "fetch" user-trace span via IoContext::
+    // makeUserTraceSpan, which reads getCurrentUserTraceSpan(). If our enterSpan
+    // correctly pushed onto the AsyncContextFrame, that fetch span's parent will be
+    // the outer span (not the top-level onset span).
+    await withSpan('hierarchy-fetch-outer', async (outer) => {
+      outer.setAttribute('case', 'fetchInsideEnterSpan');
+      const response = await env.fetchTarget.fetch('http://mock/echo');
+      assert.strictEqual(response.status, 200);
+      await response.text();
+    });
+  },
+};
+
+export const fetchInsideNestedEnterSpan = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // Deeper nesting: fetch lives inside an inner enterSpan that is itself inside
+    // an outer enterSpan. The fetch's parent must be the inner span.
+    await withSpan('hierarchy-deep-outer', async (outer) => {
+      outer.setAttribute('case', 'fetchInsideNestedEnterSpan');
+      outer.setAttribute('role', 'outer');
+      await withSpan('hierarchy-deep-inner', async (inner) => {
+        inner.setAttribute('case', 'fetchInsideNestedEnterSpan');
+        inner.setAttribute('role', 'inner');
+        const response = await env.fetchTarget.fetch('http://mock/echo-deep');
+        assert.strictEqual(response.status, 200);
+        await response.text();
+      });
+    });
+  },
+};
+
+export const siblingEnterSpans = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // Two enterSpan calls at the same level (sequential, not nested) should each
+    // produce a span whose parent is the top-level onset span, not each other.
+    withSpan('hierarchy-sibling-a', (span) => {
+      span.setAttribute('case', 'siblingEnterSpans');
+      span.setAttribute('role', 'sibling-a');
+    });
+    withSpan('hierarchy-sibling-b', (span) => {
+      span.setAttribute('case', 'siblingEnterSpans');
+      span.setAttribute('role', 'sibling-b');
+    });
+  },
+};

--- a/src/cloudflare/internal/test/tracing/tracing-hierarchy-test.wd-test
+++ b/src/cloudflare/internal/test/tracing/tracing-hierarchy-test.wd-test
@@ -1,0 +1,48 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+# Validates that enterSpan-produced user spans have the correct parent/child
+# relationships in the streaming-tail event stream. Covers nested enterSpan (sync/async),
+# fetch-inside-enterSpan, and sibling enterSpans.
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "tracing-hierarchy-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "tracing-hierarchy-test.js"),
+        ],
+        compatibilityFlags = ["experimental", "nodejs_compat"],
+        streamingTails = ["tail"],
+        bindings = [
+          (
+            name = "fetchTarget",
+            service = "tracing-hierarchy-mock"
+          ),
+          (
+            name = "tracingTest",
+            wrapped = (
+              moduleName = "cloudflare-internal:test-tracing-wrapper"
+            )
+          )
+        ],
+      )
+    ),
+    ( name = "tracing-hierarchy-mock",
+      worker = (
+        compatibilityFlags = ["experimental", "nodejs_compat"],
+        modules = [
+          (name = "worker", esModule = embed "tracing-hierarchy-mock.js"),
+        ],
+      )
+    ),
+    ( name = "tail", worker = .tailWorker, ),
+  ]
+);
+
+const tailWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "tracing-hierarchy-instrumentation-test.js"),
+    (name = "instrumentation-test-helper", esModule = embed "../instrumentation-test-helper.js")
+  ],
+  compatibilityFlags = ["experimental", "nodejs_compat"],
+);

--- a/src/cloudflare/internal/tracing-helpers.ts
+++ b/src/cloudflare/internal/tracing-helpers.ts
@@ -4,11 +4,14 @@
 
 import tracing from 'cloudflare-internal:tracing';
 
-export type Span = ReturnType<typeof tracing.startSpan>;
+export type Span = InstanceType<typeof tracing.Span>;
 
 /**
  * Helper function to wrap operations with tracing spans.
- * Automatically handles span lifecycle for both sync and async operations.
+ * Automatically handles span lifecycle for both sync and async operations via
+ * the underlying `enterSpan` primitive, which also pushes the new span onto
+ * the async context so that any spans (or async continuations) created inside
+ * `fn` nest correctly beneath it.
  *
  * @param name - The operation name for the span
  * @param fn - The function to execute within the span context
@@ -32,27 +35,8 @@ export type Span = ReturnType<typeof tracing.startSpan>;
  * spans ended immediately after the generator object is returned, not when
  * the generator is exhausted.
  */
-export function withSpan<T>(
-  name: string,
-  fn: (span: ReturnType<typeof tracing.startSpan>) => T
-): T {
-  const span = tracing.startSpan(name);
-
-  try {
-    const result = fn(span);
-
-    // Handle async results - ensure span ends after completion
-    if (result instanceof Promise) {
-      return Promise.resolve(result).finally(() => {
-        span.end();
-      }) as T;
-    }
-
-    // Synchronous result - end span immediately
-    span.end();
-    return result;
-  } catch (error) {
-    span.end();
-    throw error;
-  }
+export function withSpan<T>(name: string, fn: (span: Span) => T): T {
+  // `enterSpan` already handles sync vs. promise return (and sync-throw /
+  // promise-reject) auto-ending, so this is a pure passthrough.
+  return tracing.enterSpan(name, fn);
 }

--- a/src/cloudflare/internal/tracing.d.ts
+++ b/src/cloudflare/internal/tracing.d.ts
@@ -2,11 +2,27 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+// A value acceptable as an attribute on a span.
+type SpanValue = string | number | boolean;
+
 export class Span {
-  // Sets an attribute on this span. If value is undefined, the attribute is not set.
-  setAttribute(key: string, value: string | number | boolean | undefined): void;
-  // Closes the span
-  end(): void;
+  // Returns true if this span will be recorded to the tracing system. False when the
+  // current async context is not being traced, or when the span has already been submitted
+  // (which happens automatically when the enterSpan callback returns). Callers can gate
+  // expensive attribute-computation code on this.
+  readonly isTraced: boolean;
+
+  // Sets a single attribute on the span. If `value` is undefined, the attribute is not set,
+  // which is convenient for optional fields.
+  setAttribute(key: string, value: SpanValue | undefined): void;
 }
 
-function startSpan(name: string): Span;
+// Creates a new child span of the current span, pushes it onto the async context as the
+// active span, invokes callback(span, ...args), and automatically ends the span when the
+// callback returns (sync) or when its returned promise settles (async, either fulfilled or
+// rejected). If no IO context is present the callback runs with a no-op span.
+function enterSpan<T, A extends unknown[]>(
+  name: string,
+  callback: (span: Span) => T,
+  ...args: A
+): T;

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -7,6 +7,7 @@
 
 import entrypoints from 'cloudflare-internal:workers';
 import innerEnv from 'cloudflare-internal:env';
+import innerTracing from 'cloudflare-internal:tracing';
 
 export const WorkerEntrypoint = entrypoints.WorkerEntrypoint;
 export const DurableObject = entrypoints.DurableObject;
@@ -151,3 +152,5 @@ export const exports = new Proxy(
 );
 
 export const waitUntil = entrypoints.waitUntil.bind(entrypoints);
+
+export const tracing = innerTracing;

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -301,9 +301,9 @@ wd_cc_library(
 )
 
 wd_cc_library(
-    name = "tracing-module",
-    srcs = ["tracing-module.c++"],
-    hdrs = ["tracing-module.h"],
+    name = "tracing",
+    srcs = ["tracing.c++"],
+    hdrs = ["tracing.h"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/workerd/io",
@@ -340,7 +340,7 @@ wd_cc_library(
         ":hyperdrive",
         ":memory-cache",
         ":r2",
-        ":tracing-module",
+        ":tracing",
         ":workers-module",
         "//src/cloudflare",
         "//src/node",

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -33,6 +33,7 @@ filegroup(
         "sync-kv.c++",
         "system-streams.c++",
         "trace.c++",
+        "tracing.c++",
         "unsafe.c++",
         "url-standard.c++",
         "web-socket.c++",
@@ -80,6 +81,7 @@ filegroup(
         "sync-kv.h",
         "system-streams.h",
         "trace.h",
+        "tracing.h",
         "unsafe.h",
         "url-standard.h",
         "web-socket.h",
@@ -301,17 +303,6 @@ wd_cc_library(
 )
 
 wd_cc_library(
-    name = "tracing",
-    srcs = ["tracing.c++"],
-    hdrs = ["tracing.h"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//src/workerd/io",
-        "//src/workerd/jsg",
-    ],
-)
-
-wd_cc_library(
     name = "rtti",
     srcs = [
         "modules.c++",
@@ -340,7 +331,6 @@ wd_cc_library(
         ":hyperdrive",
         ":memory-cache",
         ":r2",
-        ":tracing",
         ":workers-module",
         "//src/cloudflare",
         "//src/node",

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -18,6 +18,7 @@
 #include <workerd/api/sockets.h>
 #include <workerd/api/system-streams.h>
 #include <workerd/api/trace.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/util.h>
 #include <workerd/api/worker-rpc.h>
 #include <workerd/io/compatibility-date.h>
@@ -81,6 +82,13 @@ jsg::Promise<CachePurgeResult> CacheContext::purge(jsg::Lock& js,
     const jsg::TypeHandler<CachePurgeResult>& resultHandler,
     const jsg::TypeHandler<jsg::Ref<JsRpcProperty>>& rpcPropHandler) {
   JSG_FAIL_REQUIRE(Error, "Cache purge is not available in this context.");
+}
+
+jsg::Optional<jsg::Ref<Tracing>> ExecutionContext::getTracing(jsg::Lock& js) {
+  if (!FeatureFlags::get(js).getWorkerdExperimental()) {
+    return kj::none;
+  }
+  return js.alloc<Tracing>();
 }
 
 void ExecutionContext::abort(jsg::Lock& js, jsg::Optional<jsg::Value> reason) {

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -27,6 +27,7 @@ class DOMException;
 
 namespace workerd::api {
 
+class Tracing;
 class TailEvent;
 class Cache;
 class CacheStorage;
@@ -289,6 +290,8 @@ class ExecutionContext: public jsg::Object {
     return js.undefined();
   }
 
+  jsg::Optional<jsg::Ref<Tracing>> getTracing(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(ExecutionContext, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     JSG_METHOD(passThroughOnException);
@@ -300,6 +303,13 @@ class ExecutionContext: public jsg::Object {
     if (flags.getEnableVersionApi()) {
       JSG_LAZY_INSTANCE_PROPERTY(version, getVersion);
     }
+
+    // ctx.tracing - user tracing API. The *type* is always visible (so the generated
+    // `Tracing` / `Span` types exist in every compat-date snapshot, not only the
+    // experimental one). The *value* is `undefined` outside the `workerdExperimental`
+    // compat flag - the gate lives in `getTracing()` in global-scope.c++.
+    // TODO: Remove this comment once the feature is stable.
+    JSG_LAZY_INSTANCE_PROPERTY(tracing, getTracing);
 
     if (flags.getWorkerdExperimental()) {
       // TODO(soon): Before making this generally available we need to:

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -11,7 +11,7 @@
 #include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/rtti.h>
 #include <workerd/api/sockets.h>
-#include <workerd/api/tracing-module.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/workers-module.h>
 #include <workerd/jsg/modules-new.h>

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -35,7 +35,7 @@
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/sync-kv.h>
 #include <workerd/api/trace.h>
-#include <workerd/api/tracing-module.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern-standard.h>
@@ -95,7 +95,7 @@
   F("sync-kv", EW_SYNC_KV_ISOLATE_TYPES)                                                           \
   F("worker-loader", EW_WORKER_LOADER_ISOLATE_TYPES)                                               \
   F("performance", EW_PERFORMANCE_ISOLATE_TYPES)                                                   \
-  F("tracing-module", EW_TRACING_MODULE_ISOLATE_TYPES)
+  F("tracing", EW_TRACING_ISOLATE_TYPES)
 
 namespace workerd::api {
 

--- a/src/workerd/api/tracing-module.c++
+++ b/src/workerd/api/tracing-module.c++
@@ -4,37 +4,323 @@
 
 #include "tracing-module.h"
 
-namespace workerd::api {
+#include <workerd/io/trace.h>
+#include <workerd/io/tracer.h>
+#include <workerd/util/thread-scopes.h>
 
-JsSpan::JsSpan(kj::Maybe<IoOwn<TraceContext>> span): span(kj::mv(span)) {}
+namespace workerd::api::user_tracing {
 
-JsSpan::~JsSpan() noexcept(false) {
+namespace {
+
+// Approximately how much data we allow to be added to a user span before we start ignoring
+// modification requests. This is a soft cap to prevent accidental misuse from unbounded
+// memory growth; downstream tail-stream submission may apply additional limits.
+constexpr size_t MAX_SPAN_BYTES = 64 * 1024;
+
+// Inside workerd::api::user_tracing, a bare `Span` resolves to our JS-visible class. Inner
+// plumbing needs the underlying runtime span struct defined in workerd/io/trace.h; use this
+// alias to keep the code readable.
+using RuntimeSpan = workerd::Span;
+
+RuntimeSpan::TagValue convertTagValue(TagValue value) {
+  KJ_SWITCH_ONEOF(value) {
+    KJ_CASE_ONEOF(b, bool) {
+      return b;
+    }
+    KJ_CASE_ONEOF(d, double) {
+      return d;
+    }
+    KJ_CASE_ONEOF(s, kj::String) {
+      return kj::ConstString(kj::mv(s));
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+size_t estimateTagValueSize(TagValue& value) {
+  // Approximate size; different encodings will produce different sizes. The goal is to bound
+  // accidental overuse, not to be byte-accurate.
+  KJ_SWITCH_ONEOF(value) {
+    KJ_CASE_ONEOF(b, bool) {
+      return 8;
+    }
+    KJ_CASE_ONEOF(d, double) {
+      return 8;
+    }
+    KJ_CASE_ONEOF(s, kj::String) {
+      return s.size();
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+}  // namespace
+
+// ======================================================================================
+// SpanImpl
+
+SpanImpl::SpanImpl(kj::Own<workerd::SpanObserver> observer, RuntimeSpan span)
+    : observer(kj::mv(observer)),
+      span(kj::mv(span)) {}
+
+SpanImpl::SpanImpl(decltype(nullptr)) {}
+
+SpanImpl::~SpanImpl() noexcept(false) {
   end();
 }
 
-void JsSpan::end() {
-  span = kj::none;
+void SpanImpl::end() {
+  // Clear the AsyncContextFrame-pushed holder first. This releases the SpanParent the holder
+  // was guarding, which in turn drops one of the outstanding refs to our SpanObserver. Any
+  // other holders (e.g. from nested enterSpan() calls that have not yet ended) remain valid -
+  // this is how parent spans remain the logical parent of already-active child spans.
+  //
+  // Doing this before observer->report() is not strictly required for correctness (the
+  // observer is kept alive by our own `observer` member until we clear it below), but it is
+  // important that we do it before this SpanImpl is destroyed; otherwise, on actor IoContexts
+  // where the IoOwn<SpanImpl> may live past end-of-request, the holder's SpanParent would
+  // keep the observer (and thus the BaseTracer) alive past end-of-request.
+  asyncContextHolder = kj::none;
+
+  KJ_IF_SOME(o, observer) {
+    KJ_IF_SOME(s, span) {
+      // Use the observer's getTime() so the end timestamp is rounded to I/O time (for
+      // Spectre mitigation) rather than taken from a high-precision clock. See
+      // UserSpanObserver::getTime() in tracer.c++.
+      s.endTime = o->getTime();
+      o->report(s);
+      span = kj::none;
+    }
+  }
+
+  // Drop the observer ref so getIsTraced() correctly returns false after end().
+  observer = kj::none;
 }
 
-void JsSpan::setAttribute(
-    jsg::Lock& js, kj::String key, jsg::Optional<kj::OneOf<bool, double, kj::String>> maybeValue) {
+bool SpanImpl::getIsTraced() {
+  return span != kj::none;
+}
+
+workerd::SpanParent SpanImpl::makeSpanParent() {
+  KJ_IF_SOME(o, observer) {
+    return workerd::SpanParent(kj::addRef(*o));
+  }
+  return workerd::SpanParent(nullptr);
+}
+
+void SpanImpl::setAttribute(kj::String key, kj::Maybe<TagValue> maybeValue) {
   KJ_IF_SOME(s, span) {
     KJ_IF_SOME(value, maybeValue) {
-      // JavaScript numbers (double) are stored as-is, not converted to int64_t
-      s->setTag(kj::ConstString(kj::mv(key)), kj::mv(value));
+      if (bytesUsed > MAX_SPAN_BYTES) {
+        return;
+      }
+      size_t valueSize = estimateTagValueSize(value);
+      bytesUsed += key.size() + valueSize;
+      if (bytesUsed > MAX_SPAN_BYTES) {
+        setSpanDataLimitError("attribute", key, valueSize);
+        return;
+      }
+      s.tags.upsert(kj::ConstString(kj::mv(key)), convertTagValue(kj::mv(value)),
+          [](RuntimeSpan::TagValue& existing, RuntimeSpan::TagValue&& newValue) {
+        existing = kj::mv(newValue);
+      });
     }
-    // If value is undefined/none, we simply don't set the attribute
+    // If value is kj::none (undefined on the JS side), leave the attribute unset. This is the
+    // idiomatic pattern for callers chaining setAttribute with optional values.
   }
 }
 
-jsg::Ref<JsSpan> TracingModule::startSpan(jsg::Lock& js, kj::String name) {
-  KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
-    TraceContext traceContext = ioContext.makeUserTraceSpan(kj::ConstString(kj::mv(name)));
-    auto ownedSpan = ioContext.addObject(kj::heap(kj::mv(traceContext)));
-    return js.alloc<JsSpan>(kj::mv(ownedSpan));
+void SpanImpl::attachAsyncContextHolder(kj::Own<workerd::UserTraceSpanHolder> holder) {
+  asyncContextHolder = kj::mv(holder);
+}
+
+void SpanImpl::setSpanDataLimitError(kj::StringPtr itemKind, kj::StringPtr name, size_t valueSize) {
+  KJ_IF_SOME(s, span) {
+    kj::String shortName;
+    if (name.size() > 64) {
+      shortName = kj::str("\"", name.slice(0, 64), "...\" (key length ", name.size(), ")");
+    } else {
+      shortName = kj::str("\"", name, "\"");
+    }
+    auto message = kj::ConstString(kj::str("exceeded span data limit while trying to record ",
+        itemKind, " ", shortName, " of size ", valueSize));
+    s.tags.upsert("ew_span_error"_kjc, RuntimeSpan::TagValue(kj::mv(message)),
+        [](RuntimeSpan::TagValue& existing, RuntimeSpan::TagValue&& newValue) {
+      existing = kj::mv(newValue);
+    });
+  }
+}
+
+// ======================================================================================
+// Span
+
+Span::Span(kj::OneOf<kj::Own<SpanImpl>, IoOwn<SpanImpl>> impl): impl(kj::mv(impl)) {}
+
+bool Span::getIsTraced() {
+  KJ_SWITCH_ONEOF(impl) {
+    KJ_CASE_ONEOF(s, kj::Own<SpanImpl>) {
+      return s->getIsTraced();
+    }
+    KJ_CASE_ONEOF(s, IoOwn<SpanImpl>) {
+      return s->getIsTraced();
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+void Span::setAttribute(jsg::Lock& js, kj::String key, jsg::Optional<TagValue> value) {
+  kj::Maybe<TagValue> maybeValue;
+  KJ_IF_SOME(v, value) {
+    maybeValue = kj::mv(v);
+  }
+  KJ_SWITCH_ONEOF(impl) {
+    KJ_CASE_ONEOF(s, kj::Own<SpanImpl>) {
+      s->setAttribute(kj::mv(key), kj::mv(maybeValue));
+    }
+    KJ_CASE_ONEOF(s, IoOwn<SpanImpl>) {
+      s->setAttribute(kj::mv(key), kj::mv(maybeValue));
+    }
+  }
+}
+
+void Span::end() {
+  KJ_SWITCH_ONEOF(impl) {
+    KJ_CASE_ONEOF(s, kj::Own<SpanImpl>) {
+      s->end();
+    }
+    KJ_CASE_ONEOF(s, IoOwn<SpanImpl>) {
+      s->end();
+    }
+  }
+}
+
+}  // namespace workerd::api::user_tracing
+
+// ======================================================================================
+// TracingModule
+
+namespace workerd::api {
+
+v8::Local<v8::Value> TracingModule::enterSpan(jsg::Lock& js,
+    kj::String operationName,
+    v8::Local<v8::Function> callback,
+    jsg::Arguments<jsg::Value> args,
+    const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler,
+    const jsg::TypeHandler<jsg::Promise<jsg::Value>>& valuePromiseHandler) {
+  // Build the child SpanImpl, allocate a fresh UserTraceSpanHolder for it, and push the
+  // holder onto the AsyncContextFrame for the duration of the callback. The holder is
+  // cleared by SpanImpl::end() so the AsyncContextFrame's stashed reference does not keep
+  // the BaseTracer alive past end-of-request on actor IoContexts - see the comment on
+  // UserTraceSpanHolder in io-context.h for the rationale.
+  //
+  // We use qualified `user_tracing::Span` / `user_tracing::SpanImpl` throughout this function
+  // because an unqualified `Span` in this namespace resolves to workerd::Span (the runtime
+  // span struct), which is a different type we also need to construct below.
+
+  kj::Own<user_tracing::SpanImpl> impl;
+  kj::Maybe<kj::Own<UserTraceSpanHolder>> maybeHolder;
+
+  if (IoContext::hasCurrent()) {
+    auto& context = IoContext::current();
+    SpanParent parent = context.getCurrentUserTraceSpan();
+
+    if (parent.isObserved()) {
+      KJ_IF_SOME(observer, parent.getObserver()) {
+        auto childObserver = observer.newChild();
+        // Bypass SpanBuilder and construct the runtime span struct directly; SpanImpl::end()
+        // submits via observer->report() so a shadow SpanBuilder would double-report.
+        kj::Date startTime = childObserver->getTime();
+        impl = kj::refcounted<user_tracing::SpanImpl>(
+            kj::mv(childObserver), Span(kj::ConstString(kj::heapString(operationName)), startTime));
+      } else {
+        impl = kj::refcounted<user_tracing::SpanImpl>(nullptr);
+      }
+    } else {
+      impl = kj::refcounted<user_tracing::SpanImpl>(nullptr);
+    }
   } else {
-    // When no IoContext is available, create a no-op span
-    return js.alloc<JsSpan>(kj::none);
+    // No IoContext: callback still runs, but with a no-op span and no async-context push.
+    impl = kj::refcounted<user_tracing::SpanImpl>(nullptr);
+  }
+
+  // If we have an observed span, allocate a fresh holder to push onto the AsyncContextFrame.
+  // The holder indirection (instead of stuffing the SpanParent directly into an IoOwn) is
+  // the actor tracer-lifetime fix - see the UserTraceSpanHolder class comment in io-context.h.
+  if (impl->getIsTraced()) {
+    auto holder = kj::refcounted<UserTraceSpanHolder>();
+    holder->setSpan(impl->makeSpanParent());
+    // Give the impl a strong ref to the holder so it can clear() the contents when the span
+    // ends (this is what releases the BaseTracer chain held via the span observer).
+    impl->attachAsyncContextHolder(kj::addRef(*holder));
+    maybeHolder = kj::mv(holder);
+  }
+
+  // Wrap impl in IoOwn (when inside an IoContext) so destruction funnels through the
+  // IoContext's delete queue and cannot cross threads. Outside an IoContext, fall back to
+  // kj::Own; enterSpan without an IoContext is a no-op tracing-wise but still runs the
+  // callback.
+  jsg::Ref<user_tracing::Span> jsSpan = [&]() -> jsg::Ref<user_tracing::Span> {
+    if (IoContext::hasCurrent()) {
+      auto ownedImpl = IoContext::current().addObject(kj::mv(impl));
+      return js.alloc<user_tracing::Span>(kj::mv(ownedImpl));
+    }
+    return js.alloc<user_tracing::Span>(kj::mv(impl));
+  }();
+
+  // Build argv for the callback: (span, ...args).
+  v8::LocalVector<v8::Value> argv(js.v8Isolate);
+  argv.push_back(spanHandler.wrap(js, jsSpan.addRef()));
+  for (auto& arg: args) {
+    argv.push_back(arg.getHandle(js));
+  }
+
+  auto executeCallback = [&]() -> v8::Local<v8::Value> {
+    auto v8Context = js.v8Context();
+    return js.tryCatch([&]() -> v8::Local<v8::Value> {
+      auto result =
+          jsg::check(callback->Call(v8Context, v8Context->Global(), argv.size(), argv.data()));
+      // If the callback returned a promise, defer end() until settlement.
+      if (result->IsPromise()) {
+        auto promise = KJ_ASSERT_NONNULL(valuePromiseHandler.tryUnwrap(js, result))
+                           .then(js,
+                               [jsSpan = jsSpan.addRef()](
+                                   jsg::Lock& js, jsg::Value value) mutable -> jsg::Value {
+          jsSpan->end();
+          return kj::mv(value);
+        },
+                               [jsSpan = jsSpan.addRef()](
+                                   jsg::Lock& js, jsg::Value exception) mutable -> jsg::Value {
+          jsSpan->end();
+          js.throwException(kj::mv(exception));
+        });
+        // If the promise never settles, the span will still be submitted when the IoOwn is
+        // destroyed (via ~SpanImpl calling end()), though this is a corner case and should
+        // generally be avoided by users.
+        return valuePromiseHandler.wrap(js, kj::mv(promise));
+      } else {
+        // Synchronous success: end immediately.
+        jsSpan->end();
+        return result;
+      }
+    }, [&](jsg::Value exception) -> v8::Local<v8::Value> {
+      // Synchronous exception: end then rethrow.
+      jsSpan->end();
+      js.throwException(kj::mv(exception));
+    });
+  };
+
+  // If we have both an IoContext and an observed span, push the holder onto the
+  // AsyncContextFrame for the duration of the callback. The StorageScope RAII object
+  // restores the prior async-context storage on scope exit; any async continuations captured
+  // during the callback will already have snapshotted the new frame and will continue to
+  // see our child span as "current".
+  KJ_IF_SOME(holder, maybeHolder) {
+    auto& context = IoContext::current();
+    jsg::AsyncContextFrame::StorageScope traceScope =
+        context.makeUserAsyncTraceScope(context.getCurrentLock(), kj::mv(holder));
+    return executeCallback();
+  } else {
+    return executeCallback();
   }
 }
 

--- a/src/workerd/api/tracing-module.h
+++ b/src/workerd/api/tracing-module.h
@@ -5,64 +5,161 @@
 #pragma once
 
 #include <workerd/io/io-context.h>
+#include <workerd/io/trace.h>
+#include <workerd/jsg/jsg.h>
 
 namespace workerd::api {
+class TracingModule;  // Forward decl; defined further down after user_tracing::Span.
+}  // namespace workerd::api
 
-// JavaScript-accessible span class that manages span ownership through IoContext
-class JsSpan: public jsg::Object {
+// The `Span` class exposed to user JavaScript lives in this sub-namespace purely to avoid
+// a name collision with the workerd::Span struct that is used internally by the runtime
+// tracing implementation. Callers outside this file generally don't need to reference this
+// namespace directly - the TracingModule class (which is what gets wired into JS) lives in
+// the surrounding workerd::api namespace.
+namespace workerd::api::user_tracing {
+
+// The types allowed for tag and log values from JavaScript.
+using TagValue = kj::OneOf<bool, double, kj::String>;
+
+// Implementation helper for a tracing span. This is refcounted because the JS-visible Span
+// wraps it in either a kj::Own or an IoOwn depending on whether an IoContext is available,
+// and because the span may be force-ended while refs are still held by JS code.
+//
+// SpanImpl owns a reference to the UserTraceSpanHolder that was pushed onto the
+// AsyncContextFrame by TracingModule::enterSpan(), and clears that holder's contents when the
+// span ends. This ensures that the underlying span observer (which transitively holds a
+// kj::Own<BaseTracer> via its SpanSubmitter) is released at end-of-span rather than at
+// IoContext destruction. Without this, actor IoContexts would leak tracer references across
+// IncomingRequest boundaries and the final "outcome" streaming-tail event would not be emitted
+// at the right time.
+class SpanImpl final: public kj::Refcounted {
  public:
-  JsSpan(kj::Maybe<IoOwn<TraceContext>> span);
-  ~JsSpan() noexcept(false);
+  // Construct an observed span.
+  explicit SpanImpl(kj::Own<workerd::SpanObserver> observer, workerd::Span span);
 
-  // Ends the span, marking its completion. Once ended, the span cannot be modified.
-  // If the span is not explicitly ended, it will be automatically ended when the
-  // JsSpan object is destroyed.
+  // Construct a no-op span (not recording). Used when there is no current user trace span
+  // (e.g., running outside a traced request) or when we are in a context where we cannot
+  // safely observe spans.
+  explicit SpanImpl(decltype(nullptr));
+
+  KJ_DISALLOW_COPY_AND_MOVE(SpanImpl);
+
+  ~SpanImpl() noexcept(false);
+
+  // Records the end time, submits the span via its observer, clears any holder we pushed
+  // onto the AsyncContextFrame, and marks the span as no longer traced. Idempotent:
+  // subsequent calls are no-ops. Called automatically by TracingModule::enterSpan() on
+  // callback completion, and implicitly by the destructor.
   void end();
-  // Sets an attribute on the span. Values can be string, number, boolean, or undefined.
-  // If undefined is passed, the attribute is not set (allows optional chaining).
-  // Note: We intentionally don't support BigInt/int64_t. JavaScript numbers (doubles)
-  // are sufficient for most tracing use cases, and BigInt conversion to int64_t would
-  // require handling truncation for values outside the int64_t range.
-  void setAttribute(
-      jsg::Lock& js, kj::String key, jsg::Optional<kj::OneOf<bool, double, kj::String>> value);
 
-  JSG_RESOURCE_TYPE(JsSpan) {
-    JSG_METHOD(end);
+  bool getIsTraced();
+
+  // Returns a SpanParent wrapping this span's observer, or a null SpanParent if the span has
+  // ended or has no observer. Used by TracingModule::enterSpan() to populate the
+  // UserTraceSpanHolder that gets pushed onto the AsyncContextFrame.
+  workerd::SpanParent makeSpanParent();
+
+  // Sets a single attribute on the span. If value is kj::none, the attribute is not set.
+  void setAttribute(kj::String key, kj::Maybe<TagValue> maybeValue);
+
+  // Attach the UserTraceSpanHolder that was pushed onto the AsyncContextFrame when this span
+  // was activated. Called by TracingModule::enterSpan() before running the callback. When the
+  // span ends, we clear() the holder so that the AsyncContextFrame's reference no longer
+  // keeps the span observer (and thus the BaseTracer) alive.
+  void attachAsyncContextHolder(kj::Own<workerd::UserTraceSpanHolder> holder);
+
+ private:
+  kj::Maybe<kj::Own<workerd::SpanObserver>> observer;
+
+  // The under-construction span, or kj::none if the span has ended.
+  kj::Maybe<workerd::Span> span;
+
+  // The AsyncContextFrame-pushed holder for this span, if any. Cleared in end() to release
+  // the underlying SpanParent (and the observer + BaseTracer chain) promptly.
+  kj::Maybe<kj::Own<workerd::UserTraceSpanHolder>> asyncContextHolder;
+
+  size_t bytesUsed = 0;
+
+  void setSpanDataLimitError(kj::StringPtr itemKind, kj::StringPtr name, size_t valueSize);
+};
+
+// JavaScript-accessible tracing span (exposed as `Span`). From the user's perspective this
+// is the only kind of span there is; internal C++ plumbing lives on SpanImpl. Kept in the
+// workerd::api::user_tracing namespace (not workerd::api) to avoid collision with the
+// runtime's own workerd::Span type.
+//
+// The impl is wrapped in IoOwn when an IoContext exists, so that destruction is funneled
+// through the IoContext's delete queue and cannot cross threads. When no IoContext is
+// available (unusual for user tracing - typically startup paths), a plain kj::Own is used.
+class Span: public jsg::Object {
+ public:
+  explicit Span(kj::OneOf<kj::Own<SpanImpl>, IoOwn<SpanImpl>> impl);
+
+  // Returns true if this span will be recorded. False when the current async context is not
+  // being traced, or when the span has already been submitted (which happens automatically
+  // when the enterSpan callback returns). Callers can gate expensive attribute-computation
+  // code on this.
+  bool getIsTraced();
+
+  // Sets a single attribute. If `value` is undefined, the attribute is not set - useful for
+  // optional fields.
+  void setAttribute(jsg::Lock& js, kj::String key, jsg::Optional<TagValue> value);
+
+  // Ends the span and submits its content to the tracing system. Not exposed to JS - only
+  // called by TracingModule::enterSpan when the user callback returns / throws / its promise
+  // settles. Callers outside this file should not need it.
+  void end();
+
+  JSG_RESOURCE_TYPE(Span) {
+    JSG_READONLY_PROTOTYPE_PROPERTY(isTraced, getIsTraced);
+
     JSG_METHOD(setAttribute);
-    JSG_DISPOSE(end);
   }
 
  private:
-  kj::Maybe<IoOwn<TraceContext>> span;
+  kj::OneOf<kj::Own<SpanImpl>, IoOwn<SpanImpl>> impl;
+
+  friend class ::workerd::api::TracingModule;
 };
 
-// Module that provides tracing capabilities for Workers.
-// This module is available as "cloudflare-internal:tracing" and provides
-// functionality to create and manage tracing spans.
+}  // namespace workerd::api::user_tracing
+
+namespace workerd::api {
+
+// Module providing user tracing capabilities to Workers. Exposed as
+// "cloudflare-internal:tracing".
 class TracingModule: public jsg::Object {
  public:
   TracingModule() = default;
   TracingModule(jsg::Lock&, const jsg::Url&) {}
 
-  // Creates a new tracing span with the given name.
-  // The span will be associated with the current IoContext and will track
-  // the execution of the code within its lifetime.
-  // If no IoContext is available (e.g., during initialization), a no-op span
-  // is returned that safely ignores all operations.
+  // Creates a new child span of the current user trace span, pushes it onto the
+  // AsyncContextFrame as the active user span, invokes callback(span, ...args), and
+  // automatically ends the span on completion. If the callback returns a Promise, the
+  // span is ended when the promise settles (whether fulfilled or rejected). If the
+  // callback returns synchronously (or throws synchronously), the span is ended
+  // before the return (or rethrow).
   //
-  // Example usage:
-  //   const span = tracing.startSpan("my-operation");
-  //   try {
-  //     // ... perform operation ...
-  //   } finally {
-  //     span.end();
-  //   }
-  jsg::Ref<JsSpan> startSpan(jsg::Lock& js, kj::String name);
+  // The span is constructed as a child of whatever span is currently active on the
+  // AsyncContextFrame (or, if none, the root user request span on the current
+  // IncomingRequest, via IoContext::getCurrentUserTraceSpan()).
+  //
+  // If no IoContext is available (e.g., during worker startup), the callback runs with
+  // a no-op span and no AsyncContextFrame push.
+  v8::Local<v8::Value> enterSpan(jsg::Lock& js,
+      kj::String operationName,
+      v8::Local<v8::Function> callback,
+      jsg::Arguments<jsg::Value> args,
+      const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler,
+      const jsg::TypeHandler<jsg::Promise<jsg::Value>>& valuePromiseHandler);
 
   JSG_RESOURCE_TYPE(TracingModule) {
-    JSG_METHOD(startSpan);
+    JSG_METHOD(enterSpan);
 
-    JSG_NESTED_TYPE(JsSpan);
+    // Use the _NAMED variant so the property ends up as `tracing.Span` rather than
+    // `tracing["user_tracing::Span"]`.
+    JSG_NESTED_TYPE_NAMED(user_tracing::Span, Span);
   }
 };
 
@@ -80,6 +177,7 @@ kj::Own<jsg::modules::ModuleBundle> getInternalTracingModuleBundle(auto featureF
   builder.addObject<TracingModule, TypeWrapper>(kSpecifier);
   return builder.finish();
 }
-};  // namespace workerd::api
 
-#define EW_TRACING_MODULE_ISOLATE_TYPES api::TracingModule, api::JsSpan
+}  // namespace workerd::api
+
+#define EW_TRACING_MODULE_ISOLATE_TYPES api::TracingModule, api::user_tracing::Span

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "tracing-module.h"
+#include "tracing.h"
 
 #include <workerd/io/trace.h>
 #include <workerd/io/tracer.h>
@@ -197,11 +197,11 @@ void Span::end() {
 }  // namespace workerd::api::user_tracing
 
 // ======================================================================================
-// TracingModule
+// Tracing
 
 namespace workerd::api {
 
-v8::Local<v8::Value> TracingModule::enterSpan(jsg::Lock& js,
+v8::Local<v8::Value> Tracing::enterSpan(jsg::Lock& js,
     kj::String operationName,
     v8::Local<v8::Function> callback,
     jsg::Arguments<jsg::Value> args,

--- a/src/workerd/api/tracing.h
+++ b/src/workerd/api/tracing.h
@@ -9,13 +9,13 @@
 #include <workerd/jsg/jsg.h>
 
 namespace workerd::api {
-class TracingModule;  // Forward decl; defined further down after user_tracing::Span.
+class Tracing;  // Forward decl; defined further down after user_tracing::Span.
 }  // namespace workerd::api
 
 // The `Span` class exposed to user JavaScript lives in this sub-namespace purely to avoid
 // a name collision with the workerd::Span struct that is used internally by the runtime
 // tracing implementation. Callers outside this file generally don't need to reference this
-// namespace directly - the TracingModule class (which is what gets wired into JS) lives in
+// namespace directly - the Tracing class (which is what gets wired into JS) lives in
 // the surrounding workerd::api namespace.
 namespace workerd::api::user_tracing {
 
@@ -27,7 +27,7 @@ using TagValue = kj::OneOf<bool, double, kj::String>;
 // and because the span may be force-ended while refs are still held by JS code.
 //
 // SpanImpl owns a reference to the UserTraceSpanHolder that was pushed onto the
-// AsyncContextFrame by TracingModule::enterSpan(), and clears that holder's contents when the
+// AsyncContextFrame by Tracing::enterSpan(), and clears that holder's contents when the
 // span ends. This ensures that the underlying span observer (which transitively holds a
 // kj::Own<BaseTracer> via its SpanSubmitter) is released at end-of-span rather than at
 // IoContext destruction. Without this, actor IoContexts would leak tracer references across
@@ -49,14 +49,14 @@ class SpanImpl final: public kj::Refcounted {
 
   // Records the end time, submits the span via its observer, clears any holder we pushed
   // onto the AsyncContextFrame, and marks the span as no longer traced. Idempotent:
-  // subsequent calls are no-ops. Called automatically by TracingModule::enterSpan() on
+  // subsequent calls are no-ops. Called automatically by Tracing::enterSpan() on
   // callback completion, and implicitly by the destructor.
   void end();
 
   bool getIsTraced();
 
   // Returns a SpanParent wrapping this span's observer, or a null SpanParent if the span has
-  // ended or has no observer. Used by TracingModule::enterSpan() to populate the
+  // ended or has no observer. Used by Tracing::enterSpan() to populate the
   // UserTraceSpanHolder that gets pushed onto the AsyncContextFrame.
   workerd::SpanParent makeSpanParent();
 
@@ -64,7 +64,7 @@ class SpanImpl final: public kj::Refcounted {
   void setAttribute(kj::String key, kj::Maybe<TagValue> maybeValue);
 
   // Attach the UserTraceSpanHolder that was pushed onto the AsyncContextFrame when this span
-  // was activated. Called by TracingModule::enterSpan() before running the callback. When the
+  // was activated. Called by Tracing::enterSpan() before running the callback. When the
   // span ends, we clear() the holder so that the AsyncContextFrame's reference no longer
   // keeps the span observer (and thus the BaseTracer) alive.
   void attachAsyncContextHolder(kj::Own<workerd::UserTraceSpanHolder> holder);
@@ -107,7 +107,7 @@ class Span: public jsg::Object {
   void setAttribute(jsg::Lock& js, kj::String key, jsg::Optional<TagValue> value);
 
   // Ends the span and submits its content to the tracing system. Not exposed to JS - only
-  // called by TracingModule::enterSpan when the user callback returns / throws / its promise
+  // called by Tracing::enterSpan when the user callback returns / throws / its promise
   // settles. Callers outside this file should not need it.
   void end();
 
@@ -120,19 +120,23 @@ class Span: public jsg::Object {
  private:
   kj::OneOf<kj::Own<SpanImpl>, IoOwn<SpanImpl>> impl;
 
-  friend class ::workerd::api::TracingModule;
+  friend class ::workerd::api::Tracing;
 };
 
 }  // namespace workerd::api::user_tracing
 
 namespace workerd::api {
 
-// Module providing user tracing capabilities to Workers. Exposed as
-// "cloudflare-internal:tracing".
-class TracingModule: public jsg::Object {
+// User-tracing module. Exposed to JS as the `Tracing` class, reachable both via
+// `import { tracing } from 'cloudflare:workers'` and as `ctx.tracing`, and registered as
+// the builtin module `cloudflare-internal:tracing`. The class name (not "TracingModule")
+// is what shows up in `.d.ts` output and in `typeof ctx.tracing` — historically this was
+// called `TracingModule` back when the API was only reachable via an ES module import;
+// that suffix is vestigial now that it's also a property on `ctx`.
+class Tracing: public jsg::Object {
  public:
-  TracingModule() = default;
-  TracingModule(jsg::Lock&, const jsg::Url&) {}
+  Tracing() = default;
+  Tracing(jsg::Lock&, const jsg::Url&) {}
 
   // Creates a new child span of the current user trace span, pushes it onto the
   // AsyncContextFrame as the active user span, invokes callback(span, ...args), and
@@ -154,18 +158,33 @@ class TracingModule: public jsg::Object {
       const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler,
       const jsg::TypeHandler<jsg::Promise<jsg::Value>>& valuePromiseHandler);
 
-  JSG_RESOURCE_TYPE(TracingModule) {
+  JSG_RESOURCE_TYPE(Tracing) {
     JSG_METHOD(enterSpan);
 
     // Use the _NAMED variant so the property ends up as `tracing.Span` rather than
     // `tracing["user_tracing::Span"]`.
     JSG_NESTED_TYPE_NAMED(user_tracing::Span, Span);
+
+    // Override the auto-generated `enterSpan(name: string, callback: Function, ...args:
+    // any[]): any` with a properly-typed generic form: the callback's first argument is
+    // typed as `Span`, the callback's trailing args flow through to the varargs, and the
+    // return value is preserved. Matches the shape documented in the user-tracing RFC.
+    JSG_TS_OVERRIDE({
+      enterSpan<T, A extends unknown[]>(
+        name: string,
+        callback: (span: Span, ...args: A) => T,
+        ...args: A
+      ): T;
+    });
   }
 };
 
+// Registers `cloudflare-internal:tracing` as a builtin module. The `Module` suffix on the
+// helper is describing what it registers (a JS module), not the name of the class — the
+// class itself is `Tracing` because that's what users see.
 template <class Registry>
 void registerTracingModule(Registry& registry, CompatibilityFlags::Reader flags) {
-  registry.template addBuiltinModule<TracingModule>(
+  registry.template addBuiltinModule<Tracing>(
       "cloudflare-internal:tracing", workerd::jsg::ModuleRegistry::Type::INTERNAL);
 }
 
@@ -174,10 +193,10 @@ kj::Own<jsg::modules::ModuleBundle> getInternalTracingModuleBundle(auto featureF
   jsg::modules::ModuleBundle::BuiltinBuilder builder(
       jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
   static const auto kSpecifier = "cloudflare-internal:tracing"_url;
-  builder.addObject<TracingModule, TypeWrapper>(kSpecifier);
+  builder.addObject<Tracing, TypeWrapper>(kSpecifier);
   return builder.finish();
 }
 
 }  // namespace workerd::api
 
-#define EW_TRACING_MODULE_ISOLATE_TYPES api::TracingModule, api::user_tracing::Span
+#define EW_TRACING_ISOLATE_TYPES api::Tracing, api::user_tracing::Span

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -39,7 +39,7 @@
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/sync-kv.h>
 #include <workerd/api/trace.h>
-#include <workerd/api/tracing-module.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern-standard.h>
@@ -143,7 +143,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_WORKERS_MODULE_ISOLATE_TYPES,
     EW_EXPORT_LOOPBACK_ISOLATE_TYPES,
     EW_PERFORMANCE_ISOLATE_TYPES,
-    EW_TRACING_MODULE_ISOLATE_TYPES,
+    EW_TRACING_ISOLATE_TYPES,
     EW_WORKERD_DEBUG_PORT_CLIENT_ISOLATE_TYPES,
     workerd::api::EnvModule,
     workerd::api::PythonPatchedEnv,

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -28,7 +28,7 @@ cc_ast_dump(
         "//src/workerd/api:memory-cache",
         "//src/workerd/api:r2",
         "//src/workerd/api:streams",
-        "//src/workerd/api:tracing-module",
+        "//src/workerd/api:tracing",
         "//src/workerd/api:urlpattern",
         "//src/workerd/api:urlpattern-standard",
         "//src/workerd/api:worker-loader",

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -28,7 +28,6 @@ cc_ast_dump(
         "//src/workerd/api:memory-cache",
         "//src/workerd/api:r2",
         "//src/workerd/api:streams",
-        "//src/workerd/api:tracing",
         "//src/workerd/api:urlpattern",
         "//src/workerd/api:urlpattern-standard",
         "//src/workerd/api:worker-loader",

--- a/src/workerd/tools/param-names-ast.c++
+++ b/src/workerd/tools/param-names-ast.c++
@@ -33,7 +33,7 @@
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/sync-kv.h>
 #include <workerd/api/trace.h>
-#include <workerd/api/tracing-module.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern-standard.h>

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -386,6 +386,8 @@ declare namespace CloudflareWorkersModule {
 
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+
+  export const tracing: Tracing;
 }
 
 declare module 'cloudflare:workers' {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -501,6 +501,7 @@ interface ExecutionContext<Props = unknown> {
     readonly key?: string;
     readonly override?: string;
   };
+  tracing?: Tracing;
   abort(reason?: any): void;
 }
 type ExportedHandlerFetchHandler<
@@ -4712,6 +4713,18 @@ interface EventCounts {
     param2?: any,
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
+}
+interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
@@ -14388,6 +14401,7 @@ declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 declare module "cloudflare:workers" {
   export = CloudflareWorkersModule;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -503,6 +503,7 @@ export interface ExecutionContext<Props = unknown> {
     readonly key?: string;
     readonly override?: string;
   };
+  tracing?: Tracing;
   abort(reason?: any): void;
 }
 export type ExportedHandlerFetchHandler<
@@ -4718,6 +4719,18 @@ export interface EventCounts {
     param2?: any,
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
+}
+export interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+export declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
@@ -14359,6 +14372,7 @@ export declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -480,6 +480,7 @@ interface ExecutionContext<Props = unknown> {
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
   cache?: CacheContext;
+  tracing?: Tracing;
 }
 type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -4052,6 +4053,18 @@ declare abstract class Performance {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/toJSON)
    */
   toJSON(): object;
+}
+interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
@@ -13728,6 +13741,7 @@ declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 declare module "cloudflare:workers" {
   export = CloudflareWorkersModule;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -482,6 +482,7 @@ export interface ExecutionContext<Props = unknown> {
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
   cache?: CacheContext;
+  tracing?: Tracing;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -4058,6 +4059,18 @@ export declare abstract class Performance {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/toJSON)
    */
   toJSON(): object;
+}
+export interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+export declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
@@ -13699,6 +13712,7 @@ export declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -115,7 +115,7 @@ export function isUnsatisfiable(typeNode: ts.TypeNode): boolean {
 // For instance, a new hypothetical API called `workerd::api::magic::MakeASpell` would be
 // `magicMakeASpell`.
 const replaceEmpty =
-  /^workerd::api::public_beta::|^workerd::api::urlpattern::|^workerd::api::node::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
+  /^workerd::api::public_beta::|^workerd::api::urlpattern::|^workerd::api::node::|^workerd::api::user_tracing::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
 // Strings to replace in fully-qualified structure names with an underscore
 const replaceUnderscore = /[<,]/g;
 export function getTypeName(


### PR DESCRIPTION
Replaces `tracing.startSpan(name) -> JsSpan` with
`tracing.enterSpan(name, callback, ...args)`, which pushes the new span onto the AsyncContextFrame for the callback's duration and auto-ends it on return, throw, or promise settlement. This makes nested spans and runtime-generated spans (e.g. `fetch`) correctly parent on the surrounding user span.

Child spans are wrapped in a fresh UserTraceSpanHolder before being pushed onto the AsyncContextFrame; the holder is cleared by SpanImpl::end() so actor IoContexts don't leak tracer refs across requests.

`Span` and `SpanImpl` live in a new `workerd::api::user_tracing` sub-namespace to avoid collision with `workerd::Span`. The JS class name is still `Span` via `JSG_NESTED_TYPE_NAMED`.

`withSpan` in tracing-helpers.ts becomes a one-line passthrough over `enterSpan`, so downstream callers (d1, images, etc.) need no changes.

Adds tracing-hierarchy-test which verifies parent/child relationships in the streaming-tail event stream for nested enterSpan (sync and async), fetch-inside-enterSpan, fetch-inside-nested-enterSpan, and sibling enterSpan calls.