### PR TITLE
Rename TracingModule class to Tracing

### DIFF
--- a/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
@@ -34,6 +34,8 @@ export const validateSpans = {
         test: 'setAttributeUndefined',
         expectedSpan: 'undefined-attr-op',
       },
+      { test: 'publicImportTracing', expectedSpan: 'public-import-op' },
+      { test: 'ctxTracing', expectedSpan: 'ctx-tracing-op' },
     ];
 
     for (const { test, expectedSpan } of testValidations) {

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import assert from 'node:assert';
+import { tracing as publicTracing } from 'cloudflare:workers';
 
 export const syncFunction = {
   async test(ctrl, env, ctx) {
@@ -179,5 +180,39 @@ export const nestedAsyncSpans = {
     );
 
     assert.strictEqual(result, 'nested-async-value');
+  },
+};
+
+// Verify the public import path: `import { tracing } from 'cloudflare:workers'`.
+// Hitting enterSpan via the public import should behave identically to the internal path.
+export const publicImportTracing = {
+  async test(ctrl, env, ctx) {
+    const result = publicTracing.enterSpan('public-import-op', (span) => {
+      span.setAttribute('test', 'publicImportTracing');
+      span.setAttribute('path', 'import-from-cloudflare-workers');
+      assert.strictEqual(span.isTraced, true);
+      return 'public-import-value';
+    });
+    assert.strictEqual(result, 'public-import-value');
+  },
+};
+
+// Verify ctx.tracing: same Tracing instance should be reachable off the execution context.
+export const ctxTracing = {
+  async test(ctrl, env, ctx) {
+    assert.ok(ctx.tracing, 'ctx.tracing should be defined');
+    assert.strictEqual(
+      typeof ctx.tracing.enterSpan,
+      'function',
+      'ctx.tracing.enterSpan should be a function'
+    );
+
+    const result = ctx.tracing.enterSpan('ctx-tracing-op', (span) => {
+      span.setAttribute('test', 'ctxTracing');
+      span.setAttribute('path', 'ctx.tracing');
+      assert.strictEqual(span.isTraced, true);
+      return 'ctx-tracing-value';
+    });
+    assert.strictEqual(result, 'ctx-tracing-value');
   },
 };

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -7,6 +7,7 @@
 
 import entrypoints from 'cloudflare-internal:workers';
 import innerEnv from 'cloudflare-internal:env';
+import innerTracing from 'cloudflare-internal:tracing';
 
 export const WorkerEntrypoint = entrypoints.WorkerEntrypoint;
 export const DurableObject = entrypoints.DurableObject;
@@ -151,3 +152,5 @@ export const exports = new Proxy(
 );
 
 export const waitUntil = entrypoints.waitUntil.bind(entrypoints);
+
+export const tracing = innerTracing;

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -301,9 +301,9 @@ wd_cc_library(
 )
 
 wd_cc_library(
-    name = "tracing-module",
-    srcs = ["tracing-module.c++"],
-    hdrs = ["tracing-module.h"],
+    name = "tracing",
+    srcs = ["tracing.c++"],
+    hdrs = ["tracing.h"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/workerd/io",
@@ -340,7 +340,7 @@ wd_cc_library(
         ":hyperdrive",
         ":memory-cache",
         ":r2",
-        ":tracing-module",
+        ":tracing",
         ":workers-module",
         "//src/cloudflare",
         "//src/node",

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -33,6 +33,7 @@ filegroup(
         "sync-kv.c++",
         "system-streams.c++",
         "trace.c++",
+        "tracing.c++",
         "unsafe.c++",
         "url-standard.c++",
         "web-socket.c++",
@@ -80,6 +81,7 @@ filegroup(
         "sync-kv.h",
         "system-streams.h",
         "trace.h",
+        "tracing.h",
         "unsafe.h",
         "url-standard.h",
         "web-socket.h",
@@ -301,17 +303,6 @@ wd_cc_library(
 )
 
 wd_cc_library(
-    name = "tracing",
-    srcs = ["tracing.c++"],
-    hdrs = ["tracing.h"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//src/workerd/io",
-        "//src/workerd/jsg",
-    ],
-)
-
-wd_cc_library(
     name = "rtti",
     srcs = [
         "modules.c++",
@@ -340,7 +331,6 @@ wd_cc_library(
         ":hyperdrive",
         ":memory-cache",
         ":r2",
-        ":tracing",
         ":workers-module",
         "//src/cloudflare",
         "//src/node",

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -18,6 +18,7 @@
 #include <workerd/api/sockets.h>
 #include <workerd/api/system-streams.h>
 #include <workerd/api/trace.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/util.h>
 #include <workerd/api/worker-rpc.h>
 #include <workerd/io/compatibility-date.h>
@@ -81,6 +82,13 @@ jsg::Promise<CachePurgeResult> CacheContext::purge(jsg::Lock& js,
     const jsg::TypeHandler<CachePurgeResult>& resultHandler,
     const jsg::TypeHandler<jsg::Ref<JsRpcProperty>>& rpcPropHandler) {
   JSG_FAIL_REQUIRE(Error, "Cache purge is not available in this context.");
+}
+
+jsg::Optional<jsg::Ref<Tracing>> ExecutionContext::getTracing(jsg::Lock& js) {
+  if (!FeatureFlags::get(js).getWorkerdExperimental()) {
+    return kj::none;
+  }
+  return js.alloc<Tracing>();
 }
 
 void ExecutionContext::abort(jsg::Lock& js, jsg::Optional<jsg::Value> reason) {

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -27,6 +27,7 @@ class DOMException;
 
 namespace workerd::api {
 
+class Tracing;
 class TailEvent;
 class Cache;
 class CacheStorage;
@@ -289,6 +290,8 @@ class ExecutionContext: public jsg::Object {
     return js.undefined();
   }
 
+  jsg::Optional<jsg::Ref<Tracing>> getTracing(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(ExecutionContext, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     JSG_METHOD(passThroughOnException);
@@ -300,6 +303,13 @@ class ExecutionContext: public jsg::Object {
     if (flags.getEnableVersionApi()) {
       JSG_LAZY_INSTANCE_PROPERTY(version, getVersion);
     }
+
+    // ctx.tracing - user tracing API. The *type* is always visible (so the generated
+    // `Tracing` / `Span` types exist in every compat-date snapshot, not only the
+    // experimental one). The *value* is `undefined` outside the `workerdExperimental`
+    // compat flag - the gate lives in `getTracing()` in global-scope.c++.
+    // TODO: Remove this comment once the feature is stable.
+    JSG_LAZY_INSTANCE_PROPERTY(tracing, getTracing);
 
     if (flags.getWorkerdExperimental()) {
       // TODO(soon): Before making this generally available we need to:

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -11,7 +11,7 @@
 #include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/rtti.h>
 #include <workerd/api/sockets.h>
-#include <workerd/api/tracing-module.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/workers-module.h>
 #include <workerd/jsg/modules-new.h>

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -35,7 +35,7 @@
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/sync-kv.h>
 #include <workerd/api/trace.h>
-#include <workerd/api/tracing-module.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern-standard.h>
@@ -95,7 +95,7 @@
   F("sync-kv", EW_SYNC_KV_ISOLATE_TYPES)                                                           \
   F("worker-loader", EW_WORKER_LOADER_ISOLATE_TYPES)                                               \
   F("performance", EW_PERFORMANCE_ISOLATE_TYPES)                                                   \
-  F("tracing-module", EW_TRACING_MODULE_ISOLATE_TYPES)
+  F("tracing", EW_TRACING_ISOLATE_TYPES)
 
 namespace workerd::api {
 

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#include "tracing-module.h"
+#include "tracing.h"
 
 #include <workerd/io/trace.h>
 #include <workerd/io/tracer.h>
@@ -197,11 +197,11 @@ void Span::end() {
 }  // namespace workerd::api::user_tracing
 
 // ======================================================================================
-// TracingModule
+// Tracing
 
 namespace workerd::api {
 
-v8::Local<v8::Value> TracingModule::enterSpan(jsg::Lock& js,
+v8::Local<v8::Value> Tracing::enterSpan(jsg::Lock& js,
     kj::String operationName,
     v8::Local<v8::Function> callback,
     jsg::Arguments<jsg::Value> args,

--- a/src/workerd/api/tracing.h
+++ b/src/workerd/api/tracing.h
@@ -9,13 +9,13 @@
 #include <workerd/jsg/jsg.h>
 
 namespace workerd::api {
-class TracingModule;  // Forward decl; defined further down after user_tracing::Span.
+class Tracing;  // Forward decl; defined further down after user_tracing::Span.
 }  // namespace workerd::api
 
 // The `Span` class exposed to user JavaScript lives in this sub-namespace purely to avoid
 // a name collision with the workerd::Span struct that is used internally by the runtime
 // tracing implementation. Callers outside this file generally don't need to reference this
-// namespace directly - the TracingModule class (which is what gets wired into JS) lives in
+// namespace directly - the Tracing class (which is what gets wired into JS) lives in
 // the surrounding workerd::api namespace.
 namespace workerd::api::user_tracing {
 
@@ -27,7 +27,7 @@ using TagValue = kj::OneOf<bool, double, kj::String>;
 // and because the span may be force-ended while refs are still held by JS code.
 //
 // SpanImpl owns a reference to the UserTraceSpanHolder that was pushed onto the
-// AsyncContextFrame by TracingModule::enterSpan(), and clears that holder's contents when the
+// AsyncContextFrame by Tracing::enterSpan(), and clears that holder's contents when the
 // span ends. This ensures that the underlying span observer (which transitively holds a
 // kj::Own<BaseTracer> via its SpanSubmitter) is released at end-of-span rather than at
 // IoContext destruction. Without this, actor IoContexts would leak tracer references across
@@ -49,14 +49,14 @@ class SpanImpl final: public kj::Refcounted {
 
   // Records the end time, submits the span via its observer, clears any holder we pushed
   // onto the AsyncContextFrame, and marks the span as no longer traced. Idempotent:
-  // subsequent calls are no-ops. Called automatically by TracingModule::enterSpan() on
+  // subsequent calls are no-ops. Called automatically by Tracing::enterSpan() on
   // callback completion, and implicitly by the destructor.
   void end();
 
   bool getIsTraced();
 
   // Returns a SpanParent wrapping this span's observer, or a null SpanParent if the span has
-  // ended or has no observer. Used by TracingModule::enterSpan() to populate the
+  // ended or has no observer. Used by Tracing::enterSpan() to populate the
   // UserTraceSpanHolder that gets pushed onto the AsyncContextFrame.
   workerd::SpanParent makeSpanParent();
 
@@ -64,7 +64,7 @@ class SpanImpl final: public kj::Refcounted {
   void setAttribute(kj::String key, kj::Maybe<TagValue> maybeValue);
 
   // Attach the UserTraceSpanHolder that was pushed onto the AsyncContextFrame when this span
-  // was activated. Called by TracingModule::enterSpan() before running the callback. When the
+  // was activated. Called by Tracing::enterSpan() before running the callback. When the
   // span ends, we clear() the holder so that the AsyncContextFrame's reference no longer
   // keeps the span observer (and thus the BaseTracer) alive.
   void attachAsyncContextHolder(kj::Own<workerd::UserTraceSpanHolder> holder);
@@ -107,7 +107,7 @@ class Span: public jsg::Object {
   void setAttribute(jsg::Lock& js, kj::String key, jsg::Optional<TagValue> value);
 
   // Ends the span and submits its content to the tracing system. Not exposed to JS - only
-  // called by TracingModule::enterSpan when the user callback returns / throws / its promise
+  // called by Tracing::enterSpan when the user callback returns / throws / its promise
   // settles. Callers outside this file should not need it.
   void end();
 
@@ -120,19 +120,23 @@ class Span: public jsg::Object {
  private:
   kj::OneOf<kj::Own<SpanImpl>, IoOwn<SpanImpl>> impl;
 
-  friend class ::workerd::api::TracingModule;
+  friend class ::workerd::api::Tracing;
 };
 
 }  // namespace workerd::api::user_tracing
 
 namespace workerd::api {
 
-// Module providing user tracing capabilities to Workers. Exposed as
-// "cloudflare-internal:tracing".
-class TracingModule: public jsg::Object {
+// User-tracing module. Exposed to JS as the `Tracing` class, reachable both via
+// `import { tracing } from 'cloudflare:workers'` and as `ctx.tracing`, and registered as
+// the builtin module `cloudflare-internal:tracing`. The class name (not "TracingModule")
+// is what shows up in `.d.ts` output and in `typeof ctx.tracing` — historically this was
+// called `TracingModule` back when the API was only reachable via an ES module import;
+// that suffix is vestigial now that it's also a property on `ctx`.
+class Tracing: public jsg::Object {
  public:
-  TracingModule() = default;
-  TracingModule(jsg::Lock&, const jsg::Url&) {}
+  Tracing() = default;
+  Tracing(jsg::Lock&, const jsg::Url&) {}
 
   // Creates a new child span of the current user trace span, pushes it onto the
   // AsyncContextFrame as the active user span, invokes callback(span, ...args), and
@@ -154,18 +158,33 @@ class TracingModule: public jsg::Object {
       const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler,
       const jsg::TypeHandler<jsg::Promise<jsg::Value>>& valuePromiseHandler);
 
-  JSG_RESOURCE_TYPE(TracingModule) {
+  JSG_RESOURCE_TYPE(Tracing) {
     JSG_METHOD(enterSpan);
 
     // Use the _NAMED variant so the property ends up as `tracing.Span` rather than
     // `tracing["user_tracing::Span"]`.
     JSG_NESTED_TYPE_NAMED(user_tracing::Span, Span);
+
+    // Override the auto-generated `enterSpan(name: string, callback: Function, ...args:
+    // any[]): any` with a properly-typed generic form: the callback's first argument is
+    // typed as `Span`, the callback's trailing args flow through to the varargs, and the
+    // return value is preserved. Matches the shape documented in the user-tracing RFC.
+    JSG_TS_OVERRIDE({
+      enterSpan<T, A extends unknown[]>(
+        name: string,
+        callback: (span: Span, ...args: A) => T,
+        ...args: A
+      ): T;
+    });
   }
 };
 
+// Registers `cloudflare-internal:tracing` as a builtin module. The `Module` suffix on the
+// helper is describing what it registers (a JS module), not the name of the class — the
+// class itself is `Tracing` because that's what users see.
 template <class Registry>
 void registerTracingModule(Registry& registry, CompatibilityFlags::Reader flags) {
-  registry.template addBuiltinModule<TracingModule>(
+  registry.template addBuiltinModule<Tracing>(
       "cloudflare-internal:tracing", workerd::jsg::ModuleRegistry::Type::INTERNAL);
 }
 
@@ -174,10 +193,10 @@ kj::Own<jsg::modules::ModuleBundle> getInternalTracingModuleBundle(auto featureF
   jsg::modules::ModuleBundle::BuiltinBuilder builder(
       jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
   static const auto kSpecifier = "cloudflare-internal:tracing"_url;
-  builder.addObject<TracingModule, TypeWrapper>(kSpecifier);
+  builder.addObject<Tracing, TypeWrapper>(kSpecifier);
   return builder.finish();
 }
 
 }  // namespace workerd::api
 
-#define EW_TRACING_MODULE_ISOLATE_TYPES api::TracingModule, api::user_tracing::Span
+#define EW_TRACING_ISOLATE_TYPES api::Tracing, api::user_tracing::Span

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -39,7 +39,7 @@
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/sync-kv.h>
 #include <workerd/api/trace.h>
-#include <workerd/api/tracing-module.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern-standard.h>
@@ -143,7 +143,7 @@ JSG_DECLARE_ISOLATE_TYPE(JsgWorkerdIsolate,
     EW_WORKERS_MODULE_ISOLATE_TYPES,
     EW_EXPORT_LOOPBACK_ISOLATE_TYPES,
     EW_PERFORMANCE_ISOLATE_TYPES,
-    EW_TRACING_MODULE_ISOLATE_TYPES,
+    EW_TRACING_ISOLATE_TYPES,
     EW_WORKERD_DEBUG_PORT_CLIENT_ISOLATE_TYPES,
     workerd::api::EnvModule,
     workerd::api::PythonPatchedEnv,

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -28,7 +28,7 @@ cc_ast_dump(
         "//src/workerd/api:memory-cache",
         "//src/workerd/api:r2",
         "//src/workerd/api:streams",
-        "//src/workerd/api:tracing-module",
+        "//src/workerd/api:tracing",
         "//src/workerd/api:urlpattern",
         "//src/workerd/api:urlpattern-standard",
         "//src/workerd/api:worker-loader",

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -28,7 +28,6 @@ cc_ast_dump(
         "//src/workerd/api:memory-cache",
         "//src/workerd/api:r2",
         "//src/workerd/api:streams",
-        "//src/workerd/api:tracing",
         "//src/workerd/api:urlpattern",
         "//src/workerd/api:urlpattern-standard",
         "//src/workerd/api:worker-loader",

--- a/src/workerd/tools/param-names-ast.c++
+++ b/src/workerd/tools/param-names-ast.c++
@@ -33,7 +33,7 @@
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/sync-kv.h>
 #include <workerd/api/trace.h>
-#include <workerd/api/tracing-module.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/unsafe.h>
 #include <workerd/api/url-standard.h>
 #include <workerd/api/urlpattern-standard.h>

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -386,6 +386,8 @@ declare namespace CloudflareWorkersModule {
 
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+
+  export const tracing: Tracing;
 }
 
 declare module 'cloudflare:workers' {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -501,6 +501,7 @@ interface ExecutionContext<Props = unknown> {
     readonly key?: string;
     readonly override?: string;
   };
+  tracing?: Tracing;
   abort(reason?: any): void;
 }
 type ExportedHandlerFetchHandler<
@@ -4712,6 +4713,18 @@ interface EventCounts {
     param2?: any,
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
+}
+interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
@@ -14388,6 +14401,7 @@ declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 declare module "cloudflare:workers" {
   export = CloudflareWorkersModule;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -503,6 +503,7 @@ export interface ExecutionContext<Props = unknown> {
     readonly key?: string;
     readonly override?: string;
   };
+  tracing?: Tracing;
   abort(reason?: any): void;
 }
 export type ExportedHandlerFetchHandler<
@@ -4718,6 +4719,18 @@ export interface EventCounts {
     param2?: any,
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
+}
+export interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+export declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
@@ -14359,6 +14372,7 @@ export declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -480,6 +480,7 @@ interface ExecutionContext<Props = unknown> {
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
   cache?: CacheContext;
+  tracing?: Tracing;
 }
 type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -4052,6 +4053,18 @@ declare abstract class Performance {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/toJSON)
    */
   toJSON(): object;
+}
+interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
@@ -13728,6 +13741,7 @@ declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 declare module "cloudflare:workers" {
   export = CloudflareWorkersModule;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -482,6 +482,7 @@ export interface ExecutionContext<Props = unknown> {
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
   cache?: CacheContext;
+  tracing?: Tracing;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -4058,6 +4059,18 @@ export declare abstract class Performance {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/toJSON)
    */
   toJSON(): object;
+}
+export interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+export declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
@@ -13699,6 +13712,7 @@ export declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -115,7 +115,7 @@ export function isUnsatisfiable(typeNode: ts.TypeNode): boolean {
 // For instance, a new hypothetical API called `workerd::api::magic::MakeASpell` would be
 // `magicMakeASpell`.
 const replaceEmpty =
-  /^workerd::api::public_beta::|^workerd::api::urlpattern::|^workerd::api::node::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
+  /^workerd::api::public_beta::|^workerd::api::urlpattern::|^workerd::api::node::|^workerd::api::user_tracing::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
 // Strings to replace in fully-qualified structure names with an underscore
 const replaceUnderscore = /[<,]/g;
 export function getTypeName(


### PR DESCRIPTION
The class name is what users see in generated .d.ts output and in `typeof` on the JS-side object. The 'Module' suffix was a vestige from when the API was only reachable as an ESM import (`import { tracing } from 'cloudflare:workers'`); it no longer describes the type accurately.

Pure refactor: no behavior change and no new JS surface. The module-registration helpers (`registerTracingModule`, `getInternalTracingModuleBundle`) keep the 'Module' suffix — they describe the JS module registration, not the class.