### PR TITLE
Expose Tracing on ctx.tracing and 'cloudflare:workers' import

### DIFF
--- a/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
@@ -34,6 +34,8 @@ export const validateSpans = {
         test: 'setAttributeUndefined',
         expectedSpan: 'undefined-attr-op',
       },
+      { test: 'publicImportTracing', expectedSpan: 'public-import-op' },
+      { test: 'ctxTracing', expectedSpan: 'ctx-tracing-op' },
     ];
 
     for (const { test, expectedSpan } of testValidations) {

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import assert from 'node:assert';
+import { tracing as publicTracing } from 'cloudflare:workers';
 
 export const syncFunction = {
   async test(ctrl, env, ctx) {
@@ -179,5 +180,39 @@ export const nestedAsyncSpans = {
     );
 
     assert.strictEqual(result, 'nested-async-value');
+  },
+};
+
+// Verify the public import path: `import { tracing } from 'cloudflare:workers'`.
+// Hitting enterSpan via the public import should behave identically to the internal path.
+export const publicImportTracing = {
+  async test(ctrl, env, ctx) {
+    const result = publicTracing.enterSpan('public-import-op', (span) => {
+      span.setAttribute('test', 'publicImportTracing');
+      span.setAttribute('path', 'import-from-cloudflare-workers');
+      assert.strictEqual(span.isTraced, true);
+      return 'public-import-value';
+    });
+    assert.strictEqual(result, 'public-import-value');
+  },
+};
+
+// Verify ctx.tracing: same Tracing instance should be reachable off the execution context.
+export const ctxTracing = {
+  async test(ctrl, env, ctx) {
+    assert.ok(ctx.tracing, 'ctx.tracing should be defined');
+    assert.strictEqual(
+      typeof ctx.tracing.enterSpan,
+      'function',
+      'ctx.tracing.enterSpan should be a function'
+    );
+
+    const result = ctx.tracing.enterSpan('ctx-tracing-op', (span) => {
+      span.setAttribute('test', 'ctxTracing');
+      span.setAttribute('path', 'ctx.tracing');
+      assert.strictEqual(span.isTraced, true);
+      return 'ctx-tracing-value';
+    });
+    assert.strictEqual(result, 'ctx-tracing-value');
   },
 };

--- a/src/cloudflare/workers.ts
+++ b/src/cloudflare/workers.ts
@@ -7,6 +7,7 @@
 
 import entrypoints from 'cloudflare-internal:workers';
 import innerEnv from 'cloudflare-internal:env';
+import innerTracing from 'cloudflare-internal:tracing';
 
 export const WorkerEntrypoint = entrypoints.WorkerEntrypoint;
 export const DurableObject = entrypoints.DurableObject;
@@ -151,3 +152,5 @@ export const exports = new Proxy(
 );
 
 export const waitUntil = entrypoints.waitUntil.bind(entrypoints);
+
+export const tracing = innerTracing;

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -33,6 +33,7 @@ filegroup(
         "sync-kv.c++",
         "system-streams.c++",
         "trace.c++",
+        "tracing.c++",
         "unsafe.c++",
         "url-standard.c++",
         "web-socket.c++",
@@ -80,6 +81,7 @@ filegroup(
         "sync-kv.h",
         "system-streams.h",
         "trace.h",
+        "tracing.h",
         "unsafe.h",
         "url-standard.h",
         "web-socket.h",
@@ -301,17 +303,6 @@ wd_cc_library(
 )
 
 wd_cc_library(
-    name = "tracing",
-    srcs = ["tracing.c++"],
-    hdrs = ["tracing.h"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//src/workerd/io",
-        "//src/workerd/jsg",
-    ],
-)
-
-wd_cc_library(
     name = "rtti",
     srcs = [
         "modules.c++",
@@ -340,7 +331,6 @@ wd_cc_library(
         ":hyperdrive",
         ":memory-cache",
         ":r2",
-        ":tracing",
         ":workers-module",
         "//src/cloudflare",
         "//src/node",

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -18,6 +18,7 @@
 #include <workerd/api/sockets.h>
 #include <workerd/api/system-streams.h>
 #include <workerd/api/trace.h>
+#include <workerd/api/tracing.h>
 #include <workerd/api/util.h>
 #include <workerd/api/worker-rpc.h>
 #include <workerd/io/compatibility-date.h>
@@ -81,6 +82,13 @@ jsg::Promise<CachePurgeResult> CacheContext::purge(jsg::Lock& js,
     const jsg::TypeHandler<CachePurgeResult>& resultHandler,
     const jsg::TypeHandler<jsg::Ref<JsRpcProperty>>& rpcPropHandler) {
   JSG_FAIL_REQUIRE(Error, "Cache purge is not available in this context.");
+}
+
+jsg::Optional<jsg::Ref<Tracing>> ExecutionContext::getTracing(jsg::Lock& js) {
+  if (!FeatureFlags::get(js).getWorkerdExperimental()) {
+    return kj::none;
+  }
+  return js.alloc<Tracing>();
 }
 
 void ExecutionContext::abort(jsg::Lock& js, jsg::Optional<jsg::Value> reason) {

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -27,6 +27,7 @@ class DOMException;
 
 namespace workerd::api {
 
+class Tracing;
 class TailEvent;
 class Cache;
 class CacheStorage;
@@ -289,6 +290,8 @@ class ExecutionContext: public jsg::Object {
     return js.undefined();
   }
 
+  jsg::Optional<jsg::Ref<Tracing>> getTracing(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(ExecutionContext, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     JSG_METHOD(passThroughOnException);
@@ -300,6 +303,13 @@ class ExecutionContext: public jsg::Object {
     if (flags.getEnableVersionApi()) {
       JSG_LAZY_INSTANCE_PROPERTY(version, getVersion);
     }
+
+    // ctx.tracing - user tracing API. The *type* is always visible (so the generated
+    // `Tracing` / `Span` types exist in every compat-date snapshot, not only the
+    // experimental one). The *value* is `undefined` outside the `workerdExperimental`
+    // compat flag - the gate lives in `getTracing()` in global-scope.c++.
+    // TODO: Remove this comment once the feature is stable.
+    JSG_LAZY_INSTANCE_PROPERTY(tracing, getTracing);
 
     if (flags.getWorkerdExperimental()) {
       // TODO(soon): Before making this generally available we need to:

--- a/src/workerd/tools/BUILD.bazel
+++ b/src/workerd/tools/BUILD.bazel
@@ -28,7 +28,6 @@ cc_ast_dump(
         "//src/workerd/api:memory-cache",
         "//src/workerd/api:r2",
         "//src/workerd/api:streams",
-        "//src/workerd/api:tracing",
         "//src/workerd/api:urlpattern",
         "//src/workerd/api:urlpattern-standard",
         "//src/workerd/api:worker-loader",

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -386,6 +386,8 @@ declare namespace CloudflareWorkersModule {
 
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+
+  export const tracing: Tracing;
 }
 
 declare module 'cloudflare:workers' {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -501,6 +501,7 @@ interface ExecutionContext<Props = unknown> {
     readonly key?: string;
     readonly override?: string;
   };
+  tracing?: Tracing;
   abort(reason?: any): void;
 }
 type ExportedHandlerFetchHandler<
@@ -4712,6 +4713,18 @@ interface EventCounts {
     param2?: any,
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
+}
+interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
@@ -14388,6 +14401,7 @@ declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 declare module "cloudflare:workers" {
   export = CloudflareWorkersModule;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -503,6 +503,7 @@ export interface ExecutionContext<Props = unknown> {
     readonly key?: string;
     readonly override?: string;
   };
+  tracing?: Tracing;
   abort(reason?: any): void;
 }
 export type ExportedHandlerFetchHandler<
@@ -4718,6 +4719,18 @@ export interface EventCounts {
     param2?: any,
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
+}
+export interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+export declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
@@ -14359,6 +14372,7 @@ export declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -480,6 +480,7 @@ interface ExecutionContext<Props = unknown> {
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
   cache?: CacheContext;
+  tracing?: Tracing;
 }
 type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -4052,6 +4053,18 @@ declare abstract class Performance {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/toJSON)
    */
   toJSON(): object;
+}
+interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
@@ -13728,6 +13741,7 @@ declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 declare module "cloudflare:workers" {
   export = CloudflareWorkersModule;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -482,6 +482,7 @@ export interface ExecutionContext<Props = unknown> {
   readonly exports: Cloudflare.Exports;
   readonly props: Props;
   cache?: CacheContext;
+  tracing?: Tracing;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,
@@ -4058,6 +4059,18 @@ export declare abstract class Performance {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Performance/toJSON)
    */
   toJSON(): object;
+}
+export interface Tracing {
+  enterSpan<T, A extends unknown[]>(
+    name: string,
+    callback: (span: Span, ...args: A) => T,
+    ...args: A
+  ): T;
+  Span: typeof Span;
+}
+export declare abstract class Span {
+  get isTraced(): boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
 }
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
@@ -13699,6 +13712,7 @@ export declare namespace CloudflareWorkersModule {
   ): unknown;
   export const env: Cloudflare.Env;
   export const exports: Cloudflare.Exports;
+  export const tracing: Tracing;
 }
 export interface SecretsStoreSecret {
   /**

--- a/types/src/generator/type.ts
+++ b/types/src/generator/type.ts
@@ -115,7 +115,7 @@ export function isUnsatisfiable(typeNode: ts.TypeNode): boolean {
 // For instance, a new hypothetical API called `workerd::api::magic::MakeASpell` would be
 // `magicMakeASpell`.
 const replaceEmpty =
-  /^workerd::api::public_beta::|^workerd::api::urlpattern::|^workerd::api::node::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
+  /^workerd::api::public_beta::|^workerd::api::urlpattern::|^workerd::api::node::|^workerd::api::user_tracing::|^workerd::api::|^workerd::jsg::|::|[ >]/g;
 // Strings to replace in fully-qualified structure names with an underscore
 const replaceUnderscore = /[<,]/g;
 export function getTypeName(


### PR DESCRIPTION
Adds `ctx.tracing` (gated on the `workerdExperimental` compat flag in `getTracing`, which returns `undefined` outside the flag) and a `tracing` named export on `cloudflare:workers` that re-exports the `cloudflare-internal:tracing` module.

The BUILD.bazel change folds `tracing.{h,c++}` into the `api:srcs` / `:hdrs` filegroups and drops the standalone `wd_cc_library(name = "tracing-module")` target. This is the idiomatic workaround for the api<->io circular dep documented in `src/workerd/io/BUILD.bazel`: `global-scope.c++` now needs the full `Tracing` definition to implement `getTracing`, and `global-scope.c++` lives inside `//src/workerd/io` via that filegroup, so a standalone tracing-module library that (transitively) depends on `//src/workerd/io` would cycle.