### PR TITLE
Change some memcpy to memmove

### DIFF
--- a/src/workerd/api/node/buffer.c++
+++ b/src/workerd/api/node/buffer.c++
@@ -655,7 +655,9 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::JsUint8Array bytes, jsg::Js
           // point (but still use the rest of the incomplete bytes from this
           // chunk) and assume that the new, unexpected byte starts a new one.
           statePtr[kMissingBytes] = 0;
-          memcpy(getIncompleteCharacterBuffer(statePtr) + getBufferedBytes(statePtr), data, i);
+          // Use memmove: data may point into the incomplete character buffer
+          // (e.g. when the caller passes decoder.lastChar as input).
+          memmove(getIncompleteCharacterBuffer(statePtr) + getBufferedBytes(statePtr), data, i);
           statePtr[kBufferedBytes] += i;
           data += i;
           nread -= i;
@@ -666,7 +668,9 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::JsUint8Array bytes, jsg::Js
 
     size_t found_bytes = std::min(nread, static_cast<size_t>(getMissingBytes(statePtr)));
     KJ_ASSERT(data != nullptr);
-    memcpy(getIncompleteCharacterBuffer(statePtr) + getBufferedBytes(statePtr), data, found_bytes);
+    // Use memmove: data may point into the incomplete character buffer
+    // (e.g. when the caller passes decoder.lastChar as input).
+    memmove(getIncompleteCharacterBuffer(statePtr) + getBufferedBytes(statePtr), data, found_bytes);
     // Adjust the two buffers.
     data += found_bytes;
     nread -= found_bytes;
@@ -757,7 +761,9 @@ jsg::JsString BufferUtil::decode(jsg::Lock& js, jsg::JsUint8Array bytes, jsg::Js
       // Copy the requested number of buffered bytes from the end of the
       // input into the incomplete character buffer.
       nread -= getBufferedBytes(statePtr);
-      memcpy(getIncompleteCharacterBuffer(statePtr), data + nread, getBufferedBytes(statePtr));
+      // Use memmove: data may point into the incomplete character buffer
+      // (e.g. when the caller passes decoder.lastChar as input).
+      memmove(getIncompleteCharacterBuffer(statePtr), data + nread, getBufferedBytes(statePtr));
     }
 
     if (nread > 0) {

--- a/src/workerd/api/streams/identity-transform-stream.c++
+++ b/src/workerd/api/streams/identity-transform-stream.c++
@@ -227,7 +227,7 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
     KJ_IF_SOME(request, state.tryGetUnsafe<WriteRequest>()) {
       if (bytes.size() >= request.bytes.size()) {
         // The write buffer will entirely fit into our read buffer; fulfill both requests.
-        memcpy(bytes.begin(), request.bytes.begin(), request.bytes.size());
+        memmove(bytes.begin(), request.bytes.begin(), request.bytes.size());
         auto result = request.bytes.size();
         request.fulfiller->fulfill();
 
@@ -238,7 +238,7 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
       }
 
       // The write buffer won't quite fit into our read buffer; fulfill only the read request.
-      memcpy(bytes.begin(), request.bytes.begin(), bytes.size());
+      memmove(bytes.begin(), request.bytes.begin(), bytes.size());
       request.bytes = request.bytes.slice(bytes.size(), request.bytes.size());
       return bytes.size();
     }
@@ -293,14 +293,14 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
 
       if (request.bytes.size() >= bytes.size()) {
         // Our write buffer will entirely fit into the read buffer; fulfill both requests.
-        memcpy(request.bytes.begin(), bytes.begin(), bytes.size());
+        memmove(request.bytes.begin(), bytes.begin(), bytes.size());
         request.fulfiller->fulfill(bytes.size());
         state.transitionTo<Idle>();
         return kj::READY_NOW;
       }
 
       // Our write buffer won't quite fit into the read buffer; fulfill only the read request.
-      memcpy(request.bytes.begin(), bytes.begin(), request.bytes.size());
+      memmove(request.bytes.begin(), bytes.begin(), request.bytes.size());
       bytes = bytes.slice(request.bytes.size(), bytes.size());
       request.fulfiller->fulfill(request.bytes.size());
 


### PR DESCRIPTION
The buffer.c++ ones can probably overlap, while the identity-transform-stream.c++ ones are just being
cautious.