### PR TITLE
Gate googlesource cookie setup on cookie presence

### DIFF
--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -61,9 +61,12 @@ runs:
       shell: bash
       # Configure git to quell an irrelevant warning for runners (they never commit / push).
       run: git config core.hooksPath githooks
+    # Skip when the cookie is empty (forks, Dependabot PRs, local runs). Bazel will
+    # fall back to the unauthenticated googlesource endpoint, which is slower / more
+    # rate-limited but works without credentials.
     - name: Configure Googlesource credentials (Unix)
       shell: bash
-      if: github.event.pull_request.head.repo.fork == false && runner.os != 'Windows'
+      if: inputs.GOOGLESOURCE_COOKIE != '' && runner.os != 'Windows'
       env:
         GOOGLESOURCE_COOKIE: ${{ inputs.GOOGLESOURCE_COOKIE }}
       run: |
@@ -74,7 +77,7 @@ runs:
         __END__
     - name: Configure Googlesource credentials (Windows)
       shell: pwsh
-      if: github.event.pull_request.head.repo.fork == false && runner.os == 'Windows'
+      if: inputs.GOOGLESOURCE_COOKIE != '' && runner.os == 'Windows'
       env:
         GOOGLESOURCE_COOKIE: ${{ inputs.GOOGLESOURCE_COOKIE }}
       run: |


### PR DESCRIPTION
The `Configure Googlesource credentials` steps in `setup-runner` currently run whenever `github.event.pull_request.head.repo.fork == false`. Dependabot PRs satisfy that condition (their branches live in-repo), but Dependabot-triggered workflows don't have access to repository Actions secrets, so `inputs.GOOGLESOURCE_COOKIE` resolves to an empty string. We still rewrite `chromium.googlesource.com` to the authenticated `/a/` endpoint and write an empty cookie, and Bazel then fails every dependency fetch with:

```
fatal: unable to access 'https://chromium.googlesource.com/a/chromium/src/third_party/zlib.git/': The requested URL returned error: 400
remote: message: "Invalid authentication credentials. Please generate a new identifier: https://chromium.googlesource.com/new-password"
```

This broke every Dependabot PR, e.g. #6418.

This PR switches to gate the credential setup on the cookie actually being present, instead of just whetehr it's a fork.
When the cookie is empty (forks, Dependabot, local/manual runs) we skip the rewrite and the cookie file, letting Bazel fall back to the unauthenticated `chromium.googlesource.com` endpoint. That endpoint is slower and more rate-limited - which is why #6511 introduced auth - but it works without credentials and is no worse than the state prior to #6511 for these cases.