### PR TITLE
[types] add restart-from-step support to WorkflowInstance.restart()

### DIFF
--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -67,9 +67,10 @@ class InstanceImpl implements WorkflowInstance {
     });
   }
 
-  async restart(): Promise<void> {
+  async restart(options?: WorkflowInstanceRestartOptions): Promise<void> {
     await callFetcher(this.fetcher, '/restart', {
       id: this.id,
+      step: options?.from,
     });
   }
 

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -108,6 +108,21 @@ interface WorkflowError {
   message: string;
 }
 
+interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /** The step name as defined in your workflow code. */
+    name: string;
+    /** 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop). */
+    count?: number;
+    /** Step type filter. Use when different step types share the same name. */
+    type?: 'do' | 'sleep' | 'waitForEvent';
+  };
+}
+
 declare abstract class WorkflowInstance {
   id: string;
 
@@ -127,9 +142,11 @@ declare abstract class WorkflowInstance {
   terminate(): Promise<void>;
 
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  restart(): Promise<void>;
+  restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
 
   /**
    * Returns the current status of the instance.


### PR DESCRIPTION
Extends WorkflowInstance.restart() to accept an optional from parameter, allowing users to restart a workflow instance from a specific step instead of from the beginning.

Supersedes #6591

> await instance.restart({ from: { name: 'aggregate' } });
> await instance.restart({ from: { name: 'process', count: 3 } });
> await instance.restart({ from: { name: 'checkpoint', type: 'do' } });