### PR TITLE
Add AgentMemoryNamespace types scaffold

### DIFF
--- a/types/defines/agent-memory.d.ts
+++ b/types/defines/agent-memory.d.ts
@@ -1,0 +1,79 @@
+// ============================================================================
+// Agent Memory — SCAFFOLD
+//
+// This file declares the minimum type surface required for user Workers to
+// reference the `AgentMemoryNamespace` binding without a type error. It was
+// introduced to unblock `wrangler types` output in workers-sdk PR
+// https://github.com/cloudflare/workers-sdk/pull/13610.
+//
+// The real runtime API is owned by the Agent Memory product team. They are
+// expected to extend this scaffold with the complete method surface, accurate
+// return types, and any supporting option / result interfaces — or replace it
+// entirely with generated types driven from a C++ JSG resource.
+//
+// Until that happens, consumers should treat every declaration in this file
+// as intentionally incomplete. Method signatures have been kept deliberately
+// narrow and only cover what is exercised by the workers-sdk e2e fixture at
+// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// ============================================================================
+
+/**
+ * Summary of an Agent Memory context.
+ *
+ * The concrete shape is owned by the Agent Memory product team and has not
+ * been declared here yet. It is modelled as an open record so user code that
+ * reads from a summary can compile, at the cost of losing property-level type
+ * checking until the real interface lands.
+ *
+ * @todo Replace with the real summary shape once defined by the Agent Memory team.
+ */
+export interface AgentMemoryContextSummary {
+  [key: string]: unknown;
+}
+
+/**
+ * A single Agent Memory context, scoped to a context id.
+ *
+ * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
+ * declares the methods exercised by the workers-sdk e2e fixture; the full API
+ * surface will be added by the Agent Memory team.
+ */
+export declare abstract class AgentMemoryContext {
+  /**
+   * Fetch a summary of this context.
+   *
+   * @returns A promise resolving to the context summary. See
+   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
+   *   declared and will be filled in by the Agent Memory team.
+   */
+  getSummary(): Promise<AgentMemoryContextSummary>;
+}
+
+/**
+ * Namespace-level Agent Memory binding.
+ *
+ * Used as the type of an `env.MEMORY`-style binding backed by the Agent
+ * Memory product. The only method known to workers-sdk today is
+ * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
+ * to extend this class with the full API.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   async fetch(_request: Request, env: Env): Promise<Response> {
+ *     const context = env.MEMORY.getContext("wrangler-e2e");
+ *     const summary = await context.getSummary();
+ *     return Response.json(summary);
+ *   },
+ * };
+ * ```
+ */
+export declare abstract class AgentMemoryNamespace {
+  /**
+   * Get a handle to a specific Agent Memory context within this namespace.
+   *
+   * @param contextId The context identifier.
+   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   */
+  getContext(contextId: string): AgentMemoryContext;
+}

--- a/types/defines/agent-memory.d.ts
+++ b/types/defines/agent-memory.d.ts
@@ -1,68 +1,238 @@
 // ============================================================================
-// Agent Memory — SCAFFOLD
+// Agent Memory
 //
-// This file declares the minimum type surface required for user Workers to
-// reference the `AgentMemoryNamespace` binding without a type error. It was
-// introduced to unblock `wrangler types` output in workers-sdk PR
-// https://github.com/cloudflare/workers-sdk/pull/13610.
-//
-// The real runtime API is owned by the Agent Memory product team. They are
-// expected to extend this scaffold with the complete method surface, accurate
-// return types, and any supporting option / result interfaces — or replace it
-// entirely with generated types driven from a C++ JSG resource.
-//
-// Until that happens, consumers should treat every declaration in this file
-// as intentionally incomplete. Method signatures have been kept deliberately
-// narrow and only cover what is exercised by the workers-sdk e2e fixture at
-// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// Public type surface for user Workers binding to an Agent Memory namespace.
 // ============================================================================
 
-/**
- * Summary of an Agent Memory context.
- *
- * The concrete shape is owned by the Agent Memory product team and has not
- * been declared here yet. It is modelled as an open record so user code that
- * reads from a summary can compile, at the cost of losing property-level type
- * checking until the real interface lands.
- *
- * @todo Replace with the real summary shape once defined by the Agent Memory team.
- */
-export interface AgentMemoryContextSummary {
-  [key: string]: unknown;
+/** Memory type — every memory is classified into exactly one. */
+export type AgentMemoryMemoryType = "fact" | "event" | "instruction" | "task";
+
+/** Search intensity for recall. */
+export type AgentMemoryThinkingLevel = "low" | "medium" | "high";
+
+/** Response verbosity for recall. */
+export type AgentMemoryResponseLength = "short" | "medium" | "long";
+
+/** A conversation message passed to ingest(). */
+export interface AgentMemoryMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  /** Optional message timestamp. */
+  timestamp?: Date;
+}
+
+/** Raw memory content passed to remember(). */
+export interface AgentMemoryIncomingMemory {
+  /** Raw memory content. The service classifies and summarizes automatically. */
+  content: string;
+  /** Optional session identifier to associate with this memory. */
+  sessionId?: string | null | undefined;
+}
+
+/** A stored memory returned from remember(), get(), and delete(). */
+export interface AgentMemoryMemory {
+  /** Memory ID. */
+  id: string;
+  /** Memory type. */
+  type: AgentMemoryMemoryType;
+  /** Text summary. */
+  summary: string;
+  /** Memory text. */
+  content: string;
+  /** Session that created this memory. */
+  sessionId: string | null;
+  /** Memory creation time. */
+  createdAt: Date;
+  /** Memory last-update time. */
+  updatedAt: Date;
+}
+
+/** Single entry in a list() response. Same shape as Memory minus full content. */
+export type AgentMemoryMemoryListEntry = Omit<AgentMemoryMemory, "content">;
+
+/** A scored memory candidate in a recall result. */
+export interface AgentMemoryScoredCandidate {
+  /** Candidate ID. */
+  id: string;
+  /** Text summary. */
+  summary: string;
+  /** Session that created this candidate, when known. */
+  sessionId: string | null;
+  /** Relevance score (higher is better). Comparable only within a single query. */
+  score: number;
+}
+
+/** Options for the ingest() method. */
+export interface AgentMemoryIngestOptions {
+  /** Session identifier to associate with memories created during ingestion. */
+  sessionId?: string | null | undefined;
+}
+
+/** Options for the getSummary() method. */
+export interface AgentMemoryGetSummaryOptions {
+  /** Session identifier to retrieve session summary for. */
+  sessionId?: string | null | undefined;
+}
+
+/** Response from the getSummary() method. */
+export interface AgentMemoryGetSummaryResponse {
+  /** Markdown summary. */
+  summary: string;
 }
 
 /**
- * A single Agent Memory context, scoped to a context id.
+ * Options for the recall() method.
  *
- * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
- * declares the methods exercised by the workers-sdk e2e fixture; the full API
- * surface will be added by the Agent Memory team.
+ * `referenceDate` accepts a Date object, an ISO-8601 date string
+ * (YYYY-MM-DD), or a full ISO-8601 datetime string. When provided, this
+ * date is used as "today" for resolving relative time references
+ * ("how many days ago", "last week") instead of the server's wall-clock time.
  */
-export declare abstract class AgentMemoryContext {
+export interface AgentMemoryRecallOptions {
+  /** Recall intensity: "low" (default), "medium", or "high". */
+  thinkingLevel?: AgentMemoryThinkingLevel;
+  /** Response verbosity: "short", "medium" (default), or "long". */
+  responseLength?: AgentMemoryResponseLength;
+  /** Temporal anchor for date arithmetic. */
+  referenceDate?: Date | string;
+}
+
+/** Response from the recall() method. */
+export interface AgentMemoryRecallResult {
+  /** Number of memories retrieved. */
+  count: number;
+  /** LLM-generated answer synthesizing the matching memories. */
+  answer: string;
+  /** Matching memories ranked by relevance. */
+  candidates: AgentMemoryScoredCandidate[];
+}
+
+/**
+ * Options for the list() method.
+ *
+ * `cursor` is the opaque continuation token returned by the previous page;
+ * pass it back unchanged to fetch the next page. `sessionId` and `type`
+ * are exact-match filters; combining them is allowed.
+ */
+export interface AgentMemoryListMemoriesOptions {
+  /** Maximum number of memories to return. Default 20, max 500. */
+  limit?: number;
+  /** Opaque cursor from a previous page. */
+  cursor?: string;
+  /** Exact-match session filter. */
+  sessionId?: string;
+  /** Exact-match memory-type filter. */
+  type?: AgentMemoryMemoryType;
+}
+
+/** Response from the list() method. */
+export interface AgentMemoryListMemoriesResult {
+  memories: AgentMemoryMemoryListEntry[];
+  /** Continuation cursor; absent when this page exhausted the result set. */
+  cursor?: string;
+}
+
+/**
+ * A single Agent Memory profile, scoped to a profile name.
+ *
+ * Returned by {@link AgentMemoryNamespace.getProfile}.
+ */
+export declare abstract class AgentMemoryProfile {
   /**
-   * Fetch a summary of this context.
+   * Retrieve a memory by ID.
    *
-   * @returns A promise resolving to the context summary. See
-   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
-   *   declared and will be filled in by the Agent Memory team.
+   * @param memoryId - ULID of the memory to retrieve.
+   * @throws if the memory does not exist.
    */
-  getSummary(): Promise<AgentMemoryContextSummary>;
+  get(memoryId: string): Promise<AgentMemoryMemory>;
+
+  /**
+   * Delete a memory by ID.
+   *
+   * Removes the memory and any source messages linked by the memory's
+   * source message IDs.
+   *
+   * @param memoryId - ULID of the memory to delete.
+   * @throws if the memory does not exist.
+   */
+  delete(memoryId: string): Promise<AgentMemoryMemory>;
+
+  /**
+   * Store a memory in this profile. The content is automatically classified,
+   * summarized, and indexed.
+   *
+   * @param memory - Raw memory content to persist.
+   */
+  remember(memory: AgentMemoryIncomingMemory): Promise<AgentMemoryMemory>;
+
+  /**
+   * Extract memories from a conversation.
+   *
+   * @param messages - Conversation messages to extract memories from.
+   * @param options  - Optional ingest options.
+   */
+  ingest(
+    messages: Iterable<AgentMemoryMessage>,
+    options?: AgentMemoryIngestOptions,
+  ): Promise<void>;
+
+  /**
+   * Get a profile summary.
+   *
+   * @param options - Optional getSummary options.
+   */
+  getSummary(
+    options?: AgentMemoryGetSummaryOptions,
+  ): Promise<AgentMemoryGetSummaryResponse>;
+
+  /**
+   * Recall memories in this profile.
+   *
+   * @param query   - Recall query matched against memory content and keywords.
+   * @param options - Optional recall parameters.
+   * @returns Matching memories with relevance scores and a synthesized answer.
+   */
+  recall(
+    query: string,
+    options?: AgentMemoryRecallOptions,
+  ): Promise<AgentMemoryRecallResult>;
+
+  /**
+   * List active memories in this profile.
+   *
+   * Returns a paginated, filterable view of stored memories. Superseded
+   * versions are excluded. Use the returned `cursor` (when present) to
+   * fetch the next page.
+   *
+   * @param options - Optional pagination and filter options.
+   */
+  list(
+    options?: AgentMemoryListMemoriesOptions,
+  ): Promise<AgentMemoryListMemoriesResult>;
+
+  /**
+   * Soft-delete every memory and message in this profile that is tagged
+   * with `sessionId`.
+   *
+   * Idempotent: deleting a sessionId that has no rows is a no-op.
+   *
+   * @param sessionId - Session to delete.
+   */
+  deleteSession(sessionId: string): Promise<void>;
 }
 
 /**
  * Namespace-level Agent Memory binding.
  *
  * Used as the type of an `env.MEMORY`-style binding backed by the Agent
- * Memory product. The only method known to workers-sdk today is
- * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
- * to extend this class with the full API.
+ * Memory product.
  *
  * @example
  * ```ts
  * export default {
  *   async fetch(_request: Request, env: Env): Promise<Response> {
- *     const context = env.MEMORY.getContext("wrangler-e2e");
- *     const summary = await context.getSummary();
+ *     const profile = await env.MEMORY.getProfile("wrangler-e2e");
+ *     const summary = await profile.getSummary();
  *     return Response.json(summary);
  *   },
  * };
@@ -70,10 +240,19 @@ export declare abstract class AgentMemoryContext {
  */
 export declare abstract class AgentMemoryNamespace {
   /**
-   * Get a handle to a specific Agent Memory context within this namespace.
+   * Get a memory profile by name. Profiles are isolated by namespace and
+   * addressed by a compound key (namespaceId:profileName).
    *
-   * @param contextId The context identifier.
-   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   * @param profileName - Profile name (validated against naming rules).
+   * @returns RPC target for interacting with the profile.
    */
-  getContext(contextId: string): AgentMemoryContext;
+  getProfile(profileName: string): Promise<AgentMemoryProfile>;
+
+  /**
+   * Soft-delete a profile and schedule deferred purge. Marks all
+   * memories and messages as deleted.
+   *
+   * @param profileName - Name of the profile to delete.
+   */
+  deleteProfile(profileName: string): Promise<void>;
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3966,23 +3966,28 @@ interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
+  readonly __stdoutp: ArrayBuffer;
+  readonly __stderrp: ArrayBuffer;
 }
 interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  stdin?: ReadableStream | "pipe";
-  stdout?: "pipe" | "ignore";
-  stderr?: "pipe" | "ignore" | "combined";
+  __stdinp?: ReadableStream | "pipe";
+  __stdoutp?: "pipe" | "ignore";
+  __stderrp?: "pipe" | "ignore" | "combined";
 }
 interface ExecProcess {
-  readonly stdin: WritableStream | null;
-  readonly stdout: ReadableStream | null;
-  readonly stderr: ReadableStream | null;
+  get stdin(): WritableStream | undefined;
+  get stdout(): ReadableStream | undefined;
+  get stderr(): ReadableStream | undefined;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
+  readonly __stdinp: WritableStream | null;
+  readonly __stdoutp: ReadableStream | null;
+  readonly __stderrp: ReadableStream | null;
 }
 interface Container {
   get running(): boolean;
@@ -4738,67 +4743,216 @@ declare abstract class Span {
 ||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 =======
 // ============================================================================
-// Agent Memory — SCAFFOLD
+// Agent Memory
 //
-// This file declares the minimum type surface required for user Workers to
-// reference the `AgentMemoryNamespace` binding without a type error. It was
-// introduced to unblock `wrangler types` output in workers-sdk PR
-// https://github.com/cloudflare/workers-sdk/pull/13610.
-//
-// The real runtime API is owned by the Agent Memory product team. They are
-// expected to extend this scaffold with the complete method surface, accurate
-// return types, and any supporting option / result interfaces — or replace it
-// entirely with generated types driven from a C++ JSG resource.
-//
-// Until that happens, consumers should treat every declaration in this file
-// as intentionally incomplete. Method signatures have been kept deliberately
-// narrow and only cover what is exercised by the workers-sdk e2e fixture at
-// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// Public type surface for user Workers binding to an Agent Memory namespace.
 // ============================================================================
-/**
- * Summary of an Agent Memory context.
- *
- * The concrete shape is owned by the Agent Memory product team and has not
- * been declared here yet. It is modelled as an open record so user code that
- * reads from a summary can compile, at the cost of losing property-level type
- * checking until the real interface lands.
- *
- * @todo Replace with the real summary shape once defined by the Agent Memory team.
- */
-interface AgentMemoryContextSummary {
-  [key: string]: unknown;
+/** Memory type — every memory is classified into exactly one. */
+type AgentMemoryMemoryType = "fact" | "event" | "instruction" | "task";
+/** Search intensity for recall. */
+type AgentMemoryThinkingLevel = "low" | "medium" | "high";
+/** Response verbosity for recall. */
+type AgentMemoryResponseLength = "short" | "medium" | "long";
+/** A conversation message passed to ingest(). */
+interface AgentMemoryMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  /** Optional message timestamp. */
+  timestamp?: Date;
+}
+/** Raw memory content passed to remember(). */
+interface AgentMemoryIncomingMemory {
+  /** Raw memory content. The service classifies and summarizes automatically. */
+  content: string;
+  /** Optional session identifier to associate with this memory. */
+  sessionId?: string | null | undefined;
+}
+/** A stored memory returned from remember(), get(), and delete(). */
+interface AgentMemoryMemory {
+  /** Memory ID. */
+  id: string;
+  /** Memory type. */
+  type: AgentMemoryMemoryType;
+  /** Text summary. */
+  summary: string;
+  /** Memory text. */
+  content: string;
+  /** Session that created this memory. */
+  sessionId: string | null;
+  /** Memory creation time. */
+  createdAt: Date;
+  /** Memory last-update time. */
+  updatedAt: Date;
+}
+/** Single entry in a list() response. Same shape as Memory minus full content. */
+type AgentMemoryMemoryListEntry = Omit<AgentMemoryMemory, "content">;
+/** A scored memory candidate in a recall result. */
+interface AgentMemoryScoredCandidate {
+  /** Candidate ID. */
+  id: string;
+  /** Text summary. */
+  summary: string;
+  /** Session that created this candidate, when known. */
+  sessionId: string | null;
+  /** Relevance score (higher is better). Comparable only within a single query. */
+  score: number;
+}
+/** Options for the ingest() method. */
+interface AgentMemoryIngestOptions {
+  /** Session identifier to associate with memories created during ingestion. */
+  sessionId?: string | null | undefined;
+}
+/** Options for the getSummary() method. */
+interface AgentMemoryGetSummaryOptions {
+  /** Session identifier to retrieve session summary for. */
+  sessionId?: string | null | undefined;
+}
+/** Response from the getSummary() method. */
+interface AgentMemoryGetSummaryResponse {
+  /** Markdown summary. */
+  summary: string;
 }
 /**
- * A single Agent Memory context, scoped to a context id.
+ * Options for the recall() method.
  *
- * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
- * declares the methods exercised by the workers-sdk e2e fixture; the full API
- * surface will be added by the Agent Memory team.
+ * `referenceDate` accepts a Date object, an ISO-8601 date string
+ * (YYYY-MM-DD), or a full ISO-8601 datetime string. When provided, this
+ * date is used as "today" for resolving relative time references
+ * ("how many days ago", "last week") instead of the server's wall-clock time.
  */
-declare abstract class AgentMemoryContext {
+interface AgentMemoryRecallOptions {
+  /** Recall intensity: "low" (default), "medium", or "high". */
+  thinkingLevel?: AgentMemoryThinkingLevel;
+  /** Response verbosity: "short", "medium" (default), or "long". */
+  responseLength?: AgentMemoryResponseLength;
+  /** Temporal anchor for date arithmetic. */
+  referenceDate?: Date | string;
+}
+/** Response from the recall() method. */
+interface AgentMemoryRecallResult {
+  /** Number of memories retrieved. */
+  count: number;
+  /** LLM-generated answer synthesizing the matching memories. */
+  answer: string;
+  /** Matching memories ranked by relevance. */
+  candidates: AgentMemoryScoredCandidate[];
+}
+/**
+ * Options for the list() method.
+ *
+ * `cursor` is the opaque continuation token returned by the previous page;
+ * pass it back unchanged to fetch the next page. `sessionId` and `type`
+ * are exact-match filters; combining them is allowed.
+ */
+interface AgentMemoryListMemoriesOptions {
+  /** Maximum number of memories to return. Default 20, max 500. */
+  limit?: number;
+  /** Opaque cursor from a previous page. */
+  cursor?: string;
+  /** Exact-match session filter. */
+  sessionId?: string;
+  /** Exact-match memory-type filter. */
+  type?: AgentMemoryMemoryType;
+}
+/** Response from the list() method. */
+interface AgentMemoryListMemoriesResult {
+  memories: AgentMemoryMemoryListEntry[];
+  /** Continuation cursor; absent when this page exhausted the result set. */
+  cursor?: string;
+}
+/**
+ * A single Agent Memory profile, scoped to a profile name.
+ *
+ * Returned by {@link AgentMemoryNamespace.getProfile}.
+ */
+declare abstract class AgentMemoryProfile {
   /**
-   * Fetch a summary of this context.
+   * Retrieve a memory by ID.
    *
-   * @returns A promise resolving to the context summary. See
-   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
-   *   declared and will be filled in by the Agent Memory team.
+   * @param memoryId - ULID of the memory to retrieve.
+   * @throws if the memory does not exist.
    */
-  getSummary(): Promise<AgentMemoryContextSummary>;
+  get(memoryId: string): Promise<AgentMemoryMemory>;
+  /**
+   * Delete a memory by ID.
+   *
+   * Removes the memory and any source messages linked by the memory's
+   * source message IDs.
+   *
+   * @param memoryId - ULID of the memory to delete.
+   * @throws if the memory does not exist.
+   */
+  delete(memoryId: string): Promise<AgentMemoryMemory>;
+  /**
+   * Store a memory in this profile. The content is automatically classified,
+   * summarized, and indexed.
+   *
+   * @param memory - Raw memory content to persist.
+   */
+  remember(memory: AgentMemoryIncomingMemory): Promise<AgentMemoryMemory>;
+  /**
+   * Extract memories from a conversation.
+   *
+   * @param messages - Conversation messages to extract memories from.
+   * @param options  - Optional ingest options.
+   */
+  ingest(
+    messages: Iterable<AgentMemoryMessage>,
+    options?: AgentMemoryIngestOptions,
+  ): Promise<void>;
+  /**
+   * Get a profile summary.
+   *
+   * @param options - Optional getSummary options.
+   */
+  getSummary(
+    options?: AgentMemoryGetSummaryOptions,
+  ): Promise<AgentMemoryGetSummaryResponse>;
+  /**
+   * Recall memories in this profile.
+   *
+   * @param query   - Recall query matched against memory content and keywords.
+   * @param options - Optional recall parameters.
+   * @returns Matching memories with relevance scores and a synthesized answer.
+   */
+  recall(
+    query: string,
+    options?: AgentMemoryRecallOptions,
+  ): Promise<AgentMemoryRecallResult>;
+  /**
+   * List active memories in this profile.
+   *
+   * Returns a paginated, filterable view of stored memories. Superseded
+   * versions are excluded. Use the returned `cursor` (when present) to
+   * fetch the next page.
+   *
+   * @param options - Optional pagination and filter options.
+   */
+  list(
+    options?: AgentMemoryListMemoriesOptions,
+  ): Promise<AgentMemoryListMemoriesResult>;
+  /**
+   * Soft-delete every memory and message in this profile that is tagged
+   * with `sessionId`.
+   *
+   * Idempotent: deleting a sessionId that has no rows is a no-op.
+   *
+   * @param sessionId - Session to delete.
+   */
+  deleteSession(sessionId: string): Promise<void>;
 }
 /**
  * Namespace-level Agent Memory binding.
  *
  * Used as the type of an `env.MEMORY`-style binding backed by the Agent
- * Memory product. The only method known to workers-sdk today is
- * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
- * to extend this class with the full API.
+ * Memory product.
  *
  * @example
  * ```ts
  * export default {
  *   async fetch(_request: Request, env: Env): Promise<Response> {
- *     const context = env.MEMORY.getContext("wrangler-e2e");
- *     const summary = await context.getSummary();
+ *     const profile = await env.MEMORY.getProfile("wrangler-e2e");
+ *     const summary = await profile.getSummary();
  *     return Response.json(summary);
  *   },
  * };
@@ -4806,12 +4960,20 @@ declare abstract class AgentMemoryContext {
  */
 declare abstract class AgentMemoryNamespace {
   /**
-   * Get a handle to a specific Agent Memory context within this namespace.
+   * Get a memory profile by name. Profiles are isolated by namespace and
+   * addressed by a compound key (namespaceId:profileName).
    *
-   * @param contextId The context identifier.
-   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   * @param profileName - Profile name (validated against naming rules).
+   * @returns RPC target for interacting with the profile.
    */
-  getContext(contextId: string): AgentMemoryContext;
+  getProfile(profileName: string): Promise<AgentMemoryProfile>;
+  /**
+   * Soft-delete a profile and schedule deferred purge. Marks all
+   * memories and messages as deleted.
+   *
+   * @param profileName - Name of the profile to delete.
+   */
+  deleteProfile(profileName: string): Promise<void>;
 }
 >>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3966,28 +3966,23 @@ interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
-  readonly __stdoutp: ArrayBuffer;
-  readonly __stderrp: ArrayBuffer;
 }
 interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  __stdinp?: ReadableStream | "pipe";
-  __stdoutp?: "pipe" | "ignore";
-  __stderrp?: "pipe" | "ignore" | "combined";
+  stdin?: ReadableStream | "pipe";
+  stdout?: "pipe" | "ignore";
+  stderr?: "pipe" | "ignore" | "combined";
 }
 interface ExecProcess {
-  get stdin(): WritableStream | undefined;
-  get stdout(): ReadableStream | undefined;
-  get stderr(): ReadableStream | undefined;
+  readonly stdin: WritableStream | null;
+  readonly stdout: ReadableStream | null;
+  readonly stderr: ReadableStream | null;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
-  readonly __stdinp: WritableStream | null;
-  readonly __stdoutp: ReadableStream | null;
-  readonly __stderrp: ReadableStream | null;
 }
 interface Container {
   get running(): boolean;
@@ -4727,7 +4722,6 @@ interface EventCounts {
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
 }
-<<<<<<< HEAD
 interface Tracing {
   enterSpan<T, A extends unknown[]>(
     name: string,
@@ -4740,8 +4734,6 @@ declare abstract class Span {
   get isTraced(): boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 }
-||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
-=======
 // ============================================================================
 // Agent Memory
 //
@@ -4975,7 +4967,6 @@ declare abstract class AgentMemoryNamespace {
    */
   deleteProfile(profileName: string): Promise<void>;
 }
->>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
 interface AiSearchNotFoundError extends Error {}

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4722,6 +4722,7 @@ interface EventCounts {
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
 }
+<<<<<<< HEAD
 interface Tracing {
   enterSpan<T, A extends unknown[]>(
     name: string,
@@ -4734,6 +4735,85 @@ declare abstract class Span {
   get isTraced(): boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 }
+||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
+=======
+// ============================================================================
+// Agent Memory — SCAFFOLD
+//
+// This file declares the minimum type surface required for user Workers to
+// reference the `AgentMemoryNamespace` binding without a type error. It was
+// introduced to unblock `wrangler types` output in workers-sdk PR
+// https://github.com/cloudflare/workers-sdk/pull/13610.
+//
+// The real runtime API is owned by the Agent Memory product team. They are
+// expected to extend this scaffold with the complete method surface, accurate
+// return types, and any supporting option / result interfaces — or replace it
+// entirely with generated types driven from a C++ JSG resource.
+//
+// Until that happens, consumers should treat every declaration in this file
+// as intentionally incomplete. Method signatures have been kept deliberately
+// narrow and only cover what is exercised by the workers-sdk e2e fixture at
+// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// ============================================================================
+/**
+ * Summary of an Agent Memory context.
+ *
+ * The concrete shape is owned by the Agent Memory product team and has not
+ * been declared here yet. It is modelled as an open record so user code that
+ * reads from a summary can compile, at the cost of losing property-level type
+ * checking until the real interface lands.
+ *
+ * @todo Replace with the real summary shape once defined by the Agent Memory team.
+ */
+interface AgentMemoryContextSummary {
+  [key: string]: unknown;
+}
+/**
+ * A single Agent Memory context, scoped to a context id.
+ *
+ * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
+ * declares the methods exercised by the workers-sdk e2e fixture; the full API
+ * surface will be added by the Agent Memory team.
+ */
+declare abstract class AgentMemoryContext {
+  /**
+   * Fetch a summary of this context.
+   *
+   * @returns A promise resolving to the context summary. See
+   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
+   *   declared and will be filled in by the Agent Memory team.
+   */
+  getSummary(): Promise<AgentMemoryContextSummary>;
+}
+/**
+ * Namespace-level Agent Memory binding.
+ *
+ * Used as the type of an `env.MEMORY`-style binding backed by the Agent
+ * Memory product. The only method known to workers-sdk today is
+ * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
+ * to extend this class with the full API.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   async fetch(_request: Request, env: Env): Promise<Response> {
+ *     const context = env.MEMORY.getContext("wrangler-e2e");
+ *     const summary = await context.getSummary();
+ *     return Response.json(summary);
+ *   },
+ * };
+ * ```
+ */
+declare abstract class AgentMemoryNamespace {
+  /**
+   * Get a handle to a specific Agent Memory context within this namespace.
+   *
+   * @param contextId The context identifier.
+   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   */
+  getContext(contextId: string): AgentMemoryContext;
+}
+>>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
 interface AiSearchNotFoundError extends Error {}

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3972,23 +3972,28 @@ export interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
+  readonly __stdoutp: ArrayBuffer;
+  readonly __stderrp: ArrayBuffer;
 }
 export interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  stdin?: ReadableStream | "pipe";
-  stdout?: "pipe" | "ignore";
-  stderr?: "pipe" | "ignore" | "combined";
+  __stdinp?: ReadableStream | "pipe";
+  __stdoutp?: "pipe" | "ignore";
+  __stderrp?: "pipe" | "ignore" | "combined";
 }
 export interface ExecProcess {
-  readonly stdin: WritableStream | null;
-  readonly stdout: ReadableStream | null;
-  readonly stderr: ReadableStream | null;
+  get stdin(): WritableStream | undefined;
+  get stdout(): ReadableStream | undefined;
+  get stderr(): ReadableStream | undefined;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
+  readonly __stdinp: WritableStream | null;
+  readonly __stdoutp: ReadableStream | null;
+  readonly __stderrp: ReadableStream | null;
 }
 export interface Container {
   get running(): boolean;
@@ -4744,67 +4749,216 @@ export declare abstract class Span {
 ||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 =======
 // ============================================================================
-// Agent Memory — SCAFFOLD
+// Agent Memory
 //
-// This file declares the minimum type surface required for user Workers to
-// reference the `AgentMemoryNamespace` binding without a type error. It was
-// introduced to unblock `wrangler types` output in workers-sdk PR
-// https://github.com/cloudflare/workers-sdk/pull/13610.
-//
-// The real runtime API is owned by the Agent Memory product team. They are
-// expected to extend this scaffold with the complete method surface, accurate
-// return types, and any supporting option / result interfaces — or replace it
-// entirely with generated types driven from a C++ JSG resource.
-//
-// Until that happens, consumers should treat every declaration in this file
-// as intentionally incomplete. Method signatures have been kept deliberately
-// narrow and only cover what is exercised by the workers-sdk e2e fixture at
-// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// Public type surface for user Workers binding to an Agent Memory namespace.
 // ============================================================================
-/**
- * Summary of an Agent Memory context.
- *
- * The concrete shape is owned by the Agent Memory product team and has not
- * been declared here yet. It is modelled as an open record so user code that
- * reads from a summary can compile, at the cost of losing property-level type
- * checking until the real interface lands.
- *
- * @todo Replace with the real summary shape once defined by the Agent Memory team.
- */
-export interface AgentMemoryContextSummary {
-  [key: string]: unknown;
+/** Memory type — every memory is classified into exactly one. */
+export type AgentMemoryMemoryType = "fact" | "event" | "instruction" | "task";
+/** Search intensity for recall. */
+export type AgentMemoryThinkingLevel = "low" | "medium" | "high";
+/** Response verbosity for recall. */
+export type AgentMemoryResponseLength = "short" | "medium" | "long";
+/** A conversation message passed to ingest(). */
+export interface AgentMemoryMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  /** Optional message timestamp. */
+  timestamp?: Date;
+}
+/** Raw memory content passed to remember(). */
+export interface AgentMemoryIncomingMemory {
+  /** Raw memory content. The service classifies and summarizes automatically. */
+  content: string;
+  /** Optional session identifier to associate with this memory. */
+  sessionId?: string | null | undefined;
+}
+/** A stored memory returned from remember(), get(), and delete(). */
+export interface AgentMemoryMemory {
+  /** Memory ID. */
+  id: string;
+  /** Memory type. */
+  type: AgentMemoryMemoryType;
+  /** Text summary. */
+  summary: string;
+  /** Memory text. */
+  content: string;
+  /** Session that created this memory. */
+  sessionId: string | null;
+  /** Memory creation time. */
+  createdAt: Date;
+  /** Memory last-update time. */
+  updatedAt: Date;
+}
+/** Single entry in a list() response. Same shape as Memory minus full content. */
+export type AgentMemoryMemoryListEntry = Omit<AgentMemoryMemory, "content">;
+/** A scored memory candidate in a recall result. */
+export interface AgentMemoryScoredCandidate {
+  /** Candidate ID. */
+  id: string;
+  /** Text summary. */
+  summary: string;
+  /** Session that created this candidate, when known. */
+  sessionId: string | null;
+  /** Relevance score (higher is better). Comparable only within a single query. */
+  score: number;
+}
+/** Options for the ingest() method. */
+export interface AgentMemoryIngestOptions {
+  /** Session identifier to associate with memories created during ingestion. */
+  sessionId?: string | null | undefined;
+}
+/** Options for the getSummary() method. */
+export interface AgentMemoryGetSummaryOptions {
+  /** Session identifier to retrieve session summary for. */
+  sessionId?: string | null | undefined;
+}
+/** Response from the getSummary() method. */
+export interface AgentMemoryGetSummaryResponse {
+  /** Markdown summary. */
+  summary: string;
 }
 /**
- * A single Agent Memory context, scoped to a context id.
+ * Options for the recall() method.
  *
- * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
- * declares the methods exercised by the workers-sdk e2e fixture; the full API
- * surface will be added by the Agent Memory team.
+ * `referenceDate` accepts a Date object, an ISO-8601 date string
+ * (YYYY-MM-DD), or a full ISO-8601 datetime string. When provided, this
+ * date is used as "today" for resolving relative time references
+ * ("how many days ago", "last week") instead of the server's wall-clock time.
  */
-export declare abstract class AgentMemoryContext {
+export interface AgentMemoryRecallOptions {
+  /** Recall intensity: "low" (default), "medium", or "high". */
+  thinkingLevel?: AgentMemoryThinkingLevel;
+  /** Response verbosity: "short", "medium" (default), or "long". */
+  responseLength?: AgentMemoryResponseLength;
+  /** Temporal anchor for date arithmetic. */
+  referenceDate?: Date | string;
+}
+/** Response from the recall() method. */
+export interface AgentMemoryRecallResult {
+  /** Number of memories retrieved. */
+  count: number;
+  /** LLM-generated answer synthesizing the matching memories. */
+  answer: string;
+  /** Matching memories ranked by relevance. */
+  candidates: AgentMemoryScoredCandidate[];
+}
+/**
+ * Options for the list() method.
+ *
+ * `cursor` is the opaque continuation token returned by the previous page;
+ * pass it back unchanged to fetch the next page. `sessionId` and `type`
+ * are exact-match filters; combining them is allowed.
+ */
+export interface AgentMemoryListMemoriesOptions {
+  /** Maximum number of memories to return. Default 20, max 500. */
+  limit?: number;
+  /** Opaque cursor from a previous page. */
+  cursor?: string;
+  /** Exact-match session filter. */
+  sessionId?: string;
+  /** Exact-match memory-type filter. */
+  type?: AgentMemoryMemoryType;
+}
+/** Response from the list() method. */
+export interface AgentMemoryListMemoriesResult {
+  memories: AgentMemoryMemoryListEntry[];
+  /** Continuation cursor; absent when this page exhausted the result set. */
+  cursor?: string;
+}
+/**
+ * A single Agent Memory profile, scoped to a profile name.
+ *
+ * Returned by {@link AgentMemoryNamespace.getProfile}.
+ */
+export declare abstract class AgentMemoryProfile {
   /**
-   * Fetch a summary of this context.
+   * Retrieve a memory by ID.
    *
-   * @returns A promise resolving to the context summary. See
-   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
-   *   declared and will be filled in by the Agent Memory team.
+   * @param memoryId - ULID of the memory to retrieve.
+   * @throws if the memory does not exist.
    */
-  getSummary(): Promise<AgentMemoryContextSummary>;
+  get(memoryId: string): Promise<AgentMemoryMemory>;
+  /**
+   * Delete a memory by ID.
+   *
+   * Removes the memory and any source messages linked by the memory's
+   * source message IDs.
+   *
+   * @param memoryId - ULID of the memory to delete.
+   * @throws if the memory does not exist.
+   */
+  delete(memoryId: string): Promise<AgentMemoryMemory>;
+  /**
+   * Store a memory in this profile. The content is automatically classified,
+   * summarized, and indexed.
+   *
+   * @param memory - Raw memory content to persist.
+   */
+  remember(memory: AgentMemoryIncomingMemory): Promise<AgentMemoryMemory>;
+  /**
+   * Extract memories from a conversation.
+   *
+   * @param messages - Conversation messages to extract memories from.
+   * @param options  - Optional ingest options.
+   */
+  ingest(
+    messages: Iterable<AgentMemoryMessage>,
+    options?: AgentMemoryIngestOptions,
+  ): Promise<void>;
+  /**
+   * Get a profile summary.
+   *
+   * @param options - Optional getSummary options.
+   */
+  getSummary(
+    options?: AgentMemoryGetSummaryOptions,
+  ): Promise<AgentMemoryGetSummaryResponse>;
+  /**
+   * Recall memories in this profile.
+   *
+   * @param query   - Recall query matched against memory content and keywords.
+   * @param options - Optional recall parameters.
+   * @returns Matching memories with relevance scores and a synthesized answer.
+   */
+  recall(
+    query: string,
+    options?: AgentMemoryRecallOptions,
+  ): Promise<AgentMemoryRecallResult>;
+  /**
+   * List active memories in this profile.
+   *
+   * Returns a paginated, filterable view of stored memories. Superseded
+   * versions are excluded. Use the returned `cursor` (when present) to
+   * fetch the next page.
+   *
+   * @param options - Optional pagination and filter options.
+   */
+  list(
+    options?: AgentMemoryListMemoriesOptions,
+  ): Promise<AgentMemoryListMemoriesResult>;
+  /**
+   * Soft-delete every memory and message in this profile that is tagged
+   * with `sessionId`.
+   *
+   * Idempotent: deleting a sessionId that has no rows is a no-op.
+   *
+   * @param sessionId - Session to delete.
+   */
+  deleteSession(sessionId: string): Promise<void>;
 }
 /**
  * Namespace-level Agent Memory binding.
  *
  * Used as the type of an `env.MEMORY`-style binding backed by the Agent
- * Memory product. The only method known to workers-sdk today is
- * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
- * to extend this class with the full API.
+ * Memory product.
  *
  * @example
  * ```ts
  * export default {
  *   async fetch(_request: Request, env: Env): Promise<Response> {
- *     const context = env.MEMORY.getContext("wrangler-e2e");
- *     const summary = await context.getSummary();
+ *     const profile = await env.MEMORY.getProfile("wrangler-e2e");
+ *     const summary = await profile.getSummary();
  *     return Response.json(summary);
  *   },
  * };
@@ -4812,12 +4966,20 @@ export declare abstract class AgentMemoryContext {
  */
 export declare abstract class AgentMemoryNamespace {
   /**
-   * Get a handle to a specific Agent Memory context within this namespace.
+   * Get a memory profile by name. Profiles are isolated by namespace and
+   * addressed by a compound key (namespaceId:profileName).
    *
-   * @param contextId The context identifier.
-   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   * @param profileName - Profile name (validated against naming rules).
+   * @returns RPC target for interacting with the profile.
    */
-  getContext(contextId: string): AgentMemoryContext;
+  getProfile(profileName: string): Promise<AgentMemoryProfile>;
+  /**
+   * Soft-delete a profile and schedule deferred purge. Marks all
+   * memories and messages as deleted.
+   *
+   * @param profileName - Name of the profile to delete.
+   */
+  deleteProfile(profileName: string): Promise<void>;
 }
 >>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3972,28 +3972,23 @@ export interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
-  readonly __stdoutp: ArrayBuffer;
-  readonly __stderrp: ArrayBuffer;
 }
 export interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  __stdinp?: ReadableStream | "pipe";
-  __stdoutp?: "pipe" | "ignore";
-  __stderrp?: "pipe" | "ignore" | "combined";
+  stdin?: ReadableStream | "pipe";
+  stdout?: "pipe" | "ignore";
+  stderr?: "pipe" | "ignore" | "combined";
 }
 export interface ExecProcess {
-  get stdin(): WritableStream | undefined;
-  get stdout(): ReadableStream | undefined;
-  get stderr(): ReadableStream | undefined;
+  readonly stdin: WritableStream | null;
+  readonly stdout: ReadableStream | null;
+  readonly stderr: ReadableStream | null;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
-  readonly __stdinp: WritableStream | null;
-  readonly __stdoutp: ReadableStream | null;
-  readonly __stderrp: ReadableStream | null;
 }
 export interface Container {
   get running(): boolean;
@@ -4733,7 +4728,6 @@ export interface EventCounts {
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
 }
-<<<<<<< HEAD
 export interface Tracing {
   enterSpan<T, A extends unknown[]>(
     name: string,
@@ -4746,8 +4740,6 @@ export declare abstract class Span {
   get isTraced(): boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 }
-||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
-=======
 // ============================================================================
 // Agent Memory
 //
@@ -4981,7 +4973,6 @@ export declare abstract class AgentMemoryNamespace {
    */
   deleteProfile(profileName: string): Promise<void>;
 }
->>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4728,6 +4728,7 @@ export interface EventCounts {
   ): void;
   [Symbol.iterator](): IterableIterator<string[]>;
 }
+<<<<<<< HEAD
 export interface Tracing {
   enterSpan<T, A extends unknown[]>(
     name: string,
@@ -4740,6 +4741,85 @@ export declare abstract class Span {
   get isTraced(): boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 }
+||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
+=======
+// ============================================================================
+// Agent Memory — SCAFFOLD
+//
+// This file declares the minimum type surface required for user Workers to
+// reference the `AgentMemoryNamespace` binding without a type error. It was
+// introduced to unblock `wrangler types` output in workers-sdk PR
+// https://github.com/cloudflare/workers-sdk/pull/13610.
+//
+// The real runtime API is owned by the Agent Memory product team. They are
+// expected to extend this scaffold with the complete method surface, accurate
+// return types, and any supporting option / result interfaces — or replace it
+// entirely with generated types driven from a C++ JSG resource.
+//
+// Until that happens, consumers should treat every declaration in this file
+// as intentionally incomplete. Method signatures have been kept deliberately
+// narrow and only cover what is exercised by the workers-sdk e2e fixture at
+// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// ============================================================================
+/**
+ * Summary of an Agent Memory context.
+ *
+ * The concrete shape is owned by the Agent Memory product team and has not
+ * been declared here yet. It is modelled as an open record so user code that
+ * reads from a summary can compile, at the cost of losing property-level type
+ * checking until the real interface lands.
+ *
+ * @todo Replace with the real summary shape once defined by the Agent Memory team.
+ */
+export interface AgentMemoryContextSummary {
+  [key: string]: unknown;
+}
+/**
+ * A single Agent Memory context, scoped to a context id.
+ *
+ * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
+ * declares the methods exercised by the workers-sdk e2e fixture; the full API
+ * surface will be added by the Agent Memory team.
+ */
+export declare abstract class AgentMemoryContext {
+  /**
+   * Fetch a summary of this context.
+   *
+   * @returns A promise resolving to the context summary. See
+   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
+   *   declared and will be filled in by the Agent Memory team.
+   */
+  getSummary(): Promise<AgentMemoryContextSummary>;
+}
+/**
+ * Namespace-level Agent Memory binding.
+ *
+ * Used as the type of an `env.MEMORY`-style binding backed by the Agent
+ * Memory product. The only method known to workers-sdk today is
+ * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
+ * to extend this class with the full API.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   async fetch(_request: Request, env: Env): Promise<Response> {
+ *     const context = env.MEMORY.getContext("wrangler-e2e");
+ *     const summary = await context.getSummary();
+ *     return Response.json(summary);
+ *   },
+ * };
+ * ```
+ */
+export declare abstract class AgentMemoryNamespace {
+  /**
+   * Get a handle to a specific Agent Memory context within this namespace.
+   *
+   * @param contextId The context identifier.
+   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   */
+  getContext(contextId: string): AgentMemoryContext;
+}
+>>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -4054,7 +4054,6 @@ declare abstract class Performance {
    */
   toJSON(): object;
 }
-<<<<<<< HEAD
 interface Tracing {
   enterSpan<T, A extends unknown[]>(
     name: string,
@@ -4067,8 +4066,6 @@ declare abstract class Span {
   get isTraced(): boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 }
-||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
-=======
 // ============================================================================
 // Agent Memory
 //
@@ -4302,7 +4299,6 @@ declare abstract class AgentMemoryNamespace {
    */
   deleteProfile(profileName: string): Promise<void>;
 }
->>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
 interface AiSearchNotFoundError extends Error {}

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -4070,67 +4070,216 @@ declare abstract class Span {
 ||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 =======
 // ============================================================================
-// Agent Memory — SCAFFOLD
+// Agent Memory
 //
-// This file declares the minimum type surface required for user Workers to
-// reference the `AgentMemoryNamespace` binding without a type error. It was
-// introduced to unblock `wrangler types` output in workers-sdk PR
-// https://github.com/cloudflare/workers-sdk/pull/13610.
-//
-// The real runtime API is owned by the Agent Memory product team. They are
-// expected to extend this scaffold with the complete method surface, accurate
-// return types, and any supporting option / result interfaces — or replace it
-// entirely with generated types driven from a C++ JSG resource.
-//
-// Until that happens, consumers should treat every declaration in this file
-// as intentionally incomplete. Method signatures have been kept deliberately
-// narrow and only cover what is exercised by the workers-sdk e2e fixture at
-// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// Public type surface for user Workers binding to an Agent Memory namespace.
 // ============================================================================
-/**
- * Summary of an Agent Memory context.
- *
- * The concrete shape is owned by the Agent Memory product team and has not
- * been declared here yet. It is modelled as an open record so user code that
- * reads from a summary can compile, at the cost of losing property-level type
- * checking until the real interface lands.
- *
- * @todo Replace with the real summary shape once defined by the Agent Memory team.
- */
-interface AgentMemoryContextSummary {
-  [key: string]: unknown;
+/** Memory type — every memory is classified into exactly one. */
+type AgentMemoryMemoryType = "fact" | "event" | "instruction" | "task";
+/** Search intensity for recall. */
+type AgentMemoryThinkingLevel = "low" | "medium" | "high";
+/** Response verbosity for recall. */
+type AgentMemoryResponseLength = "short" | "medium" | "long";
+/** A conversation message passed to ingest(). */
+interface AgentMemoryMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  /** Optional message timestamp. */
+  timestamp?: Date;
+}
+/** Raw memory content passed to remember(). */
+interface AgentMemoryIncomingMemory {
+  /** Raw memory content. The service classifies and summarizes automatically. */
+  content: string;
+  /** Optional session identifier to associate with this memory. */
+  sessionId?: string | null | undefined;
+}
+/** A stored memory returned from remember(), get(), and delete(). */
+interface AgentMemoryMemory {
+  /** Memory ID. */
+  id: string;
+  /** Memory type. */
+  type: AgentMemoryMemoryType;
+  /** Text summary. */
+  summary: string;
+  /** Memory text. */
+  content: string;
+  /** Session that created this memory. */
+  sessionId: string | null;
+  /** Memory creation time. */
+  createdAt: Date;
+  /** Memory last-update time. */
+  updatedAt: Date;
+}
+/** Single entry in a list() response. Same shape as Memory minus full content. */
+type AgentMemoryMemoryListEntry = Omit<AgentMemoryMemory, "content">;
+/** A scored memory candidate in a recall result. */
+interface AgentMemoryScoredCandidate {
+  /** Candidate ID. */
+  id: string;
+  /** Text summary. */
+  summary: string;
+  /** Session that created this candidate, when known. */
+  sessionId: string | null;
+  /** Relevance score (higher is better). Comparable only within a single query. */
+  score: number;
+}
+/** Options for the ingest() method. */
+interface AgentMemoryIngestOptions {
+  /** Session identifier to associate with memories created during ingestion. */
+  sessionId?: string | null | undefined;
+}
+/** Options for the getSummary() method. */
+interface AgentMemoryGetSummaryOptions {
+  /** Session identifier to retrieve session summary for. */
+  sessionId?: string | null | undefined;
+}
+/** Response from the getSummary() method. */
+interface AgentMemoryGetSummaryResponse {
+  /** Markdown summary. */
+  summary: string;
 }
 /**
- * A single Agent Memory context, scoped to a context id.
+ * Options for the recall() method.
  *
- * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
- * declares the methods exercised by the workers-sdk e2e fixture; the full API
- * surface will be added by the Agent Memory team.
+ * `referenceDate` accepts a Date object, an ISO-8601 date string
+ * (YYYY-MM-DD), or a full ISO-8601 datetime string. When provided, this
+ * date is used as "today" for resolving relative time references
+ * ("how many days ago", "last week") instead of the server's wall-clock time.
  */
-declare abstract class AgentMemoryContext {
+interface AgentMemoryRecallOptions {
+  /** Recall intensity: "low" (default), "medium", or "high". */
+  thinkingLevel?: AgentMemoryThinkingLevel;
+  /** Response verbosity: "short", "medium" (default), or "long". */
+  responseLength?: AgentMemoryResponseLength;
+  /** Temporal anchor for date arithmetic. */
+  referenceDate?: Date | string;
+}
+/** Response from the recall() method. */
+interface AgentMemoryRecallResult {
+  /** Number of memories retrieved. */
+  count: number;
+  /** LLM-generated answer synthesizing the matching memories. */
+  answer: string;
+  /** Matching memories ranked by relevance. */
+  candidates: AgentMemoryScoredCandidate[];
+}
+/**
+ * Options for the list() method.
+ *
+ * `cursor` is the opaque continuation token returned by the previous page;
+ * pass it back unchanged to fetch the next page. `sessionId` and `type`
+ * are exact-match filters; combining them is allowed.
+ */
+interface AgentMemoryListMemoriesOptions {
+  /** Maximum number of memories to return. Default 20, max 500. */
+  limit?: number;
+  /** Opaque cursor from a previous page. */
+  cursor?: string;
+  /** Exact-match session filter. */
+  sessionId?: string;
+  /** Exact-match memory-type filter. */
+  type?: AgentMemoryMemoryType;
+}
+/** Response from the list() method. */
+interface AgentMemoryListMemoriesResult {
+  memories: AgentMemoryMemoryListEntry[];
+  /** Continuation cursor; absent when this page exhausted the result set. */
+  cursor?: string;
+}
+/**
+ * A single Agent Memory profile, scoped to a profile name.
+ *
+ * Returned by {@link AgentMemoryNamespace.getProfile}.
+ */
+declare abstract class AgentMemoryProfile {
   /**
-   * Fetch a summary of this context.
+   * Retrieve a memory by ID.
    *
-   * @returns A promise resolving to the context summary. See
-   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
-   *   declared and will be filled in by the Agent Memory team.
+   * @param memoryId - ULID of the memory to retrieve.
+   * @throws if the memory does not exist.
    */
-  getSummary(): Promise<AgentMemoryContextSummary>;
+  get(memoryId: string): Promise<AgentMemoryMemory>;
+  /**
+   * Delete a memory by ID.
+   *
+   * Removes the memory and any source messages linked by the memory's
+   * source message IDs.
+   *
+   * @param memoryId - ULID of the memory to delete.
+   * @throws if the memory does not exist.
+   */
+  delete(memoryId: string): Promise<AgentMemoryMemory>;
+  /**
+   * Store a memory in this profile. The content is automatically classified,
+   * summarized, and indexed.
+   *
+   * @param memory - Raw memory content to persist.
+   */
+  remember(memory: AgentMemoryIncomingMemory): Promise<AgentMemoryMemory>;
+  /**
+   * Extract memories from a conversation.
+   *
+   * @param messages - Conversation messages to extract memories from.
+   * @param options  - Optional ingest options.
+   */
+  ingest(
+    messages: Iterable<AgentMemoryMessage>,
+    options?: AgentMemoryIngestOptions,
+  ): Promise<void>;
+  /**
+   * Get a profile summary.
+   *
+   * @param options - Optional getSummary options.
+   */
+  getSummary(
+    options?: AgentMemoryGetSummaryOptions,
+  ): Promise<AgentMemoryGetSummaryResponse>;
+  /**
+   * Recall memories in this profile.
+   *
+   * @param query   - Recall query matched against memory content and keywords.
+   * @param options - Optional recall parameters.
+   * @returns Matching memories with relevance scores and a synthesized answer.
+   */
+  recall(
+    query: string,
+    options?: AgentMemoryRecallOptions,
+  ): Promise<AgentMemoryRecallResult>;
+  /**
+   * List active memories in this profile.
+   *
+   * Returns a paginated, filterable view of stored memories. Superseded
+   * versions are excluded. Use the returned `cursor` (when present) to
+   * fetch the next page.
+   *
+   * @param options - Optional pagination and filter options.
+   */
+  list(
+    options?: AgentMemoryListMemoriesOptions,
+  ): Promise<AgentMemoryListMemoriesResult>;
+  /**
+   * Soft-delete every memory and message in this profile that is tagged
+   * with `sessionId`.
+   *
+   * Idempotent: deleting a sessionId that has no rows is a no-op.
+   *
+   * @param sessionId - Session to delete.
+   */
+  deleteSession(sessionId: string): Promise<void>;
 }
 /**
  * Namespace-level Agent Memory binding.
  *
  * Used as the type of an `env.MEMORY`-style binding backed by the Agent
- * Memory product. The only method known to workers-sdk today is
- * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
- * to extend this class with the full API.
+ * Memory product.
  *
  * @example
  * ```ts
  * export default {
  *   async fetch(_request: Request, env: Env): Promise<Response> {
- *     const context = env.MEMORY.getContext("wrangler-e2e");
- *     const summary = await context.getSummary();
+ *     const profile = await env.MEMORY.getProfile("wrangler-e2e");
+ *     const summary = await profile.getSummary();
  *     return Response.json(summary);
  *   },
  * };
@@ -4138,12 +4287,20 @@ declare abstract class AgentMemoryContext {
  */
 declare abstract class AgentMemoryNamespace {
   /**
-   * Get a handle to a specific Agent Memory context within this namespace.
+   * Get a memory profile by name. Profiles are isolated by namespace and
+   * addressed by a compound key (namespaceId:profileName).
    *
-   * @param contextId The context identifier.
-   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   * @param profileName - Profile name (validated against naming rules).
+   * @returns RPC target for interacting with the profile.
    */
-  getContext(contextId: string): AgentMemoryContext;
+  getProfile(profileName: string): Promise<AgentMemoryProfile>;
+  /**
+   * Soft-delete a profile and schedule deferred purge. Marks all
+   * memories and messages as deleted.
+   *
+   * @param profileName - Name of the profile to delete.
+   */
+  deleteProfile(profileName: string): Promise<void>;
 }
 >>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -4054,6 +4054,7 @@ declare abstract class Performance {
    */
   toJSON(): object;
 }
+<<<<<<< HEAD
 interface Tracing {
   enterSpan<T, A extends unknown[]>(
     name: string,
@@ -4066,6 +4067,85 @@ declare abstract class Span {
   get isTraced(): boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 }
+||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
+=======
+// ============================================================================
+// Agent Memory — SCAFFOLD
+//
+// This file declares the minimum type surface required for user Workers to
+// reference the `AgentMemoryNamespace` binding without a type error. It was
+// introduced to unblock `wrangler types` output in workers-sdk PR
+// https://github.com/cloudflare/workers-sdk/pull/13610.
+//
+// The real runtime API is owned by the Agent Memory product team. They are
+// expected to extend this scaffold with the complete method surface, accurate
+// return types, and any supporting option / result interfaces — or replace it
+// entirely with generated types driven from a C++ JSG resource.
+//
+// Until that happens, consumers should treat every declaration in this file
+// as intentionally incomplete. Method signatures have been kept deliberately
+// narrow and only cover what is exercised by the workers-sdk e2e fixture at
+// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// ============================================================================
+/**
+ * Summary of an Agent Memory context.
+ *
+ * The concrete shape is owned by the Agent Memory product team and has not
+ * been declared here yet. It is modelled as an open record so user code that
+ * reads from a summary can compile, at the cost of losing property-level type
+ * checking until the real interface lands.
+ *
+ * @todo Replace with the real summary shape once defined by the Agent Memory team.
+ */
+interface AgentMemoryContextSummary {
+  [key: string]: unknown;
+}
+/**
+ * A single Agent Memory context, scoped to a context id.
+ *
+ * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
+ * declares the methods exercised by the workers-sdk e2e fixture; the full API
+ * surface will be added by the Agent Memory team.
+ */
+declare abstract class AgentMemoryContext {
+  /**
+   * Fetch a summary of this context.
+   *
+   * @returns A promise resolving to the context summary. See
+   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
+   *   declared and will be filled in by the Agent Memory team.
+   */
+  getSummary(): Promise<AgentMemoryContextSummary>;
+}
+/**
+ * Namespace-level Agent Memory binding.
+ *
+ * Used as the type of an `env.MEMORY`-style binding backed by the Agent
+ * Memory product. The only method known to workers-sdk today is
+ * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
+ * to extend this class with the full API.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   async fetch(_request: Request, env: Env): Promise<Response> {
+ *     const context = env.MEMORY.getContext("wrangler-e2e");
+ *     const summary = await context.getSummary();
+ *     return Response.json(summary);
+ *   },
+ * };
+ * ```
+ */
+declare abstract class AgentMemoryNamespace {
+  /**
+   * Get a handle to a specific Agent Memory context within this namespace.
+   *
+   * @param contextId The context identifier.
+   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   */
+  getContext(contextId: string): AgentMemoryContext;
+}
+>>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============
 interface AiSearchInternalError extends Error {}
 interface AiSearchNotFoundError extends Error {}

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -4060,7 +4060,6 @@ export declare abstract class Performance {
    */
   toJSON(): object;
 }
-<<<<<<< HEAD
 export interface Tracing {
   enterSpan<T, A extends unknown[]>(
     name: string,
@@ -4073,8 +4072,6 @@ export declare abstract class Span {
   get isTraced(): boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 }
-||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
-=======
 // ============================================================================
 // Agent Memory
 //
@@ -4308,7 +4305,6 @@ export declare abstract class AgentMemoryNamespace {
    */
   deleteProfile(profileName: string): Promise<void>;
 }
->>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -4076,67 +4076,216 @@ export declare abstract class Span {
 ||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 =======
 // ============================================================================
-// Agent Memory — SCAFFOLD
+// Agent Memory
 //
-// This file declares the minimum type surface required for user Workers to
-// reference the `AgentMemoryNamespace` binding without a type error. It was
-// introduced to unblock `wrangler types` output in workers-sdk PR
-// https://github.com/cloudflare/workers-sdk/pull/13610.
-//
-// The real runtime API is owned by the Agent Memory product team. They are
-// expected to extend this scaffold with the complete method surface, accurate
-// return types, and any supporting option / result interfaces — or replace it
-// entirely with generated types driven from a C++ JSG resource.
-//
-// Until that happens, consumers should treat every declaration in this file
-// as intentionally incomplete. Method signatures have been kept deliberately
-// narrow and only cover what is exercised by the workers-sdk e2e fixture at
-// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// Public type surface for user Workers binding to an Agent Memory namespace.
 // ============================================================================
-/**
- * Summary of an Agent Memory context.
- *
- * The concrete shape is owned by the Agent Memory product team and has not
- * been declared here yet. It is modelled as an open record so user code that
- * reads from a summary can compile, at the cost of losing property-level type
- * checking until the real interface lands.
- *
- * @todo Replace with the real summary shape once defined by the Agent Memory team.
- */
-export interface AgentMemoryContextSummary {
-  [key: string]: unknown;
+/** Memory type — every memory is classified into exactly one. */
+export type AgentMemoryMemoryType = "fact" | "event" | "instruction" | "task";
+/** Search intensity for recall. */
+export type AgentMemoryThinkingLevel = "low" | "medium" | "high";
+/** Response verbosity for recall. */
+export type AgentMemoryResponseLength = "short" | "medium" | "long";
+/** A conversation message passed to ingest(). */
+export interface AgentMemoryMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  /** Optional message timestamp. */
+  timestamp?: Date;
+}
+/** Raw memory content passed to remember(). */
+export interface AgentMemoryIncomingMemory {
+  /** Raw memory content. The service classifies and summarizes automatically. */
+  content: string;
+  /** Optional session identifier to associate with this memory. */
+  sessionId?: string | null | undefined;
+}
+/** A stored memory returned from remember(), get(), and delete(). */
+export interface AgentMemoryMemory {
+  /** Memory ID. */
+  id: string;
+  /** Memory type. */
+  type: AgentMemoryMemoryType;
+  /** Text summary. */
+  summary: string;
+  /** Memory text. */
+  content: string;
+  /** Session that created this memory. */
+  sessionId: string | null;
+  /** Memory creation time. */
+  createdAt: Date;
+  /** Memory last-update time. */
+  updatedAt: Date;
+}
+/** Single entry in a list() response. Same shape as Memory minus full content. */
+export type AgentMemoryMemoryListEntry = Omit<AgentMemoryMemory, "content">;
+/** A scored memory candidate in a recall result. */
+export interface AgentMemoryScoredCandidate {
+  /** Candidate ID. */
+  id: string;
+  /** Text summary. */
+  summary: string;
+  /** Session that created this candidate, when known. */
+  sessionId: string | null;
+  /** Relevance score (higher is better). Comparable only within a single query. */
+  score: number;
+}
+/** Options for the ingest() method. */
+export interface AgentMemoryIngestOptions {
+  /** Session identifier to associate with memories created during ingestion. */
+  sessionId?: string | null | undefined;
+}
+/** Options for the getSummary() method. */
+export interface AgentMemoryGetSummaryOptions {
+  /** Session identifier to retrieve session summary for. */
+  sessionId?: string | null | undefined;
+}
+/** Response from the getSummary() method. */
+export interface AgentMemoryGetSummaryResponse {
+  /** Markdown summary. */
+  summary: string;
 }
 /**
- * A single Agent Memory context, scoped to a context id.
+ * Options for the recall() method.
  *
- * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
- * declares the methods exercised by the workers-sdk e2e fixture; the full API
- * surface will be added by the Agent Memory team.
+ * `referenceDate` accepts a Date object, an ISO-8601 date string
+ * (YYYY-MM-DD), or a full ISO-8601 datetime string. When provided, this
+ * date is used as "today" for resolving relative time references
+ * ("how many days ago", "last week") instead of the server's wall-clock time.
  */
-export declare abstract class AgentMemoryContext {
+export interface AgentMemoryRecallOptions {
+  /** Recall intensity: "low" (default), "medium", or "high". */
+  thinkingLevel?: AgentMemoryThinkingLevel;
+  /** Response verbosity: "short", "medium" (default), or "long". */
+  responseLength?: AgentMemoryResponseLength;
+  /** Temporal anchor for date arithmetic. */
+  referenceDate?: Date | string;
+}
+/** Response from the recall() method. */
+export interface AgentMemoryRecallResult {
+  /** Number of memories retrieved. */
+  count: number;
+  /** LLM-generated answer synthesizing the matching memories. */
+  answer: string;
+  /** Matching memories ranked by relevance. */
+  candidates: AgentMemoryScoredCandidate[];
+}
+/**
+ * Options for the list() method.
+ *
+ * `cursor` is the opaque continuation token returned by the previous page;
+ * pass it back unchanged to fetch the next page. `sessionId` and `type`
+ * are exact-match filters; combining them is allowed.
+ */
+export interface AgentMemoryListMemoriesOptions {
+  /** Maximum number of memories to return. Default 20, max 500. */
+  limit?: number;
+  /** Opaque cursor from a previous page. */
+  cursor?: string;
+  /** Exact-match session filter. */
+  sessionId?: string;
+  /** Exact-match memory-type filter. */
+  type?: AgentMemoryMemoryType;
+}
+/** Response from the list() method. */
+export interface AgentMemoryListMemoriesResult {
+  memories: AgentMemoryMemoryListEntry[];
+  /** Continuation cursor; absent when this page exhausted the result set. */
+  cursor?: string;
+}
+/**
+ * A single Agent Memory profile, scoped to a profile name.
+ *
+ * Returned by {@link AgentMemoryNamespace.getProfile}.
+ */
+export declare abstract class AgentMemoryProfile {
   /**
-   * Fetch a summary of this context.
+   * Retrieve a memory by ID.
    *
-   * @returns A promise resolving to the context summary. See
-   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
-   *   declared and will be filled in by the Agent Memory team.
+   * @param memoryId - ULID of the memory to retrieve.
+   * @throws if the memory does not exist.
    */
-  getSummary(): Promise<AgentMemoryContextSummary>;
+  get(memoryId: string): Promise<AgentMemoryMemory>;
+  /**
+   * Delete a memory by ID.
+   *
+   * Removes the memory and any source messages linked by the memory's
+   * source message IDs.
+   *
+   * @param memoryId - ULID of the memory to delete.
+   * @throws if the memory does not exist.
+   */
+  delete(memoryId: string): Promise<AgentMemoryMemory>;
+  /**
+   * Store a memory in this profile. The content is automatically classified,
+   * summarized, and indexed.
+   *
+   * @param memory - Raw memory content to persist.
+   */
+  remember(memory: AgentMemoryIncomingMemory): Promise<AgentMemoryMemory>;
+  /**
+   * Extract memories from a conversation.
+   *
+   * @param messages - Conversation messages to extract memories from.
+   * @param options  - Optional ingest options.
+   */
+  ingest(
+    messages: Iterable<AgentMemoryMessage>,
+    options?: AgentMemoryIngestOptions,
+  ): Promise<void>;
+  /**
+   * Get a profile summary.
+   *
+   * @param options - Optional getSummary options.
+   */
+  getSummary(
+    options?: AgentMemoryGetSummaryOptions,
+  ): Promise<AgentMemoryGetSummaryResponse>;
+  /**
+   * Recall memories in this profile.
+   *
+   * @param query   - Recall query matched against memory content and keywords.
+   * @param options - Optional recall parameters.
+   * @returns Matching memories with relevance scores and a synthesized answer.
+   */
+  recall(
+    query: string,
+    options?: AgentMemoryRecallOptions,
+  ): Promise<AgentMemoryRecallResult>;
+  /**
+   * List active memories in this profile.
+   *
+   * Returns a paginated, filterable view of stored memories. Superseded
+   * versions are excluded. Use the returned `cursor` (when present) to
+   * fetch the next page.
+   *
+   * @param options - Optional pagination and filter options.
+   */
+  list(
+    options?: AgentMemoryListMemoriesOptions,
+  ): Promise<AgentMemoryListMemoriesResult>;
+  /**
+   * Soft-delete every memory and message in this profile that is tagged
+   * with `sessionId`.
+   *
+   * Idempotent: deleting a sessionId that has no rows is a no-op.
+   *
+   * @param sessionId - Session to delete.
+   */
+  deleteSession(sessionId: string): Promise<void>;
 }
 /**
  * Namespace-level Agent Memory binding.
  *
  * Used as the type of an `env.MEMORY`-style binding backed by the Agent
- * Memory product. The only method known to workers-sdk today is
- * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
- * to extend this class with the full API.
+ * Memory product.
  *
  * @example
  * ```ts
  * export default {
  *   async fetch(_request: Request, env: Env): Promise<Response> {
- *     const context = env.MEMORY.getContext("wrangler-e2e");
- *     const summary = await context.getSummary();
+ *     const profile = await env.MEMORY.getProfile("wrangler-e2e");
+ *     const summary = await profile.getSummary();
  *     return Response.json(summary);
  *   },
  * };
@@ -4144,12 +4293,20 @@ export declare abstract class AgentMemoryContext {
  */
 export declare abstract class AgentMemoryNamespace {
   /**
-   * Get a handle to a specific Agent Memory context within this namespace.
+   * Get a memory profile by name. Profiles are isolated by namespace and
+   * addressed by a compound key (namespaceId:profileName).
    *
-   * @param contextId The context identifier.
-   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   * @param profileName - Profile name (validated against naming rules).
+   * @returns RPC target for interacting with the profile.
    */
-  getContext(contextId: string): AgentMemoryContext;
+  getProfile(profileName: string): Promise<AgentMemoryProfile>;
+  /**
+   * Soft-delete a profile and schedule deferred purge. Marks all
+   * memories and messages as deleted.
+   *
+   * @param profileName - Name of the profile to delete.
+   */
+  deleteProfile(profileName: string): Promise<void>;
 }
 >>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -4060,6 +4060,7 @@ export declare abstract class Performance {
    */
   toJSON(): object;
 }
+<<<<<<< HEAD
 export interface Tracing {
   enterSpan<T, A extends unknown[]>(
     name: string,
@@ -4072,6 +4073,85 @@ export declare abstract class Span {
   get isTraced(): boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 }
+||||||| parent of 2c960abf4 (Add AgentMemoryNamespace types scaffold)
+=======
+// ============================================================================
+// Agent Memory — SCAFFOLD
+//
+// This file declares the minimum type surface required for user Workers to
+// reference the `AgentMemoryNamespace` binding without a type error. It was
+// introduced to unblock `wrangler types` output in workers-sdk PR
+// https://github.com/cloudflare/workers-sdk/pull/13610.
+//
+// The real runtime API is owned by the Agent Memory product team. They are
+// expected to extend this scaffold with the complete method surface, accurate
+// return types, and any supporting option / result interfaces — or replace it
+// entirely with generated types driven from a C++ JSG resource.
+//
+// Until that happens, consumers should treat every declaration in this file
+// as intentionally incomplete. Method signatures have been kept deliberately
+// narrow and only cover what is exercised by the workers-sdk e2e fixture at
+// `packages/wrangler/e2e/remote-binding/workers/agent-memory.js`.
+// ============================================================================
+/**
+ * Summary of an Agent Memory context.
+ *
+ * The concrete shape is owned by the Agent Memory product team and has not
+ * been declared here yet. It is modelled as an open record so user code that
+ * reads from a summary can compile, at the cost of losing property-level type
+ * checking until the real interface lands.
+ *
+ * @todo Replace with the real summary shape once defined by the Agent Memory team.
+ */
+export interface AgentMemoryContextSummary {
+  [key: string]: unknown;
+}
+/**
+ * A single Agent Memory context, scoped to a context id.
+ *
+ * Returned by {@link AgentMemoryNamespace.getContext}. This scaffold only
+ * declares the methods exercised by the workers-sdk e2e fixture; the full API
+ * surface will be added by the Agent Memory team.
+ */
+export declare abstract class AgentMemoryContext {
+  /**
+   * Fetch a summary of this context.
+   *
+   * @returns A promise resolving to the context summary. See
+   *   {@link AgentMemoryContextSummary} — the concrete shape is not yet
+   *   declared and will be filled in by the Agent Memory team.
+   */
+  getSummary(): Promise<AgentMemoryContextSummary>;
+}
+/**
+ * Namespace-level Agent Memory binding.
+ *
+ * Used as the type of an `env.MEMORY`-style binding backed by the Agent
+ * Memory product. The only method known to workers-sdk today is
+ * {@link AgentMemoryNamespace.getContext}; the Agent Memory team is expected
+ * to extend this class with the full API.
+ *
+ * @example
+ * ```ts
+ * export default {
+ *   async fetch(_request: Request, env: Env): Promise<Response> {
+ *     const context = env.MEMORY.getContext("wrangler-e2e");
+ *     const summary = await context.getSummary();
+ *     return Response.json(summary);
+ *   },
+ * };
+ * ```
+ */
+export declare abstract class AgentMemoryNamespace {
+  /**
+   * Get a handle to a specific Agent Memory context within this namespace.
+   *
+   * @param contextId The context identifier.
+   * @returns An {@link AgentMemoryContext} scoped to `contextId`.
+   */
+  getContext(contextId: string): AgentMemoryContext;
+}
+>>>>>>> 2c960abf4 (Add AgentMemoryNamespace types scaffold)
 // ============ AI Search Error Interfaces ============
 export interface AiSearchInternalError extends Error {}
 export interface AiSearchNotFoundError extends Error {}


### PR DESCRIPTION
## Summary

Adds minimal scaffold type declarations for the `AgentMemoryNamespace` binding class. This unblocks `wrangler types` output in workers-sdk PR https://github.com/cloudflare/workers-sdk/pull/13610, which currently emits a reference to `AgentMemoryNamespace` that does not resolve in `@cloudflare/workers-types`.

## Scope

This PR intentionally only declares the minimum surface visible from the workers-sdk e2e test (`packages/wrangler/e2e/remote-binding/workers/agent-memory.js`):

- `AgentMemoryNamespace.getContext(contextId: string): AgentMemoryContext`
- `AgentMemoryContext.getSummary(): Promise<AgentMemoryContextSummary>`
- `AgentMemoryContextSummary` — an open record (`[key: string]: unknown`) with a `@todo` noting the real shape has not yet been declared

The real runtime API surface is owned by the Agent Memory product team. They should extend `types/defines/agent-memory.d.ts` with the complete API before the workers-sdk PR ships, or replace the scaffold with generated types from a C++ JSG resource.

## Changes

- `types/defines/agent-memory.d.ts` — new file, scaffold class declarations
- `types/generated-snapshot/experimental/index.d.ts` — regenerated
- `types/generated-snapshot/experimental/index.ts` — regenerated
- `types/generated-snapshot/latest/index.d.ts` — regenerated
- `types/generated-snapshot/latest/index.ts` — regenerated

## Test plan

- `just generate-types` runs cleanly against the new defines file locally.
- CI \`types\` check should pass — the snapshot diff is strictly additive (76 lines per file, block inserted before AI Search defines).

## Reviewer notes

Keeping this PR as a draft until:

1. The Agent Memory team has signed off on the class/method names and extended the declarations with their real API, OR
2. A decision is made to instead ship the types via C++ JSG from the agent-memory runtime binding (in which case this PR can be closed in favour of that approach).

cc @cloudflare/workers-sdk