### PR TITLE
Add a container inspect API to read labels

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -284,6 +284,29 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
   running = true;
 }
 
+jsg::Promise<kj::Maybe<Container::Info>> Container::inspect(jsg::Lock& js) {
+  return IoContext::current().awaitIo(js, rpcClient->inspectRequest().send(),
+      [](jsg::Lock& js,
+          capnp::Response<rpc::Container::InspectResults> results) -> kj::Maybe<Info> {
+    auto info = results.getInfo();
+    if (info.isNone()) {
+      return kj::none;
+    }
+    return Info{
+      .labels =
+          jsg::Dict<kj::String>{
+            .fields =
+                KJ_MAP(label, info.getStarted().getLabels()) {
+      return jsg::Dict<kj::String>::Field{
+        .name = kj::str(label.getName()),
+        .value = kj::str(label.getValue()),
+      };
+    },
+          },
+    };
+  });
+}
+
 jsg::Promise<Container::DirectorySnapshot> Container::snapshotDirectory(
     jsg::Lock& js, DirectorySnapshotOptions options) {
   JSG_REQUIRE(

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -183,6 +183,12 @@ class Container: public jsg::Object {
     JSG_STRUCT(name);
   };
 
+  struct Info {
+    jsg::Dict<kj::String> labels;
+
+    JSG_STRUCT(labels);
+  };
+
   struct StartupOptions {
     jsg::Optional<kj::Array<kj::String>> entrypoint;
     bool enableInternet = false;
@@ -250,6 +256,8 @@ class Container: public jsg::Object {
   jsg::Promise<jsg::Ref<ExecProcess>> exec(
       jsg::Lock& js, kj::Array<kj::String> cmd, jsg::Optional<ExecOptions> options);
 
+  jsg::Promise<kj::Maybe<Info>> inspect(jsg::Lock& js);
+
   // TODO(containers): listenTcp()
 
   JSG_RESOURCE_TYPE(Container, CompatibilityFlags::Reader flags) {
@@ -269,6 +277,7 @@ class Container: public jsg::Object {
     if (flags.getWorkerdExperimental()) {
       JSG_METHOD(exec);
       JSG_METHOD(interceptOutboundTcp);
+      JSG_METHOD(inspect);
     }
   }
 
@@ -294,6 +303,6 @@ class Container: public jsg::Object {
   api::ExecOutput, api::ExecOptions, api::ExecProcess, api::Container,                             \
       api::Container::DirectorySnapshot, api::Container::DirectorySnapshotOptions,                 \
       api::Container::DirectorySnapshotRestoreParams, api::Container::Snapshot,                    \
-      api::Container::SnapshotOptions, api::Container::StartupOptions
+      api::Container::SnapshotOptions, api::Container::StartupOptions, api::Container::Info
 
 }  // namespace workerd::api

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -249,4 +249,17 @@ interface Container @0x9aaceefc06523bca {
   #
   # If stdoutWriter/stderrWriter are not provided, output is discarded. If params.combinedOutput
   # is true, stderr is merged into stdout and the stderrWriter capability is ignored.
+
+  inspect @14 () -> (info :InspectInfo);
+  # Returns information about the container, or `none` if the container has not been started.
+
+  struct InspectInfo {
+    union {
+      none @0 :Void;
+      started :group {
+        labels @1 :List(Label);
+        # Echo of StartParams.labels. Empty list means start() was called with no labels.
+      }
+    }
+  }
 }

--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -48,6 +48,11 @@ constexpr kj::StringPtr SNAPSHOT_VOLUME_PREFIX = "workerd-snap-"_kj;
 constexpr kj::StringPtr SNAPSHOT_CLONE_VOLUME_PREFIX = "workerd-snap-clone-"_kj;
 constexpr kj::StringPtr CONTAINER_SNAPSHOT_IMAGE_PREFIX = "workerd-container-snap-"_kj;
 constexpr kj::StringPtr SNAPSHOT_VOLUME_CREATED_AT_LABEL = "dev.workerd.snapshot-created-at"_kj;
+
+// Prefix applied to user-supplied labels when writing them to the Docker container, and
+// stripped back out when reading them via inspect(). Lets us distinguish labels the worker
+// set via start() from labels that came from the image (via Dockerfile LABEL) or engine.
+constexpr kj::StringPtr WORKERD_LABEL_PREFIX = "workerd-"_kj;
 constexpr auto SNAPSHOT_STALE_AGE = 30 * kj::DAYS;
 
 // Maximum size of a snapshot tar archive held in memory during snapshot create/restore.
@@ -1512,7 +1517,7 @@ kj::Promise<void> ContainerClient::injectCACert() {
   succeeded = true;
 }
 
-kj::Promise<ContainerClient::InspectResponse> ContainerClient::inspectContainer() {
+kj::Promise<kj::Maybe<ContainerClient::InspectResponse>> ContainerClient::inspectContainer() {
   auto endpoint = kj::str("/containers/", containerName, "/json");
 
   auto response = co_await dockerApiRequest(
@@ -1520,7 +1525,7 @@ kj::Promise<ContainerClient::InspectResponse> ContainerClient::inspectContainer(
   // We check if the container with the given name exist, and if it's not,
   // we simply return false while avoiding an unnecessary error.
   if (response.statusCode == 404) {
-    co_return InspectResponse{.isRunning = false};
+    co_return kj::none;
   }
 
   JSG_REQUIRE(response.statusCode == 200, Error, "Container inspect failed");
@@ -1538,7 +1543,25 @@ kj::Promise<ContainerClient::InspectResponse> ContainerClient::inspectContainer(
   // perspective, a restarting container is still "alive" and should be treated as running
   // so that start() correctly refuses to start a duplicate and destroy() can clean it up.
   bool running = status == "running" || status == "restarting";
-  co_return InspectResponse{.isRunning = running};
+
+  kj::Vector<Label> labels;
+  if (jsonRoot.hasConfig() && jsonRoot.getConfig().hasLabels()) {
+    auto labelsJson = jsonRoot.getConfig().getLabels();
+    if (labelsJson.isObject()) {
+      for (auto field: labelsJson.getObject()) {
+        kj::StringPtr name = field.getName();
+        if (!name.startsWith(WORKERD_LABEL_PREFIX)) continue;
+        auto value = field.getValue();
+        JSG_REQUIRE(value.isString(), Error, "Malformed ContainerInspect label value");
+        labels.add(Label{
+          .name = kj::str(name.slice(WORKERD_LABEL_PREFIX.size())),
+          .value = kj::str(value.getString()),
+        });
+      }
+    }
+  }
+
+  co_return InspectResponse{.isRunning = running, .labels = labels.releaseAsArray()};
 }
 
 kj::Promise<kj::Maybe<ContainerClient::SidecarInspectResponse>> ContainerClient::inspectSidecar() {
@@ -1663,12 +1686,13 @@ kj::Promise<void> ContainerClient::createContainer(kj::StringPtr effectiveImage,
     jsonEnv.set(envSize + i, defaultEnv[i]);
   }
 
-  // Pass user-supplied labels as Docker object labels, visible via `docker inspect`.
+  // Pass user-supplied labels as Docker object labels, prefixed so we can distinguish
+  // them from image/engine labels when reading back via inspect().
   if (params.hasLabels()) {
     auto lbls = params.getLabels();
     auto labelsObj = jsonRoot.initLabels().initObject(lbls.size());
     for (auto i: kj::zeroTo(lbls.size())) {
-      labelsObj[i].setName(lbls[i].getName());
+      labelsObj[i].setName(kj::str(WORKERD_LABEL_PREFIX, lbls[i].getName()));
       labelsObj[i].initValue().setString(lbls[i].getValue());
     }
   }
@@ -2161,7 +2185,10 @@ kj::Promise<void> ContainerClient::status(StatusContext context) {
   co_await ready;
   KJ_DEFER(done->fulfill());
 
-  const auto [isRunning] = co_await inspectContainer();
+  bool isRunning = false;
+  KJ_IF_SOME(info, co_await inspectContainer()) {
+    isRunning = info.isRunning;
+  }
   containerStarted.store(isRunning, std::memory_order_release);
   containerSidecarStarted.store(false, std::memory_order_release);
   this->sidecarIngressHostPort = kj::none;
@@ -2180,6 +2207,23 @@ kj::Promise<void> ContainerClient::status(StatusContext context) {
   }
 
   context.getResults().setRunning(isRunning);
+}
+
+kj::Promise<void> ContainerClient::inspect(InspectContext context) {
+  auto maybeResp = co_await inspectContainer();
+  auto info = context.getResults().initInfo();
+  KJ_IF_SOME(resp, maybeResp) {
+    if (resp.isRunning) {
+      auto started = info.initStarted();
+      auto list = started.initLabels(resp.labels.size());
+      for (auto i: kj::indices(resp.labels)) {
+        list[i].setName(resp.labels[i].name);
+        list[i].setValue(resp.labels[i].value);
+      }
+      co_return;
+    }
+  }
+  info.setNone();
 }
 
 kj::Promise<void> ContainerClient::start(StartContext context) {

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -87,6 +87,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   kj::Promise<void> setEgressTcp(SetEgressTcpContext context) override;
   kj::Promise<void> snapshotDirectory(SnapshotDirectoryContext context) override;
   kj::Promise<void> snapshotContainer(SnapshotContainerContext context) override;
+  kj::Promise<void> inspect(InspectContext context) override;
 
   kj::Own<ContainerClient> addRef();
 
@@ -124,8 +125,14 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   // EgressHttpService handles CONNECT requests from proxy-anything sidecar
   friend class EgressHttpService;
 
+  struct Label {
+    kj::String name;
+    kj::String value;
+  };
+
   struct InspectResponse {
     bool isRunning;
+    kj::Array<Label> labels;
   };
 
   struct IPAMConfigResult {
@@ -154,7 +161,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
     uint32_t pid;
   };
 
-  kj::Promise<InspectResponse> inspectContainer();
+  kj::Promise<kj::Maybe<InspectResponse>> inspectContainer();
 
   kj::Promise<void> updateSidecarEgressPort(uint16_t ingressHostPort, uint16_t egressPort);
   kj::Promise<void> updateSidecarEgressConfig(uint16_t ingressHostPort, uint16_t egressPort);

--- a/src/workerd/server/docker-api.capnp
+++ b/src/workerd/server/docker-api.capnp
@@ -277,6 +277,7 @@ struct Docker {
     args @3 :List(Text) $Json.name("Args");
     state @4 :ContainerState $Json.name("State");
     networkSettings @5 :NetworkSettings $Json.name("NetworkSettings");
+    config @6 :ContainerConfig $Json.name("Config");
   }
 
   struct ImageInspectResponse {

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -553,19 +553,85 @@ export class DurableObjectExample extends DurableObject {
 
     assert.strictEqual(container.running, false);
 
-    container.start({
-      enableInternet: true,
-      labels: { team: 'workers', environment: 'testing' },
-    });
+    const labels = {
+      team: 'workers',
+      environment: 'testing',
+      'my.label/key': 'value',
+      'workerd-foo': 'bar',
+      kv: 'a=b=c',
+      emoji: '🧪',
+    };
+    container.start({ enableInternet: true, labels });
 
     const monitor = container.monitor().catch((_err) => {});
     await this.waitUntilContainerIsHealthy();
 
     assert.strictEqual(container.running, true);
 
+    const info = await container.inspect();
+    assert.deepStrictEqual(info.labels, labels);
+
     await container.destroy();
     await monitor;
     assert.strictEqual(container.running, false);
+  }
+
+  async testInspectBeforeStart() {
+    const container = this.ctx.container;
+    if (container.running) {
+      let monitor = container.monitor().catch((_err) => {});
+      await container.destroy();
+      await monitor;
+    }
+
+    assert.strictEqual(container.running, false);
+
+    const info = await container.inspect();
+    assert.strictEqual(info, null);
+  }
+
+  async testInspectEmptyLabels() {
+    const container = this.ctx.container;
+    if (container.running) {
+      let monitor = container.monitor().catch((_err) => {});
+      await container.destroy();
+      await monitor;
+    }
+
+    assert.strictEqual(container.running, false);
+
+    container.start({ enableInternet: true });
+    const monitor = container.monitor().catch((_err) => {});
+    await this.waitUntilContainerIsHealthy();
+
+    const info = await container.inspect();
+    assert.deepStrictEqual(info.labels, {});
+
+    await container.destroy();
+    await monitor;
+  }
+
+  async testInspectAfterDestroy() {
+    const container = this.ctx.container;
+    if (container.running) {
+      let monitor = container.monitor().catch((_err) => {});
+      await container.destroy();
+      await monitor;
+    }
+
+    assert.strictEqual(container.running, false);
+
+    container.start({
+      enableInternet: true,
+      labels: { foo: 'bar' },
+    });
+    const monitor = container.monitor().catch((_err) => {});
+    await this.waitUntilContainerIsHealthy();
+    await container.destroy();
+    await monitor;
+
+    const info = await container.inspect();
+    assert.strictEqual(info, null);
   }
 
   async testLabelValidation() {
@@ -2548,6 +2614,36 @@ export const testLabelValidation = {
     );
     const stub = env.MY_CONTAINER.get(id);
     await stub.testLabelValidation();
+  },
+};
+
+export const testInspectBeforeStart = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testInspectBeforeStart')
+    );
+    const stub = env.MY_CONTAINER.get(id);
+    await stub.testInspectBeforeStart();
+  },
+};
+
+export const testInspectEmptyLabels = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testInspectEmptyLabels')
+    );
+    const stub = env.MY_CONTAINER.get(id);
+    await stub.testInspectEmptyLabels();
+  },
+};
+
+export const testInspectAfterDestroy = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testInspectAfterDestroy')
+    );
+    const stub = env.MY_CONTAINER.get(id);
+    await stub.testInspectAfterDestroy();
   },
 };
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3998,6 +3998,7 @@ interface Container {
   interceptOutboundHttps(addr: string, binding: Fetcher): Promise<void>;
   exec(cmd: string[], options?: ContainerExecOptions): Promise<ExecProcess>;
   interceptOutboundTcp(addr: string, binding: Fetcher): Promise<void>;
+  inspect(): Promise<ContainerInfo | null>;
 }
 interface ContainerDirectorySnapshot {
   id: string;
@@ -4029,6 +4030,9 @@ interface ContainerStartupOptions {
   labels?: Record<string, string>;
   directorySnapshots?: ContainerDirectorySnapshotRestoreParams[];
   containerSnapshot?: ContainerSnapshot;
+}
+interface ContainerInfo {
+  labels: Record<string, string>;
 }
 /**
  * The **`FileSystemHandle`** interface of the File System API is an object which represents a file or directory entry.

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4004,6 +4004,7 @@ export interface Container {
   interceptOutboundHttps(addr: string, binding: Fetcher): Promise<void>;
   exec(cmd: string[], options?: ContainerExecOptions): Promise<ExecProcess>;
   interceptOutboundTcp(addr: string, binding: Fetcher): Promise<void>;
+  inspect(): Promise<ContainerInfo | null>;
 }
 export interface ContainerDirectorySnapshot {
   id: string;
@@ -4035,6 +4036,9 @@ export interface ContainerStartupOptions {
   labels?: Record<string, string>;
   directorySnapshots?: ContainerDirectorySnapshotRestoreParams[];
   containerSnapshot?: ContainerSnapshot;
+}
+export interface ContainerInfo {
+  labels: Record<string, string>;
 }
 /**
  * The **`FileSystemHandle`** interface of the File System API is an object which represents a file or directory entry.


### PR DESCRIPTION
There is currently no way to read the labels set in a container. Add a new `inspect` API that returns the labels set on a container.

In the future, this can be extended to also provide other information (like `entrypoint` or `env`).