### PR TITLE
Deprecate ensureReplicas/disableReplicas.

### DIFF
--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -788,7 +788,9 @@ interface DurableObjectStorage {
   waitForBookmark(bookmark: string): Promise<void>;
   /** @deprecated Use `ctx.primaryStub` instead. */
   readonly primary?: DurableObjectStub;
+  /** @deprecated Use `ctx.configureReadReplication()` instead. */
   ensureReplicas(): void;
+  /** @deprecated Use `ctx.configureReadReplication()` instead. */
   disableReplicas(): void;
 }
 interface DurableObjectReadReplicationOptions {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -790,7 +790,9 @@ export interface DurableObjectStorage {
   waitForBookmark(bookmark: string): Promise<void>;
   /** @deprecated Use `ctx.primaryStub` instead. */
   readonly primary?: DurableObjectStub;
+  /** @deprecated Use `ctx.configureReadReplication()` instead. */
   ensureReplicas(): void;
+  /** @deprecated Use `ctx.configureReadReplication()` instead. */
   disableReplicas(): void;
 }
 export interface DurableObjectReadReplicationOptions {

--- a/types/src/cloudflare.ts
+++ b/types/src/cloudflare.ts
@@ -53,6 +53,8 @@ export default {
   },
   DurableObjectStorage: {
     primary: `* @deprecated Use \`ctx.primaryStub\` instead. `,
+    ensureReplicas: `* @deprecated Use \`ctx.configureReadReplication()\` instead. `,
+    disableReplicas: `* @deprecated Use \`ctx.configureReadReplication()\` instead. `,
   },
   performance: {
     $: `*


### PR DESCRIPTION
In cases where typescript annotations mention the old methods, we should explain what is replacing them.

Once https://github.com/cloudflare/workerd/pull/6649 is merged this PR should be retargeted to main.