### PR TITLE
Adjust the auto allocate chunk size default with autogate

### DIFF
--- a/src/workerd/api/streams-test.c++
+++ b/src/workerd/api/streams-test.c++
@@ -1,6 +1,7 @@
 #include <workerd/api/streams/readable.h>
 #include <workerd/api/streams/standard.h>
 #include <workerd/tests/test-fixture.h>
+#include <workerd/util/autogate.h>
 
 #include <kj/test.h>
 
@@ -58,7 +59,12 @@ KJ_TEST("Reading from default reader") {
       auto& value = KJ_REQUIRE_NONNULL(readResult.value);
       auto handle = value.getHandle(js);
       KJ_ASSERT(handle->IsUint8Array());
-      KJ_ASSERT(4 * 1024 == handle.As<v8::Uint8Array>()->ByteLength());
+      if (util::Autogate::isEnabled(util::AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE)) {
+        // With 16KB buffer, the entire 10KB stream fits in one read.
+        KJ_ASSERT(streamLength == handle.As<v8::Uint8Array>()->ByteLength());
+      } else {
+        KJ_ASSERT(4 * 1024 == handle.As<v8::Uint8Array>()->ByteLength());
+      }
     })));
   });
 }

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -105,6 +105,11 @@ struct UnderlyingSource {
   // this default.
   static constexpr int DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE = 4096;
 
+  // We want to increase the default auto allocate chunk size but we need to do
+  // so carefully to avoid introducing memory regressions and causing workers to
+  // hit OOM errors. We'll use an autogate to roll out the new default.
+  static constexpr int DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE_2 = 16 * 1024;
+
   // Per the spec, the type property for the UnderlyingSource should be either
   // undefined, the empty string, or "bytes". When undefined, the empty string is
   // used as the default. When type is the empty string, the stream is considered

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -11,6 +11,7 @@
 #include <workerd/api/util.h>
 #include <workerd/io/features.h>
 #include <workerd/jsg/jsg.h>
+#include <workerd/util/autogate.h>
 #include <workerd/util/string-buffer.h>
 
 #include <kj/vector.h>
@@ -469,8 +470,13 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
 
   auto getOrInitStore = [&](bool errorCase = false) {
     if (store.IsEmpty()) {
-      // In an error case, where store is not provided, we can use zero length
-      byteLength = errorCase ? 0 : UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE;
+      if (errorCase) {
+        byteLength = 0;
+      } else if (util::Autogate::isEnabled(util::AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE)) {
+        byteLength = UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE_2;
+      } else {
+        byteLength = UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE;
+      }
 
       if (!v8::ArrayBuffer::MaybeNew(js.v8Isolate, byteLength).ToLocal(&store)) {
         return v8::Local<v8::ArrayBuffer>();

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -3051,9 +3051,12 @@ void ReadableStreamJsController::setup(jsg::Lock& js,
       autoAllocateChunkSize =
           underlyingSource.autoAllocateChunkSize.map([](int size) { return size; });
     } else {
-      // Legacy behavior: default to 4096 if not provided
-      autoAllocateChunkSize = underlyingSource.autoAllocateChunkSize.orDefault(
-          UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE);
+      // Legacy behavior: apply a default autoAllocateChunkSize if not provided.
+      auto defaultChunkSize = UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE;
+      if (util::Autogate::isEnabled(util::AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE)) {
+        defaultChunkSize = UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE_2;
+      }
+      autoAllocateChunkSize = underlyingSource.autoAllocateChunkSize.orDefault(defaultChunkSize);
     }
 
     auto controller =

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -43,6 +43,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "increase-sqlite-hard-heap-limit"_kj;
     case AutogateKey::USER_SPAN_CONTEXT_PROPAGATION:
       return "user-span-context-propagation"_kj;
+    case AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE:
+      return "updated-auto-allocate-chunk-size"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -48,6 +48,8 @@ enum class AutogateKey {
   INCREASE_SQLITE_HARD_HEAP_LIMIT,
   // Enable user span context propagation across worker-to-worker subrequests.
   USER_SPAN_CONTEXT_PROPAGATION,
+  // Apply an updated default autoAllocateChunkSize for ReadableStreams
+  UPDATED_AUTO_ALLOCATE_CHUNK_SIZE,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
The prior change bumped the default too high and triggered memory issues. This uses a more conservative bump and puts it behind an autogate for more testing.