### PR TITLE
pin OpenCode to  "1.4.6"

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -39,7 +39,7 @@ jobs:
           mentions: '/bigbonk'
           variant: 'max'
           permissions: write
-          opencode_version: '1.14.19'
+          opencode_version: "1.4.6"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk
           # to update their PR via /bigbonk.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -38,7 +38,7 @@ jobs:
           model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
           mentions: '/bonk,@ask-bonk'
           permissions: write
-          opencode_version: '1.14.19'
+          opencode_version: "1.4.6"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk
           # to update their PR via /bonk.

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -44,7 +44,7 @@ jobs:
           model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
           forks: 'false'
           permissions: write
-          opencode_version: '1.14.19'
+          opencode_version: "1.4.6"
           # The auto-reviewer must never push to PR branches. Its prompt
           # (bonk_reviewer.md) already forbids git write ops, but NO_PUSH
           # enforces that at the token level so it holds even if the model


### PR DESCRIPTION
This resolves the OpenCode `ProviderInit` errors that we believe were introduced via https://github.com/anomalyco/opencode/commit/6b2083898120c02413dae806e749872ae407d9d1

See also https://github.com/cloudflare/kumo/pull/432/changes