### PR TITLE
Try to debug "pushed external is not a byte stream".

### DIFF
--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -854,7 +854,8 @@ jsg::Ref<ReadableStream> ReadableStream::deserialize(
 
   kj::Own<kj::AsyncInputStream> in;
   if (rs.hasStream()) {
-    in = ioctx.getExternalPusher()->unwrapStream(rs.getStream());
+    in =
+        ioctx.getExternalPusher()->unwrapStream(rs.getStream(), externalHandler->getDebugContext());
   } else {
     kj::Maybe<uint64_t> expectedLength;
     auto el = rs.getExpectedLength();

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -217,11 +217,14 @@ struct DeserializeResult {
 };
 
 // Call to construct a JS value from an `rpc::JsValue`.
-DeserializeResult deserializeJsValue(
-    jsg::Lock& js, rpc::JsValue::Reader reader, kj::Maybe<StreamSinkImpl&> streamSink = kj::none) {
+DeserializeResult deserializeJsValue(jsg::Lock& js,
+    rpc::JsValue::Reader reader,
+    kj::LiteralStringConst debugContext,
+    kj::Maybe<StreamSinkImpl&> streamSink = kj::none) {
   auto disposalGroup = kj::heap<RpcStubDisposalGroup>();
 
-  RpcDeserializerExternalHandler externalHandler(reader.getExternals(), *disposalGroup, streamSink);
+  RpcDeserializerExternalHandler externalHandler(
+      reader.getExternals(), *disposalGroup, streamSink, debugContext);
 
   jsg::Deserializer deserializer(js, reader.getV8Serialized(), kj::none, kj::none,
       jsg::Deserializer::Options{
@@ -250,7 +253,8 @@ DeserializeResult deserializeJsValue(
 jsg::JsValue deserializeRpcReturnValue(jsg::Lock& js,
     rpc::JsRpcTarget::CallResults::Reader callResults,
     kj::Maybe<StreamSinkImpl&> streamSink) {
-  auto [value, disposalGroup, ss] = deserializeJsValue(js, callResults.getResult(), streamSink);
+  auto [value, disposalGroup, ss] =
+      deserializeJsValue(js, callResults.getResult(), "return"_kjc, streamSink);
 
   if (streamSink == kj::none) {
     KJ_REQUIRE(ss == kj::none,
@@ -1423,7 +1427,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       kj::Maybe<rpc::JsValue::Reader> args) {
     // We received arguments from the client, deserialize them back to JS.
     KJ_IF_SOME(a, args) {
-      auto [value, disposalGroup, streamSink] = deserializeJsValue(js, a);
+      auto [value, disposalGroup, streamSink] = deserializeJsValue(js, a, "params"_kjc);
       auto args = KJ_REQUIRE_NONNULL(
           value.tryCast<jsg::JsArray>(), "expected JsArray when deserializing arguments.");
       // Call() expects a `Local<Value> []`... so we populate an array.
@@ -1483,7 +1487,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
     kj::Maybe<jsg::JsArray> argsArrayFromClient;
     size_t argCountFromClient = 0;
     KJ_IF_SOME(a, args) {
-      auto [value, disposalGroup, ss] = deserializeJsValue(js, a);
+      auto [value, disposalGroup, ss] = deserializeJsValue(js, a, "paramsNonClass"_kjc);
       streamSink = kj::mv(ss);
 
       auto array = KJ_REQUIRE_NONNULL(

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -128,10 +128,12 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
   // deserializing results. If omitted, it will be constructed on-demand.
   RpcDeserializerExternalHandler(capnp::List<rpc::JsValue::External>::Reader externals,
       RpcStubDisposalGroup& disposalGroup,
-      kj::Maybe<StreamSinkImpl&> streamSink)
+      kj::Maybe<StreamSinkImpl&> streamSink,
+      kj::LiteralStringConst debugContext)
       : externals(externals),
         disposalGroup(disposalGroup),
-        streamSink(streamSink) {}
+        streamSink(streamSink),
+        debugContext(debugContext) {}
   ~RpcDeserializerExternalHandler() noexcept(false);
 
   // Read and return the next external.
@@ -154,6 +156,12 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
     return kj::mv(streamSinkCap);
   }
 
+  // Return a string literal to include in deserialization errors for debugging. (In particular
+  // this specifies if it's params or return.)
+  kj::LiteralStringConst getDebugContext() {
+    return debugContext;
+  }
+
  private:
   capnp::List<rpc::JsValue::External>::Reader externals;
   uint i = 0;
@@ -163,6 +171,8 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
 
   kj::Maybe<StreamSinkImpl&> streamSink;
   kj::Maybe<rpc::JsValue::StreamSink::Client> streamSinkCap;
+
+  kj::LiteralStringConst debugContext;
 };
 
 // Base class for objects which can be sent over RPC, but doing so actually sends a stub which

--- a/src/workerd/io/external-pusher.c++
+++ b/src/workerd/io/external-pusher.c++
@@ -131,17 +131,27 @@ kj::Promise<void> ExternalPusherImpl::pushByteStream(PushByteStreamContext conte
 }
 
 kj::Own<kj::AsyncInputStream> ExternalPusherImpl::unwrapStream(
-    ExternalPusher::InputStream::Client cap) {
-  return kj::newPromisedStream(unwrapStreamImpl(kj::mv(cap)));
+    ExternalPusher::InputStream::Client cap, kj::LiteralStringConst debugContext) {
+  return kj::newPromisedStream(unwrapStreamImpl(kj::mv(cap), debugContext));
 }
 
 kj::Promise<kj::Own<kj::AsyncInputStream>> ExternalPusherImpl::unwrapStreamImpl(
-    ExternalPusher::InputStream::Client cap) {
-  auto& unwrapped = KJ_REQUIRE_NONNULL(
-      co_await inputStreamSet.getLocalServer(cap), "pushed external is not a byte stream");
+    ExternalPusher::InputStream::Client cap, kj::LiteralStringConst debugContext) {
+  KJ_IF_SOME(unwrapped, co_await inputStreamSet.getLocalServer(cap)) {
+    co_return KJ_REQUIRE_NONNULL(kj::mv(kj::downcast<InputStreamImpl>(unwrapped).stream),
+        "pushed byte stream has already been consumed");
+  } else {
+    auto hook = capnp::ClientHook::from(cap);
+    KJ_IF_SOME(r, hook->getResolved()) {
+      hook = r.addRef();
+    }
 
-  co_return KJ_REQUIRE_NONNULL(kj::mv(kj::downcast<InputStreamImpl>(unwrapped).stream),
-      "pushed byte stream has already been consumed");
+    // If we do `typeid(*hook)`, we get a compiler warning (which becomes an error) about the
+    // parameter to typeid having a side effect... so do it here.
+    auto& hookRef = *hook;
+
+    KJ_FAIL_REQUIRE("pushed external is not a byte stream", debugContext, typeid(hookRef).name());
+  }
 }
 
 // =======================================================================================

--- a/src/workerd/io/external-pusher.h
+++ b/src/workerd/io/external-pusher.h
@@ -24,7 +24,8 @@ class ExternalPusherImpl: public rpc::JsValue::ExternalPusher::Server, public kj
 
   using ExternalPusher = rpc::JsValue::ExternalPusher;
 
-  kj::Own<kj::AsyncInputStream> unwrapStream(ExternalPusher::InputStream::Client cap);
+  kj::Own<kj::AsyncInputStream> unwrapStream(
+      ExternalPusher::InputStream::Client cap, kj::LiteralStringConst debugContext);
 
   // Box which holds the reason why an AbortSignal was aborted. May be either:
   // - A serialized V8 value if the signal was aborted from JavaScript.
@@ -51,7 +52,7 @@ class ExternalPusherImpl: public rpc::JsValue::ExternalPusher::Server, public kj
   capnp::CapabilityServerSet<ExternalPusher::AbortSignal> abortSignalSet;
 
   kj::Promise<kj::Own<kj::AsyncInputStream>> unwrapStreamImpl(
-      ExternalPusher::InputStream::Client cap);
+      ExternalPusher::InputStream::Client cap, kj::LiteralStringConst debugContext);
 
   kj::Promise<void> unwrapAbortSignalImpl(
       ExternalPusher::AbortSignal::Client cap, kj::Own<PendingAbortReason> pendingReason);


### PR DESCRIPTION
This adds some additional context:
- Whether it's in params or a return value.
- What exact type the capability is, that apparently didn't match.