### PR TITLE
Move experimental configureReadReplication from ctx.storage to ctx.

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -888,37 +888,17 @@ void DurableObjectStorage::disableReplicas() {
   return cache->disableReplicas();
 }
 
-jsg::Promise<void> DurableObjectStorage::configureReadReplication(
-    jsg::Lock& js, ReadReplicationOptions options) {
-  auto& context = IoContext::current();
-  auto traceContext =
-      context.makeUserTraceSpan("durable_object_storage_configureReadReplication"_kjc);
-
-  if (maybePrimary != kj::none) {
-    JSG_FAIL_REQUIRE(Error, "Replica Durable Objects cannot call configureReadReplication().");
-  }
-
-  bool enabled = [&]() {
-    if (options.mode == "auto"_kj) {
-      return true;
-    } else if (options.mode == "disabled"_kj) {
-      return false;
-    }
-    JSG_FAIL_REQUIRE(TypeError,
-        "configureReadReplication() called with unknown mode setting: ", options.mode, ".");
-  }();
-
-  auto promise = cache->configureReadReplication(ReadReplicationIsEnabled(enabled));
-
-  return context.attachSpans(js, context.awaitIo(js, kj::mv(promise)), kj::mv(traceContext));
-}
-
 jsg::Optional<jsg::Ref<DurableObject>> DurableObjectStorage::getPrimary(jsg::Lock& js) {
   // TODO(cleanup): the primary stub should live on DurableObjectState instead of DurableObjectStorage.
   KJ_IF_SOME(primary, maybePrimary) {
     return primary.addRef();
   }
   return kj::none;
+}
+
+bool DurableObjectStorage::isReplica() {
+  // TODO(cleanup): the primary stub should live on DurableObjectState instead of DurableObjectStorage.
+  return maybePrimary != kj::none;
 }
 
 ActorCacheOps& DurableObjectTransaction::getCache(OpName op) {
@@ -1307,6 +1287,36 @@ jsg::Optional<jsg::Ref<DurableObject>> DurableObjectState::getPrimaryStub(jsg::L
     return s->getPrimary(js);
   }
   return kj::none;
+}
+
+jsg::Promise<void> DurableObjectState::configureReadReplication(
+    jsg::Lock& js, DurableObjectState::ReadReplicationOptions options) {
+
+  auto& context = IoContext::current();
+  auto traceContext =
+      context.makeUserTraceSpan("durable_object_state_configureReadReplication"_kjc);
+
+  auto& s =
+      JSG_REQUIRE_NONNULL(storage, TypeError, "This actor does not support read replication.");
+
+  if (s->isReplica()) {
+    JSG_FAIL_REQUIRE(Error, "Replica Durable Objects cannot call configureReadReplication().");
+  }
+
+  bool enabled = [&]() {
+    if (options.mode == "auto"_kj) {
+      return true;
+    } else if (options.mode == "disabled"_kj) {
+      return false;
+    }
+    JSG_FAIL_REQUIRE(TypeError,
+        "configureReadReplication() called with unknown mode setting: ", options.mode, ".");
+  }();
+
+  auto promise =
+      s->getActorCacheInterface().configureReadReplication(ReadReplicationIsEnabled(enabled));
+
+  return context.attachSpans(js, context.awaitIo(js, kj::mv(promise)), kj::mv(traceContext));
 }
 
 kj::Array<kj::byte> serializeV8Value(jsg::Lock& js, const jsg::JsValue& value) {

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -277,7 +277,7 @@ class DurableObjectStorage: public jsg::Object, public DurableObjectStorageOpera
   // Once a Durable Object instance calls `ensureReplicas`, all subsequent calls will be no-ops,
   // making it idempotent, unless `disableReplicas` has been called between `ensureReplicas` calls.
   //
-  // Deprecated: See configureReadReplication.
+  // Deprecated: See DurableObjectState::configureReadReplication.
   void ensureReplicas();
 
   // Arrange to disable replicas for this Durable Object.
@@ -285,23 +285,16 @@ class DurableObjectStorage: public jsg::Object, public DurableObjectStorageOpera
   // If replicas have never been created, this is a no-op. Similar to `ensureReplicas`, repeated
   // calls are no-ops unless `ensureReplicas` re-enabled the replicas.
   //
-  // Deprecated: See configureReadReplication.
+  // Deprecated: See DurableObjectState::configureReadReplication.
   void disableReplicas();
 
-  struct ReadReplicationOptions {
-    kj::String mode;
-
-    JSG_STRUCT(mode);
-    JSG_STRUCT_TS_OVERRIDE(DurableObjectReadReplicationOptions { mode: "auto" | "disabled"; });
-  };
-
-  // Arrange to change replica settings for this Durable Object.
-  //
-  // Must be called with a mode of "auto" or "disabled". Repeat calls that set the same settings are
-  // idempotent.
-  jsg::Promise<void> configureReadReplication(jsg::Lock& js, ReadReplicationOptions options);
-
+  // getPrimary returns a new jsg::Ref to the primary stub, if there is one.
+  // If you only need to find out if we're a replica, isReplica does so without additional
+  // refcounting requirements.
   jsg::Optional<jsg::Ref<DurableObject>> getPrimary(jsg::Lock& js);
+
+  // isReplica returns whether we are a replica.
+  bool isReplica();
 
   JSG_RESOURCE_TYPE(DurableObjectStorage, CompatibilityFlags::Reader flags) {
     JSG_METHOD(get);
@@ -331,7 +324,6 @@ class DurableObjectStorage: public jsg::Object, public DurableObjectStorageOpera
     if (flags.getReplicaRouting()) {
       JSG_METHOD(ensureReplicas);
       JSG_METHOD(disableReplicas);
-      JSG_METHOD(configureReadReplication);
     }
 
     JSG_TS_OVERRIDE({
@@ -685,6 +677,19 @@ class DurableObjectState: public jsg::Object {
   // Returns a stub for the primary if there is one.
   jsg::Optional<jsg::Ref<DurableObject>> getPrimaryStub(jsg::Lock& js);
 
+  struct ReadReplicationOptions {
+    kj::String mode;
+
+    JSG_STRUCT(mode);
+    JSG_STRUCT_TS_OVERRIDE(DurableObjectReadReplicationOptions { mode: "auto" | "disabled"; });
+  };
+
+  // Change replica settings for this Durable Object.
+  //
+  // Must be called with a mode of "auto" or "disabled". Repeat calls that set the same settings are
+  // idempotent.
+  jsg::Promise<void> configureReadReplication(jsg::Lock& js, ReadReplicationOptions options);
+
   JSG_RESOURCE_TYPE(DurableObjectState, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     if (flags.getEnableCtxExports()) {
@@ -714,6 +719,10 @@ class DurableObjectState: public jsg::Object {
     JSG_METHOD(getTags);
 
     JSG_METHOD(abort);
+
+    if (flags.getReplicaRouting()) {
+      JSG_METHOD(configureReadReplication);
+    }
 
     JSG_TS_ROOT();
 
@@ -772,7 +781,7 @@ class DurableObjectState: public jsg::Object {
 
 #define EW_ACTOR_STATE_ISOLATE_TYPES                                                               \
   api::ActorState, api::DurableObjectState, api::DurableObjectTransaction,                         \
-      api::DurableObjectStorage, api::DurableObjectStorage::ReadReplicationOptions,                \
+      api::DurableObjectStorage, api::DurableObjectState::ReadReplicationOptions,                  \
       api::DurableObjectStorage::TransactionOptions,                                               \
       api::DurableObjectStorageOperations::ListOptions,                                            \
       api::DurableObjectStorageOperations::GetOptions,                                             \

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -710,6 +710,9 @@ interface DurableObjectState<Props = unknown> {
   getHibernatableWebSocketEventTimeout(): number | null;
   getTags(ws: WebSocket): string[];
   abort(reason?: string): void;
+  configureReadReplication(
+    options: DurableObjectReadReplicationOptions,
+  ): Promise<void>;
 }
 interface DurableObjectTransaction {
   get<T = unknown>(
@@ -787,9 +790,6 @@ interface DurableObjectStorage {
   readonly primary?: DurableObjectStub;
   ensureReplicas(): void;
   disableReplicas(): void;
-  configureReadReplication(
-    options: DurableObjectReadReplicationOptions,
-  ): Promise<void>;
 }
 interface DurableObjectReadReplicationOptions {
   mode: "auto" | "disabled";

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -712,6 +712,9 @@ export interface DurableObjectState<Props = unknown> {
   getHibernatableWebSocketEventTimeout(): number | null;
   getTags(ws: WebSocket): string[];
   abort(reason?: string): void;
+  configureReadReplication(
+    options: DurableObjectReadReplicationOptions,
+  ): Promise<void>;
 }
 export interface DurableObjectTransaction {
   get<T = unknown>(
@@ -789,9 +792,6 @@ export interface DurableObjectStorage {
   readonly primary?: DurableObjectStub;
   ensureReplicas(): void;
   disableReplicas(): void;
-  configureReadReplication(
-    options: DurableObjectReadReplicationOptions,
-  ): Promise<void>;
 }
 export interface DurableObjectReadReplicationOptions {
   mode: "auto" | "disabled";


### PR DESCRIPTION
Before read replication becomes generally available, make the API more friendly by moving configureReadReplication up. Logically, read replication is more a property of the DO itself than the storage subsystem.

Should be retargeted at main once https://github.com/cloudflare/workerd/pull/6663 is merged