### PR TITLE
Improve error for `fetch` on top-level with dedicated snapshot

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -43,6 +43,7 @@ import { PyodideVersion } from 'pyodide-internal:const';
 import { default as pythonStdlibZip } from 'pyodideRuntime-internal:python_stdlib.zip';
 import { default as pyodideAsmWasm } from 'pyodideRuntime-internal:pyodide.asm.wasm';
 import { instantiateEmscriptenModule } from 'pyodideRuntime-internal:emscriptenSetup';
+import { createImportProxy } from 'pyodide-internal:serializeJsModule';
 
 // Wire the PythonWorkersInternalError constructor's reporter to the C++ FatalReporter module.
 // See util.ts for why this indirection is needed (pool bundling constraints).
@@ -249,7 +250,14 @@ export async function loadPyodide(
       instantiateEmscriptenModule(IS_WORKERD, pythonStdlibZip, pyodideAsmWasm)
     );
     Module.compileModuleFromReadOnlyFS = compileModuleFromReadOnlyFS;
-    Module.API.config.jsglobals = globalThis;
+    if (Module.API.version === PyodideVersion.V0_28_2) {
+      Module.API.config.jsglobals = createImportProxy(
+        'global this',
+        globalThis
+      );
+    } else {
+      Module.API.config.jsglobals = globalThis;
+    }
     if (isWorkerd) {
       Module.API.config.resolveLockFilePromise!(lockfile);
     }

--- a/src/pyodide/internal/serializeJsModule.ts
+++ b/src/pyodide/internal/serializeJsModule.ts
@@ -43,14 +43,16 @@ export function deserializeJsModule(
   obj: SerializedJsModule,
   jsModules: JsModules
 ): unknown {
-  return (
-    obj.accessorList.reduce((x: JsModules, y: string): JsModules => {
+  const { accessorList, moduleName } = obj;
+  const result =
+    accessorList.reduce((x: JsModules, y: string): JsModules => {
       if (y === getPrototypeOfKey) {
         return Reflect.getPrototypeOf(x) as JsModules;
       }
       return x[y]!;
-    }, jsModules[obj.moduleName]!) ?? null
-  );
+    }, jsModules[moduleName]!) ?? null;
+  // Support stacked snapshots
+  return createImportProxy(moduleName, result, accessorList);
 }
 
 // This tracks the information needed to "serialize" attributes of js modules. We need the name and
@@ -59,11 +61,11 @@ export function deserializeJsModule(
 //
 // If the receiver of a function call is an import proxy, this can cause the call to crash, so we
 // unwrap the receiver using the getObject symbol.
-export function createImportProxy(
+export function createImportProxy<T>(
   name: string,
-  mod: any,
+  mod: T,
   accessorList: (string | symbol)[] = []
-): any {
+): T {
   if (!IS_CREATING_SNAPSHOT) {
     return mod;
   }
@@ -110,5 +112,5 @@ export function createImportProxy(
         getPrototypeOfKey,
       ]);
     },
-  });
+  }) as T;
 }

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -118,9 +118,16 @@ const HEADER_SIZE = 4 * 4;
 const LOADED_SNAPSHOT_META: LoadedSnapshotMeta | undefined = decodeSnapshot(
   MEMORY_SNAPSHOT_READER
 );
-const JS_MODULES: Record<string, any> = await importJsModulesFromSnapshot(
-  LOADED_SNAPSHOT_META?.jsModuleNames
-);
+let JS_MODULES: Record<string, any>;
+
+export async function fillSnapshotJsModules(
+  doAnImport: (mod: string) => Promise<any>
+): Promise<void> {
+  JS_MODULES = await importJsModulesFromSnapshot(
+    doAnImport,
+    LOADED_SNAPSHOT_META?.jsModuleNames
+  );
+}
 const CREATED_SNAPSHOT_META: Required<DsoLoadInfo> = {
   soMemoryBases: {},
   soTableBases: {},
@@ -572,15 +579,22 @@ ${describeValue(obj)}
 }
 
 async function importJsModulesFromSnapshot(
+  doAnImport: (mod: string) => Promise<any>,
   jsModuleNames: ReadonlyArray<string> | undefined
 ): Promise<Record<string, any>> {
   if (jsModuleNames === undefined) {
     return {};
   }
+  async function doImport(x: string): Promise<any> {
+    if (x === 'global this') {
+      return globalThis;
+    }
+    return await doAnImport(x);
+  }
   return Object.fromEntries(
     await Promise.all(
       jsModuleNames.map(
-        async (x): Promise<[string, any]> => [x, await import(x)]
+        async (x): Promise<[string, any]> => [x, await doImport(x)]
       )
     )
   );
@@ -927,7 +941,9 @@ export function finalizeBootstrap(
   customSerializedObjects: CustomSerializedObjects
 ): void {
   Module.API.config._makeSnapshot =
-    IS_CREATING_SNAPSHOT && Module.API.version !== PyodideVersion.V0_26_0a2;
+    IS_CREATING_SNAPSHOT &&
+    Module.API.version !== PyodideVersion.V0_26_0a2 &&
+    Module.API.version !== PyodideVersion.V0_28_2;
   enterJaegerSpan('finalize_bootstrap', () => {
     Module.API.finalizeBootstrap(
       LOADED_SNAPSHOT_META?.hiwire,

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -27,6 +27,7 @@ import {
 } from 'pyodide-internal:python';
 import { patchLoadPackage } from 'pyodide-internal:setupPackages';
 import {
+  fillSnapshotJsModules,
   LOADED_SNAPSHOT_TYPE,
   maybeCollectDedicatedSnapshot,
 } from 'pyodide-internal:snapshot';
@@ -115,6 +116,7 @@ export async function setDoAnImport(
       throw new PythonWorkersInternalError(message);
     },
   };
+  await fillSnapshotJsModules(doAnImport);
 }
 
 function handleSrcImport(pyodide: Pyodide, e: any): never {

--- a/src/workerd/server/tests/python/hello/worker.py
+++ b/src/workerd/server/tests/python/hello/worker.py
@@ -1,8 +1,28 @@
-def test():
-    from js import console
-    from js.WebAssembly import Suspending
+import js
+from js import console, globalThis
 
-    Suspending  # noqa: B018
+from pyodide import __version__
+from pyodide.ffi import JsException
+
+if __version__ == "0.26.0a2":
+    assert js == globalThis
+else:
+    # js should be patched at top level in order to allow snapshotting.
+    assert js != globalThis
+
+# Calling fetch at top level should give a good error message despite patching.
+try:
+    js.fetch("example.com")
+except JsException as e:
+    print(e)
+    assert "Disallowed operation called within global scope" in str(e)
+else:
+    assert False  # noqa: B011
+
+
+def test():
+    # js should be correctly restored when restoring snapshot
+    assert js == globalThis
 
     # This just tests that nothing raises when we run this. It isn't great though
     # because we don't test whether we printed anything.


### PR DESCRIPTION
Changes error for top level fetch from:
```
TypeError: Illegal invocation: function called with incorrect `this` reference.
```
to:
```
Error: Disallowed operation called within global scope. Asynchronous I/O
(ex: fetch() or connect()), setting a timeout, and generating random values are
not allowed within global scope. ...
```

This is a workaround for the fact that we don't have pyodide/pyodide#5588 in Pyodide 0.28.2, this fix is upstreamed starting with Pyodide 0.29.0