### PR TITLE
Attribute non-span tail events to the current user span

### DIFF
--- a/src/cloudflare/internal/test/tracing/BUILD.bazel
+++ b/src/cloudflare/internal/test/tracing/BUILD.bazel
@@ -11,3 +11,9 @@ wd_test(
     args = ["--experimental"],
     data = glob(["*.js"]) + ["//src/cloudflare/internal/test:instrumentation-test-helper.js"],
 )
+
+wd_test(
+    src = "tracing-log-attribution-test.wd-test",
+    args = ["--experimental"],
+    data = glob(["*.js"]),
+)

--- a/src/cloudflare/internal/test/tracing/tracing-log-attribution-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-log-attribution-instrumentation-test.js
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Tail-worker side of tracing-log-attribution-test. Collects streaming tail events
+// and asserts that Log/Exception/DiagnosticChannelEvent events carry the spanId of
+// the currently-active user span (as opened by `withSpan`/`enterSpan`), rather
+// than the root invocation's spanId.
+
+import assert from 'node:assert';
+
+// Per-invocation collector:
+//   spans: Map<spanId, { spanId, parentSpanId, name, invocationId, closed, ...attrs }>
+//   logs:  Array<{ message, spanContextSpanId, invocationId }>
+//   exceptions: Array<{ name, message, spanContextSpanId, invocationId }>
+//   diagnosticChannelEvents: Array<{ channel, spanContextSpanId, invocationId }>
+//   topLevelSpanId: string  // from the onset event
+const state = {
+  invocationPromises: [],
+  byInvocation: new Map(),
+};
+
+function getOrCreateInvocation(invocationId) {
+  let inv = state.byInvocation.get(invocationId);
+  if (!inv) {
+    inv = {
+      invocationId,
+      spans: new Map(),
+      logs: [],
+      exceptions: [],
+      diagnosticChannelEvents: [],
+      topLevelSpanId: null,
+    };
+    state.byInvocation.set(invocationId, inv);
+  }
+  return inv;
+}
+
+export default {
+  tailStream(event, env, ctx) {
+    // `event` is the onset event. `event.event.spanId` is the top-level span ID
+    // for this invocation; every other event's `spanContext.spanId` describes the
+    // span that was active at event time.
+    const inv = getOrCreateInvocation(event.invocationId);
+    inv.topLevelSpanId = event.event.spanId;
+
+    let resolveFn;
+    state.invocationPromises.push(
+      new Promise((resolve) => {
+        resolveFn = resolve;
+      })
+    );
+
+    return (event) => {
+      const inv = getOrCreateInvocation(event.invocationId);
+      const currentSpanId = event.spanContext?.spanId;
+      switch (event.event.type) {
+        case 'spanOpen':
+          inv.spans.set(event.event.spanId, {
+            spanId: event.event.spanId,
+            parentSpanId: currentSpanId,
+            name: event.event.name,
+            invocationId: event.invocationId,
+          });
+          break;
+        case 'attributes': {
+          // Attributes belong to the span whose id equals spanContext.spanId.
+          const span = inv.spans.get(currentSpanId);
+          if (span) {
+            for (const { name, value } of event.event.info) {
+              span[name] = value;
+            }
+          }
+          break;
+        }
+        case 'spanClose': {
+          const span = inv.spans.get(currentSpanId);
+          if (span) span.closed = true;
+          break;
+        }
+        case 'log':
+          inv.logs.push({
+            message: event.event.message,
+            spanContextSpanId: currentSpanId,
+            invocationId: event.invocationId,
+          });
+          break;
+        case 'exception':
+          inv.exceptions.push({
+            name: event.event.name,
+            message: event.event.message,
+            spanContextSpanId: currentSpanId,
+            invocationId: event.invocationId,
+          });
+          break;
+        case 'diagnosticChannel':
+          inv.diagnosticChannelEvents.push({
+            channel: event.event.channel,
+            spanContextSpanId: currentSpanId,
+            invocationId: event.invocationId,
+          });
+          break;
+        case 'outcome':
+          resolveFn();
+          break;
+      }
+    };
+  },
+};
+
+// Locate the invocation whose span set contains a span with the given name.
+// Also returns that span for convenience.
+function findInvocationBySpanName(spanName) {
+  const matches = [];
+  for (const inv of state.byInvocation.values()) {
+    for (const span of inv.spans.values()) {
+      if (span.name === spanName) {
+        matches.push({ inv, span });
+      }
+    }
+  }
+  assert.strictEqual(
+    matches.length,
+    1,
+    `Expected exactly one invocation containing span "${spanName}", got ${matches.length}`
+  );
+  return matches[0];
+}
+
+// Locate the invocation that produced exactly the set of top-level (non-nested)
+// spans in `spanNames`. Used for the logOutsideAnySpan case, which opens no
+// user spans but is identified by the single log it emits.
+// Log events have their `message` set to the JSON-parsed console.log argument
+// array (see Log::ToJs in trace-stream.c++), so we need a deep stringify to
+// search within.
+function logContains(log, needle) {
+  try {
+    return JSON.stringify(log.message).includes(needle);
+  } catch (_) {
+    return false;
+  }
+}
+
+function findInvocationByLogMessage(message) {
+  const matches = [];
+  for (const inv of state.byInvocation.values()) {
+    if (inv.logs.some((l) => logContains(l, message))) {
+      matches.push(inv);
+    }
+  }
+  assert.strictEqual(
+    matches.length,
+    1,
+    `Expected exactly one invocation with log message containing "${message}", got ${matches.length}`
+  );
+  return matches[0];
+}
+
+function findLog(inv, substring) {
+  const matches = inv.logs.filter((l) => logContains(l, substring));
+  assert.strictEqual(
+    matches.length,
+    1,
+    `Expected exactly one log containing "${substring}" in invocation ${inv.invocationId}, got ${matches.length}`
+  );
+  return matches[0];
+}
+
+export const validate = {
+  async test() {
+    // Wait for every invocation's `outcome` event to arrive.
+    await Promise.allSettled(state.invocationPromises);
+
+    // ---------- Case 1: logInsideEnterSpan ----------
+    // Log inside a single enterSpan must be attributed to that span (not the root).
+    {
+      const { inv, span } = findInvocationBySpanName('log-attr-single');
+      const log = findLog(inv, 'log-attr-single-message');
+      assert.strictEqual(
+        log.spanContextSpanId,
+        span.spanId,
+        `logInsideEnterSpan: log.spanContext.spanId (${log.spanContextSpanId}) should equal the enclosing span id (${span.spanId})`
+      );
+      assert.notStrictEqual(
+        log.spanContextSpanId,
+        inv.topLevelSpanId,
+        'logInsideEnterSpan: log should NOT be attributed to the root invocation span'
+      );
+    }
+
+    // ---------- Case 2: logInsideNestedEnterSpan ----------
+    {
+      const { inv, span: outer } = findInvocationBySpanName('log-attr-outer');
+      const inner = Array.from(inv.spans.values()).find(
+        (s) => s.name === 'log-attr-inner'
+      );
+      assert.ok(inner, 'expected an inner span');
+      assert.strictEqual(
+        inner.parentSpanId,
+        outer.spanId,
+        'inner span must be a child of outer'
+      );
+
+      const beforeInner = findLog(inv, 'log-attr-outer-before-inner');
+      const innerMsg = findLog(inv, 'log-attr-inner-message');
+      const afterInner = findLog(inv, 'log-attr-outer-after-inner');
+
+      assert.strictEqual(
+        beforeInner.spanContextSpanId,
+        outer.spanId,
+        'log before inner must be attributed to outer'
+      );
+      assert.strictEqual(
+        innerMsg.spanContextSpanId,
+        inner.spanId,
+        'log inside inner must be attributed to inner (not outer, not root)'
+      );
+      assert.notStrictEqual(
+        innerMsg.spanContextSpanId,
+        inv.topLevelSpanId,
+        'log inside inner must NOT be attributed to the root'
+      );
+      assert.strictEqual(
+        afterInner.spanContextSpanId,
+        outer.spanId,
+        'log after inner closes must be re-attributed to outer'
+      );
+    }
+
+    // ---------- Case 3: logAcrossAwait ----------
+    // This is the acid test: the fix only works if the AsyncContextFrame carrying
+    // the user span propagates across the microtask boundary introduced by `await`.
+    {
+      const { inv, span } = findInvocationBySpanName('log-attr-async');
+      const log = findLog(inv, 'log-attr-async-message');
+      assert.strictEqual(
+        log.spanContextSpanId,
+        span.spanId,
+        'logAcrossAwait: log inside async enterSpan after await must be attributed to that span'
+      );
+      assert.notStrictEqual(
+        log.spanContextSpanId,
+        inv.topLevelSpanId,
+        'logAcrossAwait: log must NOT be attributed to the root'
+      );
+    }
+
+    // ---------- Case 4: logOutsideAnySpan (fall-back path) ----------
+    // No user span is active, so the log's spanContext.spanId must equal the
+    // invocation's top-level (onset) span id. This proves we don't break logs
+    // that have no user span to attribute to.
+    {
+      const inv = findInvocationByLogMessage('log-attr-root-message');
+      const log = findLog(inv, 'log-attr-root-message');
+      assert.strictEqual(
+        log.spanContextSpanId,
+        inv.topLevelSpanId,
+        'logOutsideAnySpan: with no user span active, log must fall back to the root invocation span'
+      );
+    }
+
+    // ---------- Case 5: diagnosticsChannelInsideEnterSpan ----------
+    {
+      const { inv, span } = findInvocationBySpanName('log-attr-dc');
+      assert.strictEqual(
+        inv.diagnosticChannelEvents.length,
+        1,
+        'expected exactly one diagnosticChannelEvent'
+      );
+      const dce = inv.diagnosticChannelEvents[0];
+      assert.strictEqual(
+        dce.channel,
+        'log-attr-dc-channel',
+        'diagnosticChannelEvent channel name'
+      );
+      assert.strictEqual(
+        dce.spanContextSpanId,
+        span.spanId,
+        'diagnosticChannelEvent must be attributed to the enclosing user span'
+      );
+      assert.notStrictEqual(
+        dce.spanContextSpanId,
+        inv.topLevelSpanId,
+        'diagnosticChannelEvent must NOT be attributed to the root'
+      );
+    }
+
+    console.log('All tracing-log-attribution tests passed!');
+  },
+};

--- a/src/cloudflare/internal/test/tracing/tracing-log-attribution-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-log-attribution-test.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Tests that non-span tail events (Log, Exception, DiagnosticChannelEvent) emitted
+// to a streaming tail worker carry the spanContext of the currently-active user
+// span (pushed via ctx.tracing.enterSpan / withSpan), rather than always pointing
+// at the root invocation span. See EW-10672.
+//
+// The companion tail worker in tracing-log-attribution-instrumentation-test.js
+// collects the streaming tail events and runs the assertions in a follow-up
+// `validate` test.
+
+import { channel } from 'node:diagnostics_channel';
+
+export const logInsideEnterSpan = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // Baseline: a log inside an enterSpan must be attributed to that span.
+    withSpan('log-attr-single', (span) => {
+      span.setAttribute('case', 'logInsideEnterSpan');
+      console.log('log-attr-single-message');
+    });
+  },
+};
+
+export const logInsideNestedEnterSpan = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // Nested spans: the log inside the inner span must be attributed to the inner
+    // span (not the outer, and not the root invocation).
+    withSpan('log-attr-outer', (outer) => {
+      outer.setAttribute('case', 'logInsideNestedEnterSpan');
+      outer.setAttribute('role', 'outer');
+      // Log inside outer (before opening inner) -- attributed to outer.
+      console.log('log-attr-outer-before-inner');
+      withSpan('log-attr-inner', (inner) => {
+        inner.setAttribute('case', 'logInsideNestedEnterSpan');
+        inner.setAttribute('role', 'inner');
+        console.log('log-attr-inner-message');
+      });
+      // After inner closes, this log should be re-attributed to outer.
+      console.log('log-attr-outer-after-inner');
+    });
+  },
+};
+
+export const logAcrossAwait = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // Log inside an async enterSpan AFTER an await. The fix only works if the
+    // AsyncContextFrame carrying the user span propagates across microtasks.
+    await withSpan('log-attr-async', async (span) => {
+      span.setAttribute('case', 'logAcrossAwait');
+      await new Promise((r) => setTimeout(r, 5));
+      console.log('log-attr-async-message');
+    });
+  },
+};
+
+export const logOutsideAnySpan = {
+  async test(ctrl, env, ctx) {
+    // Logs outside any enterSpan should still land at the top-level onset span
+    // (i.e., their parentSpanId equals the root). This confirms we haven't
+    // broken the fall-back path.
+    console.log('log-attr-root-message');
+  },
+};
+
+export const diagnosticsChannelInsideEnterSpan = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // diagnostics_channel.publish() emits a DiagnosticChannelEvent tail event when
+    // there is at least one subscriber. The event should be attributed to the
+    // enclosing user span.
+    const ch = channel('log-attr-dc-channel');
+    ch.subscribe(() => {});
+    withSpan('log-attr-dc', (span) => {
+      span.setAttribute('case', 'diagnosticsChannelInsideEnterSpan');
+      ch.publish({ hello: 'world' });
+    });
+  },
+};

--- a/src/cloudflare/internal/test/tracing/tracing-log-attribution-test.wd-test
+++ b/src/cloudflare/internal/test/tracing/tracing-log-attribution-test.wd-test
@@ -1,0 +1,36 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+# Validates that non-span tail events (Log, Exception, DiagnosticChannelEvent)
+# emitted to a streaming tail worker carry the spanContext of the currently-
+# active user span (pushed via ctx.tracing.enterSpan / withSpan), rather than
+# always pointing at the root invocation span. See EW-10672.
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "tracing-log-attribution-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "tracing-log-attribution-test.js"),
+        ],
+        compatibilityFlags = ["experimental", "nodejs_compat"],
+        streamingTails = ["tail"],
+        bindings = [
+          (
+            name = "tracingTest",
+            wrapped = (
+              moduleName = "cloudflare-internal:test-tracing-wrapper"
+            )
+          )
+        ],
+      )
+    ),
+    ( name = "tail", worker = .tailWorker, ),
+  ]
+);
+
+const tailWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker", esModule = embed "tracing-log-attribution-instrumentation-test.js"),
+  ],
+  compatibilityFlags = ["experimental", "nodejs_compat"],
+);

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1119,6 +1119,16 @@ SpanParent IoContext::getCurrentTraceSpan() {
 }
 
 SpanParent IoContext::getCurrentUserTraceSpan() {
+  // Skip the AsyncContextFrame probe when user tracing isn't wired up: an unobserved
+  // root means enterSpan can't have pushed anything (see Tracing::enterSpan).
+  if (incomingRequests.empty()) {
+    return SpanParent(nullptr);
+  }
+  SpanParent root = getCurrentIncomingRequest().getRootUserTraceSpan();
+  if (!root.isObserved()) {
+    return kj::mv(root);
+  }
+
   // If called while lock is held, try to use the trace info stored in the async context.
   KJ_IF_SOME(lock, currentLock) {
     KJ_IF_SOME(frame, jsg::AsyncContextFrame::current(lock)) {
@@ -1130,11 +1140,7 @@ SpanParent IoContext::getCurrentUserTraceSpan() {
       }
     }
   }
-  // If async context is unavailable, fall back to the root user span of the current request.
-  if (incomingRequests.empty()) {
-    return SpanParent(nullptr);
-  }
-  return getCurrentIncomingRequest().getRootUserTraceSpan();
+  return kj::mv(root);
 }
 
 SpanBuilder IoContext::makeTraceSpan(kj::ConstString operationName) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -909,8 +909,16 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   SpanParent getCurrentTraceSpan();
   SpanParent getCurrentUserTraceSpan();
 
-  tracing::InvocationSpanContext& getInvocationSpanContext() {
-    return getCurrentIncomingRequest().getInvocationSpanContext();
+  // Returns the invocation's traceId/invocationId paired with the currently-active user
+  // span's spanId (as pushed by `ctx.tracing.enterSpan`), falling back to the invocation
+  // root's spanId when no user span is active.
+  tracing::InvocationSpanContext getInvocationSpanContext() {
+    auto& base = getCurrentIncomingRequest().getInvocationSpanContext();
+    tracing::SpanId sid = getCurrentUserTraceSpan().getSpanId();
+    if (sid != tracing::SpanId::nullId) {
+      return tracing::InvocationSpanContext(base.getTraceId(), base.getInvocationId(), sid);
+    }
+    return base.clone();
   }
 
   // Returns a builder for recording tracing spans (or a no-op builder if tracing is inactive).

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -1051,6 +1051,9 @@ class SpanParent {
   // Return the serializable identity of this span for cross-boundary propagation.
   kj::Maybe<tracing::SpanContext> toSpanContext();
 
+  // Returns the observer's spanId, or SpanId::nullId if there is none.
+  tracing::SpanId getSpanId();
+
  private:
   kj::Maybe<kj::Own<SpanObserver>> observer;
 };
@@ -1186,6 +1189,11 @@ class SpanObserver: public kj::Refcounted {
   virtual kj::Maybe<tracing::SpanContext> toSpanContext() {
     return kj::none;
   }
+
+  // Returns this observer's spanId, or SpanId::nullId if it has no identity.
+  virtual tracing::SpanId getSpanId() {
+    return tracing::SpanId::nullId;
+  }
 };
 
 inline kj::Maybe<tracing::SpanContext> SpanParent::toSpanContext() {
@@ -1193,6 +1201,13 @@ inline kj::Maybe<tracing::SpanContext> SpanParent::toSpanContext() {
     return obs->toSpanContext();
   }
   return kj::none;
+}
+
+inline tracing::SpanId SpanParent::getSpanId() {
+  KJ_IF_SOME(obs, observer) {
+    return obs->getSpanId();
+  }
+  return tracing::SpanId::nullId;
 }
 
 inline SpanParent::SpanParent(SpanBuilder& builder): observer(mapAddRef(builder.observer)) {}

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -247,7 +247,7 @@ class UserSpanObserver final: public SpanObserver {
   void onClose(kj::Date endTime, Span::TagMap&& tags, kj::Vector<Span::Log>&& logs) override;
   kj::Date getTime() override;
   kj::Maybe<tracing::SpanContext> toSpanContext() override;
-  tracing::SpanId getSpanId();
+  tracing::SpanId getSpanId() override;
 
  private:
   kj::Own<SpanSubmitter> submitter;


### PR DESCRIPTION
IoContext::getInvocationSpanContext() now substitutes in the currently-active user span's spanId (from the AsyncContextFrame pushed by Tracing::enterSpan), falling back to the invocation root when none is active. Previously Log/Exception/DiagnosticChannelEvent/JsRpc Attribute tail events always reported the root spanId, even when emitted inside a ctx.tracing.enterSpan() callback.