### PR TITLE
Fix early GC collection of Reader

### DIFF
--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -388,6 +388,14 @@ class ReadableStreamController {
     // When a Reader lock is released, the controller will signal to the reader that it has been
     // detached.
     virtual void detach() = 0;
+
+    // Returns a ref-counted reference to this Reader, keeping it alive independently of
+    // its JS wrapper. Used by ReaderLocked to prevent premature GC of the reader while
+    // the stream still needs it. Returns kj::none for non-ref-counted readers (e.g.,
+    // DrainingReader).
+    virtual kj::Maybe<kj::Own<void>> addRef() {
+      return kj::none;
+    }
   };
 
   struct ByobOptions {
@@ -810,21 +818,34 @@ class ReaderLocked {
   static constexpr kj::StringPtr NAME KJ_UNUSED = "reader-locked"_kj;
   ReaderLocked(ReadableStreamController::Reader& reader,
       jsg::Promise<void>::Resolver closedFulfiller,
+      kj::Maybe<kj::Own<void>> readerRef = kj::none,
       kj::Maybe<IoOwn<kj::Canceler>> canceler = kj::none)
       : reader(reader),
         closedFulfiller(kj::mv(closedFulfiller)),
+        readerRef_(kj::mv(readerRef)),
         canceler(kj::mv(canceler)) {}
 
   ReaderLocked(ReaderLocked&&) = default;
   ~ReaderLocked() noexcept(false) {
-    KJ_IF_SOME(r, reader) {
-      r.detach();
-    }
+    // Note: we intentionally do NOT call reader.detach() here. In the normal flow, the
+    // controller settles the closedFulfiller via onClose()/onError() and the reader is
+    // detached explicitly via releaseReader(). If we get here with the reader still set,
+    // it means the stream is being torn down — calling detach() on a potentially-destroyed
+    // reader would be undefined behavior (the reader may already be mid-destruction if
+    // this is part of a GC cascade). The readerRef_ prevents premature destruction of
+    // JSG readers.
   }
   KJ_DISALLOW_COPY(ReaderLocked);
 
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(closedFulfiller);
+    // Once the closedFulfiller has been settled (consumed by maybeResolvePromise or
+    // maybeRejectPromise, which set it to kj::none), the reader ref is no longer needed.
+    // Release it to break the ref cycle: ReaderLocked → Reader → Ref<ReadableStream> →
+    // controller → ReaderLocked.
+    if (closedFulfiller == kj::none) {
+      readerRef_ = kj::none;
+    }
   }
 
   ReadableStreamController::Reader& getReader() {
@@ -839,9 +860,17 @@ class ReaderLocked {
     return canceler;
   }
 
+  // Release the ref-counted reference to the Reader. Should be called when the
+  // closedFulfiller is settled to eagerly break the ref cycle. Also released
+  // automatically as a backup in visitForGc when the fulfiller has been consumed.
+  void releaseReaderRef() {
+    readerRef_ = kj::none;
+  }
+
   void clear() {
     reader = kj::none;
     closedFulfiller = kj::none;
+    readerRef_ = kj::none;
     canceler = kj::none;
   }
 
@@ -853,6 +882,11 @@ class ReaderLocked {
  private:
   kj::Maybe<ReadableStreamController::Reader&> reader;
   kj::Maybe<jsg::Promise<void>::Resolver> closedFulfiller;
+  // Ref-counted reference to the Reader. Keeps the Reader's C++ object alive
+  // independently of its JS wrapper, so that a reader created as a temporary (e.g.,
+  // `rs.getReader().closed.then(...)`) is not collected by GC before the stream has
+  // a chance to settle the closedFulfiller.
+  kj::Maybe<kj::Own<void>> readerRef_;
   kj::Maybe<IoOwn<kj::Canceler>> canceler;
 };
 

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -676,6 +676,13 @@ class WritableStreamController {
     // The ready promise can be replaced whenever backpressure is signaled by the underlying
     // controller.
     virtual void replaceReadyPromise(jsg::Lock& js, jsg::Promise<void> readyPromise) = 0;
+
+    // Returns a ref-counted reference to this Writer, keeping it alive independently of
+    // its JS wrapper. Used by WriterLocked to prevent premature GC of the writer while
+    // the stream still needs it. Returns kj::none for non-ref-counted writers.
+    virtual kj::Maybe<kj::Own<void>> addRef() {
+      return kj::none;
+    }
   };
 
   struct PendingAbort {
@@ -897,20 +904,32 @@ class WriterLocked {
   static constexpr kj::StringPtr NAME KJ_UNUSED = "writer-locked"_kj;
   WriterLocked(WritableStreamController::Writer& writer,
       jsg::Promise<void>::Resolver closedFulfiller,
-      kj::Maybe<jsg::Promise<void>::Resolver> readyFulfiller = kj::none)
+      kj::Maybe<jsg::Promise<void>::Resolver> readyFulfiller = kj::none,
+      kj::Maybe<kj::Own<void>> writerRef = kj::none)
       : writer(writer),
         closedFulfiller(kj::mv(closedFulfiller)),
-        readyFulfiller(kj::mv(readyFulfiller)) {}
+        readyFulfiller(kj::mv(readyFulfiller)),
+        writerRef_(kj::mv(writerRef)) {}
 
   WriterLocked(WriterLocked&&) = default;
   ~WriterLocked() noexcept(false) {
-    KJ_IF_SOME(w, writer) {
-      w.detach();
-    }
+    // Note: we intentionally do NOT call writer.detach() here. In the normal flow, the
+    // controller settles the closedFulfiller and the writer is detached explicitly via
+    // releaseWriter(). If we get here with the writer still set, it means the stream is
+    // being torn down — calling detach() on a potentially-destroyed writer would be
+    // undefined behavior (the writer may already be mid-destruction if this is part of a
+    // GC cascade). The writerRef_ prevents premature destruction of JSG writers.
   }
 
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(closedFulfiller, readyFulfiller);
+    // Once the closedFulfiller has been settled (consumed by maybeResolvePromise or
+    // maybeRejectPromise, which set it to kj::none), the writer ref is no longer needed.
+    // Release it to break the ref cycle: WriterLocked → Writer → Ref<WritableStream> →
+    // controller → WriterLocked.
+    if (closedFulfiller == kj::none) {
+      writerRef_ = kj::none;
+    }
   }
 
   WritableStreamController::Writer& getWriter() {
@@ -932,10 +951,18 @@ class WriterLocked {
     }
   }
 
+  // Release the ref-counted reference to the Writer. Should be called when the
+  // closedFulfiller is settled to eagerly break the ref cycle. Also released
+  // automatically as a backup in visitForGc when the fulfiller has been consumed.
+  void releaseWriterRef() {
+    writerRef_ = kj::none;
+  }
+
   void clear() {
     writer = kj::none;
     closedFulfiller = kj::none;
     readyFulfiller = kj::none;
+    writerRef_ = kj::none;
   }
 
   JSG_MEMORY_INFO(WriterLocked) {
@@ -947,6 +974,11 @@ class WriterLocked {
   kj::Maybe<WritableStreamController::Writer&> writer;
   kj::Maybe<jsg::Promise<void>::Resolver> closedFulfiller;
   kj::Maybe<jsg::Promise<void>::Resolver> readyFulfiller;
+  // Ref-counted reference to the Writer. Keeps the Writer's C++ object alive
+  // independently of its JS wrapper, so that a writer created as a temporary (e.g.,
+  // `ws.getWriter().closed.then(...)`) is not collected by GC before the stream has
+  // a chance to settle the closedFulfiller.
+  kj::Maybe<kj::Own<void>> writerRef_;
 };
 
 template <typename T>

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -825,7 +825,7 @@ class ReaderLocked {
   static constexpr kj::StringPtr NAME KJ_UNUSED = "reader-locked"_kj;
   ReaderLocked(ReadableStreamController::Reader& reader,
       jsg::Promise<void>::Resolver closedFulfiller,
-      kj::Maybe<kj::Own<void>> readerRef = kj::none,
+      kj::Maybe<IoOwn<kj::Own<void>>> readerRef = kj::none,
       kj::Maybe<IoOwn<kj::Canceler>> canceler = kj::none)
       : reader(reader),
         closedFulfiller(kj::mv(closedFulfiller)),
@@ -870,6 +870,7 @@ class ReaderLocked {
   // Release the ref-counted reference to the Reader. Should be called when the
   // closedFulfiller is settled to eagerly break the ref cycle. Also released
   // automatically as a backup in visitForGc when the fulfiller has been consumed.
+  // Also released automatically by IoContext teardown since the ref is IoOwn-managed.
   void releaseReaderRef() {
     readerRef_ = kj::none;
   }
@@ -889,11 +890,13 @@ class ReaderLocked {
  private:
   kj::Maybe<ReadableStreamController::Reader&> reader;
   kj::Maybe<jsg::Promise<void>::Resolver> closedFulfiller;
-  // Ref-counted reference to the Reader. Keeps the Reader's C++ object alive
-  // independently of its JS wrapper, so that a reader created as a temporary (e.g.,
-  // `rs.getReader().closed.then(...)`) is not collected by GC before the stream has
-  // a chance to settle the closedFulfiller.
-  kj::Maybe<kj::Own<void>> readerRef_;
+  // Ref-counted reference to the Reader, managed by the IoContext. Keeps the Reader's
+  // C++ object alive independently of its JS wrapper, so that a reader created as a
+  // temporary (e.g., `rs.getReader().closed.then(...)`) is not collected by GC before
+  // the stream has a chance to settle the closedFulfiller. Using IoOwn ensures the ref
+  // is released when the IoContext is torn down, breaking the cycle and preventing leaks
+  // when streams never reach a terminal state.
+  kj::Maybe<IoOwn<kj::Own<void>>> readerRef_;
   kj::Maybe<IoOwn<kj::Canceler>> canceler;
 };
 
@@ -905,7 +908,7 @@ class WriterLocked {
   WriterLocked(WritableStreamController::Writer& writer,
       jsg::Promise<void>::Resolver closedFulfiller,
       kj::Maybe<jsg::Promise<void>::Resolver> readyFulfiller = kj::none,
-      kj::Maybe<kj::Own<void>> writerRef = kj::none)
+      kj::Maybe<IoOwn<kj::Own<void>>> writerRef = kj::none)
       : writer(writer),
         closedFulfiller(kj::mv(closedFulfiller)),
         readyFulfiller(kj::mv(readyFulfiller)),
@@ -954,6 +957,7 @@ class WriterLocked {
   // Release the ref-counted reference to the Writer. Should be called when the
   // closedFulfiller is settled to eagerly break the ref cycle. Also released
   // automatically as a backup in visitForGc when the fulfiller has been consumed.
+  // Also released automatically by IoContext teardown since the ref is IoOwn-managed.
   void releaseWriterRef() {
     writerRef_ = kj::none;
   }
@@ -974,11 +978,9 @@ class WriterLocked {
   kj::Maybe<WritableStreamController::Writer&> writer;
   kj::Maybe<jsg::Promise<void>::Resolver> closedFulfiller;
   kj::Maybe<jsg::Promise<void>::Resolver> readyFulfiller;
-  // Ref-counted reference to the Writer. Keeps the Writer's C++ object alive
-  // independently of its JS wrapper, so that a writer created as a temporary (e.g.,
-  // `ws.getWriter().closed.then(...)`) is not collected by GC before the stream has
-  // a chance to settle the closedFulfiller.
-  kj::Maybe<kj::Own<void>> writerRef_;
+  // Ref-counted reference to the Writer, managed by the IoContext. See ReaderLocked
+  // for detailed explanation.
+  kj::Maybe<IoOwn<kj::Own<void>>> writerRef_;
 };
 
 template <typename T>

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -838,6 +838,7 @@ void ReadableStreamInternalController::doClose(jsg::Lock& js) {
   state.transitionTo<StreamStates::Closed>();
   KJ_IF_SOME(locked, readState.tryGetUnsafe<ReaderLocked>()) {
     maybeResolvePromise(js, locked.getClosedFulfiller());
+    locked.releaseReaderRef();
   } else {
     (void)readState.transitionFromTo<PipeLocked, Unlocked>();
   }
@@ -850,6 +851,7 @@ void ReadableStreamInternalController::doError(jsg::Lock& js, v8::Local<v8::Valu
   state.transitionTo<StreamStates::Errored>(js.v8Ref(reason));
   KJ_IF_SOME(locked, readState.tryGetUnsafe<ReaderLocked>()) {
     maybeRejectPromise<void>(js, locked.getClosedFulfiller(), reason);
+    locked.releaseReaderRef();
   } else {
     (void)readState.transitionFromTo<PipeLocked, Unlocked>();
   }
@@ -952,15 +954,17 @@ bool ReadableStreamInternalController::lockReader(jsg::Lock& js, Reader& reader)
   auto prp = js.newPromiseAndResolver<void>();
   prp.promise.markAsHandled(js);
 
-  auto lock = ReaderLocked(
-      reader, kj::mv(prp.resolver), IoContext::current().addObject(kj::heap<kj::Canceler>()));
+  auto lock = ReaderLocked(reader, kj::mv(prp.resolver), reader.addRef(),
+      IoContext::current().addObject(kj::heap<kj::Canceler>()));
 
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
       maybeResolvePromise(js, lock.getClosedFulfiller());
+      lock.releaseReaderRef();
     }
     KJ_CASE_ONEOF(errored, StreamStates::Errored) {
       maybeRejectPromise<void>(js, lock.getClosedFulfiller(), errored.getHandle(js));
+      lock.releaseReaderRef();
     }
     KJ_CASE_ONEOF(readable, Readable) {
       // Nothing to do.

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -954,8 +954,11 @@ bool ReadableStreamInternalController::lockReader(jsg::Lock& js, Reader& reader)
   auto prp = js.newPromiseAndResolver<void>();
   prp.promise.markAsHandled(js);
 
-  auto lock = ReaderLocked(reader, kj::mv(prp.resolver), reader.addRef(),
-      IoContext::current().addObject(kj::heap<kj::Canceler>()));
+  auto& ioctx = IoContext::current();
+  auto readerRef = reader.addRef().map(
+      [&ioctx](kj::Own<void> ref) { return ioctx.addObject(kj::heap(kj::mv(ref))); });
+  auto lock = ReaderLocked(
+      reader, kj::mv(prp.resolver), kj::mv(readerRef), ioctx.addObject(kj::heap<kj::Canceler>()));
 
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
@@ -1479,8 +1482,10 @@ bool WritableStreamInternalController::lockWriter(jsg::Lock& js, Writer& writer)
   auto readyPrp = js.newPromiseAndResolver<void>();
   readyPrp.promise.markAsHandled(js);
 
-  auto lock =
-      WriterLocked(writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver), writer.addRef());
+  auto writerRef = writer.addRef().map(
+      [](kj::Own<void> ref) { return IoContext::current().addObject(kj::heap(kj::mv(ref))); });
+  auto lock = WriterLocked(
+      writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver), kj::mv(writerRef));
 
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1479,16 +1479,19 @@ bool WritableStreamInternalController::lockWriter(jsg::Lock& js, Writer& writer)
   auto readyPrp = js.newPromiseAndResolver<void>();
   readyPrp.promise.markAsHandled(js);
 
-  auto lock = WriterLocked(writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver));
+  auto lock =
+      WriterLocked(writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver), writer.addRef());
 
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
       maybeResolvePromise(js, lock.getClosedFulfiller());
       maybeResolvePromise(js, lock.getReadyFulfiller());
+      lock.releaseWriterRef();
     }
     KJ_CASE_ONEOF(errored, StreamStates::Errored) {
       maybeRejectPromise<void>(js, lock.getClosedFulfiller(), errored.getHandle(js));
       maybeRejectPromise<void>(js, lock.getReadyFulfiller(), errored.getHandle(js));
+      lock.releaseWriterRef();
     }
     KJ_CASE_ONEOF(writable, IoOwn<Writable>) {
       maybeResolvePromise(js, lock.getReadyFulfiller());
@@ -1544,6 +1547,7 @@ void WritableStreamInternalController::doClose(jsg::Lock& js) {
   KJ_IF_SOME(locked, writeState.tryGetUnsafe<WriterLocked>()) {
     maybeResolvePromise(js, locked.getClosedFulfiller());
     maybeResolvePromise(js, locked.getReadyFulfiller());
+    locked.releaseWriterRef();
     writeState.transitionTo<Locked>();
   } else {
     (void)writeState.transitionFromTo<PipeLocked, Unlocked>();
@@ -1559,6 +1563,7 @@ void WritableStreamInternalController::doError(jsg::Lock& js, v8::Local<v8::Valu
   KJ_IF_SOME(locked, writeState.tryGetUnsafe<WriterLocked>()) {
     maybeRejectPromise<void>(js, locked.getClosedFulfiller(), reason);
     maybeResolvePromise(js, locked.getReadyFulfiller());
+    locked.releaseWriterRef();
     writeState.transitionTo<Locked>();
   } else {
     (void)writeState.transitionFromTo<PipeLocked, Unlocked>();

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -134,6 +134,10 @@ public:
 
   inline bool isByteOriented() const override { return false; }
 
+  kj::Maybe<kj::Own<void>> addRef() override {
+    return kj::Own<void>(kj::addRef(*this));
+  }
+
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
     tracker.trackField("impl", impl);
   }
@@ -209,6 +213,10 @@ public:
   void lockToStream(jsg::Lock& js, ReadableStream& stream);
 
   inline bool isByteOriented() const override { return true; }
+
+  kj::Maybe<kj::Own<void>> addRef() override {
+    return kj::Own<void>(kj::addRef(*this));
+  }
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
     tracker.trackField("impl", impl);

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -244,12 +244,14 @@ bool ReadableLockImpl<Controller>::lockReader(jsg::Lock& js, Controller& self, R
   auto prp = js.newPromiseAndResolver<void>();
   prp.promise.markAsHandled(js);
 
-  auto lock = ReaderLocked(reader, kj::mv(prp.resolver));
+  auto lock = ReaderLocked(reader, kj::mv(prp.resolver), reader.addRef());
 
   if (self.state.template is<StreamStates::Closed>()) {
     maybeResolvePromise(js, lock.getClosedFulfiller());
+    lock.releaseReaderRef();
   } else KJ_IF_SOME(errored, self.state.template tryGetUnsafe<StreamStates::Errored>()) {
     maybeRejectPromise<void>(js, lock.getClosedFulfiller(), errored.getHandle(js));
+    lock.releaseReaderRef();
   }
 
   state.template transitionTo<ReaderLocked>(kj::mv(lock));
@@ -328,6 +330,7 @@ void ReadableLockImpl<Controller>::onClose(jsg::Lock& js) {
       // point is not recoverable. Log and move on.
       LOG_NOSENTRY(ERROR, "Error resolving ReadableStream reader closed promise");
     };
+    locked.releaseReaderRef();
   } else {
     (void)state.template transitionFromTo<PipeLocked, Unlocked>();
   }
@@ -345,6 +348,7 @@ void ReadableLockImpl<Controller>::onError(jsg::Lock& js, v8::Local<v8::Value> r
       // point is not recoverable. Log and move on.
       LOG_NOSENTRY(ERROR, "Error rejecting ReadableStream reader closed promise");
     }
+    locked.releaseReaderRef();
   } else {
     (void)state.template transitionFromTo<PipeLocked, Unlocked>();
   }

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -384,14 +384,17 @@ bool WritableLockImpl<Controller>::lockWriter(jsg::Lock& js, Controller& self, W
   auto readyPrp = js.newPromiseAndResolver<void>();
   readyPrp.promise.markAsHandled(js);
 
-  auto lock = WriterLocked(writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver));
+  auto lock =
+      WriterLocked(writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver), writer.addRef());
 
   if (self.state.template is<StreamStates::Closed>()) {
     maybeResolvePromise(js, lock.getClosedFulfiller());
     maybeResolvePromise(js, lock.getReadyFulfiller());
+    lock.releaseWriterRef();
   } else KJ_IF_SOME(errored, self.state.template tryGetUnsafe<StreamStates::Errored>()) {
     maybeRejectPromise<void>(js, lock.getClosedFulfiller(), errored.getHandle(js));
     maybeRejectPromise<void>(js, lock.getReadyFulfiller(), errored.getHandle(js));
+    lock.releaseWriterRef();
   } else {
     if (FeatureFlags::get(js).getWritableStreamSpecCompliantWriter()) {
       // Per spec (SetUpWritableStreamDefaultWriter step 4), the ready promise
@@ -3956,6 +3959,7 @@ void WritableStreamJsController::doClose(jsg::Lock& js) {
   KJ_IF_SOME(locked, lock.state.tryGetUnsafe<WriterLocked>()) {
     maybeResolvePromise(js, locked.getClosedFulfiller());
     maybeResolvePromise(js, locked.getReadyFulfiller());
+    locked.releaseWriterRef();
   } else {
     (void)lock.state.transitionFromTo<WritableLockImpl::PipeLocked, Unlocked>();
   }
@@ -3974,6 +3978,7 @@ void WritableStreamJsController::doError(jsg::Lock& js, v8::Local<v8::Value> rea
   KJ_IF_SOME(locked, lock.state.tryGetUnsafe<WriterLocked>()) {
     maybeRejectPromise<void>(js, locked.getClosedFulfiller(), reason);
     maybeResolvePromise(js, locked.getReadyFulfiller());
+    locked.releaseWriterRef();
   } else KJ_IF_SOME(pipeLocked, lock.state.tryGetUnsafe<WritableLockImpl::PipeLocked>()) {
     // When the writable side of a pipe errors, we need to release the source stream.
     // The pipeLoop may be waiting on a read from the source that will never complete,

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -244,7 +244,9 @@ bool ReadableLockImpl<Controller>::lockReader(jsg::Lock& js, Controller& self, R
   auto prp = js.newPromiseAndResolver<void>();
   prp.promise.markAsHandled(js);
 
-  auto lock = ReaderLocked(reader, kj::mv(prp.resolver), reader.addRef());
+  auto readerRef = reader.addRef().map(
+      [](kj::Own<void> ref) { return IoContext::current().addObject(kj::heap(kj::mv(ref))); });
+  auto lock = ReaderLocked(reader, kj::mv(prp.resolver), kj::mv(readerRef));
 
   if (self.state.template is<StreamStates::Closed>()) {
     maybeResolvePromise(js, lock.getClosedFulfiller());
@@ -384,8 +386,10 @@ bool WritableLockImpl<Controller>::lockWriter(jsg::Lock& js, Controller& self, W
   auto readyPrp = js.newPromiseAndResolver<void>();
   readyPrp.promise.markAsHandled(js);
 
-  auto lock =
-      WriterLocked(writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver), writer.addRef());
+  auto writerRef = writer.addRef().map(
+      [](kj::Own<void> ref) { return IoContext::current().addObject(kj::heap(kj::mv(ref))); });
+  auto lock = WriterLocked(
+      writer, kj::mv(closedPrp.resolver), kj::mv(readyPrp.resolver), kj::mv(writerRef));
 
   if (self.state.template is<StreamStates::Closed>()) {
     maybeResolvePromise(js, lock.getClosedFulfiller());

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -72,6 +72,10 @@ class WritableStreamDefaultWriter: public jsg::Object, public WritableStreamCont
 
   void detach() override;
 
+  kj::Maybe<kj::Own<void>> addRef() override {
+    return kj::addRef(*this);
+  }
+
   void lockToStream(jsg::Lock& js, WritableStream& stream);
 
   void replaceReadyPromise(jsg::Lock& js, jsg::Promise<void> readyPromise) override;


### PR DESCRIPTION
Adds a refcounted reference to the Reader object to stop it going away too early.

This bug was detected with a gc-stress mode on a test in streams-test.ts:
"ReadableStream start should be able to return a promise and reject it"

The test is as follows:

```js
promise_test(() => {
  const theError = new Error('rejected!');
  const rs = new ReadableStream({
    start() {
      return delay(1).then(() => { throw theError; });
    }
  });
  return rs.getReader().closed.then(() => {
    assert_unreached('closed promise should be rejected');
  }, e => {
    assert_equals(e, theError, 'promise should be rejected with the same error');
  });
}, 'ReadableStream start should be able to return a promise and reject it');
```

The root cause is that the Reader has a reference to the Stream, but the Stream has no reference to the Reader. If the user does not keep a reference to the Reader, it can be collected early, which causes a destructor to remove promises from the queue and never resolve them.

When the Reader is GC'd, the following cascade occurs:

1. V8 GC collects the Reader's JS wrapper (unreachable from JS roots)
2. CppGC collects the shim → `detachWrapper()` on the Reader's Wrappable
3. Reader C++ object is destroyed:
   - `ReaderImpl::~ReaderImpl()` destroys `closedPromise` (the C++ handle; the JS promise object survives, held by the `.then()` chain)
   - `ReaderImpl::~ReaderImpl()` destroys `state`, which is `Attached`
   - `Attached::~Attached()` destroys `jsg::Ref<ReadableStream>` — the **last** ref to the stream (the `rs` local variable went out of scope when the test function returned)
4. `ReadableStream` is destroyed:
   - `ReadableStreamJsController` (member) is destroyed
   - `kj::Own<ValueReadable>` state is destroyed
   - `ValueReadable::~ValueReadable()` destroys its `Consumer`
   - `~ConsumerImpl()` calls `queue.removeConsumer(*this)` (queue.h:390) — **removes itself from the Controller's queue**
   - `ReadableLockImpl` (the `lock` member) is destroyed
   - `ReaderLocked::~ReaderLocked()` calls `reader.detach()` — but the Reader is already destroyed, so this is a **use-after-free** on the raw `Reader&` (common.h:815). In practice this likely doesn't crash because the memory hasn't been reused yet.
   - `ReaderLocked::~ReaderLocked()` then implicitly destroys `closedFulfiller` (the Resolver) **without ever resolving or rejecting it**

5. Later: `delay(1)` fires → `start()` promise rejects → `onFailure` lambda fires → `ReadableImpl::doError()` on the Controller (which is alive, held by the lambda's `Ref<ReadableStreamDefaultController>`) → `queue.error()` → iterates consumers → **no consumers left** (removed in step 4) → `onConsumerError` is never called → `ReadableStreamJsController::doError` is never called → `lock.onError()` is never called → `closedFulfiller` was already destroyed