### PR TITLE
Create primaryStub and deprecate 'primary' field.

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -914,6 +914,7 @@ jsg::Promise<void> DurableObjectStorage::configureReadReplication(
 }
 
 jsg::Optional<jsg::Ref<DurableObject>> DurableObjectStorage::getPrimary(jsg::Lock& js) {
+  // TODO(cleanup): the primary stub should live on DurableObjectState instead of DurableObjectStorage.
   KJ_IF_SOME(primary, maybePrimary) {
     return primary.addRef();
   }
@@ -1299,6 +1300,13 @@ kj::Maybe<uint32_t> DurableObjectState::getHibernatableWebSocketEventTimeout() {
 
 kj::Array<kj::StringPtr> DurableObjectState::getTags(jsg::Lock& js, jsg::Ref<api::WebSocket> ws) {
   return ws->getHibernatableTags();
+}
+
+jsg::Optional<jsg::Ref<DurableObject>> DurableObjectState::getPrimaryStub(jsg::Lock& js) {
+  KJ_IF_SOME(s, storage) {
+    return s->getPrimary(js);
+  }
+  return kj::none;
 }
 
 kj::Array<kj::byte> serializeV8Value(jsg::Lock& js, const jsg::JsValue& value) {

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -682,6 +682,9 @@ class DurableObjectState: public jsg::Object {
   // hibernatable, we'll throw an error because regular websockets do not have tags.
   kj::Array<kj::StringPtr> getTags(jsg::Lock& js, jsg::Ref<api::WebSocket> ws);
 
+  // Returns a stub for the primary if there is one.
+  jsg::Optional<jsg::Ref<DurableObject>> getPrimaryStub(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(DurableObjectState, CompatibilityFlags::Reader flags) {
     JSG_METHOD(waitUntil);
     if (flags.getEnableCtxExports()) {
@@ -695,6 +698,11 @@ class DurableObjectState: public jsg::Object {
     if (flags.getEnableVersionApi()) {
       JSG_LAZY_INSTANCE_PROPERTY(version, getVersion);
     }
+
+    if (flags.getWorkerdExperimental()) {
+      JSG_LAZY_READONLY_INSTANCE_PROPERTY(primaryStub, getPrimaryStub);
+    }
+
     JSG_METHOD(blockConcurrencyWhile);
     JSG_METHOD(acceptWebSocket);
     JSG_METHOD(getWebSockets);

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -699,6 +699,7 @@ interface DurableObjectState<Props = unknown> {
   container?: Container;
   facets: DurableObjectFacets;
   version?: DurableObjectStateVersion;
+  readonly primaryStub?: DurableObjectStub;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -782,6 +783,7 @@ interface DurableObjectStorage {
   getBookmarkForTime(timestamp: number | Date): Promise<string>;
   onNextSessionRestoreBookmark(bookmark: string): Promise<string>;
   waitForBookmark(bookmark: string): Promise<void>;
+  /** @deprecated Use `ctx.primaryStub` instead. */
   readonly primary?: DurableObjectStub;
   ensureReplicas(): void;
   disableReplicas(): void;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -701,6 +701,7 @@ export interface DurableObjectState<Props = unknown> {
   container?: Container;
   facets: DurableObjectFacets;
   version?: DurableObjectStateVersion;
+  readonly primaryStub?: DurableObjectStub;
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
   acceptWebSocket(ws: WebSocket, tags?: string[]): void;
   getWebSockets(tag?: string): WebSocket[];
@@ -784,6 +785,7 @@ export interface DurableObjectStorage {
   getBookmarkForTime(timestamp: number | Date): Promise<string>;
   onNextSessionRestoreBookmark(bookmark: string): Promise<string>;
   waitForBookmark(bookmark: string): Promise<void>;
+  /** @deprecated Use `ctx.primaryStub` instead. */
   readonly primary?: DurableObjectStub;
   ensureReplicas(): void;
   disableReplicas(): void;

--- a/types/src/cloudflare.ts
+++ b/types/src/cloudflare.ts
@@ -51,6 +51,9 @@ export default {
 * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/)
 `,
   },
+  DurableObjectStorage: {
+    primary: `* @deprecated Use \`ctx.primaryStub\` instead. `,
+  },
   performance: {
     $: `*
 * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,


### PR DESCRIPTION
The 'primary' field name is confusing, as it is easy to read code like

    if (!this.ctx.storage.primary)

and assume it's a boolean, not a stub. you might think the above is a test to make sure we're not the primary, but because the primary stub is set only on replicas, it's the opposite!

    if (!this.ctx.primaryStub)

is easier to read and understand that this is an 'if' checking if we're the primary.

This change also moves the registration location to be outside of .ctx.storage.
