### PR TITLE
Fix stale import attributes description in module registry docs

### DIFF
--- a/docs/reference/detail/new-module-registry.md
+++ b/docs/reference/detail/new-module-registry.md
@@ -314,7 +314,8 @@ User code: const mod = await import('./bar.js')
 
 1. V8 calls dynamicImport(context, host_options, resource_name, specifier, attrs)
 
-2. Reject any import attributes (not yet supported)
+2. Parse import attributes (parseImportAttributes). Supports `type: 'json'`;
+   throws TypeError for unrecognized keys or unsupported type values.
 
 3. Parse referrer from resource_name (or fall back to bundleBase)
 


### PR DESCRIPTION
The Dynamic Import Flow section in new-module-registry.md says import attributes are rejected ("not yet supported"), but #6423 added `parseImportAttributes` support for `type: 'json'`. The Evaluation Invariants section in the same document already describes the correct behavior. This updates the flow to match.