### PR TITLE
Don't log errors when connect fails due to a user error

### DIFF
--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -436,7 +436,8 @@ void Socket::handleProxyStatus(
     // Let's not log errors when we have a disconnected exception.
     // If we don't filter this out, whenever connect() fails, we'll
     // have noisy errors even though the user catches the error on JS side.
-    if (e.getType() != kj::Exception::Type::DISCONNECTED) {
+    if (e.getType() != kj::Exception::Type::DISCONNECTED &&
+        e.getDetail(jsg::EXCEPTION_IS_USER_ERROR) == kj::none) {
       LOG_ERROR_PERIODICALLY("Socket proxy disconnected abruptly", e);
     }
     return kj::HttpClient::ConnectRequest::Status(500, nullptr, kj::Own<kj::HttpHeaders>());
@@ -481,7 +482,9 @@ void Socket::handleProxyStatus(jsg::Lock& js, kj::Promise<kj::Maybe<kj::Exceptio
   // TODO(cleanup): Extend awaitIo to provide the jsg::Lock in more cases.
   auto& context = IoContext::current();
   auto errorHandler = [](kj::Exception&& e) -> kj::Maybe<kj::Exception> {
-    LOG_ERROR_PERIODICALLY("Socket proxy disconnected abruptly", e);
+    if (e.getDetail(jsg::EXCEPTION_IS_USER_ERROR) == kj::none) {
+      LOG_ERROR_PERIODICALLY("Socket proxy disconnected abruptly", e);
+    }
     return KJ_EXCEPTION(FAILED, "connectResult raised an error");
   };
   auto func = [this, self = JSG_THIS](jsg::Lock& js, kj::Maybe<kj::Exception> result) -> void {


### PR DESCRIPTION
This should address the logs we're getting when connect is invoked without a connect handler being present

================

Not sure if this is the right approach here – might be better to change how exception handling works for connect? I have some tests available locally, but they only reproduce the issue, they're not able to check for the error not being logged.