### PR TITLE
Report internalError outcome for overloaded exceptions

### DIFF
--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1613,6 +1613,10 @@ class RequestObserverWithTracer final: public RequestObserver, public WorkerInte
     } else if (source == RequestObserver::FailureSource::DEFERRED_PROXY &&
         exception.getType() == kj::Exception::Type::DISCONNECTED) {
       outcome = EventOutcome::RESPONSE_STREAM_DISCONNECTED;
+    } else if (exception.getType() == kj::Exception::Type::OVERLOADED) {
+      // We use exception details to describe some overloaded exceptions accurately, if no such
+      // detail is present report internalError.
+      outcome = EventOutcome::INTERNAL_ERROR;
     } else {
       outcome = EventOutcome::EXCEPTION;
     }


### PR DESCRIPTION
overloaded-type exceptions are generally due to some internal limit being hit – they are generally unrelated to the worker CPU limit and not something directly caused by a worker script, so internalError fits better than exceededCpu. Note that only exceptions without a qualifying exception detail are affected, for those we continue to report a more precise outcome.

=====================
As suggested by @dom96 when overloaded exceptions came up.
Also see the downstream PR.