### PR TITLE
containers: Keep sidecar warm across destroy/start

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -2245,8 +2245,18 @@ kj::Promise<void> ContainerClient::start(StartContext context) {
   }
 
   co_await ensureEgressListenerStarted();
-  containerSidecarStarted.store(false, std::memory_order_release);
   co_await ensureSidecarStarted();
+
+  // Refresh the sidecar's egress configuration on every start(). This is required because:
+  //   - `internetEnabled` may have changed since the sidecar was originally created.
+  //   - The DNS allow-list may have changed (egress mappings added/removed between starts).
+  // The sidecar applies this synchronously and atomically (proxy-everything's PUT /egress
+  // updates an atomic.Pointer before the response). On the cold path, ensureSidecarStarted()
+  // has already pushed an initial config; this second push is a single fast PUT and is
+  // idempotent.
+  KJ_IF_SOME(ingressHostPort, sidecarIngressHostPort) {
+    co_await updateSidecarEgressConfig(ingressHostPort, egressListenerPort);
+  }
 
   caCertInjected.store(false, std::memory_order_release);
   co_await createContainer(effectiveImage, entrypoint, environment, restoreMounts.asPtr(), params);
@@ -2293,9 +2303,16 @@ kj::Promise<void> ContainerClient::destroy(DestroyContext context) {
   co_await ready;
   KJ_DEFER(done->fulfill());
 
-  this->sidecarIngressHostPort = kj::none;
+  // Tear down the app container; the sidecar is kept warm so a subsequent start() can
+  // reuse it (creating a fresh sidecar — and waiting for its iptables / network namespace
+  // setup — costs 4–8 seconds under Docker daemon contention; reusing the warm sidecar
+  // skips that cost entirely). The sidecar's egress configuration is refreshed on the
+  // next start() via updateSidecarEgressConfig.
+  //
+  // The sidecar will be cleaned up when the ContainerClient is destroyed (cleanupCallback
+  // in the destructor), or on the next start() if state is inconsistent (e.g. workerd
+  // restart left an orphaned sidecar; status() recovery handles that case).
   co_await destroyContainer();
-  co_await destroySidecarContainer();
 }
 
 kj::Promise<void> ContainerClient::signal(SignalContext context) {


### PR DESCRIPTION
container-client tests flake on CI because each container.start() recreates the proxy-everything sidecar, and that path dominates start() cost under dockerd contention (bridge IPAM lock + iptables in the new netns). CI's ~1400 concurrent tests on one dockerd socket regularly push start() past the 10s readiness-probe budget.
The sidecar is workerd-internal; container.capnp makes no promises about its lifetime. Reusing it across destroy/start within one workerd process is safe and eliminates the dominant per-start cost. Scope: localDocker container engine only — local-dev/test, gated behind --experimental. No production code path affected.

Measured impact:
bazel --jobs=16 --local_test_jobs=16 --runs_per_test=10:
  Before:  @ 10/10 fail · @all-autogates 9/10 timeout · @all-compat-flags 7/10 timeout
  After:   @ 10/10 PASS · @all-autogates 10/10 PASS  · @all-compat-flags 10/10 PASS
Sidecar phase under contention (instrumented, then reverted):
  Cold:  avg 1.48s, max 6.90s
  Warm:  avg 32us,  max 291us
32% of start() calls take the warm path. The new PUT /egress on every
start() is ~1ms.

Changes:
- start() no longer resets containerSidecarStarted; the flag's invariant ("true iff a sidecar is running") is correctly maintained by ensureSidecarStarted (sets on cold-path success, clears via KJ_ON_SCOPE_FAILURE) and status() (re-derives from Docker at DO startup). The previous per-start reset was redundant — status() already handles workerd-restart orphan recovery.
- destroy() no longer tears down the sidecar.
- start() always pushes the egress config (PUT /egress is synchronous; proxy-everything updates an atomic.Pointer before responding), so internetEnabled and DNS allow-list changes still take effect. User-visible Container API (status/start/destroy/monitor/getTcpPort/ exec/setEgress*/snapshot) is unchanged.

Risks:
- `docker ps` shows *-proxy sidecars between destroy() and the next start() (or until DO eviction). ~15MB per warm sidecar.
- Orphan recovery unchanged: status() reattaches if app+sidecar both running; otherwise next start() cold path clears the orphan.
- TLS-intercept CA cert now stable across destroy/start within one workerd process instead of regenerating per start. No documented contract about CA rotation.

# Examples
1. https://github.com/cloudflare/workerd/actions/runs/24923537111/job/72990269801