### PR TITLE
Fix remaining object serialization callsites

### DIFF
--- a/src/workerd/api/tests/stw-jsrpc-dataclone-callee.js
+++ b/src/workerd/api/tests/stw-jsrpc-dataclone-callee.js
@@ -8,3 +8,19 @@ export class RpcEntrypoint extends WorkerEntrypoint {
     return 'ok';
   }
 }
+
+export default {
+  async fetch() {
+    return new Response('ok', { status: 201 });
+  },
+
+  async queue() {
+    return {
+      outcome: 'ok',
+      retryBatch: { retry: false },
+      ackAll: true,
+      retryMessages: [],
+      explicitAcks: [],
+    };
+  },
+};

--- a/src/workerd/api/tests/stw-jsrpc-dataclone-tail.js
+++ b/src/workerd/api/tests/stw-jsrpc-dataclone-tail.js
@@ -3,45 +3,101 @@
 //     https://opensource.org/licenses/Apache-2.0
 import * as assert from 'node:assert';
 
-let result;
+let jsrpcResult;
+let fetchReturnResult;
+let queueOnsetResult;
+
+async function captureInfo(info, env) {
+  const result = {
+    type: info.type,
+    protoIsObjectPrototype: Object.getPrototypeOf(info) === Object.prototype,
+  };
+
+  if ('statusCode' in info) {
+    result.statusCode = info.statusCode;
+  }
+  if ('batchSize' in info) {
+    result.batchSize = info.batchSize;
+  }
+
+  try {
+    await env.RECEIVER.capture(info);
+    result.rpcOk = true;
+  } catch (err) {
+    result.rpcOk = false;
+    result.errorName = err?.name;
+    result.errorMessage = err?.message;
+  }
+
+  return result;
+}
 
 export default {
   async tailStream(onsetEvent, env) {
-    const info = onsetEvent.event.info;
-    if (info?.type !== 'jsrpc' || result !== undefined) return;
+    const onsetInfo = onsetEvent.event.info;
 
-    const proto = Object.getPrototypeOf(info);
-    result = {
-      type: info.type,
-      protoIsObjectPrototype: proto === Object.prototype,
-    };
-
-    try {
-      await env.RECEIVER.capture(info);
-      result.rpcOk = true;
-    } catch (err) {
-      result.rpcOk = false;
-      result.errorName = err?.name;
-      result.errorMessage = err?.message;
+    if (onsetInfo?.type === 'jsrpc' && jsrpcResult === undefined) {
+      jsrpcResult = await captureInfo(onsetInfo, env);
+      return;
     }
+
+    if (onsetInfo?.type === 'queue' && queueOnsetResult === undefined) {
+      queueOnsetResult = await captureInfo(onsetInfo, env);
+      return;
+    }
+
+    return async (event) => {
+      const info = event.event.info;
+      if (
+        event.event.type === 'return' &&
+        info?.type === 'fetch' &&
+        fetchReturnResult === undefined
+      ) {
+        fetchReturnResult = await captureInfo(info, env);
+      }
+    };
   },
 };
 
 export const test = {
   async test(ctrl, env) {
     await env.RECEIVER.reset();
-    result = undefined;
+    jsrpcResult = undefined;
+    fetchReturnResult = undefined;
+    queueOnsetResult = undefined;
+
+    const response = await env.CALLEE.fetch('http://callee/');
+    assert.strictEqual(response.status, 201);
+    assert.strictEqual(await response.text(), 'ok');
+
+    const timestamp = new Date();
+    const queueResult = await env.CALLEE.queue('stw-jsrpc-dataclone-test', [
+      { id: '#0', timestamp, body: 'hello', attempts: 1 },
+    ]);
+    assert.strictEqual(queueResult.outcome, 'ok');
 
     assert.strictEqual(await env.CALLEE_RPC.ping(), 'ok');
     await scheduler.wait(100);
 
-    assert.ok(result, 'missing jsrpc onset.info result');
-    assert.strictEqual(result.type, 'jsrpc');
+    assert.ok(fetchReturnResult, 'missing fetch return info result');
+    assert.strictEqual(fetchReturnResult.type, 'fetch');
+    assert.strictEqual(fetchReturnResult.statusCode, 201);
+    assert.strictEqual(fetchReturnResult.protoIsObjectPrototype, true);
+    assert.strictEqual(fetchReturnResult.rpcOk, true);
+
+    assert.ok(queueOnsetResult, 'missing queue onset.info result');
+    assert.strictEqual(queueOnsetResult.type, 'queue');
+    assert.strictEqual(queueOnsetResult.batchSize, 1);
+    assert.strictEqual(queueOnsetResult.protoIsObjectPrototype, true);
+    assert.strictEqual(queueOnsetResult.rpcOk, true);
+
+    assert.ok(jsrpcResult, 'missing jsrpc onset.info result');
+    assert.strictEqual(jsrpcResult.type, 'jsrpc');
     assert.strictEqual(
-      result.protoIsObjectPrototype,
+      jsrpcResult.protoIsObjectPrototype,
       true,
       'jsrpc onset.info should be a plain object'
     );
-    assert.strictEqual(result.rpcOk, true);
+    assert.strictEqual(jsrpcResult.rpcOk, true);
   },
 };

--- a/src/workerd/api/tests/stw-jsrpc-dataclone-test.wd-test
+++ b/src/workerd/api/tests/stw-jsrpc-dataclone-test.wd-test
@@ -12,7 +12,7 @@ const calleeWorker :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "stw-jsrpc-dataclone-callee.js")
   ],
-  compatibilityFlags = ["nodejs_compat", "experimental", "rpc"],
+  compatibilityFlags = ["nodejs_compat", "experimental", "rpc", "service_binding_extra_handlers"],
   streamingTails = ["stw"],
 );
 
@@ -20,7 +20,7 @@ const tailWorker :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "stw-jsrpc-dataclone-tail.js")
   ],
-  compatibilityFlags = ["nodejs_compat", "experimental", "rpc"],
+  compatibilityFlags = ["nodejs_compat", "experimental", "rpc", "service_binding_extra_handlers"],
   bindings = [
     (name = "CALLEE", service = "callee"),
     (name = "CALLEE_RPC", service = (name = "callee", entrypoint = "RpcEntrypoint")),

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -185,9 +185,10 @@ jsg::JsValue ToJs(jsg::Lock& js, kj::ArrayPtr<const Attribute> attributes, Strin
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const FetchResponseInfo& info, StringCache& cache) {
-  static const kj::StringPtr keys[] = {TYPE_STR, STATUSCODE_STR};
-  jsg::JsValue values[] = {cache.get(js, FETCH_STR), js.num(info.statusCode)};
-  return js.obj(kj::arrayPtr(keys), kj::arrayPtr(values));
+  auto obj = js.obj();
+  obj.set(js, TYPE_STR, cache.get(js, FETCH_STR));
+  obj.set(js, STATUSCODE_STR, js.num(info.statusCode));
+  return obj;
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const FetchEventInfo& info, StringCache& cache) {
@@ -243,17 +244,20 @@ jsg::JsValue ToJs(jsg::Lock& js, const AlarmEventInfo& info, StringCache& cache)
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const QueueEventInfo& info, StringCache& cache) {
-  static const kj::StringPtr keys[] = {TYPE_STR, QUEUENAME_STR, BATCHSIZE_STR};
-  jsg::JsValue values[] = {
-    cache.get(js, QUEUE_STR), js.str(info.queueName), js.num(info.batchSize)};
-  return js.obj(kj::arrayPtr(keys), kj::arrayPtr(values));
+  auto obj = js.obj();
+  obj.set(js, TYPE_STR, cache.get(js, QUEUE_STR));
+  obj.set(js, QUEUENAME_STR, js.str(info.queueName));
+  obj.set(js, BATCHSIZE_STR, js.num(info.batchSize));
+  return obj;
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const EmailEventInfo& info, StringCache& cache) {
-  static const kj::StringPtr keys[] = {TYPE_STR, MAILFROM_STR, RCPTTO_STR, RAWSIZE_STR};
-  jsg::JsValue values[] = {
-    cache.get(js, EMAIL_STR), js.str(info.mailFrom), js.str(info.rcptTo), js.num(info.rawSize)};
-  return js.obj(kj::arrayPtr(keys), kj::arrayPtr(values));
+  auto obj = js.obj();
+  obj.set(js, TYPE_STR, cache.get(js, EMAIL_STR));
+  obj.set(js, MAILFROM_STR, js.str(info.mailFrom));
+  obj.set(js, RCPTTO_STR, js.str(info.rcptTo));
+  obj.set(js, RAWSIZE_STR, js.num(info.rawSize));
+  return obj;
 }
 
 jsg::JsValue ToJs(jsg::Lock& js, const TraceEventInfo& info, StringCache& cache) {


### PR DESCRIPTION
## Summary

Follow-up to #6662.

This fixes the remaining object-construction paths that were still using `js.obj(keys, values)` producing unserializable objects.

### Tests

regression tests cover `fetch` and `queue` but not email because I couldn't find an existing e2e test harness for email