### PR TITLE
Allow wd_rust_crate to override test size; bump jsg-test to large

### DIFF
--- a/build/wd_rust_crate.bzl
+++ b/build/wd_rust_crate.bzl
@@ -58,6 +58,7 @@ def wd_rust_crate(
         test_tags = [],
         test_deps = [],
         test_proc_macro_deps = [],
+        test_size = "medium",
         cxx_bridge_deps = [],
         cxx_bridge_tags = [],
         cxx_bridge_local_defines = [],
@@ -78,6 +79,8 @@ def wd_rust_crate(
         test_tags: additional test tags.
         test_deps: test-only dependencies.
         test_proc_macro_deps: test-only proc_macro dependencies.
+        test_size: Bazel test size (default "medium"); affects test timeout. Use "large" for
+            crates with many subtests, since RUST_TEST_THREADS=1 forces serial execution.
         cxx_bridge_deps: either a flat dependency list applied to every bridge source, or a dict of
             bridge source => dependency list.
     """
@@ -155,6 +158,7 @@ def wd_rust_crate(
             # our tests are usually very heavy and do not support concurrent invocation
             "RUST_TEST_THREADS": "1",
         } | test_env,
+        size = test_size,
         tags = test_tags + ["no-coverage"],
         crate_features = crate_features,
         deps = test_deps,

--- a/src/rust/jsg-test/BUILD.bazel
+++ b/src/rust/jsg-test/BUILD.bazel
@@ -37,6 +37,9 @@ wd_rust_crate(
         "lib.rs",
     ],
     test_proc_macro_deps = ["//src/rust/jsg-macros"],
+    # The crate has hundreds of subtests and uses RUST_TEST_THREADS=1 (serial),
+    # so the default "medium" (15s) timeout is too tight under CI load.
+    test_size = "large",
     visibility = ["//visibility:public"],
     deps = [
         ":ffi-impl",


### PR DESCRIPTION
The default Bazel test size (medium) gives a 15s timeout under our .bazelrc test_timeout settings, which is too tight for jsg-test_test: it has 280+ subtests and is forced to run serially via RUST_TEST_THREADS=1. The test has been observed to hit the 15s wall on three retries in a row in CI.

Add a test_size parameter to wd_rust_crate (mirroring the existing parameter on wd_rust_binary) and set test_size = "large" on jsg-test, giving it the 60s timeout it needs.

Assisted-by: OpenCode:claude-opus-4.7