### PR TITLE
Implement SHA-3 support for node crypto

### DIFF
--- a/deps/rust/Cargo.lock
+++ b/deps/rust/Cargo.lock
@@ -145,6 +145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,10 +355,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -368,6 +398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +427,15 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -433,8 +481,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -455,6 +515,7 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures",
+ "hmac",
  "lol_html_c_api",
  "nix",
  "pico-args",
@@ -466,6 +527,7 @@ dependencies = [
  "scratch",
  "serde",
  "serde_json",
+ "sha3",
  "static_assertions",
  "swc_common",
  "swc_ts_fast_strip",
@@ -757,6 +819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "hstr"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +839,15 @@ dependencies = [
  "rustc-hash",
  "serde",
  "triomphe",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -934,6 +1014,16 @@ checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1527,8 +1617,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
 ]
 
 [[package]]

--- a/deps/rust/Cargo.toml
+++ b/deps/rust/Cargo.toml
@@ -43,6 +43,8 @@ ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.12.1"
 # param_extractor depends on unbounded_depth feature
 serde_json = { version = "1", features = ["unbounded_depth"] }
 serde = { version = "1", features = ["derive"] }
+sha3 = "0"
+hmac = "0"
 thiserror = "2"
 # tokio is huge, let's enable only features when we actually need them.
 tokio = { version = "1", default-features = false, features = ["net", "rt", "rt-multi-thread", "time"] }

--- a/src/node/crypto.ts
+++ b/src/node/crypto.ts
@@ -190,9 +190,9 @@ export function getHashes(): string[] {
   // expected to change infrequently based of bssl's stability-focused approach.
 
   // prettier-ignore
-  return ['md4', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512', 'md5-sha1', 'RSA-MD5',
-          'RSA-SHA1', 'RSA-SHA224', 'RSA-SHA256', 'RSA-SHA384', 'RSA-SHA512', 'DSA-SHA',
-          'DSA-SHA1', 'ecdsa-with-SHA1'];
+  return ['md4', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512', 'sha3-224', 'sha3-256',
+          'sha3-384', 'sha3-512', 'md5-sha1', 'RSA-MD5', 'RSA-SHA1', 'RSA-SHA224', 'RSA-SHA256',
+          'RSA-SHA384', 'RSA-SHA512', 'DSA-SHA', 'DSA-SHA1', 'ecdsa-with-SHA1'];
 }
 
 // We do not implement the openssl secure heap.

--- a/src/rust/api/BUILD.bazel
+++ b/src/rust/api/BUILD.bazel
@@ -11,6 +11,8 @@ wd_rust_crate(
     visibility = ["//visibility:public"],
     deps = [
         "//src/rust/jsg",
+        "@crates_vendor//:hmac",
+        "@crates_vendor//:sha3",
         "@crates_vendor//:thiserror",
     ],
 )

--- a/src/rust/api/lib.rs
+++ b/src/rust/api/lib.rs
@@ -4,7 +4,15 @@
 
 use std::pin::Pin;
 
+use hmac::Mac;
+use hmac::SimpleHmac;
+use hmac::digest::KeyInit;
 use jsg::ToJS;
+use sha3::Digest;
+use sha3::Sha3_224;
+use sha3::Sha3_256;
+use sha3::Sha3_384;
+use sha3::Sha3_512;
 
 use crate::dns::DnsUtil;
 
@@ -12,6 +20,14 @@ pub mod dns;
 
 #[cxx::bridge(namespace = "workerd::rust::api")]
 mod ffi {
+    #[derive(Clone, Copy)]
+    enum Sha3Algorithm {
+        Sha3_224,
+        Sha3_256,
+        Sha3_384,
+        Sha3_512,
+    }
+
     #[namespace = "workerd::rust::jsg"]
     unsafe extern "C++" {
         include!("workerd/rust/jsg/ffi.h");
@@ -19,7 +35,133 @@ mod ffi {
         type ModuleRegistry = jsg::v8::ffi::ModuleRegistry;
     }
     extern "Rust" {
+        type Sha3Hash;
+        type Sha3Hmac;
+
         pub fn register_nodejs_modules(registry: Pin<&mut ModuleRegistry>);
+
+        #[expect(clippy::unnecessary_box_returns)]
+        fn new_sha3_hash(algorithm: Sha3Algorithm) -> Box<Sha3Hash>;
+        fn sha3_hash_update(hash: &mut Sha3Hash, data: &[u8]);
+        #[expect(clippy::unnecessary_box_returns)]
+        fn sha3_hash_clone(hash: &Sha3Hash) -> Box<Sha3Hash>;
+        fn sha3_hash_digest_size(hash: &Sha3Hash) -> usize;
+        fn sha3_hash_digest(hash: &Sha3Hash) -> Vec<u8>;
+
+        #[expect(clippy::unnecessary_box_returns)]
+        fn new_sha3_hmac(algorithm: Sha3Algorithm, key: &[u8]) -> Box<Sha3Hmac>;
+        fn sha3_hmac_update(hmac: &mut Sha3Hmac, data: &[u8]);
+        fn sha3_hmac_digest(hmac: &Sha3Hmac) -> Vec<u8>;
+    }
+}
+
+#[derive(Clone)]
+pub enum Sha3Hash {
+    Sha3_224(Sha3_224),
+    Sha3_256(Sha3_256),
+    Sha3_384(Sha3_384),
+    Sha3_512(Sha3_512),
+}
+
+pub enum Sha3Hmac {
+    Sha3_224(SimpleHmac<Sha3_224>),
+    Sha3_256(SimpleHmac<Sha3_256>),
+    Sha3_384(SimpleHmac<Sha3_384>),
+    Sha3_512(SimpleHmac<Sha3_512>),
+}
+
+impl Clone for Sha3Hmac {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Sha3_224(hmac) => Self::Sha3_224(hmac.clone()),
+            Self::Sha3_256(hmac) => Self::Sha3_256(hmac.clone()),
+            Self::Sha3_384(hmac) => Self::Sha3_384(hmac.clone()),
+            Self::Sha3_512(hmac) => Self::Sha3_512(hmac.clone()),
+        }
+    }
+}
+
+pub fn new_sha3_hash(algorithm: ffi::Sha3Algorithm) -> Box<Sha3Hash> {
+    Box::new(match algorithm {
+        ffi::Sha3Algorithm::Sha3_224 => Sha3Hash::Sha3_224(Sha3_224::new()),
+        ffi::Sha3Algorithm::Sha3_256 => Sha3Hash::Sha3_256(Sha3_256::new()),
+        ffi::Sha3Algorithm::Sha3_384 => Sha3Hash::Sha3_384(Sha3_384::new()),
+        ffi::Sha3Algorithm::Sha3_512 => Sha3Hash::Sha3_512(Sha3_512::new()),
+        _ => unreachable!(),
+    })
+}
+
+pub fn sha3_hash_update(hash: &mut Sha3Hash, data: &[u8]) {
+    match hash {
+        Sha3Hash::Sha3_224(hash) => hash.update(data),
+        Sha3Hash::Sha3_256(hash) => hash.update(data),
+        Sha3Hash::Sha3_384(hash) => hash.update(data),
+        Sha3Hash::Sha3_512(hash) => hash.update(data),
+    }
+}
+
+pub fn sha3_hash_clone(hash: &Sha3Hash) -> Box<Sha3Hash> {
+    Box::new(hash.clone())
+}
+
+pub fn sha3_hash_digest_size(hash: &Sha3Hash) -> usize {
+    match hash {
+        Sha3Hash::Sha3_224(_) => 28,
+        Sha3Hash::Sha3_256(_) => 32,
+        Sha3Hash::Sha3_384(_) => 48,
+        Sha3Hash::Sha3_512(_) => 64,
+    }
+}
+
+pub fn sha3_hash_digest(hash: &Sha3Hash) -> Vec<u8> {
+    match hash {
+        Sha3Hash::Sha3_224(hash) => hash.clone().finalize().to_vec(),
+        Sha3Hash::Sha3_256(hash) => hash.clone().finalize().to_vec(),
+        Sha3Hash::Sha3_384(hash) => hash.clone().finalize().to_vec(),
+        Sha3Hash::Sha3_512(hash) => hash.clone().finalize().to_vec(),
+    }
+}
+
+fn unwrap_hmac<T>(hmac: Result<T, hmac::digest::InvalidLength>) -> T {
+    match hmac {
+        Ok(hmac) => hmac,
+        Err(_) => unreachable!("HMAC accepts keys of any length"),
+    }
+}
+
+pub fn new_sha3_hmac(algorithm: ffi::Sha3Algorithm, key: &[u8]) -> Box<Sha3Hmac> {
+    Box::new(match algorithm {
+        ffi::Sha3Algorithm::Sha3_224 => {
+            Sha3Hmac::Sha3_224(unwrap_hmac(SimpleHmac::<Sha3_224>::new_from_slice(key)))
+        }
+        ffi::Sha3Algorithm::Sha3_256 => {
+            Sha3Hmac::Sha3_256(unwrap_hmac(SimpleHmac::<Sha3_256>::new_from_slice(key)))
+        }
+        ffi::Sha3Algorithm::Sha3_384 => {
+            Sha3Hmac::Sha3_384(unwrap_hmac(SimpleHmac::<Sha3_384>::new_from_slice(key)))
+        }
+        ffi::Sha3Algorithm::Sha3_512 => {
+            Sha3Hmac::Sha3_512(unwrap_hmac(SimpleHmac::<Sha3_512>::new_from_slice(key)))
+        }
+        _ => unreachable!(),
+    })
+}
+
+pub fn sha3_hmac_update(hmac: &mut Sha3Hmac, data: &[u8]) {
+    match hmac {
+        Sha3Hmac::Sha3_224(hmac) => hmac.update(data),
+        Sha3Hmac::Sha3_256(hmac) => hmac.update(data),
+        Sha3Hmac::Sha3_384(hmac) => hmac.update(data),
+        Sha3Hmac::Sha3_512(hmac) => hmac.update(data),
+    }
+}
+
+pub fn sha3_hmac_digest(hmac: &Sha3Hmac) -> Vec<u8> {
+    match hmac {
+        Sha3Hmac::Sha3_224(hmac) => hmac.clone().finalize().into_bytes().to_vec(),
+        Sha3Hmac::Sha3_256(hmac) => hmac.clone().finalize().into_bytes().to_vec(),
+        Sha3Hmac::Sha3_384(hmac) => hmac.clone().finalize().into_bytes().to_vec(),
+        Sha3Hmac::Sha3_512(hmac) => hmac.clone().finalize().into_bytes().to_vec(),
     }
 }
 

--- a/src/workerd/api/crypto/digest.c++
+++ b/src/workerd/api/crypto/digest.c++
@@ -10,11 +10,38 @@
 #include <workerd/api/crypto/crypto.h>
 #include <workerd/io/io-context.h>
 
+#include <kj-rs/convert.h>
 #include <openssl/hmac.h>
 #include <openssl/mem.h>
+#include <rust/cxx.h>
+
+#include <cstring>
 
 namespace workerd::api {
 namespace {
+using Sha3Algorithm = workerd::rust::api::Sha3Algorithm;
+
+kj::Maybe<Sha3Algorithm> lookupSha3Algorithm(kj::StringPtr algorithm) {
+  if (strcasecmp(algorithm.cStr(), "sha3-224") == 0) {
+    return Sha3Algorithm::Sha3_224;
+  }
+  if (strcasecmp(algorithm.cStr(), "sha3-256") == 0) {
+    return Sha3Algorithm::Sha3_256;
+  }
+  if (strcasecmp(algorithm.cStr(), "sha3-384") == 0) {
+    return Sha3Algorithm::Sha3_384;
+  }
+  if (strcasecmp(algorithm.cStr(), "sha3-512") == 0) {
+    return Sha3Algorithm::Sha3_512;
+  }
+  return kj::none;
+}
+
+jsg::JsUint8Array makeUint8Array(jsg::Lock& js, ::rust::Vec<uint8_t> data) {
+  auto buf = jsg::JsUint8Array::create(js, data.size());
+  memcpy(buf.asArrayPtr().begin(), data.data(), data.size());
+  return buf;
+}
 
 class HmacKey final: public CryptoKey::Impl {
  public:
@@ -133,8 +160,36 @@ void zeroOutTrailingKeyBits(kj::Array<kj::byte>& keyDataArray, int keyBitLength)
   }
 }
 
-kj::Own<HMAC_CTX> initHmacContext(
+HmacContext::State initHmacContext(
     jsg::Lock& js, kj::StringPtr algorithm, HmacContext::KeyData& key) {
+  KJ_IF_SOME(sha3, lookupSha3Algorithm(algorithm)) {
+    auto handle = [](Sha3Algorithm algorithm, kj::ArrayPtr<kj::byte> key) {
+      JSG_REQUIRE(key.size() <= INT_MAX, RangeError, "key is too long");
+      return workerd::rust::api::new_sha3_hmac(algorithm, key.as<kj_rs::Rust>());
+    };
+
+    KJ_SWITCH_ONEOF(key) {
+      KJ_CASE_ONEOF(buf, kj::ArrayPtr<kj::byte>) {
+        return handle(sha3, buf);
+      }
+      KJ_CASE_ONEOF(key2, CryptoKey::Impl*) {
+        // We already checked that the key is a secret key, so the following should succeed.
+        SubtleCrypto::ExportKeyData keyData = key2->exportKey(js, "raw"_kj);
+
+        KJ_SWITCH_ONEOF(keyData) {
+          KJ_CASE_ONEOF(key_data, jsg::JsRef<jsg::JsArrayBuffer>) {
+            auto buf = key_data.getHandle(js);
+            return handle(sha3, buf.asArrayPtr());
+          }
+          KJ_CASE_ONEOF(jwk, SubtleCrypto::JsonWebKey) {
+            KJ_UNREACHABLE;
+          }
+        }
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
   static constexpr auto handle = [](kj::StringPtr algorithm, kj::ArrayPtr<kj::byte> key) {
     ClearErrorOnReturn clearErrorOnReturn;
     JSG_REQUIRE(key.size() <= INT_MAX, RangeError, "key is too long");
@@ -180,6 +235,10 @@ void HmacContext::update(kj::ArrayPtr<kj::byte> data) {
       JSG_REQUIRE(data.size() <= INT_MAX, RangeError, "data is too long");
       KJ_ASSERT(HMAC_Update(ctx.get(), data.begin(), data.size()) == 1);
     }
+    KJ_CASE_ONEOF(ctx, ::rust::Box<workerd::rust::api::Sha3Hmac>) {
+      JSG_REQUIRE(data.size() <= INT_MAX, RangeError, "data is too long");
+      workerd::rust::api::sha3_hmac_update(*ctx, data.as<kj_rs::Rust>());
+    }
     KJ_CASE_ONEOF(digest, jsg::JsRef<jsg::JsUint8Array>) {
       JSG_FAIL_REQUIRE(DOMOperationError, "HMAC context has already been finalized.");
     }
@@ -198,6 +257,11 @@ jsg::JsUint8Array HmacContext::digest(jsg::Lock& js) {
       state = buf.addRef(js);
       return buf;
     }
+    KJ_CASE_ONEOF(ctx, ::rust::Box<workerd::rust::api::Sha3Hmac>) {
+      auto buf = makeUint8Array(js, workerd::rust::api::sha3_hmac_digest(*ctx));
+      state = buf.addRef(js);
+      return buf;
+    }
     KJ_CASE_ONEOF(digest, jsg::JsRef<jsg::JsUint8Array>) {
       auto cached = digest.getHandle(js);
       return jsg::JsUint8Array::create(js, cached.asArrayPtr());
@@ -210,6 +274,9 @@ jsg::JsUint8Array HmacContext::digest(jsg::Lock& js) {
 size_t HmacContext::size() const {
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(ctx, kj::Own<HMAC_CTX>) {
+      return 0;
+    }
+    KJ_CASE_ONEOF(ctx, ::rust::Box<workerd::rust::api::Sha3Hmac>) {
       return 0;
     }
     KJ_CASE_ONEOF(digest, jsg::JsRef<jsg::JsUint8Array>) {
@@ -325,7 +392,11 @@ kj::Own<CryptoKey::Impl> CryptoKey::Impl::importHmac(jsg::Lock& js,
 // ======================================================================================
 
 namespace {
-kj::Own<EVP_MD_CTX> initDigestCtx(kj::StringPtr algorithm) {
+HashContext::State initDigestCtx(kj::StringPtr algorithm) {
+  KJ_IF_SOME(sha3, lookupSha3Algorithm(algorithm)) {
+    return workerd::rust::api::new_sha3_hash(sha3);
+  }
+
   const EVP_MD* md = EVP_get_digestbyname(algorithm.begin());
   JSG_REQUIRE(md != nullptr, Error, "Digest method not supported");
   auto ctx = OSSL_NEW(EVP_MD_CTX);
@@ -341,13 +412,27 @@ void checkXofLen(EVP_MD_CTX* ctx, kj::Maybe<uint32_t>& maybeXof) {
     }
   }
 }
+
+void checkSha3XofLen(workerd::rust::api::Sha3Hash& hash, kj::Maybe<uint32_t>& maybeXof) {
+  KJ_IF_SOME(xof, maybeXof) {
+    JSG_REQUIRE(
+        xof == workerd::rust::api::sha3_hash_digest_size(hash), Error, "invalid digest size");
+  }
+}
 }  // namespace
 
-HashContext::HashContext(kj::OneOf<kj::Own<EVP_MD_CTX>, jsg::JsRef<jsg::JsUint8Array>> state,
-    kj::Maybe<uint32_t> maybeXof)
+HashContext::HashContext(State state, kj::Maybe<uint32_t> maybeXof)
     : state(kj::mv(state)),
       maybeXof(kj::mv(maybeXof)) {
-  checkXofLen(this->state.get<kj::Own<EVP_MD_CTX>>().get(), this->maybeXof);
+  KJ_SWITCH_ONEOF(this->state) {
+    KJ_CASE_ONEOF(ctx, kj::Own<EVP_MD_CTX>) {
+      checkXofLen(ctx.get(), this->maybeXof);
+    }
+    KJ_CASE_ONEOF(ctx, ::rust::Box<workerd::rust::api::Sha3Hash>) {
+      checkSha3XofLen(*ctx, this->maybeXof);
+    }
+    KJ_CASE_ONEOF(digest, jsg::JsRef<jsg::JsUint8Array>) {}
+  }
 }
 
 HashContext::HashContext(kj::StringPtr algorithm, kj::Maybe<uint32_t> maybeXof)
@@ -358,6 +443,10 @@ void HashContext::update(kj::ArrayPtr<kj::byte> data) {
     KJ_CASE_ONEOF(ctx, kj::Own<EVP_MD_CTX>) {
       JSG_REQUIRE(data.size() <= INT_MAX, RangeError, "data is too long");
       OSSLCALL(EVP_DigestUpdate(ctx.get(), data.begin(), data.size()));
+    }
+    KJ_CASE_ONEOF(ctx, ::rust::Box<workerd::rust::api::Sha3Hash>) {
+      JSG_REQUIRE(data.size() <= INT_MAX, RangeError, "data is too long");
+      workerd::rust::api::sha3_hash_update(*ctx, data.as<kj_rs::Rust>());
     }
     KJ_CASE_ONEOF(digest, jsg::JsRef<jsg::JsUint8Array>) {
       JSG_FAIL_REQUIRE(DOMOperationError, "Hash context has already been finalized.");
@@ -394,6 +483,11 @@ jsg::JsUint8Array HashContext::digest(jsg::Lock& js) {
       state = buf.addRef(js);
       return buf;
     }
+    KJ_CASE_ONEOF(ctx, ::rust::Box<workerd::rust::api::Sha3Hash>) {
+      auto buf = makeUint8Array(js, workerd::rust::api::sha3_hash_digest(*ctx));
+      state = buf.addRef(js);
+      return buf;
+    }
     KJ_CASE_ONEOF(digest, jsg::JsRef<jsg::JsUint8Array>) {
       auto cached = digest.getHandle(js);
       return jsg::JsUint8Array::create(js, cached.asArrayPtr());
@@ -411,6 +505,9 @@ HashContext HashContext::clone(jsg::Lock& js, kj::Maybe<uint32_t> xofLen) {
       OSSLCALL(EVP_MD_CTX_copy_ex(newCtx, ctx.get()));
       return HashContext(kj::mv(newCtx), kj::mv(xofLen));
     }
+    KJ_CASE_ONEOF(ctx, ::rust::Box<workerd::rust::api::Sha3Hash>) {
+      return HashContext(workerd::rust::api::sha3_hash_clone(*ctx), kj::mv(xofLen));
+    }
     KJ_CASE_ONEOF(digest, jsg::JsRef<jsg::JsUint8Array>) {
       JSG_FAIL_REQUIRE(DOMOperationError, "Hash context has already been finalized.");
     }
@@ -421,6 +518,9 @@ HashContext HashContext::clone(jsg::Lock& js, kj::Maybe<uint32_t> xofLen) {
 size_t HashContext::size() const {
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(ctx, kj::Own<EVP_MD_CTX>) {
+      return 0;
+    }
+    KJ_CASE_ONEOF(ctx, ::rust::Box<workerd::rust::api::Sha3Hash>) {
       return 0;
     }
     KJ_CASE_ONEOF(digest, jsg::JsRef<jsg::JsUint8Array>) {

--- a/src/workerd/api/crypto/digest.h
+++ b/src/workerd/api/crypto/digest.h
@@ -3,6 +3,7 @@
 #include "impl.h"
 
 #include <workerd/api/crypto/crypto.h>
+#include <workerd/rust/api/lib.rs.h>
 
 KJ_DECLARE_NON_POLYMORPHIC(HMAC_CTX)
 
@@ -10,6 +11,9 @@ namespace workerd::api {
 class HmacContext final {
  public:
   using KeyData = kj::OneOf<kj::ArrayPtr<kj::byte>, CryptoKey::Impl*>;
+  using State = kj::OneOf<kj::Own<HMAC_CTX>,
+      ::rust::Box<workerd::rust::api::Sha3Hmac>,
+      jsg::JsRef<jsg::JsUint8Array>>;
 
   HmacContext(jsg::Lock& js, kj::StringPtr algorithm, KeyData key);
   HmacContext(HmacContext&&) = default;
@@ -22,13 +26,17 @@ class HmacContext final {
   size_t size() const;
 
  private:
-  // Will be kj::Own<HMAC_CTX> while the HMAC data is being updated,
+  // Will be kj::Own<HMAC_CTX> or Rust SHA-3 HMAC state while the HMAC data is being updated,
   // and jsg::JsRef<jsg::JsUint8Array> after the digest() has been called.
-  kj::OneOf<kj::Own<HMAC_CTX>, jsg::JsRef<jsg::JsUint8Array>> state;
+  State state;
 };
 
 class HashContext final {
  public:
+  using State = kj::OneOf<kj::Own<EVP_MD_CTX>,
+      ::rust::Box<workerd::rust::api::Sha3Hash>,
+      jsg::JsRef<jsg::JsUint8Array>>;
+
   HashContext(kj::StringPtr algorithm, kj::Maybe<uint32_t> maybeXof);
   HashContext(HashContext&&) = default;
   HashContext& operator=(HashContext&&) = default;
@@ -41,12 +49,11 @@ class HashContext final {
   size_t size() const;
 
  private:
-  HashContext(
-      kj::OneOf<kj::Own<EVP_MD_CTX>, jsg::JsRef<jsg::JsUint8Array>>, kj::Maybe<uint32_t> maybeXof);
+  HashContext(State state, kj::Maybe<uint32_t> maybeXof);
 
-  // Will be kj::Own<EVP_MD_CTX> while the hash data is being updated,
+  // Will be kj::Own<EVP_MD_CTX> or Rust SHA-3 state while the hash data is being updated,
   // and jsg::JsRef<jsg::JsUint8Array> after the digest() has been called.
-  kj::OneOf<kj::Own<EVP_MD_CTX>, jsg::JsRef<jsg::JsUint8Array>> state;
+  State state;
   kj::Maybe<uint32_t> maybeXof;
 };
 }  // namespace workerd::api

--- a/src/workerd/api/node/tests/crypto_hash-test.js
+++ b/src/workerd/api/node/tests/crypto_hash-test.js
@@ -130,6 +130,35 @@ export const hash_correctness_tests = {
       .update('123')
       .digest('hex');
     assert.strictEqual(h1, h2);
+
+    const sha3Vectors = {
+      'sha3-224': 'e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf',
+      'sha3-256':
+        '3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532',
+      'sha3-384':
+        'ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b29' +
+        '8d88cea927ac7f539f1edf228376d25',
+      'sha3-512':
+        'b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e' +
+        '10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0',
+    };
+
+    for (const [algorithm, expected] of Object.entries(sha3Vectors)) {
+      assert.ok(crypto.getHashes().includes(algorithm));
+      assert.strictEqual(
+        crypto.createHash(algorithm).update('abc').digest('hex'),
+        expected
+      );
+      assert.strictEqual(
+        crypto
+          .createHash(algorithm.toUpperCase())
+          .update('a')
+          .update('bc')
+          .digest('hex'),
+        expected
+      );
+      assert.strictEqual(crypto.hash(algorithm, 'abc'), expected);
+    }
   },
 };
 
@@ -261,6 +290,17 @@ export const hash_copy_test = {
     const d = crypto.createHash('sha512').update('abcdef');
     assert.strictEqual(a.digest('hex'), b.digest('hex'));
     assert.strictEqual(c.digest('hex'), d.digest('hex'));
+
+    const sha3 = crypto.createHash('sha3-256').update('abc');
+    const sha3Copy = sha3.copy().update('def');
+    assert.strictEqual(
+      sha3.digest('hex'),
+      '3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532'
+    );
+    assert.strictEqual(
+      sha3Copy.digest('hex'),
+      '59890c1d183aa279505750422e6384ccb1499c793872d6f31bb3bcaa4bc9f5a5'
+    );
   },
 };
 

--- a/src/workerd/api/node/tests/crypto_hmac-test.js
+++ b/src/workerd/api/node/tests/crypto_hmac-test.js
@@ -152,6 +152,13 @@ export const hmac_correctness_tests = {
       for (const hash in hmac) testHmac(hash, key, data, hmac[hash]);
     }
 
+    testHmac(
+      'sha3-256',
+      'key',
+      'The quick brown fox jumps over the lazy dog',
+      '8c6e0683409427f8931711b10ca92a506eb1fafa48fadd66d76126f47ac2c333'
+    );
+
     // Test HMAC-SHA-* (rfc 4231 Test Cases)
     const rfc4231 = [
       {

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -94,6 +94,7 @@ wd_cc_library(
         ":wasm-instantiate-shim",
         ":worker-interface",
         ":worker-source",
+        "//src/rust/api",
         "//src/rust/cxx-integration",
         "//src/workerd/api:analytics-engine_capnp",
         "//src/workerd/api:deferred-proxy",


### PR DESCRIPTION
## Summary

- Adds `sha3-224`, `sha3-256`, `sha3-384`, and `sha3-512` support for `node:crypto` hashes and `createHmac()`.
- Uses RustCrypto's `sha3` crate through the existing Rust CXX bridge because BoringSSL does not provide SHA-3 EVP digests.
- Lists SHA-3 algorithms in `crypto.getHashes()` and covers streaming, one-shot, case-insensitive names, copy, and HMAC behavior in node crypto tests.

## Implementation

- Introduces opaque Rust SHA-3 hash and HMAC states in `src/rust/api/lib.rs`.
- Routes only SHA-3 algorithm names through the Rust path in `HashContext` and `HmacContext`; existing BoringSSL-backed algorithms continue using EVP/HMAC.
- Preserves `Hash.copy()` by cloning RustCrypto hash state before finalization.
- Preserves Node-style repeated `digest()` behavior by caching the finalized JS-visible digest in the existing context state.

## Dependency Security View

- The implementation uses RustCrypto crates `sha3` and `hmac`, which are widely used Rust cryptography implementations maintained under the RustCrypto organization.
- `sha3` implements the standardized FIPS 202 SHA-3 family and depends on the RustCrypto `keccak` permutation implementation.
- The C++ boundary keeps the Rust state opaque and only passes byte slices into Rust and finalized digest bytes back to C++; there is no unsafe Rust added in this change.
- The dependency is used only for SHA-3 hash/HMAC algorithms that BoringSSL does not expose, limiting new cryptographic surface area to the missing Node-compatible algorithms.
- Cargo.lock pins exact crate versions and checksums, and Bazel resolves those locked versions for reproducible builds.

## Tests

- `bazel build //src/rust/api //src/workerd/api/node:node`
- `bazel test //src/workerd/api/node/tests:crypto_hash-test@ //src/workerd/api/node/tests:crypto_hmac-test@ --nocache_test_results`
- `bazel test //src/rust/... --nocache_test_results`
- `bazel test //src/workerd/api/node/tests:crypto_hash-test@ //src/workerd/api/node/tests:crypto_hash-test@all-compat-flags //src/workerd/api/node/tests:crypto_hash-test@all-autogates //src/workerd/api/node/tests:crypto_hmac-test@ //src/workerd/api/node/tests:crypto_hmac-test@all-compat-flags //src/workerd/api/node/tests:crypto_hmac-test@all-autogates --nocache_test_results`
- `just format`