### PR TITLE
GC stress mode

### DIFF
--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -12,6 +12,7 @@ def wd_test(
         generate_default_variant = True,
         generate_all_autogates_variant = True,
         generate_all_compat_flags_variant = True,
+        generate_gc_stress_variant = True,
         compat_date = "",
         **kwargs):
     """Rule to define tests that run `workerd test` with a particular config.
@@ -26,6 +27,7 @@ def wd_test(
      generate_default_variant: If True (default), generate the default variant with oldest compat date.
      generate_all_autogates_variant: If True (default), generate @all-autogates variants.
      generate_all_compat_flags_variant: If True (default), generate @all-compat-flags variants.
+     generate_gc_stress_variant: If True (default), generate @gc-stress variant (debug builds only).
      compat_date: If specified, use this compat date for the default variant instead of 2000-01-01.
         Does not affect the @all-compat-flags variant which always uses 2999-12-31.
 
@@ -33,6 +35,7 @@ def wd_test(
      - name@ (if generate_default_variant): oldest compat date (2000-01-01)
      - name@all-compat-flags (if generate_all_compat_flags_variant): newest compat date (2999-12-31)
      - name@all-autogates (if generate_all_autogates_variant): all autogates + oldest compat date
+     - name@gc-stress (if generate_gc_stress_variant): forced GC at every continuation
     """
 
     # Add workerd binary to "data" dependencies.
@@ -127,6 +130,25 @@ def wd_test(
             args = base_args + default_compat_args + ["--all-autogates"],
             python_snapshot_test = python_snapshot_test,
             **kwargs
+        )
+
+    # GC stress variant: forced full GC at every awaitIo continuation.
+    # Uses newest compat date unless the test opted out of @all-compat-flags (meaning
+    # it is compat-date-sensitive), in which case it uses the default compat date.
+    # Debug builds only — the GC injection points are gated on #ifndef NDEBUG.
+    # Tagged off-by-default so it only runs when explicitly requested.
+    if generate_gc_stress_variant:
+        gc_stress_compat = newest_compat_args if generate_all_compat_flags_variant else default_compat_args
+        gc_stress_kwargs = dict(kwargs)
+        gc_stress_tags = gc_stress_kwargs.pop("tags", []) + ["gc-stress", "no-coverage", "off-by-default"]
+        _wd_test(
+            src = src,
+            name = name + "@gc-stress",
+            data = data,
+            args = base_args + gc_stress_compat + ["--gc-stress"],
+            python_snapshot_test = python_snapshot_test,
+            tags = gc_stress_tags,
+            **gc_stress_kwargs
         )
 
 WINDOWS_TEMPLATE = """

--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -27,7 +27,7 @@ def wd_test(
      generate_default_variant: If True (default), generate the default variant with oldest compat date.
      generate_all_autogates_variant: If True (default), generate @all-autogates variants.
      generate_all_compat_flags_variant: If True (default), generate @all-compat-flags variants.
-     generate_gc_stress_variant: If True (default), generate @gc-stress variant (debug builds only).
+     generate_gc_stress_variant: If True (default), generate @gc-stress variant.
      compat_date: If specified, use this compat date for the default variant instead of 2000-01-01.
         Does not affect the @all-compat-flags variant which always uses 2999-12-31.
 

--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -135,7 +135,6 @@ def wd_test(
     # GC stress variant: forced full GC at every awaitIo continuation.
     # Uses newest compat date unless the test opted out of @all-compat-flags (meaning
     # it is compat-date-sensitive), in which case it uses the default compat date.
-    # Debug builds only — the GC injection points are gated on #ifndef NDEBUG.
     # Tagged off-by-default so it only runs when explicitly requested.
     if generate_gc_stress_variant:
         gc_stress_compat = newest_compat_args if generate_all_compat_flags_variant else default_compat_args

--- a/justfile
+++ b/justfile
@@ -166,5 +166,10 @@ profile path:
 test-gc-stress *args="//src/...":
   bazel test $(bazel query 'attr(tags, gc-stress, kind("_wd_test rule", {{args}}))' 2>/dev/null) --test_tag_filters=gc-stress
 
+# Like test-gc-stress but with AddressSanitizer to detect use-after-free.
+# Leak detection is disabled to avoid masking more serious issues.
+test-gc-stress-asan *args="//src/...":
+  bazel test $(bazel query 'attr(tags, gc-stress, kind("_wd_test rule", {{args}}))' 2>/dev/null) --config=asan --test_tag_filters=gc-stress,-no-asan --test_timeout=300 --test_env=ASAN_OPTIONS=detect_leaks=0
+
 watch *args="build":
   watchexec -rc -w src -w build just {{args}}

--- a/justfile
+++ b/justfile
@@ -159,5 +159,12 @@ profile path:
     echo "No valid perf.data file found for {{path}}"; \
   fi
 
+# Run the @gc-stress test variants to detect GC-related bugs (premature collection,
+# missing visitForGc, etc). Debug builds only. These variants are tagged off-by-default
+# so they won't run in normal `just test` invocations.
+# e.g. just test-gc-stress //src/workerd/api/tests:all
+test-gc-stress *args="//src/...":
+  bazel test $(bazel query 'attr(tags, gc-stress, kind("_wd_test rule", {{args}}))' 2>/dev/null) --test_tag_filters=gc-stress
+
 watch *args="build":
   watchexec -rc -w src -w build just {{args}}

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -12,6 +12,7 @@
 #include <workerd/util/autogate.h>
 #include <workerd/util/own-util.h>
 #include <workerd/util/sentry.h>
+#include <workerd/util/thread-scopes.h>
 #include <workerd/util/uncaught-exception-source.h>
 
 #include <kj/debug.h>
@@ -1300,6 +1301,17 @@ void IoContext::runImpl(Runnable& runnable,
         }
       }
 
+#ifndef NDEBUG
+      // In debug builds with --gc-stress, force a full GC after microtasks run. This
+      // catches objects that became unreachable during JS execution / microtask processing
+      // (e.g., a ReadableStreamDefaultReader with no JS variable binding whose closed
+      // promise is still pending).
+      if (isGcStressModeForTest()) {
+        workerLock.getIsolate()->RequestGarbageCollectionForTesting(
+            v8::Isolate::kFullGarbageCollection);
+      }
+#endif
+
       // Run FinalizationRegistry cleanup tasks without an IoContext
       {
         SuppressIoContextScope noIoCtxt;
@@ -1331,6 +1343,18 @@ void IoContext::runImpl(Runnable& runnable,
         }
       }
     });
+
+#ifndef NDEBUG
+    // In debug builds with --gc-stress, force a full GC before each awaitIo continuation.
+    // This helps detect KJ async objects (promises, streams, etc.) stored on the JS heap
+    // without IoOwn wrapping. Such objects crash under DISALLOW_KJ_IO_DESTRUCTORS_SCOPE
+    // when collected by GC, but normally the timing window is too brief to hit. Forcing
+    // GC at every continuation makes these bugs deterministic.
+    if (isGcStressModeForTest()) {
+      workerLock.getIsolate()->RequestGarbageCollectionForTesting(
+          v8::Isolate::kFullGarbageCollection);
+    }
+#endif
 
     v8::TryCatch tryCatch(workerLock.getIsolate());
     try {

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1301,16 +1301,14 @@ void IoContext::runImpl(Runnable& runnable,
         }
       }
 
-#ifndef NDEBUG
-      // In debug builds with --gc-stress, force a full GC after microtasks run. This
-      // catches objects that became unreachable during JS execution / microtask processing
-      // (e.g., a ReadableStreamDefaultReader with no JS variable binding whose closed
-      // promise is still pending).
+      // With --gc-stress, force a full GC after microtasks run. This catches objects that
+      // became unreachable during JS execution / microtask processing (e.g., a
+      // ReadableStreamDefaultReader with no JS variable binding whose closed promise is
+      // still pending).
       if (isGcStressModeForTest()) {
         workerLock.getIsolate()->RequestGarbageCollectionForTesting(
             v8::Isolate::kFullGarbageCollection);
       }
-#endif
 
       // Run FinalizationRegistry cleanup tasks without an IoContext
       {
@@ -1344,17 +1342,15 @@ void IoContext::runImpl(Runnable& runnable,
       }
     });
 
-#ifndef NDEBUG
-    // In debug builds with --gc-stress, force a full GC before each awaitIo continuation.
-    // This helps detect KJ async objects (promises, streams, etc.) stored on the JS heap
-    // without IoOwn wrapping. Such objects crash under DISALLOW_KJ_IO_DESTRUCTORS_SCOPE
-    // when collected by GC, but normally the timing window is too brief to hit. Forcing
-    // GC at every continuation makes these bugs deterministic.
+    // With --gc-stress, force a full GC before each awaitIo continuation. This helps detect
+    // KJ async objects (promises, streams, etc.) stored on the JS heap without IoOwn
+    // wrapping. Such objects crash under DISALLOW_KJ_IO_DESTRUCTORS_SCOPE when collected
+    // by GC, but normally the timing window is too brief to hit. Forcing GC at every
+    // continuation makes these bugs deterministic.
     if (isGcStressModeForTest()) {
       workerLock.getIsolate()->RequestGarbageCollectionForTesting(
           v8::Isolate::kFullGarbageCollection);
     }
-#endif
 
     v8::TryCatch tryCatch(workerLock.getIsolate());
     try {

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -169,7 +169,7 @@ void V8System::init(kj::Own<v8::Platform> platformParam,
   v8::V8::SetFlagsFromString("--single-threaded-gc");
 #endif  // __APPLE__
 
-  if (isPredictableModeForTest()) {
+  if (isPredictableModeForTest() || isGcStressModeForTest()) {
     v8::V8::SetFlagsFromString("--expose-gc");
   }
 
@@ -312,6 +312,7 @@ void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
       handle.As<v8::Object>().Get(isolate)->GetAlignedPointerFromInternalField(
           Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
           static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX)));
+
   // V8 gets angry if we do not EXPLICITLY call `Reset()` on the wrapper. If we merely destroy it
   // (which is what `detachWrapper()` will do) it is not satisfied, and will come back and try to
   // visit the reference again, but it will DCHECK-fail on that second attempt because the

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -7,6 +7,8 @@
 #include "jsg.h"
 #include "setup.h"
 
+#include <workerd/util/thread-scopes.h>
+
 #include <cppgc/allocation.h>
 #include <cppgc/garbage-collected.h>
 #include <v8-cppgc.h>
@@ -178,19 +180,22 @@ void HeapTracer::addToFreelist(JSGWrappable::CppgcShim& shim) {
 }
 
 JSGWrappable::CppgcShim* HeapTracer::allocateShim(JSGWrappable& wrappable) {
-  KJ_IF_SOME(shim, freelistedShims) {
-    freelistedShims = shim.state.get<JSGWrappable::CppgcShim::Freelisted>().next;
-    KJ_IF_SOME(next, freelistedShims) {
-      next.state.get<JSGWrappable::CppgcShim::Freelisted>().prev = &freelistedShims;
+  // Under gc-stress, skip freelist reuse so each shim has a unique address in logs.
+  if (!isGcStressModeForTest()) {
+    KJ_IF_SOME(shim, freelistedShims) {
+      freelistedShims = shim.state.get<JSGWrappable::CppgcShim::Freelisted>().next;
+      KJ_IF_SOME(next, freelistedShims) {
+        next.state.get<JSGWrappable::CppgcShim::Freelisted>().prev = &freelistedShims;
+      }
+      shim.state = JSGWrappable::CppgcShim::Active{kj::addRef(wrappable)};
+      KJ_DASSERT(wrappable.cppgcShim == kj::none);
+      wrappable.cppgcShim = shim;
+      return &shim;
     }
-    shim.state = JSGWrappable::CppgcShim::Active{kj::addRef(wrappable)};
-    KJ_DASSERT(wrappable.cppgcShim == kj::none);
-    wrappable.cppgcShim = shim;
-    return &shim;
-  } else {
-    auto& cppgcAllocHandle = isolate->GetCppHeap()->GetAllocationHandle();
-    return cppgc::MakeGarbageCollected<JSGWrappable::CppgcShim>(cppgcAllocHandle, wrappable);
   }
+  auto& cppgcAllocHandle = isolate->GetCppHeap()->GetAllocationHandle();
+  auto* shim = cppgc::MakeGarbageCollected<JSGWrappable::CppgcShim>(cppgcAllocHandle, wrappable);
+  return shim;
 }
 
 void HeapTracer::clearFreelistedShims() {

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -937,6 +937,13 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
     },
             "Enable predictable mode. This makes workerd behave more deterministically by using "
             "pre-set values instead of random data or timestamps to facilitate testing.")
+        .addOption({"gc-stress"},
+            [this]() {
+      gcStress = true;
+      return true;
+    },
+            "Force a full V8 GC at each awaitIo continuation (debug builds only). "
+            "Detects KJ async objects on the JS heap without IoOwn wrapping. Very slow.")
         .addOption({"all-autogates"},
             [this]() {
       allAutogates = true;
@@ -1476,6 +1483,9 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
     if (predictable) {
       setPredictableModeForTest();
     }
+    if (gcStress) {
+      setGcStressModeForTest();
+    }
     if (allAutogates) {
       util::Autogate::initAllAutogates();
     }
@@ -1551,6 +1561,7 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
   bool configOnly = false;
   bool noVerbose = false;
   bool predictable = false;
+  bool gcStress = false;
   bool allAutogates = false;
   kj::Maybe<kj::String> testCompatDate;
   kj::Maybe<FileWatcher> watcher;

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -942,7 +942,7 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
       gcStress = true;
       return true;
     },
-            "Force a full V8 GC at each awaitIo continuation (debug builds only). "
+            "Force a full V8 GC at each awaitIo continuation. "
             "Detects KJ async objects on the JS heap without IoOwn wrapping. Very slow.")
         .addOption({"all-autogates"},
             [this]() {

--- a/src/workerd/util/thread-scopes.c++
+++ b/src/workerd/util/thread-scopes.c++
@@ -7,6 +7,7 @@
 #include <kj/debug.h>
 
 #include <atomic>
+#include <cstdlib>
 
 namespace workerd {
 
@@ -56,7 +57,14 @@ void setPredictableModeForTest() {
 }
 
 bool isGcStressModeForTest() {
-  return gcStressMode;
+  // Also honor the WORKERD_GC_STRESS environment variable so that gc-stress mode can be enabled
+  // in binaries that don't have a --gc-stress CLI flag (e.g., edgeworker's prod subcommand).
+  // The env var is checked once and cached; thread-safe via C++ static local initialization.
+  static const bool fromEnv = [] {
+    const char* val = std::getenv("WORKERD_GC_STRESS");
+    return val != nullptr && val[0] != '0' && val[0] != '\0';
+  }();
+  return gcStressMode || fromEnv;
 }
 
 void setGcStressModeForTest() {

--- a/src/workerd/util/thread-scopes.c++
+++ b/src/workerd/util/thread-scopes.c++
@@ -18,6 +18,7 @@ thread_local uint allowV8BackgroundThreadScopeCount = 0;
 
 bool multiTenantProcess = false;
 bool predictableMode = false;
+bool gcStressMode = false;
 
 // This variable is read in signal handlers, so use atomic stores and compiler barriers as
 // needed in regular code. Atomic loads are unnecessary, because we're not synchronizing with
@@ -52,6 +53,14 @@ bool isPredictableModeForTest() {
 
 void setPredictableModeForTest() {
   predictableMode = true;
+}
+
+bool isGcStressModeForTest() {
+  return gcStressMode;
+}
+
+void setGcStressModeForTest() {
+  gcStressMode = true;
 }
 
 ThreadProgressCounter::ThreadProgressCounter(uint64_t& counter)

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -70,6 +70,10 @@ void setPredictableModeForTest();
 // are reachable from the JS heap without proper IoOwn wrapping — such objects would violate
 // DISALLOW_KJ_IO_DESTRUCTORS_SCOPE when collected. Only effective in debug builds. This makes
 // tests significantly slower and should only be used for targeted stress testing.
+//
+// Can be enabled via setGcStressModeForTest() (used by workerd's --gc-stress CLI flag) or by
+// setting the WORKERD_GC_STRESS=1 environment variable (useful for binaries without a dedicated
+// CLI flag, e.g., edgeworker tests where the test-runner spawns the server as a subprocess).
 bool isGcStressModeForTest();
 void setGcStressModeForTest();
 

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -68,8 +68,8 @@ void setPredictableModeForTest();
 // When enabled, forces a full V8 garbage collection at key points where the KJ event loop
 // re-enters JavaScript (e.g., awaitIo continuations). This helps detect KJ async objects that
 // are reachable from the JS heap without proper IoOwn wrapping — such objects would violate
-// DISALLOW_KJ_IO_DESTRUCTORS_SCOPE when collected. Only effective in debug builds. This makes
-// tests significantly slower and should only be used for targeted stress testing.
+// DISALLOW_KJ_IO_DESTRUCTORS_SCOPE when collected. This makes tests significantly slower and
+// should only be used for targeted stress testing.
 //
 // Can be enabled via setGcStressModeForTest() (used by workerd's --gc-stress CLI flag) or by
 // setting the WORKERD_GC_STRESS=1 environment variable (useful for binaries without a dedicated

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -65,6 +65,14 @@ bool isPredictableModeForTest();
 // etc. This should only be used in tests.
 void setPredictableModeForTest();
 
+// When enabled, forces a full V8 garbage collection at key points where the KJ event loop
+// re-enters JavaScript (e.g., awaitIo continuations). This helps detect KJ async objects that
+// are reachable from the JS heap without proper IoOwn wrapping — such objects would violate
+// DISALLOW_KJ_IO_DESTRUCTORS_SCOPE when collected. Only effective in debug builds. This makes
+// tests significantly slower and should only be used for targeted stress testing.
+bool isGcStressModeForTest();
+void setGcStressModeForTest();
+
 // RAII class which allows the thread's active watchdog to observe forward progress through
 // changes in a uint64_t. Use this in places where your code cannot call Watchdog::checkIn() and
 // may block for longer than the watchdog timeout, but can still observe forward progress.


### PR DESCRIPTION
The new mode calls GC just after microtasks and at awaitIO continuations

This catches some cases where an unfortunately timed GC leads
to intermittent issues.  Running the just-recipe reveals current
failing tests, but the security issue that it unearthed has been
fixed.  Some of the failures are just timing.

Not currently enabled in the CI.