### PR TITLE
Process pth files in python_modules

### DIFF
--- a/src/pyodide/internal/metadata.ts
+++ b/src/pyodide/internal/metadata.ts
@@ -63,6 +63,7 @@ export const EXTERNAL_SDK = !!COMPATIBILITY_FLAGS.enable_python_external_sdk;
 export const LEGACY_GLOBAL_HANDLERS = !NO_GLOBAL_HANDLERS;
 export const LEGACY_VENDOR_PATH = !FORCE_NEW_VENDOR_PATH;
 export const CHECK_RNG_STATE = !!COMPATIBILITY_FLAGS.python_check_rng_state;
+export const PROCESS_PTH_FILES = !!COMPATIBILITY_FLAGS.python_process_pth_files;
 
 export const setCpuLimitNearlyExceededCallback =
   MetadataReader.setCpuLimitNearlyExceededCallback.bind(MetadataReader);

--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -23,6 +23,7 @@ import {
 } from 'pyodide-internal:topLevelEntropy/lib';
 import {
   LEGACY_VENDOR_PATH,
+  PROCESS_PTH_FILES,
   setCpuLimitNearlyExceededCallback,
 } from 'pyodide-internal:metadata';
 import { default as FatalReporter } from 'pyodide-internal:fatal-reporter';
@@ -79,12 +80,11 @@ function prepareWasmLinearMemory(
 }
 
 function setupPythonSearchPath(pyodide: Pyodide): void {
-  pyodide.runPython(`
-    def _tmp():
+  const setup = pyodide.runPython(`
+    def _setup_python_search_path(*, LEGACY_VENDOR_PATH, PROCESS_PTH_FILES):
       import sys
-      from pathlib import Path
+      from site import addsitedir
 
-      LEGACY_VENDOR_PATH = "${LEGACY_VENDOR_PATH}" == "true"
       VENDOR_PATH = "/session/metadata/vendor"
       PYTHON_MODULES_PATH = "/session/metadata/python_modules"
 
@@ -113,9 +113,21 @@ function setupPythonSearchPath(pyodide: Pyodide): void {
         # If no site-packages found, fail
         raise ValueError("No site-packages found in sys.path")
 
-    _tmp()
-    del _tmp
-  `);
+      if PROCESS_PTH_FILES:
+        # addsitedir processes any .pth files in PYTHON_MODULES_PATH, allowing
+        # packages to extend sys.path declaratively. It also re-adds the
+        # directory to sys.path, but it was already inserted above so this is a
+        # no-op for that purpose.
+        addsitedir(PYTHON_MODULES_PATH)
+
+    _setup_python_search_path
+  `) as PyCallable;
+  pyodide.runPython('del _setup_python_search_path');
+  setup.callKwargs({
+    LEGACY_VENDOR_PATH,
+    PROCESS_PTH_FILES,
+  });
+  setup.destroy();
 }
 
 /**

--- a/src/pyodide/types/Pyodide.d.ts
+++ b/src/pyodide/types/Pyodide.d.ts
@@ -10,10 +10,12 @@ declare type PyCallable = ((...args: any[]) => any) & {
   call: (...args: any[]) => any;
   callRelaxed: (...args: any[]) => any;
   callPromising: (...args: any[]) => any;
+  callKwargs: (...args: any[]) => any;
   callWithOptions?: (
     options: { relaxed?: boolean; promising?: boolean; kwargs?: boolean },
     ...args: any[]
   ) => any;
+  destroy(): void;
 };
 
 declare type PyDict = object;

--- a/src/pyodide/types/runtime-generated/metadata.d.ts
+++ b/src/pyodide/types/runtime-generated/metadata.d.ts
@@ -12,6 +12,7 @@ declare namespace MetadataReader {
     enable_python_external_sdk?: boolean;
     python_check_rng_state?: boolean;
     python_workflows_implicit_dependencies?: boolean;
+    python_process_pth_files?: boolean;
   }
 
   const isWorkerd: () => boolean;

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1530,4 +1530,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # The rollback function is bundled into the RPC call for the engine to invoke
   # as a compensation action on failure. Without this flag, the step object is
   # passed through unwrapped and .rollback() is not available.
+
+  pythonProcessPthFiles @176 :Bool
+      $compatEnableFlag("python_process_pth_files")
+      $compatDisableFlag("disable_python_process_pth_files");
+  # When enabled, Python Workers process `.pth` files placed in the
+  # `python_modules/` directory by calling `site.addsitedir()` on it during
+  # startup. This allows packages to extend `sys.path` declaratively (e.g. to
+  # add subdirectories or register import hooks). Without this flag, `.pth`
+  # files in `python_modules/` are ignored.
 }

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -83,3 +83,5 @@ py_wd_test(
 )
 
 py_wd_test("python-compat-flag")
+
+py_wd_test("pth-file")

--- a/src/workerd/server/tests/python/pth-file/extra_module.py
+++ b/src/workerd/server/tests/python/pth-file/extra_module.py
@@ -1,0 +1,11 @@
+# should be able to use ffi at this point.
+import js
+
+
+def use(mod):
+    pass
+
+
+use(js)
+
+VALUE = 42

--- a/src/workerd/server/tests/python/pth-file/pth-file.wd-test
+++ b/src/workerd/server/tests/python/pth-file/pth-file.wd-test
@@ -1,0 +1,21 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "pth-file",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "worker.py"),
+          # The .pth file must live in python_modules/ so that addsitedir() picks
+          # it up.
+          (name = "python_modules/setup.pth", data = embed "setup.pth"),
+          # The .pth file adds "extra_dir" (relative to python_modules/) to
+          # sys.path. extra_module lives there.
+          (name = "python_modules/extra_dir/extra_module.py",
+              pythonModule = embed "extra_module.py"),
+        ],
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "disable_python_no_global_handlers", "python_process_pth_files"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/pth-file/setup.pth
+++ b/src/workerd/server/tests/python/pth-file/setup.pth
@@ -1,0 +1,1 @@
+extra_dir

--- a/src/workerd/server/tests/python/pth-file/worker.py
+++ b/src/workerd/server/tests/python/pth-file/worker.py
@@ -1,0 +1,15 @@
+import sys
+
+# The .pth file added a relative path "extra_dir" which should resolve to
+# /session/metadata/python_modules/extra_dir and be on sys.path.
+expected_extra_dir = "/session/metadata/python_modules/extra_dir"
+assert expected_extra_dir in sys.path
+
+# And the module living in that directory must be importable.
+import extra_module
+
+assert extra_module.VALUE == 42
+
+
+def test():
+    pass


### PR DESCRIPTION
Some packages rely on this behavior. I also want to use it in workers-runtime-sdk to implement entropy hooks.