### PR TITLE
Streams cleanups, migrate from jsg::BufferSource/jsg::Value/v8::Local to jsg::Js* types

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -154,8 +154,8 @@ jsg::Promise<jsg::Ref<ExecOutput>> ExecProcess::output(jsg::Lock& js) {
     stdoutPromise =
         stream->getController()
             .readAllBytes(js, IoContext::current().getLimitEnforcer().getBufferingLimit())
-            .then(js, [](jsg::Lock&, jsg::BufferSource bytes) {
-      return kj::heapArray(bytes.asArrayPtr());
+            .then(js, [](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> bytes) {
+      return bytes.getHandle(js).copy();
     });
   }
 
@@ -165,8 +165,8 @@ jsg::Promise<jsg::Ref<ExecOutput>> ExecProcess::output(jsg::Lock& js) {
         "Cannot call output() after stderr has started being consumed.");
     stderrPromise = stream->getController()
                         .readAllBytes(js, kj::maxValue)
-                        .then(js, [](jsg::Lock&, jsg::BufferSource bytes) {
-      return kj::heapArray(bytes.asArrayPtr());
+                        .then(js, [](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> bytes) {
+      return bytes.getHandle(js).copy();
     });
   }
 

--- a/src/workerd/api/crypto/crypto.c++
+++ b/src/workerd/api/crypto/crypto.c++
@@ -800,7 +800,7 @@ void DigestStream::dispose(jsg::Lock& js) {
     KJ_IF_SOME(ready, state.tryGet<Ready>()) {
       auto reason = js.typeError("The DigestStream was disposed.");
       ready.resolver.reject(js, reason);
-      state.init<StreamStates::Errored>(js.v8Ref<v8::Value>(reason));
+      state.init<StreamStates::Errored>(reason.addRef(js));
     }
   }
   JSG_CATCH(exception) {
@@ -859,7 +859,7 @@ void DigestStream::abort(jsg::Lock& js, jsg::JsValue reason) {
   // If the state is already closed or errored, then this is a non-op
   KJ_IF_SOME(ready, state.tryGet<Ready>()) {
     ready.resolver.reject(js, reason);
-    state.init<StreamStates::Errored>(js.v8Ref<v8::Value>(reason));
+    state.init<StreamStates::Errored>(reason.addRef(js));
   }
 }
 

--- a/src/workerd/api/filesystem.c++
+++ b/src/workerd/api/filesystem.c++
@@ -490,7 +490,7 @@ void FileSystemModule::close(jsg::Lock& js, int fd) {
 }
 
 uint32_t FileSystemModule::write(
-    jsg::Lock& js, int fd, kj::Array<jsg::JsBufferSource> data, WriteOptions options) {
+    jsg::Lock& js, int fd, kj::Array<jsg::JsRef<jsg::JsBufferSource>> data, WriteOptions options) {
   auto& vfs = workerd::VirtualFileSystem::current(js);
 
   KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
@@ -513,7 +513,7 @@ uint32_t FileSystemModule::write(
         auto pos = getPosition(js, opened.addRef(), file.addRef(), options);
         uint32_t total = 0;
         for (auto& buffer: data) {
-          KJ_SWITCH_ONEOF(file->write(js, pos, buffer.asArrayPtr())) {
+          KJ_SWITCH_ONEOF(file->write(js, pos, buffer.getHandle(js).asArrayPtr())) {
             KJ_CASE_ONEOF(written, uint32_t) {
               pos += written;
               total += written;
@@ -546,7 +546,7 @@ uint32_t FileSystemModule::write(
 }
 
 uint32_t FileSystemModule::read(
-    jsg::Lock& js, int fd, kj::Array<jsg::JsUint8Array> data, WriteOptions options) {
+    jsg::Lock& js, int fd, kj::Array<jsg::JsRef<jsg::JsUint8Array>> data, WriteOptions options) {
   auto& vfs = workerd::VirtualFileSystem::current(js);
   KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
     if (!opened->read) {
@@ -561,11 +561,12 @@ uint32_t FileSystemModule::read(
         }
         uint32_t total = 0;
         for (auto& buffer: data) {
-          auto read = file->read(js, pos, buffer.asArrayPtr());
+          auto handle = buffer.getHandle(js);
+          auto read = file->read(js, pos, handle.asArrayPtr());
           // if read is less than the size of the buffer, we are at EOF.
           pos += read;
           total += read;
-          if (read < buffer.size()) break;
+          if (read < handle.size()) break;
         }
         // We only update the position if the options.position is not set.
         if (options.position == kj::none) {
@@ -788,7 +789,7 @@ uint32_t FileSystemModule::writeAll(jsg::Lock& js,
           // If the file descriptor was opened in append mode, or if the append option
           // is set, then we'll use write instead to append to the end of the file.
           if (opened->append || options.append) {
-            return write(js, fd, kj::arr(kj::mv(data)),
+            return write(js, fd, kj::arr(data.addRef(js)),
                 {
                   .position = stat.size,
                 });

--- a/src/workerd/api/filesystem.c++
+++ b/src/workerd/api/filesystem.c++
@@ -490,7 +490,7 @@ void FileSystemModule::close(jsg::Lock& js, int fd) {
 }
 
 uint32_t FileSystemModule::write(
-    jsg::Lock& js, int fd, kj::Array<jsg::BufferSource> data, WriteOptions options) {
+    jsg::Lock& js, int fd, kj::Array<jsg::JsBufferSource> data, WriteOptions options) {
   auto& vfs = workerd::VirtualFileSystem::current(js);
 
   KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
@@ -513,7 +513,7 @@ uint32_t FileSystemModule::write(
         auto pos = getPosition(js, opened.addRef(), file.addRef(), options);
         uint32_t total = 0;
         for (auto& buffer: data) {
-          KJ_SWITCH_ONEOF(file->write(js, pos, buffer)) {
+          KJ_SWITCH_ONEOF(file->write(js, pos, buffer.asArrayPtr())) {
             KJ_CASE_ONEOF(written, uint32_t) {
               pos += written;
               total += written;
@@ -546,7 +546,7 @@ uint32_t FileSystemModule::write(
 }
 
 uint32_t FileSystemModule::read(
-    jsg::Lock& js, int fd, kj::Array<jsg::BufferSource> data, WriteOptions options) {
+    jsg::Lock& js, int fd, kj::Array<jsg::JsUint8Array> data, WriteOptions options) {
   auto& vfs = workerd::VirtualFileSystem::current(js);
   KJ_IF_SOME(opened, vfs.tryGetFd(js, fd)) {
     if (!opened->read) {
@@ -561,7 +561,7 @@ uint32_t FileSystemModule::read(
         }
         uint32_t total = 0;
         for (auto& buffer: data) {
-          auto read = file->read(js, pos, buffer);
+          auto read = file->read(js, pos, buffer.asArrayPtr());
           // if read is less than the size of the buffer, we are at EOF.
           pos += read;
           total += read;
@@ -588,7 +588,7 @@ uint32_t FileSystemModule::read(
   }
 }
 
-jsg::BufferSource FileSystemModule::readAll(jsg::Lock& js, kj::OneOf<int, FilePath> pathOrFd) {
+jsg::JsUint8Array FileSystemModule::readAll(jsg::Lock& js, kj::OneOf<int, FilePath> pathOrFd) {
   auto& vfs = workerd::VirtualFileSystem::current(js);
   KJ_SWITCH_ONEOF(pathOrFd) {
     KJ_CASE_ONEOF(path, FilePath) {
@@ -597,8 +597,8 @@ jsg::BufferSource FileSystemModule::readAll(jsg::Lock& js, kj::OneOf<int, FilePa
         KJ_SWITCH_ONEOF(node) {
           KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
             KJ_SWITCH_ONEOF(file->readAllBytes(js)) {
-              KJ_CASE_ONEOF(data, jsg::BufferSource) {
-                return kj::mv(data);
+              KJ_CASE_ONEOF(data, jsg::JsUint8Array) {
+                return data;
               }
               KJ_CASE_ONEOF(err, workerd::FsError) {
                 throwFsError(js, err, "readAll"_kj);
@@ -635,8 +635,8 @@ jsg::BufferSource FileSystemModule::readAll(jsg::Lock& js, kj::OneOf<int, FilePa
           });
 
           KJ_SWITCH_ONEOF(file->readAllBytes(js)) {
-            KJ_CASE_ONEOF(data, jsg::BufferSource) {
-              return kj::mv(data);
+            KJ_CASE_ONEOF(data, jsg::JsUint8Array) {
+              return data;
             }
             KJ_CASE_ONEOF(err, workerd::FsError) {
               throwFsError(js, err, "freadAll"_kj);
@@ -656,7 +656,7 @@ jsg::BufferSource FileSystemModule::readAll(jsg::Lock& js, kj::OneOf<int, FilePa
 
 uint32_t FileSystemModule::writeAll(jsg::Lock& js,
     kj::OneOf<int, FilePath> pathOrFd,
-    jsg::BufferSource data,
+    jsg::JsBufferSource data,
     WriteAllOptions options) {
   auto& vfs = workerd::VirtualFileSystem::current(js);
 
@@ -684,7 +684,7 @@ uint32_t FileSystemModule::writeAll(jsg::Lock& js,
             // If the append option is set, we will write to the end of the file
             // instead of overwriting it.
             if (options.append) {
-              KJ_SWITCH_ONEOF(file->write(js, stat.size, data)) {
+              KJ_SWITCH_ONEOF(file->write(js, stat.size, data.asArrayPtr())) {
                 KJ_CASE_ONEOF(written, uint32_t) {
                   return written;
                 }
@@ -696,7 +696,7 @@ uint32_t FileSystemModule::writeAll(jsg::Lock& js,
             }
 
             // Otherwise, we overwrite the entire file.
-            KJ_SWITCH_ONEOF(file->writeAll(js, data)) {
+            KJ_SWITCH_ONEOF(file->writeAll(js, data.asArrayPtr())) {
               KJ_CASE_ONEOF(written, uint32_t) {
                 return written;
               }
@@ -737,7 +737,7 @@ uint32_t FileSystemModule::writeAll(jsg::Lock& js,
               node::THROW_ERR_UV_EPERM(js, "writeAll"_kj);
             }
             auto file = workerd::File::newWritable(js, static_cast<uint32_t>(data.size()));
-            KJ_SWITCH_ONEOF(file->writeAll(js, data)) {
+            KJ_SWITCH_ONEOF(file->writeAll(js, data.asArrayPtr())) {
               KJ_CASE_ONEOF(written, uint32_t) {
                 KJ_IF_SOME(err, dir->add(js, relative.name, kj::mv(file))) {
                   throwFsError(js, err, "writeAll"_kj);
@@ -795,7 +795,7 @@ uint32_t FileSystemModule::writeAll(jsg::Lock& js,
           }
 
           // Otherwise, we overwrite the entire file.
-          KJ_SWITCH_ONEOF(file->writeAll(js, data)) {
+          KJ_SWITCH_ONEOF(file->writeAll(js, data.asArrayPtr())) {
             KJ_CASE_ONEOF(written, uint32_t) {
               return written;
             }
@@ -1890,9 +1890,8 @@ jsg::Ref<Blob> FileSystemModule::openAsBlob(
       }
       KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
         KJ_SWITCH_ONEOF(file->readAllBytes(js)) {
-          KJ_CASE_ONEOF(bytes, jsg::BufferSource) {
-            return js.alloc<Blob>(
-                js, bytes.getJsHandle(js), kj::mv(options.type).orDefault(kj::String()));
+          KJ_CASE_ONEOF(bytes, jsg::JsUint8Array) {
+            return js.alloc<Blob>(js, bytes, kj::mv(options.type).orDefault(kj::String()));
           }
           KJ_CASE_ONEOF(err, workerd::FsError) {
             throwFsError(js, err, "open"_kj);
@@ -2557,10 +2556,10 @@ jsg::Promise<jsg::Ref<File>> FileSystemFileHandle::getFile(
       KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
         auto stat = file->stat(js);
         KJ_SWITCH_ONEOF(file->readAllBytes(js)) {
-          KJ_CASE_ONEOF(bytes, jsg::BufferSource) {
+          KJ_CASE_ONEOF(bytes, jsg::JsUint8Array) {
             return js.resolvedPromise(
-                js.alloc<File>(js, bytes.getJsHandle(js), jsg::USVString(kj::str(getName(js))),
-                    kj::String(), (stat.lastModified - kj::UNIX_EPOCH) / kj::MILLISECONDS));
+                js.alloc<File>(js, bytes, jsg::USVString(kj::str(getName(js))), kj::String(),
+                    (stat.lastModified - kj::UNIX_EPOCH) / kj::MILLISECONDS));
           }
           KJ_CASE_ONEOF(err, workerd::FsError) {
             return js.rejectedPromise<jsg::Ref<File>>(
@@ -2724,7 +2723,7 @@ FileSystemWritableFileStream::FileSystemWritableFileStream(
       sharedState(kj::mv(sharedState)) {}
 
 jsg::Promise<void> FileSystemWritableFileStream::write(jsg::Lock& js,
-    kj::OneOf<jsg::Ref<Blob>, jsg::BufferSource, kj::String, WriteParams> data,
+    kj::OneOf<jsg::Ref<Blob>, jsg::JsBufferSource, kj::String, WriteParams> data,
     const jsg::TypeHandler<jsg::Ref<jsg::DOMException>>& deHandler) {
   JSG_REQUIRE(!getController().isLockedToWriter(), TypeError,
       "Cannot write to a stream that is locked to a reader");
@@ -2750,8 +2749,8 @@ jsg::Promise<void> FileSystemWritableFileStream::writeImpl(jsg::Lock& js,
             }
           }
         }
-        KJ_CASE_ONEOF(buffer, jsg::BufferSource) {
-          KJ_SWITCH_ONEOF(inner->write(js, state.position, buffer)) {
+        KJ_CASE_ONEOF(buffer, jsg::JsBufferSource) {
+          KJ_SWITCH_ONEOF(inner->write(js, state.position, buffer.asArrayPtr())) {
             KJ_CASE_ONEOF(written, uint32_t) {
               state.position += written;
             }
@@ -2799,8 +2798,8 @@ jsg::Promise<void> FileSystemWritableFileStream::writeImpl(jsg::Lock& js,
                     }
                     KJ_UNREACHABLE;
                   }
-                  KJ_CASE_ONEOF(buffer, jsg::BufferSource) {
-                    KJ_SWITCH_ONEOF(inner->write(js, offset, buffer)) {
+                  KJ_CASE_ONEOF(buffer, jsg::JsRef<jsg::JsBufferSource>) {
+                    KJ_SWITCH_ONEOF(inner->write(js, offset, buffer.getHandle(js).asArrayPtr())) {
                       KJ_CASE_ONEOF(written, uint32_t) {
                         state.position = offset + written;
                         return js.resolvedPromise();

--- a/src/workerd/api/filesystem.h
+++ b/src/workerd/api/filesystem.h
@@ -103,10 +103,10 @@ class FileSystemModule final: public jsg::Object {
     JSG_STRUCT(position);
   };
 
-  uint32_t write(jsg::Lock& js, int fd, kj::Array<jsg::BufferSource> data, WriteOptions options);
-  uint32_t read(jsg::Lock& js, int fd, kj::Array<jsg::BufferSource> data, WriteOptions options);
+  uint32_t write(jsg::Lock& js, int fd, kj::Array<jsg::JsBufferSource> data, WriteOptions options);
+  uint32_t read(jsg::Lock& js, int fd, kj::Array<jsg::JsUint8Array> data, WriteOptions options);
 
-  jsg::BufferSource readAll(jsg::Lock& js, kj::OneOf<int, FilePath> pathOrFd);
+  jsg::JsUint8Array readAll(jsg::Lock& js, kj::OneOf<int, FilePath> pathOrFd);
 
   struct WriteAllOptions {
     bool exclusive;
@@ -116,7 +116,7 @@ class FileSystemModule final: public jsg::Object {
 
   uint32_t writeAll(jsg::Lock& js,
       kj::OneOf<int, FilePath> pathOrFd,
-      jsg::BufferSource data,
+      jsg::JsBufferSource data,
       WriteAllOptions options);
 
   struct RenameOrCopyOptions {
@@ -298,12 +298,12 @@ struct FileSystemFileWriteParams {
   jsg::Optional<uint32_t> position;
   // Yes, wrapping the kj::Maybe with a jsg::Optional is intentional here. We need to
   // be able to accept null or undefined values and handle them per the spec.
-  jsg::Optional<kj::Maybe<kj::OneOf<jsg::Ref<Blob>, jsg::BufferSource, kj::String>>> data;
+  jsg::Optional<kj::Maybe<kj::OneOf<jsg::Ref<Blob>, jsg::JsRef<jsg::JsBufferSource>, kj::String>>> data;
   JSG_STRUCT(type, size, position, data);
 };
 
 using FileSystemWritableData =
-    kj::OneOf<jsg::Ref<Blob>, jsg::BufferSource, kj::String, FileSystemFileWriteParams>;
+    kj::OneOf<jsg::Ref<Blob>, jsg::JsBufferSource, kj::String, FileSystemFileWriteParams>;
 
 class FileSystemFileHandle final: public FileSystemHandle {
  public:

--- a/src/workerd/api/filesystem.h
+++ b/src/workerd/api/filesystem.h
@@ -103,8 +103,8 @@ class FileSystemModule final: public jsg::Object {
     JSG_STRUCT(position);
   };
 
-  uint32_t write(jsg::Lock& js, int fd, kj::Array<jsg::JsBufferSource> data, WriteOptions options);
-  uint32_t read(jsg::Lock& js, int fd, kj::Array<jsg::JsUint8Array> data, WriteOptions options);
+  uint32_t write(jsg::Lock& js, int fd, kj::Array<jsg::JsRef<jsg::JsBufferSource>> data, WriteOptions options);
+  uint32_t read(jsg::Lock& js, int fd, kj::Array<jsg::JsRef<jsg::JsUint8Array>> data, WriteOptions options);
 
   jsg::JsUint8Array readAll(jsg::Lock& js, kj::OneOf<int, FilePath> pathOrFd);
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -242,7 +242,7 @@ bool Body::getBodyUsed() {
   }
   return false;
 }
-jsg::Promise<jsg::BufferSource> Body::arrayBuffer(jsg::Lock& js) {
+jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> Body::arrayBuffer(jsg::Lock& js) {
   KJ_IF_SOME(i, impl) {
     return js.evalNow([&] {
       JSG_REQUIRE(!i.stream->isDisturbed(), TypeError,
@@ -255,13 +255,15 @@ jsg::Promise<jsg::BufferSource> Body::arrayBuffer(jsg::Lock& js) {
 
   // If there's no body, we just return an empty array.
   // See https://fetch.spec.whatwg.org/#concept-body-consume-body
-  auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 0);
-  return js.resolvedPromise(jsg::BufferSource(js, kj::mv(backing)));
+  auto empty = jsg::JsArrayBuffer::create(js, 0);
+  return js.resolvedPromise(empty.addRef(js));
 }
 
-jsg::Promise<jsg::BufferSource> Body::bytes(jsg::Lock& js) {
-  return arrayBuffer(js).then(js,
-      [](jsg::Lock& js, jsg::BufferSource data) { return data.getTypedView<v8::Uint8Array>(js); });
+jsg::Promise<jsg::JsRef<jsg::JsUint8Array>> Body::bytes(jsg::Lock& js) {
+  return arrayBuffer(js).then(js, [](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> data) {
+    jsg::JsUint8Array u8 = data.getHandle(js);
+    return u8.addRef(js);
+  });
 }
 
 jsg::Promise<kj::String> Body::text(jsg::Lock& js) {
@@ -331,7 +333,7 @@ jsg::Promise<jsg::Value> Body::json(jsg::Lock& js) {
 }
 
 jsg::Promise<jsg::Ref<Blob>> Body::blob(jsg::Lock& js) {
-  return arrayBuffer(js).then(js, [this](jsg::Lock& js, jsg::BufferSource buffer) {
+  return arrayBuffer(js).then(js, [this](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> buffer) {
     kj::String contentType = headersRef.getCommon(js, capnp::CommonHeaderName::CONTENT_TYPE)
                                  .map([](auto&& b) -> kj::String {
       return kj::mv(b);
@@ -344,7 +346,7 @@ jsg::Promise<jsg::Ref<Blob>> Body::blob(jsg::Lock& js) {
       }).orDefault(nullptr);
     }
 
-    return js.alloc<Blob>(js, buffer.getJsHandle(js), kj::mv(contentType));
+    return js.alloc<Blob>(js, buffer.getHandle(js), kj::mv(contentType));
   });
 }
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -164,8 +164,8 @@ class Body: public jsg::Object {
 
   kj::Maybe<jsg::Ref<ReadableStream>> getBody();
   bool getBodyUsed();
-  jsg::Promise<jsg::BufferSource> arrayBuffer(jsg::Lock& js);
-  jsg::Promise<jsg::BufferSource> bytes(jsg::Lock& js);
+  jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> arrayBuffer(jsg::Lock& js);
+  jsg::Promise<jsg::JsRef<jsg::JsUint8Array>> bytes(jsg::Lock& js);
   jsg::Promise<kj::String> text(jsg::Lock& js);
   jsg::Promise<jsg::Ref<FormData>> formData(jsg::Lock& js);
   jsg::Promise<jsg::Value> json(jsg::Lock& js);
@@ -362,7 +362,8 @@ class Fetcher: public JsRpcClientProvider {
       kj::OneOf<jsg::Ref<Request>, kj::String> requestOrUrl,
       jsg::Optional<kj::OneOf<RequestInitializerDict, jsg::Ref<Request>>> requestInit);
 
-  using GetResult = kj::OneOf<jsg::Ref<ReadableStream>, jsg::BufferSource, kj::String, jsg::Value>;
+  using GetResult =
+      kj::OneOf<jsg::Ref<ReadableStream>, jsg::JsRef<jsg::JsArrayBuffer>, kj::String, jsg::Value>;
 
   jsg::Promise<GetResult> get(jsg::Lock& js, kj::String url, jsg::Optional<kj::String> type);
 

--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -176,7 +176,7 @@ jsg::JsValue deserialize(
   if (type == IncomingQueueMessage::ContentType::TEXT) {
     return js.str(body);
   } else if (type == IncomingQueueMessage::ContentType::BYTES) {
-    return jsg::JsValue(js.bytes(kj::mv(body)).getHandle(js));
+    return jsg::JsUint8Array::create(js, body);
   } else if (type == IncomingQueueMessage::ContentType::JSON) {
     return jsg::JsValue::fromJson(js, body.asChars());
   } else if (type == IncomingQueueMessage::ContentType::V8) {
@@ -196,8 +196,7 @@ jsg::JsValue deserialize(jsg::Lock& js, rpc::QueueMessage::Reader message) {
   if (type == IncomingQueueMessage::ContentType::TEXT) {
     return js.str(message.getData().asChars());
   } else if (type == IncomingQueueMessage::ContentType::BYTES) {
-    kj::Array<kj::byte> bytes = kj::heapArray(message.getData().asBytes());
-    return jsg::JsValue(js.bytes(kj::mv(bytes)).getHandle(js));
+    return jsg::JsUint8Array::create(js, message.getData().asBytes());
   } else if (type == IncomingQueueMessage::ContentType::JSON) {
     return jsg::JsValue::fromJson(js, message.getData().asChars());
   } else if (type == IncomingQueueMessage::ContentType::V8) {

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -1367,7 +1367,7 @@ void R2Bucket::HeadResult::writeHttpMetadata(jsg::Lock& js, Headers& headers) {
   }
 }
 
-jsg::Promise<jsg::BufferSource> R2Bucket::GetResult::arrayBuffer(jsg::Lock& js) {
+jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> R2Bucket::GetResult::arrayBuffer(jsg::Lock& js) {
   return js.evalNow([&] {
     JSG_REQUIRE(!body->isDisturbed(), TypeError,
         "Body has already been used. "
@@ -1378,7 +1378,7 @@ jsg::Promise<jsg::BufferSource> R2Bucket::GetResult::arrayBuffer(jsg::Lock& js) 
   });
 }
 
-jsg::Promise<jsg::BufferSource> R2Bucket::GetResult::bytes(jsg::Lock& js) {
+jsg::Promise<jsg::JsRef<jsg::JsUint8Array>> R2Bucket::GetResult::bytes(jsg::Lock& js) {
   return js.evalNow([&] {
     JSG_REQUIRE(!body->isDisturbed(), TypeError,
         "Body has already been used. "
@@ -1387,8 +1387,9 @@ jsg::Promise<jsg::BufferSource> R2Bucket::GetResult::bytes(jsg::Lock& js) {
     auto& context = IoContext::current();
     return body->getController()
         .readAllBytes(js, context.getLimitEnforcer().getBufferingLimit())
-        .then(js, [](jsg::Lock& js, jsg::BufferSource data) {
-      return data.getTypedView<v8::Uint8Array>(js);
+        .then(js, [](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> data) {
+      jsg::JsUint8Array u8 = data.getHandle(js);
+      return u8.addRef(js);
     });
   });
 }
@@ -1422,11 +1423,11 @@ jsg::Promise<jsg::Value> R2Bucket::GetResult::json(jsg::Lock& js) {
 
 jsg::Promise<jsg::Ref<Blob>> R2Bucket::GetResult::blob(jsg::Lock& js) {
   // Copy-pasted from http.c++
-  return arrayBuffer(js).then(js, [this](jsg::Lock& js, jsg::BufferSource buffer) {
+  return arrayBuffer(js).then(js, [this](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> buffer) {
     // httpMetadata can't be null because GetResult always populates it.
     kj::String contentType =
         mapCopyString(KJ_REQUIRE_NONNULL(httpMetadata).contentType).orDefault(nullptr);
-    return js.alloc<Blob>(js, buffer.getJsHandle(js), kj::mv(contentType));
+    return js.alloc<Blob>(js, buffer.getHandle(js), kj::mv(contentType));
   });
 }
 

--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -572,7 +572,7 @@ jsg::Promise<kj::Maybe<jsg::Ref<R2Bucket::HeadResult>>> R2Bucket::put(jsg::Lock&
         KJ_SWITCH_ONEOF(v) {
           KJ_CASE_ONEOF(v, jsg::Ref<ReadableStream>) {
             (*v).cancel(js,
-                js.v8Error(
+                js.error(
                     "Stream cancelled because the associated put operation encountered an error."));
           }
           KJ_CASE_ONEOF_DEFAULT {}

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -387,8 +387,8 @@ class R2Bucket: public jsg::Object {
       return body->isDisturbed();
     }
 
-    jsg::Promise<jsg::BufferSource> arrayBuffer(jsg::Lock& js);
-    jsg::Promise<jsg::BufferSource> bytes(jsg::Lock& js);
+    jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> arrayBuffer(jsg::Lock& js);
+    jsg::Promise<jsg::JsRef<jsg::JsUint8Array>> bytes(jsg::Lock& js);
     jsg::Promise<kj::String> text(jsg::Lock& js);
     jsg::Promise<jsg::Value> json(jsg::Lock& js);
     jsg::Promise<jsg::Ref<Blob>> blob(jsg::Lock& js);

--- a/src/workerd/api/sockets-test.c++
+++ b/src/workerd/api/sockets-test.c++
@@ -123,8 +123,8 @@ KJ_TEST("socket writes are blocked by output gate") {
     auto blocker = actor.getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
     auto writable = socket->getWritable();
     auto data = kj::heapArray<kj::byte>({'h', 'i'});
-    auto jsBuffer = env.js.bytes(kj::mv(data)).getHandle(env.js);
-    writable->getController().write(env.js, jsBuffer).markAsHandled(env.js);
+    auto u8 = jsg::JsUint8Array::create(env.js, data);
+    writable->getController().write(env.js, u8).markAsHandled(env.js);
 
     // With autogate (@all-autogates), connect is deferred. Wait for it.
     // After co_await, Worker lock is released — no V8 calls allowed.

--- a/src/workerd/api/streams-test.c++
+++ b/src/workerd/api/streams-test.c++
@@ -107,7 +107,7 @@ KJ_TEST("Reading from byob reader") {
         auto handle = value.getHandle(js);
         auto view = KJ_REQUIRE_NONNULL(handle.tryCast<jsg::JsUint8Array>());
         KJ_ASSERT(kj::min(test.streamLength, test.bufferSize) == view.size());
-        KJ_ASSERT(test.bufferSize, view.getBuffer().size());
+        KJ_ASSERT(test.bufferSize == view.getBuffer().size());
       })));
       return kj::READY_NOW;
     });

--- a/src/workerd/api/streams-test.c++
+++ b/src/workerd/api/streams-test.c++
@@ -58,12 +58,13 @@ KJ_TEST("Reading from default reader") {
       KJ_ASSERT(!readResult.done);
       auto& value = KJ_REQUIRE_NONNULL(readResult.value);
       auto handle = value.getHandle(js);
-      KJ_ASSERT(handle->IsUint8Array());
+      KJ_ASSERT(handle.isUint8Array());
+      jsg::JsBufferSource source(handle);
       if (util::Autogate::isEnabled(util::AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE)) {
         // With 16KB buffer, the entire 10KB stream fits in one read.
-        KJ_ASSERT(streamLength == handle.As<v8::Uint8Array>()->ByteLength());
+        KJ_ASSERT(streamLength == source.size());
       } else {
-        KJ_ASSERT(4 * 1024 == handle.As<v8::Uint8Array>()->ByteLength());
+        KJ_ASSERT(4 * 1024 == source.size());
       }
     })));
   });
@@ -104,10 +105,9 @@ KJ_TEST("Reading from byob reader") {
 
         auto& value = KJ_REQUIRE_NONNULL(readResult.value);
         auto handle = value.getHandle(js);
-        KJ_ASSERT(handle->IsUint8Array());
-        auto view = handle.As<v8::Uint8Array>();
-        KJ_ASSERT(kj::min(test.streamLength, test.bufferSize) == view->ByteLength());
-        KJ_ASSERT(test.bufferSize == view->Buffer()->ByteLength());
+        auto view = KJ_REQUIRE_NONNULL(handle.tryCast<jsg::JsUint8Array>());
+        KJ_ASSERT(kj::min(test.streamLength, test.bufferSize) == view.size());
+        KJ_ASSERT(test.bufferSize, view.getBuffer().size());
       })));
       return kj::READY_NOW;
     });
@@ -177,7 +177,8 @@ KJ_TEST("PumpToReader regression") {
                              [](jsg::Lock& js, auto controller) {
       auto& c = KJ_REQUIRE_NONNULL(
           controller.template tryGet<jsg::Ref<ReadableStreamDefaultController>>());
-      c->enqueue(js, v8::ArrayBuffer::New(js.v8Isolate, 10));
+      auto ab = jsg::JsArrayBuffer::create(js, 10);
+      c->enqueue(js, ab);
       c->close(js);
       return js.resolvedPromise();
     }},

--- a/src/workerd/api/streams-test.c++
+++ b/src/workerd/api/streams-test.c++
@@ -95,9 +95,7 @@ KJ_TEST("Reading from byob reader") {
       KJ_REQUIRE(reader.is<jsg::Ref<ReadableStreamBYOBReader>>());
       auto& byobReader = reader.get<jsg::Ref<ReadableStreamBYOBReader>>();
 
-      auto buffer = v8::Uint8Array::New(
-          v8::ArrayBuffer::New(js.v8Isolate, test.bufferSize), 0, test.bufferSize);
-
+      auto buffer = jsg::JsUint8Array::create(js, test.bufferSize);
       return env.context.awaitJs(js, byobReader->read(js, buffer, {}).then(js,
                   JSG_VISITABLE_LAMBDA(
                       (test, reader = byobReader.addRef(), stream = stream.addRef()),

--- a/src/workerd/api/streams/common.c++
+++ b/src/workerd/api/streams/common.c++
@@ -7,14 +7,14 @@
 namespace workerd::api {
 
 WritableStreamController::PendingAbort::PendingAbort(
-    jsg::Lock& js, jsg::PromiseResolverPair<void> prp, v8::Local<v8::Value> reason, bool reject)
+    jsg::Lock& js, jsg::PromiseResolverPair<void> prp, jsg::JsValue reason, bool reject)
     : resolver(kj::mv(prp.resolver)),
       promise(kj::mv(prp.promise)),
-      reason(js.v8Ref(reason)),
+      reason(reason.addRef(js)),
       reject(reject) {}
 
 WritableStreamController::PendingAbort::PendingAbort(
-    jsg::Lock& js, v8::Local<v8::Value> reason, bool reject)
+    jsg::Lock& js, jsg::JsValue reason, bool reject)
     : WritableStreamController::PendingAbort(js, js.newPromiseAndResolver<void>(), reason, reject) {
 }
 
@@ -26,7 +26,7 @@ void WritableStreamController::PendingAbort::complete(jsg::Lock& js) {
   }
 }
 
-void WritableStreamController::PendingAbort::fail(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void WritableStreamController::PendingAbort::fail(jsg::Lock& js, jsg::JsValue reason) {
   maybeRejectPromise<void>(js, resolver, reason);
 }
 

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -57,7 +57,7 @@ inline bool hasUtf8Bom(kj::ArrayPtr<const kj::byte> data) {
 }
 
 struct ReadResult {
-  jsg::Optional<jsg::Value> value;
+  jsg::Optional<jsg::JsRef<jsg::JsValue>> value;
   bool done;
 
   JSG_STRUCT(value, done);
@@ -80,7 +80,7 @@ struct DrainingReadResult {
 };
 
 struct StreamQueuingStrategy {
-  using SizeAlgorithm = uint64_t(v8::Local<v8::Value>);
+  using SizeAlgorithm = uint64_t(jsg::JsValue);
 
   jsg::Optional<uint64_t> highWaterMark;
   jsg::Optional<jsg::Function<SizeAlgorithm>> size;
@@ -96,7 +96,7 @@ struct UnderlyingSource {
       kj::OneOf<jsg::Ref<ReadableStreamDefaultController>, jsg::Ref<ReadableByteStreamController>>;
   using StartAlgorithm = jsg::Promise<void>(Controller);
   using PullAlgorithm = jsg::Promise<void>(Controller);
-  using CancelAlgorithm = jsg::Promise<void>(v8::Local<v8::Value> reason);
+  using CancelAlgorithm = jsg::Promise<void>(jsg::JsValue reason);
 
   // The autoAllocateChunkSize mechanism allows byte streams to operate as if a BYOB
   // reader is being used even if it is just a default reader. Support is optional
@@ -152,8 +152,8 @@ struct UnderlyingSource {
 struct UnderlyingSink {
   using Controller = jsg::Ref<WritableStreamDefaultController>;
   using StartAlgorithm = jsg::Promise<void>(Controller);
-  using WriteAlgorithm = jsg::Promise<void>(v8::Local<v8::Value>, Controller);
-  using AbortAlgorithm = jsg::Promise<void>(v8::Local<v8::Value> reason);
+  using WriteAlgorithm = jsg::Promise<void>(jsg::JsValue, Controller);
+  using AbortAlgorithm = jsg::Promise<void>(jsg::JsValue);
   using CloseAlgorithm = jsg::Promise<void>();
 
   // Per the spec, the type property for the UnderlyingSink should always be either
@@ -179,9 +179,9 @@ struct UnderlyingSink {
 struct Transformer {
   using Controller = jsg::Ref<TransformStreamDefaultController>;
   using StartAlgorithm = jsg::Promise<void>(Controller);
-  using TransformAlgorithm = jsg::Promise<void>(v8::Local<v8::Value>, Controller);
+  using TransformAlgorithm = jsg::Promise<void>(jsg::JsValue, Controller);
   using FlushAlgorithm = jsg::Promise<void>(Controller);
-  using CancelAlgorithm = jsg::Promise<void>(jsg::JsValue reason);
+  using CancelAlgorithm = jsg::Promise<void>(jsg::JsValue);
 
   jsg::Optional<kj::String> readableType;
   jsg::Optional<kj::String> writableType;
@@ -319,12 +319,12 @@ namespace StreamStates {
 struct Closed {
   static constexpr kj::StringPtr NAME KJ_UNUSED = "closed"_kj;
 };
-using Errored = jsg::Value;
+using Errored = jsg::JsRef<jsg::JsValue>;
 struct Erroring {
   static constexpr kj::StringPtr NAME KJ_UNUSED = "erroring"_kj;
-  jsg::Value reason;
+  jsg::JsRef<jsg::JsValue> reason;
 
-  Erroring(jsg::Value reason): reason(kj::mv(reason)) {}
+  Erroring(jsg::Lock& js, jsg::JsValue reason): reason(reason.addRef(js)) {}
 
   void visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(reason);
@@ -426,7 +426,7 @@ class ReadableStreamController {
       virtual ~Branch() noexcept(false) {}
 
       virtual void doClose(jsg::Lock& js) = 0;
-      virtual void doError(jsg::Lock& js, v8::Local<v8::Value> reason) = 0;
+      virtual void doError(jsg::Lock& js, jsg::JsValue reason) = 0;
       virtual void handleData(jsg::Lock& js, ReadResult result) = 0;
     };
 
@@ -443,7 +443,7 @@ class ReadableStreamController {
         inner->doClose(js);
       }
 
-      inline void doError(jsg::Lock& js, v8::Local<v8::Value> reason) {
+      inline void doError(jsg::Lock& js, jsg::JsValue reason) {
         inner->doError(js, reason);
       }
 
@@ -468,7 +468,7 @@ class ReadableStreamController {
 
     virtual void close(jsg::Lock& js) = 0;
 
-    virtual void error(jsg::Lock& js, v8::Local<v8::Value> reason) = 0;
+    virtual void error(jsg::Lock& js, jsg::JsValue reason) = 0;
 
     virtual void ensurePulling(jsg::Lock& js) = 0;
 
@@ -484,11 +484,11 @@ class ReadableStreamController {
    public:
     virtual ~PipeController() noexcept(false) {}
     virtual bool isClosed() = 0;
-    virtual kj::Maybe<v8::Local<v8::Value>> tryGetErrored(jsg::Lock& js) = 0;
-    virtual void cancel(jsg::Lock& js, v8::Local<v8::Value> reason) = 0;
+    virtual kj::Maybe<jsg::JsValue> tryGetErrored(jsg::Lock& js) = 0;
+    virtual void cancel(jsg::Lock& js, jsg::JsValue reason) = 0;
     virtual void close(jsg::Lock& js) = 0;
-    virtual void error(jsg::Lock& js, v8::Local<v8::Value> reason) = 0;
-    virtual void release(jsg::Lock& js, kj::Maybe<v8::Local<v8::Value>> maybeError = kj::none) = 0;
+    virtual void error(jsg::Lock& js, jsg::JsValue reason) = 0;
+    virtual void release(jsg::Lock& js, kj::Maybe<jsg::JsValue> maybeError = kj::none) = 0;
     virtual kj::Maybe<kj::Promise<void>> tryPumpTo(WritableStreamSink& sink, bool end) = 0;
     virtual jsg::Promise<ReadResult> read(jsg::Lock& js) = 0;
   };
@@ -535,7 +535,7 @@ class ReadableStreamController {
       jsg::Lock& js, WritableStreamController& destination, PipeToOptions options) = 0;
 
   // Indicates that the consumer no longer has any interest in the streams data.
-  virtual jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) = 0;
+  virtual jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason) = 0;
 
   // Branches the ReadableStreamController into two ReadableStream instances that will receive
   // this streams data. The specific details of how the branching occurs is entirely up to the
@@ -672,19 +672,17 @@ class WritableStreamController {
   struct PendingAbort {
     kj::Maybe<jsg::Promise<void>::Resolver> resolver;
     jsg::Promise<void> promise;
-    jsg::Value reason;
+    jsg::JsRef<jsg::JsValue> reason;
     bool reject = false;
 
-    PendingAbort(jsg::Lock& js,
-        jsg::PromiseResolverPair<void> prp,
-        v8::Local<v8::Value> reason,
-        bool reject);
+    PendingAbort(
+        jsg::Lock& js, jsg::PromiseResolverPair<void> prp, jsg::JsValue reason, bool reject);
 
-    PendingAbort(jsg::Lock& js, v8::Local<v8::Value> reason, bool reject);
+    PendingAbort(jsg::Lock& js, jsg::JsValue reason, bool reject);
 
     void complete(jsg::Lock& js);
 
-    void fail(jsg::Lock& js, v8::Local<v8::Value> reason);
+    void fail(jsg::Lock& js, jsg::JsValue reason);
 
     inline jsg::Promise<void> whenResolved(jsg::Lock& js) {
       return promise.whenResolved(js);
@@ -721,7 +719,7 @@ class WritableStreamController {
   // The controller implementation will determine what kind of JavaScript data
   // it is capable of writing, returning a rejected promise if the written
   // data type is not supported.
-  virtual jsg::Promise<void> write(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> value) = 0;
+  virtual jsg::Promise<void> write(jsg::Lock& js, jsg::Optional<jsg::JsValue> value) = 0;
 
   // Indicates that no additional data will be written to the controller. All
   // existing pending writes should be allowed to complete.
@@ -732,7 +730,7 @@ class WritableStreamController {
   virtual jsg::Promise<void> flush(jsg::Lock& js, bool markAsHandled = false) = 0;
 
   // Immediately interrupts existing pending writes and errors the stream.
-  virtual jsg::Promise<void> abort(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) = 0;
+  virtual jsg::Promise<void> abort(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason) = 0;
 
   // The tryPipeFrom attempts to establish a data pipe where source's data
   // is delivered to this WritableStreamController as efficiently as possible.
@@ -764,7 +762,7 @@ class WritableStreamController {
   // If maybeJs is set, the writer's closed and ready promises will be resolved.
   virtual void releaseWriter(Writer& writer, kj::Maybe<jsg::Lock&> maybeJs) = 0;
 
-  virtual kj::Maybe<v8::Local<v8::Value>> isErroring(jsg::Lock& js) = 0;
+  virtual kj::Maybe<jsg::JsValue> isErroring(jsg::Lock& js) = 0;
 
   virtual void visitForGc(jsg::GcVisitor& visitor) {};
 
@@ -934,7 +932,7 @@ inline void maybeResolvePromise(
 template <typename T>
 void maybeRejectPromise(jsg::Lock& js,
     kj::Maybe<typename jsg::Promise<T>::Resolver>& maybeResolver,
-    v8::Local<v8::Value> reason) {
+    jsg::JsValue reason) {
   KJ_IF_SOME(resolver, maybeResolver) {
     resolver.reject(js, reason);
     maybeResolver = kj::none;
@@ -942,8 +940,7 @@ void maybeRejectPromise(jsg::Lock& js,
 }
 
 template <typename T>
-jsg::Promise<T> rejectedMaybeHandledPromise(
-    jsg::Lock& js, v8::Local<v8::Value> reason, bool handled) {
+jsg::Promise<T> rejectedMaybeHandledPromise(jsg::Lock& js, jsg::JsValue reason, bool handled) {
   auto prp = js.newPromiseAndResolver<T>();
   if (handled) {
     prp.promise.markAsHandled(js);
@@ -955,6 +952,11 @@ jsg::Promise<T> rejectedMaybeHandledPromise(
 inline kj::Maybe<IoContext&> tryGetIoContext() {
   // TODO(cleanup): This function is obsolete; callers should just call IoContext::tryCurrent()
   return IoContext::tryCurrent();
+}
+
+inline bool isByteSource(const jsg::JsValue& value) {
+  return value.isArrayBuffer() || value.isSharedArrayBuffer() || value.isArrayBufferView() ||
+      value.isString();
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -573,7 +573,8 @@ class ReadableStreamController {
   //
   // limit specifies an upper maximum bound on the number of bytes permitted to be read.
   // The promise will reject if the read will produce more bytes than the limit.
-  virtual jsg::Promise<jsg::BufferSource> readAllBytes(jsg::Lock& js, uint64_t limit) = 0;
+  virtual jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> readAllBytes(
+      jsg::Lock& js, uint64_t limit) = 0;
 
   // Fully consumes the ReadableStream. If the stream is already locked to a reader or
   // errored, the returned JS promise will reject. If the stream is already closed, the

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -393,9 +393,7 @@ class ReadableStreamController {
   struct ByobOptions {
     static constexpr size_t DEFAULT_AT_LEAST = 1;
 
-    jsg::V8Ref<v8::ArrayBufferView> bufferView;
-    size_t byteOffset = 0;
-    size_t byteLength;
+    jsg::JsRef<jsg::JsArrayBufferView> bufferView;
 
     // The minimum number of elements that should be read. When not specified, the default
     // is DEFAULT_AT_LEAST. This is a non-standard, Workers-specific extension to

--- a/src/workerd/api/streams/encoding.c++
+++ b/src/workerd/api/streams/encoding.c++
@@ -75,15 +75,13 @@ jsg::Ref<TextEncoderStream> TextEncoderStream::constructor(jsg::Lock& js) {
     auto utf8Length = result.count;
     KJ_DASSERT(utf8Length > 0 && utf8Length >= end);
 
-    auto backingStore = js.allocBackingStore(utf8Length, jsg::Lock::AllocOption::UNINITIALIZED);
-    auto dest = kj::ArrayPtr<char>(static_cast<char*>(backingStore->Data()), utf8Length);
-    [[maybe_unused]] auto written =
-        simdutf::convert_utf16_to_utf8(slice.begin(), slice.size(), dest.begin());
+    auto dest = jsg::JsArrayBuffer::create(js, utf8Length);
+    [[maybe_unused]] auto written = simdutf::convert_utf16_to_utf8(
+        slice.begin(), slice.size(), dest.asArrayPtr().asChars().begin());
     KJ_DASSERT(written == utf8Length, "simdutf should write exactly utf8Length bytes");
 
-    auto array = v8::Uint8Array::New(
-        v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backingStore)), 0, utf8Length);
-    controller->enqueue(js, jsg::JsUint8Array(array));
+    auto u8 = jsg::JsUint8Array::create(js, dest);
+    controller->enqueue(js, u8);
     return js.resolvedPromise();
   };
 
@@ -91,9 +89,9 @@ jsg::Ref<TextEncoderStream> TextEncoderStream::constructor(jsg::Lock& js) {
                    jsg::Lock& js, jsg::Ref<TransformStreamDefaultController> controller) mutable {
     // If stream ends with orphaned high surrogate, emit replacement character
     if (holder->pending != kj::none) {
-      auto backingStore = js.allocBackingStore(3, jsg::Lock::AllocOption::UNINITIALIZED);
-      memcpy(backingStore->Data(), REPLACEMENT_UTF8, 3);
-      controller->enqueue(js, jsg::JsUint8Array::create(js, kj::mv(backingStore), 0, 3));
+      auto u8 = jsg::JsUint8Array::create(js, 3);
+      u8.asArrayPtr().copyFrom(REPLACEMENT_UTF8);
+      controller->enqueue(js, u8);
     }
     return js.resolvedPromise();
   };
@@ -150,7 +148,7 @@ jsg::Ref<TextDecoderStream> TextDecoderStream::constructor(
                         JSG_REQUIRE(chunk->IsArrayBuffer() || chunk->IsArrayBufferView(), TypeError,
                             "This TransformStream is being used as a byte stream, "
                             "but received a value that is not a BufferSource.");
-                        jsg::BufferSource source(js, chunk);
+                        jsg::JsBufferSource source(chunk);
                         auto decoded =
                             JSG_REQUIRE_NONNULL(decoder->decodePtr(js, source.asArrayPtr(), false),
                                 TypeError, "Failed to decode input.");

--- a/src/workerd/api/streams/encoding.c++
+++ b/src/workerd/api/streams/encoding.c++
@@ -42,9 +42,9 @@ struct Holder: public kj::Refcounted {
 jsg::Ref<TextEncoderStream> TextEncoderStream::constructor(jsg::Lock& js) {
   auto state = kj::rc<Holder>();
 
-  auto transform = [holder = state.addRef()](jsg::Lock& js, v8::Local<v8::Value> chunk,
+  auto transform = [holder = state.addRef()](jsg::Lock& js, jsg::JsValue chunk,
                        jsg::Ref<TransformStreamDefaultController> controller) mutable {
-    auto str = jsg::check(chunk->ToString(js.v8Context()));
+    v8::Local<v8::String> str = chunk.toJsString(js);
     size_t length = str->Length();
     if (length == 0) return js.resolvedPromise();
 
@@ -142,23 +142,25 @@ jsg::Ref<TextDecoderStream> TextDecoderStream::constructor(
     readableStrategy = StreamQueuingStrategy{};
   }
   auto transformer = TransformStream::constructor(js,
-      Transformer{.transform = jsg::Function<Transformer::TransformAlgorithm>( JSG_VISITABLE_LAMBDA(
-                      (decoder = decoder.addRef()), (decoder),
-                      (jsg::Lock& js, auto chunk, auto controller) {
-                        JSG_REQUIRE(chunk->IsArrayBuffer() || chunk->IsArrayBufferView(), TypeError,
-                            "This TransformStream is being used as a byte stream, "
-                            "but received a value that is not a BufferSource.");
-                        jsg::JsBufferSource source(chunk);
-                        auto decoded =
-                            JSG_REQUIRE_NONNULL(decoder->decodePtr(js, source.asArrayPtr(), false),
-                                TypeError, "Failed to decode input.");
-                        // Only enqueue if there's actual output - don't emit empty chunks
-                        // for incomplete multi-byte sequences
-                        if (decoded.length(js) > 0) {
-                        controller->enqueue(js, decoded);
-                        }
-                        return js.resolvedPromise();
-                      })),
+      Transformer{.transform = jsg::Function<Transformer::TransformAlgorithm>(
+                      JSG_VISITABLE_LAMBDA((decoder = decoder.addRef()), (decoder),
+                          (jsg::Lock& js, auto chunk, auto controller) {
+                            JSG_REQUIRE(chunk.isArrayBuffer() || chunk.isSharedArrayBuffer() ||
+                                    chunk.isArrayBufferView(),
+                                TypeError,
+                                "This TransformStream is being used as a byte stream, "
+                                "but received a value that is not a BufferSource.");
+                            jsg::JsBufferSource source(chunk);
+                            auto decoded = JSG_REQUIRE_NONNULL(
+                                decoder->decodePtr(js, source.asArrayPtr(), false), TypeError,
+                                "Failed to decode input.");
+                            // Only enqueue if there's actual output - don't emit empty chunks
+                            // for incomplete multi-byte sequences
+                            if (decoded.length(js) > 0) {
+                            controller->enqueue(js, decoded);
+                            }
+                            return js.resolvedPromise();
+                          })),
         .flush = jsg::Function<Transformer::FlushAlgorithm>(
             JSG_VISITABLE_LAMBDA((decoder = decoder.addRef()), (decoder),
                 (jsg::Lock& js, auto controller) {

--- a/src/workerd/api/streams/internal-test.c++
+++ b/src/workerd/api/streams/internal-test.c++
@@ -753,8 +753,7 @@ KJ_TEST("ReadableStreamBYOBReader rejects read with zero-sized buffer") {
     auto rs = makeByteStream(env.js);
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 0);
-    auto view = v8::Uint8Array::New(buffer, 0, 0);
+    auto view = jsg::JsUint8Array::create(env.js, 0);
 
     bool rejected = false;
     reader->read(env.js, view, kj::none)
@@ -777,8 +776,7 @@ KJ_TEST("ReadableStreamBYOBReader rejects read with atLeast=0") {
     auto rs = makeByteStream(env.js);
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 10);
-    auto view = v8::Uint8Array::New(buffer, 0, 10);
+    auto view = jsg::JsUint8Array::create(env.js, 10);
 
     bool rejected = false;
     reader->readAtLeast(env.js, 0, view)
@@ -801,8 +799,7 @@ KJ_TEST("ReadableStreamBYOBReader rejects read when atLeast exceeds buffer size"
     auto rs = makeByteStream(env.js);
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 10);
-    auto view = v8::Uint8Array::New(buffer, 0, 10);
+    auto view = jsg::JsUint8Array::create(env.js, 10);
 
     bool rejected = false;
     reader->readAtLeast(env.js, 20, view)
@@ -832,7 +829,7 @@ KJ_TEST("ReadableStreamBYOBReader readAtLeast with element count within capacity
     auto view = v8::Uint32Array::New(buffer, 0, 10);
 
     bool rejected = false;
-    reader->readAtLeast(env.js, 10, view)
+    reader->readAtLeast(env.js, 10, jsg::JsArrayBufferView(view))
         .catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
       rejected = true;
       auto ex = js.exceptionToKj(kj::mv(reason));
@@ -859,7 +856,7 @@ KJ_TEST("ReadableStreamBYOBReader readAtLeast rejects when element count exceeds
     auto view = v8::Uint32Array::New(buffer, 0, 10);
 
     bool rejected = false;
-    reader->readAtLeast(env.js, 11, view)
+    reader->readAtLeast(env.js, 11, jsg::JsArrayBufferView(view))
         .catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
       rejected = true;
       auto ex = js.exceptionToKj(kj::mv(reason));
@@ -883,7 +880,7 @@ KJ_TEST("ReadableStreamBYOBReader readAtLeast rejects byteLength as element coun
     auto view = v8::Uint32Array::New(buffer, 0, 1024);
 
     bool rejected = false;
-    reader->readAtLeast(env.js, 4096, view)
+    reader->readAtLeast(env.js, 4096, jsg::JsArrayBufferView(view))
         .catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
       rejected = true;
       auto ex = js.exceptionToKj(kj::mv(reason));
@@ -911,7 +908,7 @@ KJ_TEST("ReadableStreamBYOBReader read() with min exceeding element capacity rej
     ReadableStreamBYOBReader::ReadableStreamBYOBReaderReadOptions opts;
     opts.min = 11;
     bool rejected = false;
-    reader->read(env.js, view, kj::mv(opts))
+    reader->read(env.js, jsg::JsArrayBufferView(view), kj::mv(opts))
         .catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
       rejected = true;
       auto ex = js.exceptionToKj(kj::mv(reason));
@@ -930,8 +927,7 @@ KJ_TEST("ReadableStreamBYOBReader rejects read after releaseLock") {
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
     reader->releaseLock(env.js);
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 10);
-    auto view = v8::Uint8Array::New(buffer, 0, 10);
+    auto view = jsg::JsUint8Array::create(env.js, 10);
 
     bool rejected = false;
     reader->read(env.js, view, kj::none)

--- a/src/workerd/api/streams/internal-test.c++
+++ b/src/workerd/api/streams/internal-test.c++
@@ -280,12 +280,12 @@ KJ_TEST("WritableStreamInternalController queue size assertion") {
           "is currently locked to a writer.");
     }
 
-    auto buffersource = env.js.bytes(kj::heapArray<kj::byte>(10));
+    auto u8 = jsg::JsUint8Array::create(env.js, 10);
 
     bool writeFailed = false;
 
     auto write = sink->getController()
-                     .write(env.js, buffersource.getHandle(env.js))
+                     .write(env.js, u8)
                      .catch_(env.js, [&](jsg::Lock& js, jsg::Value value) {
       writeFailed = true;
       auto ex = js.exceptionToKj(kj::mv(value));
@@ -376,9 +376,9 @@ KJ_TEST("WritableStreamInternalController observability") {
     stream = env.js.alloc<WritableStream>(env.context, kj::heap<NoopSink>(), kj::mv(myObserver));
 
     auto write = [&](size_t size) {
-      auto buffersource = env.js.bytes(kj::heapArray<kj::byte>(size));
-      return env.context.awaitJs(env.js,
-          KJ_ASSERT_NONNULL(stream)->getController().write(env.js, buffersource.getHandle(env.js)));
+      auto u8 = jsg::JsUint8Array::create(env.js, size);
+      return env.context.awaitJs(
+          env.js, KJ_ASSERT_NONNULL(stream)->getController().write(env.js, u8));
     };
 
     KJ_ASSERT(observer.queueSize == 0);
@@ -427,8 +427,7 @@ KJ_TEST("WritableStreamInternalController pipeLoop abort during pending read") {
       auto& c = KJ_ASSERT_NONNULL(controller.tryGet<jsg::Ref<ReadableStreamDefaultController>>());
       if (pullCount == 1) {
         // First pull: enqueue some data so the pipe loop can make progress
-        auto data = js.bytes(kj::heapArray<kj::byte>({1, 2, 3, 4}));
-        c->enqueue(js, data.getHandle(js));
+        c->enqueue(js, jsg::JsUint8Array::create(js, 4));
       }
       // Second pull onwards: don't enqueue anything, leaving the read pending.
       // This simulates an async data source that hasn't received data yet.
@@ -445,7 +444,7 @@ KJ_TEST("WritableStreamInternalController pipeLoop abort during pending read") {
     env.js.runMicrotasks();
 
     // Abort while pipeLoop is waiting for a pending read
-    auto abortPromise = sink->getController().abort(env.js, env.js.v8TypeError("Test abort"_kj));
+    auto abortPromise = sink->getController().abort(env.js, env.js.typeError("Test abort"_kj));
     abortPromise.markAsHandled(env.js);
     env.js.runMicrotasks();
 

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -253,10 +253,10 @@ class AllReader final {
 };
 
 kj::Exception reasonToException(jsg::Lock& js,
-    jsg::Optional<v8::Local<v8::Value>> maybeReason,
+    jsg::Optional<jsg::JsValue> maybeReason,
     kj::String defaultDescription = kj::str(JSG_EXCEPTION(Error) ": Stream was cancelled.")) {
   KJ_IF_SOME(reason, maybeReason) {
-    return js.exceptionToKj(js.v8Ref(reason));
+    return js.exceptionToKj(reason);
   } else {
     // We get here if the caller is something like `r.cancel()` (or `r.cancel(undefined)`).
     return kj::Exception(
@@ -489,7 +489,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
         // by the ArrayBuffer passed in the options.
         KJ_IF_SOME(view, getOrInitView(true)) {
           return js.resolvedPromise(ReadResult{
-            .value = js.v8Ref(v8::Local<v8::Value>(view.slice(js, 0, 0))),
+            .value = jsg::JsValue(view.slice(js, 0, 0)).addRef(js),
             .done = true,
           });
         } else {
@@ -510,7 +510,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
       //   TransformStream implementation is primarily (only?) used for constructing manually
       //   streamed Responses, and no teed ReadableStream has ever supported them.
       if (readPending) {
-        return js.rejectedPromise<ReadResult>(js.v8TypeError(
+        return js.rejectedPromise<ReadResult>(js.typeError(
             "This ReadableStream only supports a single pending read request at a time."_kj));
       }
       readPending = true;
@@ -525,7 +525,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
         if (bytes.size() == 0) {
           // There's no point in trying to read into a zero-length buffer.
           return js.resolvedPromise(ReadResult{
-            .value = js.v8Ref(v8::Local<v8::Value>(view.slice(js, 0, 0))),
+            .value = jsg::JsValue(view.slice(js, 0, 0)).addRef(js),
             .done = false,
           });
         }
@@ -568,7 +568,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
             } else {}
             if (isByob && FeatureFlags::get(js).getInternalStreamByobReturn()) {
               return js.resolvedPromise(ReadResult{
-                .value = js.v8Ref(v8::Local<v8::Value>(handle.slice(js, 0, 0))),
+                .value = jsg::JsValue(handle.slice(js, 0, 0)).addRef(js),
                 .done = true,
               });
             }
@@ -592,7 +592,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
                 "happening."_kj);
 
             return js.resolvedPromise(ReadResult{
-              .value = js.v8Ref(v8::Local<v8::Value>(handle.slice(js, 0, 0))),
+              .value = jsg::JsValue(handle.slice(js, 0, 0)).addRef(js),
               .done = false,
             });
           }
@@ -609,7 +609,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
 
             if (handle.size() == 0) {
               return js.resolvedPromise(ReadResult{
-                .value = js.v8Ref(v8::Local<v8::Value>(handle.slice(js, 0, 0))),
+                .value = jsg::JsValue(handle.slice(js, 0, 0)).addRef(js),
                 .done = false,
               });
             }
@@ -617,9 +617,8 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
           }
 
           handle.asArrayPtr().first(amount).copyFrom(dest.asPtr().first(amount));
-
           return js.resolvedPromise(ReadResult{
-            .value = js.v8Ref(v8::Local<v8::Value>(handle.slice(js, 0, amount))),
+            .value = jsg::JsValue(handle.slice(js, 0, amount)).addRef(js),
             .done = false,
           });
         })),
@@ -628,10 +627,11 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
                   (ref),
                   (jsg::Lock& js, jsg::Value reason) -> jsg::Promise<ReadResult> {
         readPending = false;
+        auto handle = jsg::JsValue(reason.getHandle(js));
         if (!state.is<StreamStates::Errored>()) {
-          doError(js, reason.getHandle(js));
+          doError(js, handle);
         }
-        return js.rejectedPromise<ReadResult>(kj::mv(reason));
+        return js.rejectedPromise<ReadResult>(handle);
       })));
 
       } else {
@@ -656,7 +656,7 @@ kj::Maybe<jsg::Promise<DrainingReadResult>> ReadableStreamInternalController::dr
 
   if (isPendingClosure) {
     return js.rejectedPromise<DrainingReadResult>(
-        js.v8TypeError("This ReadableStream belongs to an object that is closing."_kj));
+        js.typeError("This ReadableStream belongs to an object that is closing."_kj));
   }
 
   static constexpr size_t kAtLeast = 1;
@@ -672,7 +672,7 @@ kj::Maybe<jsg::Promise<DrainingReadResult>> ReadableStreamInternalController::dr
     }
     KJ_CASE_ONEOF(readable, Readable) {
       if (readPending) {
-        return js.rejectedPromise<DrainingReadResult>(js.v8TypeError(
+        return js.rejectedPromise<DrainingReadResult>(js.typeError(
             "This ReadableStream only supports a single pending read request at a time."_kj));
       }
       readPending = true;
@@ -730,10 +730,11 @@ kj::Maybe<jsg::Promise<DrainingReadResult>> ReadableStreamInternalController::dr
                   (ref),
                   (jsg::Lock& js, jsg::Value reason) -> jsg::Promise<DrainingReadResult> {
         readPending = false;
+        auto handle = jsg::JsValue(reason.getHandle(js));
         if (!state.is<StreamStates::Errored>()) {
-          doError(js, reason.getHandle(js));
+          doError(js, handle);
         }
-        return js.rejectedPromise<DrainingReadResult>(kj::mv(reason));
+        return js.rejectedPromise<DrainingReadResult>(handle);
       })));
     }
   }
@@ -748,7 +749,7 @@ jsg::Promise<void> ReadableStreamInternalController::pipeTo(
 
   if (isPendingClosure) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This ReadableStream belongs to an object that is closing."_kj));
+        js.typeError("This ReadableStream belongs to an object that is closing."_kj));
   }
 
   disturbed = true;
@@ -758,11 +759,11 @@ jsg::Promise<void> ReadableStreamInternalController::pipeTo(
   }
 
   return js.rejectedPromise<void>(
-      js.v8TypeError("This ReadableStream cannot be piped to this WritableStream."_kj));
+      js.typeError("This ReadableStream cannot be piped to this WritableStream."_kj));
 }
 
 jsg::Promise<void> ReadableStreamInternalController::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   disturbed = true;
 
   KJ_IF_SOME(errored, state.tryGetUnsafe<StreamStates::Errored>()) {
@@ -775,7 +776,7 @@ jsg::Promise<void> ReadableStreamInternalController::cancel(
 }
 
 void ReadableStreamInternalController::doCancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   auto exception = reasonToException(js, maybeReason);
   KJ_IF_SOME(locked, readState.tryGetUnsafe<ReaderLocked>()) {
     KJ_IF_SOME(canceler, locked.getCanceler()) {
@@ -800,11 +801,11 @@ void ReadableStreamInternalController::doClose(jsg::Lock& js) {
   }
 }
 
-void ReadableStreamInternalController::doError(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void ReadableStreamInternalController::doError(jsg::Lock& js, jsg::JsValue reason) {
   // If already in a terminal state, nothing to do.
   if (state.isTerminal()) return;
 
-  state.transitionTo<StreamStates::Errored>(js.v8Ref(reason));
+  state.transitionTo<StreamStates::Errored>(reason.addRef(js));
   KJ_IF_SOME(locked, readState.tryGetUnsafe<ReaderLocked>()) {
     maybeRejectPromise<void>(js, locked.getClosedFulfiller(), reason);
   } else {
@@ -939,7 +940,7 @@ void ReadableStreamInternalController::releaseReader(
             "Cannot call releaseLock() on a reader with outstanding read promises.");
       }
       maybeRejectPromise<void>(js, locked.getClosedFulfiller(),
-          js.v8TypeError("This ReadableStream reader has been released."_kj));
+          js.typeError("This ReadableStream reader has been released."_kj));
     }
     locked.clear();
 
@@ -970,18 +971,41 @@ jsg::Ref<WritableStream> WritableStreamInternalController::addRef() {
 }
 
 jsg::Promise<void> WritableStreamInternalController::write(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> value) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> value) {
   if (isPendingClosure) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream belongs to an object that is closing."_kj));
+        js.typeError("This WritableStream belongs to an object that is closing."_kj));
   }
   if (isClosedOrClosing()) {
-    return js.rejectedPromise<void>(js.v8TypeError("This WritableStream has been closed."_kj));
+    return js.rejectedPromise<void>(js.typeError("This WritableStream has been closed."_kj));
   }
   if (isPiping()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream is currently being piped to."_kj));
+        js.typeError("This WritableStream is currently being piped to."_kj));
   }
+
+  auto processChunk = [this](jsg::Lock& js, kj::ArrayPtr<const kj::byte> chunk) {
+    auto prp = js.newPromiseAndResolver<void>();
+    adjustWriteBufferSize(js, chunk.size());
+    KJ_IF_SOME(o, observer) {
+      o->onChunkEnqueued(chunk.size());
+    }
+
+    auto data = kj::heapArray<kj::byte>(chunk.size());
+    data.asPtr().copyFrom(chunk);
+    auto ptr = data.asPtr();
+    queue.push_back(
+        WriteEvent{.outputLock = IoContext::current().waitForOutputLocksIfNecessaryIoOwn(),
+          .event = kj::heap<Write>({
+            .promise = kj::mv(prp.resolver),
+            .totalBytes = data.size(),
+            .ownBytes = kj::mv(data),
+            .bytes = ptr,
+          })});
+
+    ensureWriting(js);
+    return kj::mv(prp.promise);
+  };
 
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
@@ -997,58 +1021,28 @@ jsg::Promise<void> WritableStreamInternalController::write(
       }
       auto chunk = KJ_ASSERT_NONNULL(value);
 
-      std::shared_ptr<v8::BackingStore> store;
-      size_t byteLength = 0;
-      size_t byteOffset = 0;
-      if (chunk->IsArrayBuffer()) {
-        auto buffer = chunk.As<v8::ArrayBuffer>();
-        store = buffer->GetBackingStore();
-        byteLength = buffer->ByteLength();
-      } else if (chunk->IsArrayBufferView()) {
-        auto view = chunk.As<v8::ArrayBufferView>();
-        store = view->Buffer()->GetBackingStore();
-        byteLength = view->ByteLength();
-        byteOffset = view->ByteOffset();
-      } else if (chunk->IsString()) {
-        // TODO(later): This really ought to return a rejected promise and not a sync throw.
-        // This case caused me a moment of confusion during testing, so I think it's worth
-        // a specific error message.
-        throwTypeErrorAndConsoleWarn(
-            "This TransformStream is being used as a byte stream, but received a string on its "
-            "writable side. If you wish to write a string, you'll probably want to explicitly "
-            "UTF-8-encode it with TextEncoder.");
-      } else {
-        // TODO(later): This really ought to return a rejected promise and not a sync throw.
-        throwTypeErrorAndConsoleWarn(
-            "This TransformStream is being used as a byte stream, but received an object of "
-            "non-ArrayBuffer/ArrayBufferView type on its writable side.");
+      KJ_IF_SOME(ab, chunk.tryCast<jsg::JsArrayBuffer>()) {
+        if (ab.size() == 0) return js.resolvedPromise();
+        return processChunk(js, ab.asArrayPtr());
       }
-
-      if (byteLength == 0) {
-        return js.resolvedPromise();
+      KJ_IF_SOME(sab, chunk.tryCast<jsg::JsSharedArrayBuffer>()) {
+        if (sab.size() == 0) return js.resolvedPromise();
+        return processChunk(js, sab.asArrayPtr());
       }
-
-      auto prp = js.newPromiseAndResolver<void>();
-      adjustWriteBufferSize(js, byteLength);
-      KJ_IF_SOME(o, observer) {
-        o->onChunkEnqueued(byteLength);
+      KJ_IF_SOME(view, chunk.tryCast<jsg::JsArrayBufferView>()) {
+        if (view.size() == 0) return js.resolvedPromise();
+        return processChunk(js, view.asArrayPtr());
       }
-
-      auto src = kj::arrayPtr(static_cast<kj::byte*>(store->Data()) + byteOffset, byteLength);
-      auto data = kj::heapArray<kj::byte>(src.size());
-      data.asPtr().copyFrom(src);
-      auto ptr = data.asPtr();
-      queue.push_back(
-          WriteEvent{.outputLock = IoContext::current().waitForOutputLocksIfNecessaryIoOwn(),
-            .event = kj::heap<Write>({
-              .promise = kj::mv(prp.resolver),
-              .totalBytes = store->ByteLength(),
-              .ownBytes = kj::mv(data),
-              .bytes = ptr,
-            })});
-
-      ensureWriting(js);
-      return kj::mv(prp.promise);
+      KJ_IF_SOME(str, chunk.tryCast<jsg::JsString>()) {
+        auto kjstr = str.toDOMString(js);
+        if (kjstr.size() == 0) return js.resolvedPromise();
+        // Trim the null terminator
+        return processChunk(js, kjstr.asBytes().slice(0, kjstr.size()));
+      }
+      // TODO(later): This really ought to return a rejected promise and not a sync throw.
+      throwTypeErrorAndConsoleWarn(
+          "This TransformStream is being used as a byte stream, but received an object of "
+          "non-ArrayBuffer/ArrayBufferView/string type on its writable side.");
     }
   }
 
@@ -1090,7 +1084,7 @@ jsg::Promise<void> WritableStreamInternalController::closeImpl(jsg::Lock& js, bo
     return js.resolvedPromise();
   }
   if (isPiping()) {
-    auto reason = js.v8TypeError("This WritableStream is currently being piped to."_kj);
+    auto reason = js.typeError("This WritableStream is currently being piped to."_kj);
     return rejectedMaybeHandledPromise<void>(js, reason, markAsHandled);
   }
 
@@ -1143,11 +1137,11 @@ jsg::Promise<void> WritableStreamInternalController::close(jsg::Lock& js, bool m
 
 jsg::Promise<void> WritableStreamInternalController::flush(jsg::Lock& js, bool markAsHandled) {
   if (isClosedOrClosing()) {
-    auto reason = js.v8TypeError("This WritableStream has been closed."_kj);
+    auto reason = js.typeError("This WritableStream has been closed."_kj);
     return rejectedMaybeHandledPromise<void>(js, reason, markAsHandled);
   }
   if (isPiping()) {
-    auto reason = js.v8TypeError("This WritableStream is currently being piped to."_kj);
+    auto reason = js.typeError("This WritableStream is currently being piped to."_kj);
     return rejectedMaybeHandledPromise<void>(js, reason, markAsHandled);
   }
 
@@ -1177,15 +1171,15 @@ jsg::Promise<void> WritableStreamInternalController::flush(jsg::Lock& js, bool m
 }
 
 jsg::Promise<void> WritableStreamInternalController::abort(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   // While it may be confusing to users to throw `undefined` rather than a more helpful Error here,
   // doing so is required by the relevant spec:
   // https://streams.spec.whatwg.org/#writable-stream-abort
-  return doAbort(js, maybeReason.orDefault(js.v8Undefined()));
+  return doAbort(js, maybeReason.orDefault(js.undefined()));
 }
 
 jsg::Promise<void> WritableStreamInternalController::doAbort(
-    jsg::Lock& js, v8::Local<v8::Value> reason, AbortOptions options) {
+    jsg::Lock& js, jsg::JsValue reason, AbortOptions options) {
   // If maybePendingAbort is set, then the returned abort promise will be rejected
   // with the specified error once the abort is completed, otherwise the promise will
   // be resolved with undefined.
@@ -1202,7 +1196,7 @@ jsg::Promise<void> WritableStreamInternalController::doAbort(
   }
 
   KJ_IF_SOME(writable, state.tryGetUnsafe<IoOwn<Writable>>()) {
-    auto exception = js.exceptionToKj(js.v8Ref(reason));
+    auto exception = js.exceptionToKj(reason.addRef(js));
 
     if (FeatureFlags::get(js).getInternalWritableStreamAbortClearsQueue()) {
       // If this flag is set, we will clear the queue proactively and immediately
@@ -1251,7 +1245,7 @@ kj::Maybe<jsg::Promise<void>> WritableStreamInternalController::tryPipeFrom(
   auto pipeThrough = options.pipeThrough;
 
   if (isPiping()) {
-    auto reason = js.v8TypeError("This WritableStream is currently being piped to."_kj);
+    auto reason = js.typeError("This WritableStream is currently being piped to."_kj);
     return rejectedMaybeHandledPromise<void>(js, reason, pipeThrough);
   }
 
@@ -1322,7 +1316,7 @@ kj::Maybe<jsg::Promise<void>> WritableStreamInternalController::tryPipeFrom(
   // If the destination has closed, the spec requires us to close the source if
   // preventCancel is false (Propagate closing backward).
   if (isClosedOrClosing()) {
-    auto destClosed = js.v8TypeError("This destination writable stream is closed."_kj);
+    auto destClosed = js.typeError("This destination writable stream is closed."_kj);
     writeState.transitionTo<Unlocked>();
 
     if (!preventCancel) {
@@ -1459,7 +1453,7 @@ void WritableStreamInternalController::releaseWriter(
     KJ_ASSERT(&locked.getWriter() == &writer);
     KJ_IF_SOME(js, maybeJs) {
       maybeRejectPromise<void>(js, locked.getClosedFulfiller(),
-          js.v8TypeError("This WritableStream writer has been released."_kj));
+          js.typeError("This WritableStream writer has been released."_kj));
     }
     locked.clear();
 
@@ -1504,11 +1498,11 @@ void WritableStreamInternalController::doClose(jsg::Lock& js) {
   PendingAbort::dequeue(maybePendingAbort);
 }
 
-void WritableStreamInternalController::doError(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void WritableStreamInternalController::doError(jsg::Lock& js, jsg::JsValue reason) {
   // If already in a terminal state, nothing to do.
   if (state.isTerminal()) return;
 
-  state.transitionTo<StreamStates::Errored>(js.v8Ref(reason));
+  state.transitionTo<StreamStates::Errored>(reason.addRef(js));
   KJ_IF_SOME(locked, writeState.tryGetUnsafe<WriterLocked>()) {
     maybeRejectPromise<void>(js, locked.getClosedFulfiller(), reason);
     maybeResolvePromise(js, locked.getReadyFulfiller());
@@ -1546,7 +1540,7 @@ void WritableStreamInternalController::finishClose(jsg::Lock& js) {
   doClose(js);
 }
 
-void WritableStreamInternalController::finishError(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void WritableStreamInternalController::finishError(jsg::Lock& js, jsg::JsValue reason) {
   KJ_IF_SOME(pendingAbort, PendingAbort::dequeue(maybePendingAbort)) {
     // In this case, and only this case, we ignore any pending rejection
     // that may be stored in the pendingAbort. The current exception takes
@@ -1682,7 +1676,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
                                        jsg::Lock& js, jsg::Value reason) -> jsg::Promise<void> {
         // Under some conditions, the clean up has already happened.
         if (queue.empty()) return js.resolvedPromise();
-        auto handle = reason.getHandle(js);
+        auto handle = jsg::JsValue(reason.getHandle(js));
         auto& request = check.template operator()<Write>();
         auto& writable = state.getUnsafe<IoOwn<Writable>>();
         adjustWriteBufferSize(js, -amountToWrite);
@@ -1729,7 +1723,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
         // If the source is errored, the spec requires us to error the destination unless the
         // preventAbort option is true.
         if (!request->preventAbort()) {
-          auto ex = js.exceptionToKj(js.v8Ref(errored));
+          auto ex = js.exceptionToKj(errored.addRef(js));
           writable->abort(kj::mv(ex));
           drain(js, errored);
         } else {
@@ -1788,7 +1782,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
         }),
             ioContext.addFunctor(
                 [this, check, preventAbort](jsg::Lock& js, jsg::Value reason) mutable {
-          auto handle = reason.getHandle(js);
+          auto handle = jsg::JsValue(reason.getHandle(js));
           auto& request = check.template operator()<Pipe>();
           maybeRejectPromise<void>(js, request.promise(), handle);
           // TODO(conform): Remember all those checks we performed in ReadableStream::pipeTo()?
@@ -1839,7 +1833,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
               ioContext.addFunctor([this, check](jsg::Lock& js, jsg::Value reason) {
         // Under some conditions, the clean up has already happened.
         if (queue.empty()) return;
-        auto handle = reason.getHandle(js);
+        auto handle = jsg::JsValue(reason.getHandle(js));
         auto& request = check.template operator()<Close>();
         maybeRejectPromise<void>(js, request.promise, handle);
         queue.pop_front();
@@ -1893,7 +1887,7 @@ bool WritableStreamInternalController::Pipe::State::checkSignal(jsg::Lock& js) {
         parent.writeState.transitionTo<Unlocked>();
       }
       if (!preventCancelCopy) {
-        sourceRef.release(js, v8::Local<v8::Value>(reason));
+        sourceRef.release(js, reason);
       } else {
         sourceRef.release(js);
       }
@@ -1905,40 +1899,36 @@ bool WritableStreamInternalController::Pipe::State::checkSignal(jsg::Lock& js) {
 }
 
 jsg::Promise<void> WritableStreamInternalController::Pipe::State::write(
-    v8::Local<v8::Value> handle) {
-  auto& writable = parent.state.getUnsafe<IoOwn<Writable>>();
-  // TODO(soon): Once jsg::BufferSource lands and we're able to use it, this can be simplified.
-  KJ_ASSERT(handle->IsArrayBuffer() || handle->IsArrayBufferView());
-  std::shared_ptr<v8::BackingStore> store;
-  size_t byteLength = 0;
-  size_t byteOffset = 0;
-  if (handle->IsArrayBuffer()) {
-    auto buffer = handle.template As<v8::ArrayBuffer>();
-    store = buffer->GetBackingStore();
-    byteLength = buffer->ByteLength();
-  } else {
-    auto view = handle.template As<v8::ArrayBufferView>();
-    store = view->Buffer()->GetBackingStore();
-    byteLength = view->ByteLength();
-    byteOffset = view->ByteOffset();
-  }
-  kj::byte* data = reinterpret_cast<kj::byte*>(store->Data()) + byteOffset;
-  // TODO(cleanup): Have this method accept a jsg::Lock& from the caller instead of using
-  // v8::Isolate::GetCurrent();
-  auto& js = jsg::Lock::current();
+    jsg::Lock& js, jsg::JsValue handle) {
+  KJ_DASSERT(isByteSource(handle));
 
-  // For resizable ArrayBuffers or shared backing stores, we must eagerly copy
-  // the data. A resizable ArrayBuffer's logical byte length can be changed by user
-  // JS after write() returns but before the sink consumes the data, making the
-  // cached byteLength stale.
-  // But also just beacuse of V8 Sandbox requirements, we really should be copying
-  // the data from the ArrayBuffer anyway... We incur an allocation and copy cost
-  // here but that's to be expected.
-  auto backing = kj::heapArray<kj::byte>(byteLength);
-  backing.asPtr().copyFrom(kj::arrayPtr(data, byteLength));
-  return IoContext::current().awaitIo(js,
-      writable->canceler.wrap(writable->sink->write(backing)).attach(kj::mv(backing)),
-      [](jsg::Lock&) {});
+  auto processChunk = [this](jsg::Lock& js, kj::ArrayPtr<const kj::byte> data) {
+    auto& writable = parent.state.getUnsafe<IoOwn<Writable>>();
+    auto backing = kj::heapArray<kj::byte>(data.size());
+    backing.asPtr().copyFrom(data);
+    return IoContext::current().awaitIo(js,
+        writable->canceler.wrap(writable->sink->write(backing)).attach(kj::mv(backing)),
+        [](jsg::Lock&) {});
+  };
+
+  KJ_IF_SOME(ab, handle.tryCast<jsg::JsArrayBuffer>()) {
+    if (ab.size() == 0) return js.resolvedPromise();
+    return processChunk(js, ab.asArrayPtr());
+  }
+  KJ_IF_SOME(sab, handle.tryCast<jsg::JsSharedArrayBuffer>()) {
+    if (sab.size() == 0) return js.resolvedPromise();
+    return processChunk(js, sab.asArrayPtr());
+  }
+  KJ_IF_SOME(view, handle.tryCast<jsg::JsArrayBufferView>()) {
+    if (view.size() == 0) return js.resolvedPromise();
+    return processChunk(js, view.asArrayPtr());
+  }
+  KJ_IF_SOME(str, handle.tryCast<jsg::JsString>()) {
+    auto kjstr = str.toDOMString(js);
+    if (kjstr.size() == 0) return js.resolvedPromise();
+    return processChunk(js, kjstr.asBytes().slice(0, kjstr.size()));
+  }
+  KJ_UNREACHABLE;
 }
 
 jsg::Promise<void> WritableStreamInternalController::Pipe::State::pipeLoop(jsg::Lock& js) {
@@ -1972,7 +1962,7 @@ jsg::Promise<void> WritableStreamInternalController::Pipe::State::pipeLoop(jsg::
     source.release(js);
     if (!preventAbort) {
       KJ_IF_SOME(writable, parent.state.tryGetUnsafe<IoOwn<Writable>>()) {
-        auto ex = js.exceptionToKj(js.v8Ref(errored));
+        auto ex = js.exceptionToKj(errored.addRef(js));
         writable->abort(kj::mv(ex));
         return js.rejectedPromise<void>(errored);
       }
@@ -2011,7 +2001,7 @@ jsg::Promise<void> WritableStreamInternalController::Pipe::State::pipeLoop(jsg::
         }),
                 ioContext.addFunctor([state = kj::addRef(*this)](jsg::Lock& js, jsg::Value reason) {
           if (state->aborted) return;
-          state->parent.finishError(js, reason.getHandle(js));
+          state->parent.finishError(js, jsg::JsValue(reason.getHandle(js)));
         }));
       }
       parent.writeState.transitionTo<Unlocked>();
@@ -2020,7 +2010,7 @@ jsg::Promise<void> WritableStreamInternalController::Pipe::State::pipeLoop(jsg::
   }
 
   if (parent.isClosedOrClosing()) {
-    auto destClosed = js.v8TypeError("This destination writable stream is closed."_kj);
+    auto destClosed = js.typeError("This destination writable stream is closed."_kj);
     parent.writeState.transitionTo<Unlocked>();
 
     if (!preventCancel) {
@@ -2044,36 +2034,37 @@ jsg::Promise<void> WritableStreamInternalController::Pipe::State::pipeLoop(jsg::
     // we sent those bytes on to the WritableStreamSink.
     KJ_IF_SOME(value, result.value) {
       auto handle = value.getHandle(js);
-      if (handle->IsArrayBuffer() || handle->IsArrayBufferView()) {
-        return state->write(handle).then(js,
-            [state = kj::addRef(*state)](jsg::Lock& js) mutable -> jsg::Promise<void> {
+      if (isByteSource(handle)) {
+        return state->write(js, handle)
+            .then(js,
+                [state = kj::addRef(*state)](jsg::Lock& js) mutable -> jsg::Promise<void> {
           if (state->aborted) {
             return js.resolvedPromise();
           }
           // The signal will be checked again at the start of the next loop iteration.
           return state->pipeLoop(js);
         },
-            [state = kj::addRef(*state)](
-                jsg::Lock& js, jsg::Value reason) mutable -> jsg::Promise<void> {
+                [state = kj::addRef(*state)](
+                    jsg::Lock& js, jsg::Value reason) mutable -> jsg::Promise<void> {
           if (state->aborted) {
             return js.resolvedPromise();
           }
-          state->parent.doError(js, reason.getHandle(js));
+          state->parent.doError(js, jsg::JsValue(reason.getHandle(js)));
           return state->pipeLoop(js);
         });
       }
     }
     // Undefined and null are perfectly valid values to pass through a ReadableStream,
     // but we can't interpret them as bytes so if we get them here, we error the pipe.
-    auto error = js.v8TypeError("This WritableStream only supports writing byte types."_kj);
+    auto error = js.typeError("This WritableStream only supports writing byte types."_kj);
     auto& writable = state->parent.state.getUnsafe<IoOwn<Writable>>();
-    auto ex = js.exceptionToKj(js.v8Ref(error));
+    auto ex = js.exceptionToKj(error);
     writable->abort(kj::mv(ex));
     // The error condition will be handled at the start of the next iteration.
     return state->pipeLoop(js);
   }),
-      ioContext.addFunctor([state = kj::addRef(*this)](
-                               jsg::Lock& js, jsg::Value reason) mutable -> jsg::Promise<void> {
+      ioContext.addFunctor(
+          [state = kj::addRef(*this)](jsg::Lock& js, jsg::Value) mutable -> jsg::Promise<void> {
     if (state->aborted) {
       return js.resolvedPromise();
     }
@@ -2082,7 +2073,7 @@ jsg::Promise<void> WritableStreamInternalController::Pipe::State::pipeLoop(jsg::
   }));
 }
 
-void WritableStreamInternalController::drain(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void WritableStreamInternalController::drain(jsg::Lock& js, jsg::JsValue reason) {
   doError(js, reason);
   while (!queue.empty()) {
     KJ_SWITCH_ONEOF(queue.front().event) {
@@ -2149,16 +2140,14 @@ bool ReadableStreamInternalController::PipeLocked::isClosed() {
   return inner.state.is<StreamStates::Closed>();
 }
 
-kj::Maybe<v8::Local<v8::Value>> ReadableStreamInternalController::PipeLocked::tryGetErrored(
-    jsg::Lock& js) {
+kj::Maybe<jsg::JsValue> ReadableStreamInternalController::PipeLocked::tryGetErrored(jsg::Lock& js) {
   KJ_IF_SOME(errored, inner.state.tryGetUnsafe<StreamStates::Errored>()) {
     return errored.getHandle(js);
   }
   return kj::none;
 }
 
-void ReadableStreamInternalController::PipeLocked::cancel(
-    jsg::Lock& js, v8::Local<v8::Value> reason) {
+void ReadableStreamInternalController::PipeLocked::cancel(jsg::Lock& js, jsg::JsValue reason) {
   if (inner.state.is<Readable>()) {
     inner.doCancel(js, reason);
   }
@@ -2168,13 +2157,12 @@ void ReadableStreamInternalController::PipeLocked::close(jsg::Lock& js) {
   inner.doClose(js);
 }
 
-void ReadableStreamInternalController::PipeLocked::error(
-    jsg::Lock& js, v8::Local<v8::Value> reason) {
+void ReadableStreamInternalController::PipeLocked::error(jsg::Lock& js, jsg::JsValue reason) {
   inner.doError(js, reason);
 }
 
 void ReadableStreamInternalController::PipeLocked::release(
-    jsg::Lock& js, kj::Maybe<v8::Local<v8::Value>> maybeError) {
+    jsg::Lock& js, kj::Maybe<jsg::JsValue> maybeError) {
   KJ_IF_SOME(error, maybeError) {
     cancel(js, error);
   }
@@ -2201,7 +2189,7 @@ jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> ReadableStreamInternalController::r
   }
   if (isPendingClosure) {
     return js.rejectedPromise<jsg::JsRef<jsg::JsArrayBuffer>>(
-        js.v8TypeError("This ReadableStream belongs to an object that is closing."_kj));
+        js.typeError("This ReadableStream belongs to an object that is closing."_kj));
   }
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
@@ -2235,7 +2223,7 @@ jsg::Promise<kj::String> ReadableStreamInternalController::readAllText(
   }
   if (isPendingClosure) {
     return js.rejectedPromise<kj::String>(
-        js.v8TypeError("This ReadableStream belongs to an object that is closing."_kj));
+        js.typeError("This ReadableStream belongs to an object that is closing."_kj));
   }
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -588,7 +588,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
                 "detached while the read was pending. The read completed with a zero-length buffer "
                 "and the data that was read is lost. Avoid detaching buffers that are being used "
                 "for active read operations on streams, or use the "
-                "streams_byob_reader_detaches_buffer compatibility flag, to prevent this from"
+                "streams_byob_reader_detaches_buffer compatibility flag, to prevent this from "
                 "happening."_kj);
 
             return js.resolvedPromise(ReadResult{

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -2236,23 +2236,23 @@ jsg::Promise<ReadResult> ReadableStreamInternalController::PipeLocked::read(jsg:
   return KJ_ASSERT_NONNULL(inner.read(js, kj::none));
 }
 
-jsg::Promise<jsg::BufferSource> ReadableStreamInternalController::readAllBytes(
+jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> ReadableStreamInternalController::readAllBytes(
     jsg::Lock& js, uint64_t limit) {
   if (isLockedToReader()) {
-    return js.rejectedPromise<jsg::BufferSource>(KJ_EXCEPTION(
+    return js.rejectedPromise<jsg::JsRef<jsg::JsArrayBuffer>>(KJ_EXCEPTION(
         FAILED, "jsg.TypeError: This ReadableStream is currently locked to a reader."));
   }
   if (isPendingClosure) {
-    return js.rejectedPromise<jsg::BufferSource>(
+    return js.rejectedPromise<jsg::JsRef<jsg::JsArrayBuffer>>(
         js.v8TypeError("This ReadableStream belongs to an object that is closing."_kj));
   }
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 0);
-      return js.resolvedPromise(jsg::BufferSource(js, kj::mv(backing)));
+      auto ab = jsg::JsArrayBuffer::create(js, 0);
+      return js.resolvedPromise(ab.addRef(js));
     }
     KJ_CASE_ONEOF(errored, StreamStates::Errored) {
-      return js.rejectedPromise<jsg::BufferSource>(errored.addRef(js));
+      return js.rejectedPromise<jsg::JsRef<jsg::JsArrayBuffer>>(errored.addRef(js));
     }
     KJ_CASE_ONEOF(readable, Readable) {
       auto source = KJ_ASSERT_NONNULL(removeSource(js));
@@ -2261,10 +2261,9 @@ jsg::Promise<jsg::BufferSource> ReadableStreamInternalController::readAllBytes(
       // the sandbox. This will require a change to the API of ReadableStreamSource::readAllBytes.
       // For now, we'll read and allocate into a proper backing store.
       return context.awaitIoLegacy(js, source->readAllBytes(limit).attach(kj::mv(source)))
-          .then(js, [](jsg::Lock& js, kj::Array<kj::byte> bytes) -> jsg::BufferSource {
-        auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, bytes.size());
-        backing.asArrayPtr().copyFrom(bytes);
-        return jsg::BufferSource(js, kj::mv(backing));
+          .then(js, [](jsg::Lock& js, kj::Array<kj::byte> bytes) -> jsg::JsRef<jsg::JsArrayBuffer> {
+        auto ab = jsg::JsArrayBuffer::create(js, bytes);
+        return ab.addRef(js);
       });
     }
   }

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -444,45 +444,40 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
 
   if (isPendingClosure) {
     return js.rejectedPromise<ReadResult>(
-        js.v8TypeError("This ReadableStream belongs to an object that is closing."_kj));
+        js.typeError("This ReadableStream belongs to an object that is closing."_kj));
   }
 
-  v8::Local<v8::ArrayBuffer> store;
-  size_t byteLength = 0;
-  size_t byteOffset = 0;
+  kj::Maybe<jsg::JsArrayBufferView> view;
   size_t atLeast = 1;
 
   KJ_IF_SOME(byobOptions, maybeByobOptions) {
-    store = byobOptions.bufferView.getHandle(js)->Buffer();
-    byteOffset = byobOptions.byteOffset;
-    byteLength = byobOptions.byteLength;
+    auto handle = byobOptions.bufferView.getHandle(js);
     atLeast = byobOptions.atLeast.orDefault(atLeast);
     if (byobOptions.detachBuffer) {
-      if (!store->IsDetachable()) {
+      if (!handle.isDetachable()) {
         return js.rejectedPromise<ReadResult>(
-            js.v8TypeError("Unable to use non-detachable ArrayBuffer"_kj));
+            js.typeError("Unable to use non-detachable ArrayBuffer"_kj));
       }
-      auto backing = store->GetBackingStore();
-      jsg::check(store->Detach(v8::Local<v8::Value>()));
-      store = v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backing));
+      view = handle.detachAndTake(js);
+    } else {
+      view = handle;
     }
   }
 
-  auto getOrInitStore = [&](bool errorCase = false) {
-    if (store.IsEmpty()) {
-      if (errorCase) {
-        byteLength = 0;
-      } else if (util::Autogate::isEnabled(util::AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE)) {
-        byteLength = UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE_2;
-      } else {
-        byteLength = UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE;
-      }
-
-      if (!v8::ArrayBuffer::MaybeNew(js.v8Isolate, byteLength).ToLocal(&store)) {
-        return v8::Local<v8::ArrayBuffer>();
-      }
+  auto getOrInitView = [&](bool errorCase = false) -> kj::Maybe<jsg::JsArrayBufferView> {
+    KJ_IF_SOME(v, view) {
+      return v;
     }
-    return store;
+
+    if (errorCase) {
+      jsg::JsArrayBufferView v = jsg::JsUint8Array::create(js, 0);
+      return v;
+    } else if (util::Autogate::isEnabled(util::AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE)) {
+      return jsg::JsUint8Array::tryCreate(js, UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE_2)
+          .map([](auto u8) -> jsg::JsArrayBufferView { return u8; });
+    }
+    return jsg::JsUint8Array::tryCreate(js, UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE)
+        .map([](auto u8) -> jsg::JsArrayBufferView { return u8; });
   };
 
   disturbed = true;
@@ -492,15 +487,15 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
       if (maybeByobOptions != kj::none && FeatureFlags::get(js).getInternalStreamByobReturn()) {
         // When using the BYOB reader, we must return a sized-0 Uint8Array that is backed
         // by the ArrayBuffer passed in the options.
-        auto theStore = getOrInitStore(true);
-        if (theStore.IsEmpty()) {
+        KJ_IF_SOME(view, getOrInitView(true)) {
+          return js.resolvedPromise(ReadResult{
+            .value = js.v8Ref(v8::Local<v8::Value>(view.slice(js, 0, 0))),
+            .done = true,
+          });
+        } else {
           return js.rejectedPromise<ReadResult>(
-              js.v8TypeError("Unable to allocate memory for read"_kj));
+              js.typeError("Unable to allocate memory for read"_kj));
         }
-        return js.resolvedPromise(ReadResult{
-          .value = js.v8Ref(v8::Uint8Array::New(theStore, 0, 0).As<v8::Value>()),
-          .done = true,
-        });
       }
       return js.resolvedPromise(ReadResult{.done = true});
     }
@@ -520,158 +515,115 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
       }
       readPending = true;
 
-      auto theStore = getOrInitStore();
-      if (theStore.IsEmpty()) {
-        return js.rejectedPromise<ReadResult>(
-            js.v8TypeError("Unable to allocate memory for read"_kj));
-      }
+      KJ_IF_SOME(view, getOrInitView()) {
+        // For resizable ArrayBuffers, the buffer may be resized while the read is
+        // pending, decommitting memory pages and making the pointer invalid (SIGSEGV).
+        // We read into a temporary buffer and copy the data back in the .then()
+        // callback, where we can validate the buffer is still large enough.
 
-      // In the case the ArrayBuffer is detached/transfered while the read is pending, we
-      // need to make sure that the ptr remains stable, so we grab a shared ptr to the
-      // backing store and use that to get the pointer to the data. If the buffer is detached
-      // while the read is pending, this does mean that the read data will end up being lost,
-      // but there's not really a better option. The best we can do here is warn the user
-      // that this is happening so they can avoid doing it in the future.
-      // Also, the user really shouldn't do this because the read will end up completing into
-      // the detached backing store still which could cause issues with whatever code now actually
-      // owns the transfered buffer. Below we'll warn the user about this if it happens so they
-      // can avoid doing it in the future.
-      auto backing = theStore->GetBackingStore();
+        auto bytes = view.asArrayPtr();
+        if (bytes.size() == 0) {
+          // There's no point in trying to read into a zero-length buffer.
+          return js.resolvedPromise(ReadResult{
+            .value = js.v8Ref(v8::Local<v8::Value>(view.slice(js, 0, 0))),
+            .done = false,
+          });
+        }
 
-      // For resizable ArrayBuffers, the buffer may be resized while the read is
-      // pending, decommitting memory pages and making the pointer invalid (SIGSEGV).
-      // We read into a temporary buffer and copy the data back in the .then()
-      // callback, where we can validate the buffer is still large enough.
-      bool isResizable = theStore->IsResizableByUserJavaScript();
+        KJ_ASSERT(atLeast <= bytes.size(), "minBytes must not exceed maxBytes in tryRead");
 
-      kj::Array<kj::byte> tempBuffer;
-      kj::byte* readPtr;
-      if (isResizable) {
-        auto currentByteLength = theStore->ByteLength();
-        if (byteOffset >= currentByteLength) {
+        auto dest = kj::heapArray<kj::byte>(bytes.size());
+        auto promise =
+            kj::evalNow([&] { return readable->tryRead(dest.begin(), atLeast, dest.size()); });
+        KJ_IF_SOME(readerLock, readState.tryGetUnsafe<ReaderLocked>()) {
+          promise = KJ_ASSERT_NONNULL(readerLock.getCanceler())->wrap(kj::mv(promise));
+        }
+
+        // TODO(soon): We use awaitIoLegacy() here because if the stream terminates in JavaScript
+        // in this same isolate, then the promise may actually be waiting on JavaScript to do
+        // something, and so should not be considered waiting on external I/O. We will need to use
+        // registerPendingEvent() manually when reading from an external stream. Ideally, we would
+        // refactor the implementation so that when waiting on a JavaScript stream, we strictly use
+        // jsg::Promises and not kj::Promises, so that it doesn't look like I/O at all, and there's
+        // no need to drop the isolate lock and take it again every time some data is read/written.
+        // That's a larger refactor, though.
+        auto& ioContext = IoContext::current();
+        return ioContext.awaitIoLegacy(js, kj::mv(promise))
+            .then(js, ioContext.addFunctor(JSG_VISITABLE_LAMBDA(
+                  (this, ref = addRef(),
+                   view = view.addRef(js),
+                   dest = kj::mv(dest),
+                   isByob = maybeByobOptions != kj::none),
+                  (ref, view),
+                  (jsg::Lock& js, size_t amount) mutable -> jsg::Promise<ReadResult> {
           readPending = false;
-          return js.resolvedPromise(ReadResult{
-            .value = js.v8Ref(v8::Uint8Array::New(theStore, 0, 0).As<v8::Value>()),
-            .done = false,
-          });
-        }
-        if (byteOffset + byteLength > currentByteLength) {
-          byteLength = currentByteLength - byteOffset;
-          if (atLeast > byteLength) {
-            atLeast = byteLength > 0 ? byteLength : 1;
+          KJ_ASSERT(amount <= dest.size());
+          auto handle = view.getHandle(js);
+          if (amount == 0) {
+            if (!state.is<StreamStates::Errored>()) {
+              doClose(js);
+            }
+            KJ_IF_SOME(o, owner) {
+              o.signalEof(js);
+            } else {}
+            if (isByob && FeatureFlags::get(js).getInternalStreamByobReturn()) {
+              return js.resolvedPromise(ReadResult{
+                .value = js.v8Ref(v8::Local<v8::Value>(handle.slice(js, 0, 0))),
+                .done = true,
+              });
+            }
+            return js.resolvedPromise(ReadResult{.done = true});
           }
-        }
-        tempBuffer = kj::heapArray<kj::byte>(byteLength);
-        readPtr = tempBuffer.begin();
-      } else {
-        auto ptr = static_cast<kj::byte*>(backing->Data());
-        readPtr = ptr + byteOffset;
-      }
-      auto bytes = kj::arrayPtr(readPtr, byteLength);
+          // Return a slice so the script can see how many bytes were read.
 
-      KJ_ASSERT(atLeast <= bytes.size(), "minBytes must not exceed maxBytes in tryRead");
+          // We have to check to see if the store was detached while we were waiting
+          // for the read to complete.
+          if (handle.isDetached()) {
+            // If the buffer was detached, we resolve with a new zero-length ArrayBuffer.
+            // The bytes that were read are lost, but this is a valid result.
 
-      auto promise = kj::evalNow([&] {
-        return readable->tryRead(bytes.begin(), atLeast, bytes.size()).attach(kj::mv(backing));
-      });
-      KJ_IF_SOME(readerLock, readState.tryGetUnsafe<ReaderLocked>()) {
-        promise = KJ_ASSERT_NONNULL(readerLock.getCanceler())->wrap(kj::mv(promise));
-      }
+            // Silly user, trix are for kids.
+            IoContext::current().logWarningOnce(
+                "A buffer that was being used for a read operation on a ReadableStream was "
+                "detached while the read was pending. The read completed with a zero-length buffer "
+                "and the data that was read is lost. Avoid detaching buffers that are being used "
+                "for active read operations on streams, or use the "
+                "streams_byob_reader_detaches_buffer compatibility flag, to prevent this from"
+                "happening."_kj);
 
-      // TODO(soon): We use awaitIoLegacy() here because if the stream terminates in JavaScript in
-      // this same isolate, then the promise may actually be waiting on JavaScript to do something,
-      // and so should not be considered waiting on external I/O. We will need to use
-      // registerPendingEvent() manually when reading from an external stream. Ideally, we would
-      // refactor the implementation so that when waiting on a JavaScript stream, we strictly use
-      // jsg::Promises and not kj::Promises, so that it doesn't look like I/O at all, and there's
-      // no need to drop the isolate lock and take it again every time some data is read/written.
-      // That's a larger refactor, though.
-      auto& ioContext = IoContext::current();
-      return ioContext.awaitIoLegacy(js, kj::mv(promise))
-          .then(js, ioContext.addFunctor(JSG_VISITABLE_LAMBDA(
-                (this, ref = addRef(), store = js.v8Ref(store),
-                 byteOffset, byteLength, isByob = maybeByobOptions != kj::none,
-                 isResizable, readPtr, tempBuffer = kj::mv(tempBuffer)),
-                (ref),
-                (jsg::Lock& js, size_t amount) mutable -> jsg::Promise<ReadResult> {
-        readPending = false;
-        KJ_ASSERT(amount <= byteLength);
-        if (amount == 0) {
-          if (!state.is<StreamStates::Errored>()) {
-            doClose(js);
-          }
-          KJ_IF_SOME(o, owner) {
-            o.signalEof(js);
-          } else {}
-          if (isByob && FeatureFlags::get(js).getInternalStreamByobReturn()) {
-            // When using the BYOB reader, we must return a sized-0 Uint8Array that is backed
-            // by the ArrayBuffer passed in the options.
-            auto u8 = v8::Uint8Array::New(store.getHandle(js), 0, 0);
             return js.resolvedPromise(ReadResult{
-              .value = js.v8Ref(u8.As<v8::Value>()),
-              .done = true,
-            });
-          }
-          return js.resolvedPromise(ReadResult{.done = true});
-        }
-        // Return a slice so the script can see how many bytes were read.
-
-        // We have to check to see if the store was detached or resized while we were waiting
-        // for the read to complete.
-        auto handle = store.getHandle(js);
-        if (handle->WasDetached()) {
-          // If the buffer was detached, we resolve with a new zero-length ArrayBuffer.
-          // The bytes that were read are lost, but this is a valid result.
-
-          // Silly user, trix are for kids.
-          IoContext::current().logWarningOnce(
-              "A buffer that was being used for a read operation on a ReadableStream was detached "
-              "while the read was pending. The read completed with a zero-length buffer and the data "
-              "that was read is lost. Avoid detaching buffers that are being used for active read "
-              "operations on streams, or use the streams_byob_reader_detaches_buffer compatibility "
-              "flag, to prevent this from happening."_kj);
-
-          auto buffer = v8::ArrayBuffer::New(js.v8Isolate, 0);
-          return js.resolvedPromise(ReadResult{
-            .value = js.v8Ref(v8::Uint8Array::New(buffer, 0, 0).As<v8::Value>()),
-            .done = false,
-          });
-        }
-
-        if (byteOffset + amount > handle->ByteLength()) {
-          // If the buffer was resized smaller, we return a truncated result.
-
-          IoContext::current().logWarningOnce(
-              "A buffer that was being used for a read operation on a ReadableStream was resized "
-              "smaller while the read was pending. The read completed with a truncated buffer "
-              "containing only the bytes that fit within the new size. Avoid resizing buffers that "
-              "are being used for active read operations on streams, or use the "
-              "streams_byob_reader_detaches_buffer compatibility flag, to prevent this from "
-              "happening."_kj);
-
-          if (byteOffset >= handle->ByteLength()) {
-            return js.resolvedPromise(ReadResult{
-              .value = js.v8Ref(v8::Uint8Array::New(store.getHandle(js), 0, 0).As<v8::Value>()),
+              .value = js.v8Ref(v8::Local<v8::Value>(handle.slice(js, 0, 0))),
               .done = false,
             });
           }
-          amount = handle->ByteLength() - byteOffset;
-        }
 
-        if (isResizable && byteOffset + amount <= handle->ByteLength()) {
-          // For resizable buffers, the data was read into a temporary buffer.
-          // Copy it back into the user's (still valid) buffer region.
-          auto destPtr = static_cast<kj::byte*>(handle->GetBackingStore()->Data());
-          memcpy(destPtr + byteOffset, readPtr, amount);
-        }
+          // If the buffer was resized smaller, we return a truncated result.
+          if (amount > handle.size()) {
+            IoContext::current().logWarningOnce(
+                "A buffer that was being used for a read operation on a ReadableStream was resized "
+                "smaller while the read was pending. The read completed with a truncated buffer "
+                "containing only the bytes that fit within the new size. Avoid resizing buffers "
+                "that are being used for active read operations on streams, or use the "
+                "streams_byob_reader_detaches_buffer compatibility flag, to prevent this from "
+                "happening."_kj);
 
-        return js.resolvedPromise(ReadResult{
-          .value = js.v8Ref(
-              v8::Uint8Array::New(store.getHandle(js), byteOffset, amount).As<v8::Value>()),
-          .done = false,
-        });
-      })),
-              ioContext.addFunctor(JSG_VISITABLE_LAMBDA(
+            if (handle.size() == 0) {
+              return js.resolvedPromise(ReadResult{
+                .value = js.v8Ref(v8::Local<v8::Value>(handle.slice(js, 0, 0))),
+                .done = false,
+              });
+            }
+            amount = handle.size();
+          }
+
+          handle.asArrayPtr().first(amount).copyFrom(dest.asPtr().first(amount));
+
+          return js.resolvedPromise(ReadResult{
+            .value = js.v8Ref(v8::Local<v8::Value>(handle.slice(js, 0, amount))),
+            .done = false,
+          });
+        })),
+                ioContext.addFunctor(JSG_VISITABLE_LAMBDA(
                   (this, ref = addRef()),
                   (ref),
                   (jsg::Lock& js, jsg::Value reason) -> jsg::Promise<ReadResult> {
@@ -681,6 +633,11 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
         }
         return js.rejectedPromise<ReadResult>(kj::mv(reason));
       })));
+
+      } else {
+        return js.rejectedPromise<ReadResult>(
+            js.typeError("Unable to allocate memory for read"_kj));
+      }
     }
   }
   KJ_UNREACHABLE;

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -103,7 +103,7 @@ class ReadableStreamInternalController: public ReadableStreamController {
 
   void visitForGc(jsg::GcVisitor& visitor) override;
 
-  jsg::Promise<jsg::BufferSource> readAllBytes(jsg::Lock& js, uint64_t limit) override;
+  jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> readAllBytes(jsg::Lock& js, uint64_t limit) override;
   jsg::Promise<kj::String> readAllText(jsg::Lock& js, uint64_t limit) override;
 
   kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) override;

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -28,7 +28,7 @@ namespace workerd::api {
 // The ReadableStreamInternalController is always in one of three states: Readable, Closed,
 // or Errored. When the state is Readable, the controller has an associated ReadableStreamSource.
 // When the state is Errored, the ReadableStreamSource has been released and the controller
-// stores a jsg::Value with whatever value was used to error. When Closed, the
+// stores a JS value with whatever value was used to error. When Closed, the
 // ReadableStreamSource has been released.
 
 // Likewise, the WritableStreamInternalController is always either Writable, Closed, or Errored.
@@ -71,7 +71,7 @@ class ReadableStreamInternalController: public ReadableStreamController {
   jsg::Promise<void> pipeTo(
       jsg::Lock& js, WritableStreamController& destination, PipeToOptions options) override;
 
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) override;
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason) override;
 
   Tee tee(jsg::Lock& js) override;
 
@@ -124,9 +124,9 @@ class ReadableStreamInternalController: public ReadableStreamController {
   void jsgGetMemoryInfo(jsg::MemoryTracker& info) const override;
 
  private:
-  void doCancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
+  void doCancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason);
   void doClose(jsg::Lock& js);
-  void doError(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void doError(jsg::Lock& js, jsg::JsValue reason);
 
   class PipeLocked: public PipeController {
    public:
@@ -135,15 +135,15 @@ class ReadableStreamInternalController: public ReadableStreamController {
 
     bool isClosed() override;
 
-    kj::Maybe<v8::Local<v8::Value>> tryGetErrored(jsg::Lock& js) override;
+    kj::Maybe<jsg::JsValue> tryGetErrored(jsg::Lock& js) override;
 
-    void cancel(jsg::Lock& js, v8::Local<v8::Value> reason) override;
+    void cancel(jsg::Lock& js, jsg::JsValue reason) override;
 
     void close(jsg::Lock& js) override;
 
-    void error(jsg::Lock& js, v8::Local<v8::Value> reason) override;
+    void error(jsg::Lock& js, jsg::JsValue reason) override;
 
-    void release(jsg::Lock& js, kj::Maybe<v8::Local<v8::Value>> maybeError = kj::none) override;
+    void release(jsg::Lock& js, kj::Maybe<jsg::JsValue> maybeError = kj::none) override;
 
     kj::Maybe<kj::Promise<void>> tryPumpTo(WritableStreamSink& sink, bool end) override;
 
@@ -222,13 +222,13 @@ class WritableStreamInternalController: public WritableStreamController {
 
   jsg::Ref<WritableStream> addRef() override;
 
-  jsg::Promise<void> write(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> value) override;
+  jsg::Promise<void> write(jsg::Lock& js, jsg::Optional<jsg::JsValue> value) override;
 
   jsg::Promise<void> close(jsg::Lock& js, bool markAsHandled = false) override;
 
   jsg::Promise<void> flush(jsg::Lock& js, bool markAsHandled = false) override;
 
-  jsg::Promise<void> abort(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) override;
+  jsg::Promise<void> abort(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason) override;
 
   kj::Maybe<jsg::Promise<void>> tryPipeFrom(
       jsg::Lock& js, jsg::Ref<ReadableStream> source, PipeToOptions options) override;
@@ -247,7 +247,7 @@ class WritableStreamInternalController: public WritableStreamController {
   void releaseWriter(Writer& writer, kj::Maybe<jsg::Lock&> maybeJs) override;
   // See the comment for releaseWriter in common.h for details on the use of maybeJs
 
-  kj::Maybe<v8::Local<v8::Value>> isErroring(jsg::Lock& js) override {
+  kj::Maybe<jsg::JsValue> isErroring(jsg::Lock& js) override {
     // TODO(later): The internal controller has no concept of an "erroring"
     // state, so for now we just return kj::none here.
     return kj::none;
@@ -280,17 +280,17 @@ class WritableStreamInternalController: public WritableStreamController {
   };
 
   jsg::Promise<void> doAbort(jsg::Lock& js,
-      v8::Local<v8::Value> reason,
+      jsg::JsValue reason,
       AbortOptions options = {.reject = false, .handled = false});
   void doClose(jsg::Lock& js);
-  void doError(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void doError(jsg::Lock& js, jsg::JsValue reason);
   void ensureWriting(jsg::Lock& js);
   jsg::Promise<void> writeLoop(jsg::Lock& js, IoContext& ioContext);
   jsg::Promise<void> writeLoopAfterFrontOutputLock(jsg::Lock& js);
 
-  void drain(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void drain(jsg::Lock& js, jsg::JsValue reason);
   void finishClose(jsg::Lock& js);
-  void finishError(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void finishError(jsg::Lock& js, jsg::JsValue reason);
   jsg::Promise<void> closeImpl(jsg::Lock& js, bool markAsHandled);
 
   struct PipeLocked {
@@ -405,7 +405,7 @@ class WritableStreamInternalController: public WritableStreamController {
 
       bool checkSignal(jsg::Lock& js);
       jsg::Promise<void> pipeLoop(jsg::Lock& js);
-      jsg::Promise<void> write(v8::Local<v8::Value> value);
+      jsg::Promise<void> write(jsg::Lock& js, jsg::JsValue value);
 
       JSG_MEMORY_INFO(State) {
         tracker.trackField("resolver", promise);
@@ -462,8 +462,8 @@ class WritableStreamInternalController: public WritableStreamController {
     jsg::Promise<void> pipeLoop(jsg::Lock& js) {
       return state->pipeLoop(js);
     }
-    jsg::Promise<void> write(v8::Local<v8::Value> value) {
-      return state->write(value);
+    jsg::Promise<void> write(jsg::Lock& js, jsg::JsValue value) {
+      return state->write(js, value);
     }
 
     JSG_MEMORY_INFO(Pipe) {

--- a/src/workerd/api/streams/queue-test.c++
+++ b/src/workerd/api/streams/queue-test.c++
@@ -81,17 +81,18 @@ auto read(jsg::Lock& js, auto& consumer) {
 
 auto byobRead(jsg::Lock& js, auto& consumer, int size) {
   auto prp = js.newPromiseAndResolver<ReadResult>();
+  auto view = jsg::JsUint8Array::create(js, size);
   consumer.read(js,
       ByteQueue::ReadRequest(kj::mv(prp.resolver),
           {
-            .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, size)),
+            .store = jsg::JsArrayBufferView(view).addRef(js),
             .type = ByteQueue::ReadRequest::Type::BYOB,
           }));
   return kj::mv(prp.promise);
 };
 
 auto getEntry(jsg::Lock& js, auto size) {
-  return kj::rc<ValueQueue::Entry>(js.v8Ref(v8::True(js.v8Isolate).As<v8::Value>()), size);
+  return kj::rc<ValueQueue::Entry>(js, js.boolean(true), size);
 }
 
 #pragma region ValueQueue Tests
@@ -129,7 +130,7 @@ KJ_TEST("ValueQueue erroring works") {
   preamble([](jsg::Lock& js) {
     ValueQueue queue(2);
 
-    queue.error(js, js.v8Ref(js.v8Error("boom"_kj)));
+    queue.error(js, js.error("boom"_kj));
 
     KJ_ASSERT(queue.desiredSize() == 0);
 
@@ -162,10 +163,10 @@ KJ_TEST("ValueQueue with single consumer") {
     auto prp = js.newPromiseAndResolver<ReadResult>();
     consumer.read(js, ValueQueue::ReadRequest{.resolver = kj::mv(prp.resolver)});
 
-    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsTrue());
+      KJ_ASSERT(value.getHandle(js).isTrue());
 
       KJ_ASSERT(consumer.size() == 0);
       KJ_ASSERT(queue.size() == 0);
@@ -199,10 +200,10 @@ KJ_TEST("ValueQueue with multiple consumers") {
     KJ_ASSERT(queue.size() == 2);
     KJ_ASSERT(queue.desiredSize() == 0);
 
-    MustCall<ReadContinuation> read1Continuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> read1Continuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsTrue());
+      KJ_ASSERT(value.getHandle(js).isTrue());
 
       KJ_ASSERT(consumer1.size() == 0);
       KJ_ASSERT(consumer2.size() == 2);
@@ -214,10 +215,10 @@ KJ_TEST("ValueQueue with multiple consumers") {
       return read(js, consumer2);
     });
 
-    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsTrue());
+      KJ_ASSERT(value.getHandle(js).isTrue());
 
       KJ_ASSERT(consumer2.size() == 0);
 
@@ -262,10 +263,10 @@ KJ_TEST("ValueQueue consumer with multiple-reads") {
     ValueQueue::Consumer consumer(queue);
 
     // The first read will produce a value.
-    MustCall<ReadContinuation> read1Continuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> read1Continuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsTrue());
+      KJ_ASSERT(value.getHandle(js).isTrue());
       return js.resolvedPromise(kj::mv(result));
     });
     read(js, consumer).then(js, read1Continuation);
@@ -307,7 +308,7 @@ KJ_TEST("ValueQueue errors consumer with multiple-reads") {
     read(js, consumer).then(js, readContinuation, errorContinuation);
     read(js, consumer).then(js, readContinuation, errorContinuation);
 
-    queue.error(js, js.v8Ref(js.v8Error("boom"_kj)));
+    queue.error(js, js.error("boom"_kj));
 
     js.runMicrotasks();
   });
@@ -325,7 +326,7 @@ KJ_TEST("ValueQueue with multiple consumers with pending reads") {
     MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsTrue());
+      KJ_ASSERT(value.getHandle(js).isTrue());
 
       // Both reads were fulfilled immediately without buffering.
       KJ_ASSERT(consumer1.size() == 0);
@@ -360,7 +361,8 @@ KJ_TEST("ByteQueue basics work") {
     KJ_ASSERT(queue.desiredSize() == 2);
     KJ_ASSERT(queue.size() == 0);
 
-    auto entry = kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)));
+    auto ab = jsg::JsUint8Array::create(js, 4);
+    auto entry = kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(ab));
 
     queue.push(js, kj::mv(entry));
 
@@ -372,7 +374,8 @@ KJ_TEST("ByteQueue basics work") {
     queue.close(js);
 
     try {
-      auto entry = kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)));
+      auto ab = jsg::JsUint8Array::create(js, 4);
+      auto entry = kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(ab));
       queue.push(js, kj::mv(entry));
       KJ_FAIL_ASSERT("The queue push after close should have failed.");
     } catch (kj::Exception& ex) {
@@ -388,12 +391,13 @@ KJ_TEST("ByteQueue erroring works") {
   preamble([](jsg::Lock& js) {
     ByteQueue queue(2);
 
-    queue.error(js, js.v8Ref(js.v8Error("boom"_kj)));
+    queue.error(js, js.error("boom"_kj));
 
     KJ_ASSERT(queue.desiredSize() == 0);
 
     try {
-      auto entry = kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)));
+      auto ab = jsg::JsUint8Array::create(js, 4);
+      auto entry = kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(ab));
       queue.push(js, kj::mv(entry));
       KJ_FAIL_ASSERT("The queue push after close should have failed.");
     } catch (kj::Exception& ex) {
@@ -410,10 +414,10 @@ KJ_TEST("ByteQueue with single consumer") {
 
     KJ_ASSERT(queue.desiredSize() == 2);
 
-    auto store = jsg::BackingStore::alloc(js, 4);
-    store.asArrayPtr().fill('a');
+    auto u8 = jsg::JsUint8Array::create(js, 4);
+    u8.asArrayPtr().fill('a');
 
-    auto entry = kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store)));
+    auto entry = kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(u8));
     queue.push(js, kj::mv(entry));
 
     // The item was pushed into the consumer.
@@ -424,17 +428,18 @@ KJ_TEST("ByteQueue with single consumer") {
     KJ_ASSERT(queue.desiredSize() == -2);
 
     auto prp = js.newPromiseAndResolver<ReadResult>();
+    auto u8_2 = jsg::JsUint8Array::create(js, 4);
     consumer.read(js,
         ByteQueue::ReadRequest(kj::mv(prp.resolver),
             {
-              .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)),
+              .store = jsg::JsArrayBufferView(u8_2).addRef(js),
             }));
 
-    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       KJ_ASSERT(source.size() == 4);
       KJ_ASSERT(source.asArrayPtr()[0] == 'a');
       KJ_ASSERT(source.asArrayPtr()[1] == 'a');
@@ -461,18 +466,19 @@ KJ_TEST("ByteQueue with single byob consumer") {
     ByteQueue::Consumer consumer(queue);
 
     auto prp = js.newPromiseAndResolver<ReadResult>();
+    auto u8 = jsg::JsUint8Array::create(js, 4);
     consumer.read(js,
         ByteQueue::ReadRequest(kj::mv(prp.resolver),
             {
-              .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)),
+              .store = jsg::JsArrayBufferView(u8).addRef(js),
               .type = ByteQueue::ReadRequest::Type::BYOB,
             }));
 
-    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 3);
       KJ_ASSERT(ptr[0] == 'b');
@@ -493,7 +499,7 @@ KJ_TEST("ByteQueue with single byob consumer") {
     KJ_ASSERT(!pendingByob->isInvalidated());
 
     auto& req = pendingByob->getRequest();
-    auto ptr = req.pullInto.store.asArrayPtr();
+    auto ptr = req.pullInto.store.getHandle(js).asArrayPtr();
     ptr.first(3).fill('b');
     pendingByob->respond(js, 3);
     KJ_ASSERT(pendingByob->isInvalidated());
@@ -515,18 +521,19 @@ KJ_TEST("ByteQueue with byob consumer and default consumer") {
     ByteQueue::Consumer consumer2(queue);
 
     auto prp = js.newPromiseAndResolver<ReadResult>();
+    auto u8 = jsg::JsUint8Array::create(js, 4);
     consumer1.read(js,
         ByteQueue::ReadRequest(kj::mv(prp.resolver),
             {
-              .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)),
+              .store = jsg::JsArrayBufferView(u8).addRef(js),
               .type = ByteQueue::ReadRequest::Type::BYOB,
             }));
 
-    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 3);
       KJ_ASSERT(ptr[0] == 'b');
@@ -548,7 +555,7 @@ KJ_TEST("ByteQueue with byob consumer and default consumer") {
     KJ_ASSERT(!pendingByob->isInvalidated());
 
     auto& req = pendingByob->getRequest();
-    auto ptr = req.pullInto.store.asArrayPtr();
+    auto ptr = req.pullInto.store.getHandle(js).asArrayPtr();
     ptr.first(3).fill('b');
     pendingByob->respond(js, 3);
     KJ_ASSERT(pendingByob->isInvalidated());
@@ -561,11 +568,11 @@ KJ_TEST("ByteQueue with byob consumer and default consumer") {
 
     js.runMicrotasks();
 
-    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       // The second consumer receives exactly the same data.
       KJ_ASSERT(source.size() == 3);
@@ -581,10 +588,11 @@ KJ_TEST("ByteQueue with byob consumer and default consumer") {
     });
 
     auto prp2 = js.newPromiseAndResolver<ReadResult>();
+    auto u8_2 = jsg::JsUint8Array::create(js, 4);
     consumer2.read(js,
         ByteQueue::ReadRequest(kj::mv(prp2.resolver),
             {
-              .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)),
+              .store = jsg::JsArrayBufferView(u8_2).addRef(js),
               .type = ByteQueue::ReadRequest::Type::DEFAULT,
             }));
     prp2.promise.then(js, read2Continuation);
@@ -600,11 +608,11 @@ KJ_TEST("ByteQueue with multiple byob consumers") {
     ByteQueue::Consumer consumer1(queue);
     ByteQueue::Consumer consumer2(queue);
 
-    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 3);
       KJ_ASSERT(ptr[0] == 'b');
@@ -630,7 +638,7 @@ KJ_TEST("ByteQueue with multiple byob consumers") {
     KJ_ASSERT(!pendingByob->isInvalidated());
 
     auto& req = pendingByob->getRequest();
-    auto ptr = req.pullInto.store.asArrayPtr();
+    auto ptr = req.pullInto.store.getHandle(js).asArrayPtr();
     ptr.first(3).fill('b');
     pendingByob->respond(js, 3);
     KJ_ASSERT(pendingByob->isInvalidated());
@@ -656,11 +664,11 @@ KJ_TEST("ByteQueue with multiple byob consumers") {
     ByteQueue::Consumer consumer1(queue);
     ByteQueue::Consumer consumer2(queue);
 
-    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 3);
       KJ_ASSERT(ptr[0] == 'b');
@@ -686,7 +694,7 @@ KJ_TEST("ByteQueue with multiple byob consumers") {
     KJ_ASSERT(!pendingByob->isInvalidated());
 
     auto& req = pendingByob->getRequest();
-    auto ptr = req.pullInto.store.asArrayPtr();
+    auto ptr = req.pullInto.store.getHandle(js).asArrayPtr();
     ptr.first(3).fill('b');
     pendingByob->respond(js, 3);
     KJ_ASSERT(pendingByob->isInvalidated());
@@ -712,11 +720,11 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads)") {
     ByteQueue::Consumer consumer1(queue);
     ByteQueue::Consumer consumer2(queue);
 
-    MustCall<ReadContinuation> readConsumer1([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readConsumer1([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 3);
       KJ_ASSERT(ptr[0] == 'a');
@@ -726,11 +734,11 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads)") {
       return js.resolvedPromise(kj::mv(result));
     });
 
-    MustCall<ReadContinuation> readConsumer2([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readConsumer2([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 3);
       KJ_ASSERT(ptr[0] == 'a');
@@ -740,11 +748,11 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads)") {
       return byobRead(js, consumer2, 4);
     });
 
-    MustCall<ReadContinuation> secondReadBothConsumers([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> secondReadBothConsumers([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 2);
       KJ_ASSERT(ptr[0] == 'b');
@@ -766,7 +774,7 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads)") {
     MustCall<void(ByteQueue::ByobRequest&)> respond([&](jsg::Lock&, auto& pending) {
       static uint counter = 0;
       auto& req = pending.getRequest();
-      auto ptr = req.pullInto.store.asArrayPtr();
+      auto ptr = req.pullInto.store.getHandle(js).asArrayPtr();
       auto num = 3 - counter;
       ptr.first(num).fill('a' + counter++);
       pending.respond(js, num);
@@ -793,11 +801,11 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads, 2)") {
     ByteQueue::Consumer consumer1(queue);
     ByteQueue::Consumer consumer2(queue);
 
-    MustCall<ReadContinuation> readConsumer1([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readConsumer1([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 3);
       KJ_ASSERT(ptr[0] == 'a');
@@ -806,11 +814,11 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads, 2)") {
       return js.resolvedPromise(kj::mv(result));
     });
 
-    MustCall<ReadContinuation> readConsumer2([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> readConsumer2([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 3);
       KJ_ASSERT(ptr[0] == 'a');
@@ -820,11 +828,11 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads, 2)") {
       return byobRead(js, consumer2, 4);
     });
 
-    MustCall<ReadContinuation> secondReadBothConsumers([&](jsg::Lock& js, auto&& result) -> auto {
+    MustCall<ReadContinuation> secondReadBothConsumers([&](jsg::Lock& js, auto result) -> auto {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
-      KJ_ASSERT(value.getHandle(js)->IsArrayBufferView());
-      jsg::BufferSource source(js, value.getHandle(js));
+      KJ_ASSERT(value.getHandle(js).isArrayBufferView());
+      jsg::JsBufferSource source(value.getHandle(js));
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 2);
       KJ_ASSERT(ptr[0] == 'b');
@@ -846,7 +854,7 @@ KJ_TEST("ByteQueue with multiple byob consumers (multi-reads, 2)") {
     MustCall<void(ByteQueue::ByobRequest&)> respond([&](jsg::Lock&, auto& pending) {
       static uint counter = 0;
       auto& req = pending.getRequest();
-      auto ptr = req.pullInto.store.asArrayPtr();
+      auto ptr = req.pullInto.store.getHandle(js).asArrayPtr();
       auto num = 3 - counter;
       ptr.first(num).fill('a' + counter++);
       pending.respond(js, num);
@@ -874,10 +882,11 @@ KJ_TEST("ByteQueue with default consumer with atLeast") {
 
     const auto read = [&](jsg::Lock& js, uint atLeast) {
       auto prp = js.newPromiseAndResolver<ReadResult>();
+      auto u8 = jsg::JsUint8Array::create(js, 5);
       consumer.read(js,
           ByteQueue::ReadRequest(kj::mv(prp.resolver),
               {
-                .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 5)),
+                .store = jsg::JsArrayBufferView(u8).addRef(js),
                 .atLeast = atLeast,
               }));
       return kj::mv(prp.promise);
@@ -885,18 +894,18 @@ KJ_TEST("ByteQueue with default consumer with atLeast") {
 
     const auto push = [&](auto store) {
       try {
-        queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store))));
+        queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store)));
       } catch (kj::Exception& ex) {
         KJ_DBG(ex.getDescription());
       }
     };
 
-    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> readContinuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(ptr[0] == 1);
       KJ_ASSERT(ptr[1] == 2);
@@ -908,12 +917,12 @@ KJ_TEST("ByteQueue with default consumer with atLeast") {
       return read(js, 1);
     });
 
-    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       KJ_ASSERT(source.asArrayPtr()[0], 6);
       KJ_ASSERT(source.size() == 1);
       return js.resolvedPromise(kj::mv(result));
@@ -921,25 +930,25 @@ KJ_TEST("ByteQueue with default consumer with atLeast") {
 
     read(js, 5).then(js, readContinuation).then(js, read2Continuation);
 
-    auto store1 = jsg::BackingStore::alloc(js, 2);
+    auto store1 = jsg::JsUint8Array::create(js, 2);
     store1.asArrayPtr()[0] = 1;
     store1.asArrayPtr()[1] = 2;
-    push(kj::mv(store1));
+    push(store1);
 
     KJ_ASSERT(queue.desiredSize() == 0);
 
-    auto store2 = jsg::BackingStore::alloc(js, 2);
+    auto store2 = jsg::JsUint8Array::create(js, 2);
     store2.asArrayPtr()[0] = 3;
     store2.asArrayPtr()[1] = 4;
-    push(kj::mv(store2));
+    push(store2);
 
     // Backpressure should be accumulating because the read has not yet fullilled.
     KJ_ASSERT(queue.desiredSize() == -2);
 
-    auto store3 = jsg::BackingStore::alloc(js, 2);
+    auto store3 = jsg::JsUint8Array::create(js, 2);
     store3.asArrayPtr()[0] = 5;
     store3.asArrayPtr()[1] = 6;
-    push(kj::mv(store3));
+    push(store3);
 
     // Some backpressure should be released because pushing the final minimum
     // amount into the queue should have caused the read to be fulfilled.
@@ -962,10 +971,11 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (same rate)") {
 
     const auto read = [&](jsg::Lock& js, auto& consumer, uint atLeast = 1) {
       auto prp = js.newPromiseAndResolver<ReadResult>();
+      auto u8 = jsg::JsUint8Array::create(js, 5);
       consumer.read(js,
           ByteQueue::ReadRequest(kj::mv(prp.resolver),
               {
-                .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 5)),
+                .store = jsg::JsArrayBufferView(u8).addRef(js),
                 .atLeast = atLeast,
               }));
       return kj::mv(prp.promise);
@@ -973,18 +983,18 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (same rate)") {
 
     const auto push = [&](auto store) {
       try {
-        queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store))));
+        queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store)));
       } catch (kj::Exception& ex) {
         KJ_DBG(ex.getDescription());
       }
     };
 
-    MustCall<ReadContinuation> read1Continuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> read1Continuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(ptr[0] == 1);
       KJ_ASSERT(ptr[1] == 2);
@@ -996,12 +1006,12 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (same rate)") {
       return read(js, consumer1);
     });
 
-    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(ptr[0] == 1);
       KJ_ASSERT(ptr[1] == 2);
@@ -1013,12 +1023,12 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (same rate)") {
       return read(js, consumer2);
     });
 
-    MustCall<ReadContinuation> readFinalContinuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> readFinalContinuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       KJ_ASSERT(source.asArrayPtr()[0], 6);
       KJ_ASSERT(source.size() == 1);
       return js.resolvedPromise(kj::mv(result));
@@ -1027,25 +1037,25 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (same rate)") {
     read(js, consumer1, 5).then(js, read1Continuation).then(js, readFinalContinuation);
     read(js, consumer2, 5).then(js, read2Continuation).then(js, readFinalContinuation);
 
-    auto store1 = jsg::BackingStore::alloc(js, 2);
+    auto store1 = jsg::JsUint8Array::create(js, 2);
     store1.asArrayPtr()[0] = 1;
     store1.asArrayPtr()[1] = 2;
-    push(kj::mv(store1));
+    push(store1);
 
     KJ_ASSERT(queue.desiredSize() == 0);
 
-    auto store2 = jsg::BackingStore::alloc(js, 2);
+    auto store2 = jsg::JsUint8Array::create(js, 2);
     store2.asArrayPtr()[0] = 3;
     store2.asArrayPtr()[1] = 4;
-    push(kj::mv(store2));
+    push(store2);
 
     // Backpressure should be accumulating because the read has not yet fullilled.
     KJ_ASSERT(queue.desiredSize() == -2);
 
-    auto store3 = jsg::BackingStore::alloc(js, 2);
+    auto store3 = jsg::JsUint8Array::create(js, 2);
     store3.asArrayPtr()[0] = 5;
     store3.asArrayPtr()[1] = 6;
-    push(kj::mv(store3));
+    push(store3);
 
     // Some backpressure should be released because pushing the final minimum
     // amount into the queue should have caused the read to be fulfilled.
@@ -1068,10 +1078,11 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)
 
     const auto read = [&](jsg::Lock& js, auto& consumer, uint atLeast = 1) {
       auto prp = js.newPromiseAndResolver<ReadResult>();
+      auto u8 = jsg::JsUint8Array::create(js, 5);
       consumer.read(js,
           ByteQueue::ReadRequest(kj::mv(prp.resolver),
               {
-                .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 5)),
+                .store = jsg::JsArrayBufferView(u8).addRef(js),
                 .atLeast = atLeast,
               }));
       return kj::mv(prp.promise);
@@ -1079,18 +1090,18 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)
 
     const auto push = [&](auto store) {
       try {
-        queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store))));
+        queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store)));
       } catch (kj::Exception& ex) {
         KJ_DBG(ex.getDescription());
       }
     };
 
-    MustCall<ReadContinuation> read1Continuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> read1Continuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       KJ_ASSERT(source.size() == 4);
       auto ptr = source.asArrayPtr();
       // Our read was for at least 3 bytes, with a maximum of 5.
@@ -1103,12 +1114,12 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)
       return js.resolvedPromise(kj::mv(result));
     });
 
-    MustCall<ReadContinuation> read1FinalContinuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> read1FinalContinuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       KJ_ASSERT(source.size() == 2);
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(ptr[0] == 5);
@@ -1116,12 +1127,12 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)
       return js.resolvedPromise(kj::mv(result));
     });
 
-    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> read2Continuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       auto ptr = source.asArrayPtr();
       KJ_ASSERT(source.size() == 5);
       KJ_ASSERT(ptr[0] == 1);
@@ -1133,12 +1144,12 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)
       return read(js, consumer2);
     });
 
-    MustCall<ReadContinuation> read2FinalContinuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<ReadContinuation> read2FinalContinuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       auto& value = KJ_ASSERT_NONNULL(result.value);
       auto view = value.getHandle(js);
-      KJ_ASSERT(view->IsArrayBufferView());
-      jsg::BufferSource source(js, view);
+      KJ_ASSERT(view.isArrayBufferView());
+      jsg::JsBufferSource source(view);
       KJ_ASSERT(source.asArrayPtr()[0] == 6);
       KJ_ASSERT(source.size() == 1);
       return js.resolvedPromise(kj::mv(result));
@@ -1151,17 +1162,17 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)
     // Consumer 2 will read serially with a larger minimum chunk...
     read(js, consumer2, 5).then(js, read2Continuation).then(js, read2FinalContinuation);
 
-    auto store1 = jsg::BackingStore::alloc(js, 2);
+    auto store1 = jsg::JsUint8Array::create(js, 2);
     store1.asArrayPtr()[0] = 1;
     store1.asArrayPtr()[1] = 2;
-    push(kj::mv(store1));
+    push(store1);
 
     KJ_ASSERT(queue.desiredSize() == 0);
 
-    auto store2 = jsg::BackingStore::alloc(js, 2);
+    auto store2 = jsg::JsUint8Array::create(js, 2);
     store2.asArrayPtr()[0] = 3;
     store2.asArrayPtr()[1] = 4;
-    push(kj::mv(store2));
+    push(store2);
 
     // Consumer1 should not have any data buffered since its first read was for
     // between 3 and 5 bytes and it has received four so far.
@@ -1174,10 +1185,10 @@ KJ_TEST("ByteQueue with multiple default consumers with atLeast (different rate)
     // Queue backpressure should reflect that consumer2 has data buffered.
     KJ_ASSERT(queue.desiredSize() == -2);
 
-    auto store3 = jsg::BackingStore::alloc(js, 2);
+    auto store3 = jsg::JsUint8Array::create(js, 2);
     store3.asArrayPtr()[0] = 5;
     store3.asArrayPtr()[1] = 6;
-    push(kj::mv(store3));
+    push(store3);
 
     // Most of the backpressure should have been resolved since we delivered 5 bytes
     // to consumer2, but there's still one byte remaining.
@@ -1243,7 +1254,7 @@ KJ_TEST("ValueQueue push to errored consumer is safe") {
     ValueQueue::Consumer consumer2(queue);
 
     // Error consumer2
-    consumer2.error(js, js.v8Ref(js.v8Error("error reason"_kj)));
+    consumer2.error(js, js.error("error reason"_kj));
 
     // Now push to the queue
     queue.push(js, getEntry(js, 4));
@@ -1266,9 +1277,9 @@ KJ_TEST("ByteQueue push to closed consumer is safe") {
     consumer2.close(js);
 
     // Now push to the queue
-    auto store = jsg::BackingStore::alloc(js, 4);
+    auto store = jsg::JsUint8Array::create(js, 4);
     memset(store.asArrayPtr().begin(), 'A', 4);
-    auto entry = kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store)));
+    auto entry = kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store));
     queue.push(js, kj::mv(entry));
 
     // consumer1 should have received the data
@@ -1291,17 +1302,16 @@ KJ_TEST("ValueQueue draining read with buffered data") {
     ValueQueue::Consumer consumer(queue);
 
     // Push an ArrayBuffer
-    auto store = jsg::BackingStore::alloc(js, 4);
+    auto store = jsg::JsUint8Array::create(js, 4);
     store.asArrayPtr()[0] = 'a';
     store.asArrayPtr()[1] = 'b';
     store.asArrayPtr()[2] = 'c';
     store.asArrayPtr()[3] = 'd';
-    auto ab = jsg::BufferSource(js, kj::mv(store)).getHandle(js);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(ab.As<v8::Value>()), 4));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, store, 4));
 
     // Push a string
-    auto str = jsg::v8Str(js.v8Isolate, "hello");
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(str.As<v8::Value>()), 5));
+    auto str = js.str("hello"_kj);
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, str, 5));
 
     KJ_ASSERT(consumer.size() == 9);
 
@@ -1404,7 +1414,7 @@ KJ_TEST("ValueQueue draining read on errored stream") {
     ValueQueue queue(10);
     ValueQueue::Consumer consumer(queue);
 
-    queue.error(js, js.v8Ref(js.v8Error("boom"_kj)));
+    queue.error(js, js.error("boom"_kj));
 
     MustNotCall<DrainingReadContinuation> readContinuation;
     MustCall<DrainingReadErrorContinuation> errorContinuation([&](jsg::Lock& js, auto&& value) {
@@ -1423,19 +1433,19 @@ KJ_TEST("ByteQueue draining read with buffered data") {
     ByteQueue::Consumer consumer(queue);
 
     // Push first chunk
-    auto store1 = jsg::BackingStore::alloc(js, 4);
+    auto store1 = jsg::JsUint8Array::create(js, 4);
     store1.asArrayPtr()[0] = 'a';
     store1.asArrayPtr()[1] = 'b';
     store1.asArrayPtr()[2] = 'c';
     store1.asArrayPtr()[3] = 'd';
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store1))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store1)));
 
     // Push second chunk
-    auto store2 = jsg::BackingStore::alloc(js, 3);
+    auto store2 = jsg::JsUint8Array::create(js, 3);
     store2.asArrayPtr()[0] = 'e';
     store2.asArrayPtr()[1] = 'f';
     store2.asArrayPtr()[2] = 'g';
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store2))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store2)));
 
     KJ_ASSERT(consumer.size() == 7);
 
@@ -1472,10 +1482,11 @@ KJ_TEST("ByteQueue draining read rejects with pending reads") {
 
     // Queue a regular read
     auto prp = js.newPromiseAndResolver<ReadResult>();
+    auto u8 = jsg::JsUint8Array::create(js, 4);
     consumer.read(js,
         ByteQueue::ReadRequest(kj::mv(prp.resolver),
             {
-              .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)),
+              .store = jsg::JsArrayBufferView(u8).addRef(js),
             }));
 
     KJ_ASSERT(consumer.hasReadRequests());
@@ -1511,10 +1522,11 @@ KJ_TEST("ByteQueue read rejects with pending draining read") {
       return js.rejectedPromise<ReadResult>(kj::mv(value));
     });
 
+    auto u8 = jsg::JsUint8Array::create(js, 4);
     consumer.read(js,
         ByteQueue::ReadRequest(kj::mv(prp.resolver),
             {
-              .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)),
+              .store = jsg::JsArrayBufferView(u8).addRef(js),
             }));
     prp.promise.then(js, readContinuation, errorContinuation);
     js.runMicrotasks();
@@ -1544,7 +1556,7 @@ KJ_TEST("ByteQueue draining read on errored stream") {
     ByteQueue queue(10);
     ByteQueue::Consumer consumer(queue);
 
-    queue.error(js, js.v8Ref(js.v8Error("boom"_kj)));
+    queue.error(js, js.error("boom"_kj));
 
     MustNotCall<DrainingReadContinuation> readContinuation;
     MustCall<DrainingReadErrorContinuation> errorContinuation([&](jsg::Lock& js, auto&& value) {
@@ -1563,18 +1575,17 @@ KJ_TEST("ValueQueue draining read with close signal") {
     ValueQueue::Consumer consumer(queue);
 
     // Push some data
-    auto store = jsg::BackingStore::alloc(js, 4);
+    auto store = jsg::JsUint8Array::create(js, 4);
     store.asArrayPtr()[0] = 'a';
     store.asArrayPtr()[1] = 'b';
     store.asArrayPtr()[2] = 'c';
     store.asArrayPtr()[3] = 'd';
-    auto ab = jsg::BufferSource(js, kj::mv(store)).getHandle(js);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(ab.As<v8::Value>()), 4));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, store, 4));
 
     // Close the queue
     queue.close(js);
 
-    MustCall<DrainingReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<DrainingReadContinuation> readContinuation([&](jsg::Lock& js, auto result) {
       // Should have the data and done should be true since stream is closed
       KJ_ASSERT(result.done);
       KJ_ASSERT(result.chunks.size() == 1);
@@ -1593,17 +1604,17 @@ KJ_TEST("ByteQueue draining read with close signal") {
     ByteQueue::Consumer consumer(queue);
 
     // Push some data
-    auto store = jsg::BackingStore::alloc(js, 4);
+    auto store = jsg::JsUint8Array::create(js, 4);
     store.asArrayPtr()[0] = 'a';
     store.asArrayPtr()[1] = 'b';
     store.asArrayPtr()[2] = 'c';
     store.asArrayPtr()[3] = 'd';
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store)));
 
     // Close the queue
     queue.close(js);
 
-    MustCall<DrainingReadContinuation> readContinuation([&](jsg::Lock& js, auto&& result) {
+    MustCall<DrainingReadContinuation> readContinuation([&](jsg::Lock& js, auto result) {
       // Should have the data and done should be true since stream is closed
       KJ_ASSERT(result.done);
       KJ_ASSERT(result.chunks.size() == 1);
@@ -1624,8 +1635,7 @@ KJ_TEST("ValueQueue draining read errors on non-byte value") {
     ValueQueue::Consumer consumer(queue);
 
     // Push a plain object - this cannot be converted to bytes
-    auto obj = v8::Object::New(js.v8Isolate);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(obj.As<v8::Value>()), 1));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, js.obj(), 1));
 
     KJ_ASSERT(consumer.size() == 1);
 
@@ -1659,8 +1669,7 @@ KJ_TEST("ValueQueue draining read errors on number value") {
     ValueQueue::Consumer consumer(queue);
 
     // Push a number - this cannot be converted to bytes
-    auto num = v8::Number::New(js.v8Isolate, 42);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(num.As<v8::Value>()), 1));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, js.num(42), 1));
 
     MustNotCall<DrainingReadContinuation> readContinuation;
     MustCall<DrainingReadErrorContinuation> errorContinuation([&](jsg::Lock& js, auto&& value) {
@@ -1691,15 +1700,13 @@ KJ_TEST("ValueQueue draining read respects maxRead during buffer drain") {
     ValueQueue::Consumer consumer(queue);
 
     // Buffer 200 bytes of data (two 100-byte chunks)
-    auto store1 = jsg::BackingStore::alloc(js, 100);
+    auto store1 = jsg::JsUint8Array::create(js, 100);
     store1.asArrayPtr().fill(0xAA);
-    auto ab1 = jsg::BufferSource(js, kj::mv(store1)).getHandle(js);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(ab1.As<v8::Value>()), 100));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, store1, 100));
 
-    auto store2 = jsg::BackingStore::alloc(js, 100);
+    auto store2 = jsg::JsUint8Array::create(js, 100);
     store2.asArrayPtr().fill(0xBB);
-    auto ab2 = jsg::BufferSource(js, kj::mv(store2)).getHandle(js);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(ab2.As<v8::Value>()), 100));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, store2, 100));
 
     KJ_ASSERT(consumer.size() == 200);
 
@@ -1727,19 +1734,19 @@ KJ_TEST("ByteQueue draining read respects maxRead during buffer drain") {
     ByteQueue::Consumer consumer(queue);
 
     // Buffer 200 bytes of data (two 100-byte chunks)
-    auto store1 = jsg::BackingStore::alloc(js, 100);
+    auto store1 = jsg::JsUint8Array::create(js, 100);
     store1.asArrayPtr().fill(0xAA);
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store1))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store1)));
 
-    auto store2 = jsg::BackingStore::alloc(js, 100);
+    auto store2 = jsg::JsUint8Array::create(js, 100);
     store2.asArrayPtr().fill(0xBB);
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store2))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store2)));
 
     KJ_ASSERT(consumer.size() == 200);
 
     // maxRead=50: first 100-byte chunk is drained, then stops. Second chunk stays buffered.
     MustCall<DrainingReadContinuation> readContinuation(
-        [&](jsg::Lock& js, DrainingReadResult&& result) {
+        [&](jsg::Lock& js, DrainingReadResult result) {
       KJ_ASSERT(!result.done);
       KJ_ASSERT(result.chunks.size() == 1);
       KJ_ASSERT(result.chunks[0].size() == 100);
@@ -1758,15 +1765,13 @@ KJ_TEST("ValueQueue draining read with large maxRead drains entire buffer") {
     ValueQueue::Consumer consumer(queue);
 
     // Buffer 200 bytes (two 100-byte chunks)
-    auto store1 = jsg::BackingStore::alloc(js, 100);
+    auto store1 = jsg::JsUint8Array::create(js, 100);
     store1.asArrayPtr().fill(0xAA);
-    auto ab1 = jsg::BufferSource(js, kj::mv(store1)).getHandle(js);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(ab1.As<v8::Value>()), 100));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, store1, 100));
 
-    auto store2 = jsg::BackingStore::alloc(js, 100);
+    auto store2 = jsg::JsUint8Array::create(js, 100);
     store2.asArrayPtr().fill(0xBB);
-    auto ab2 = jsg::BufferSource(js, kj::mv(store2)).getHandle(js);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(ab2.As<v8::Value>()), 100));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, store2, 100));
 
     KJ_ASSERT(consumer.size() == 200);
 
@@ -1792,14 +1797,12 @@ KJ_TEST("ValueQueue draining read with default maxRead (unlimited)") {
     ValueQueue::Consumer consumer(queue);
 
     // Buffer some data
-    auto store = jsg::BackingStore::alloc(js, 100);
+    auto store = jsg::JsUint8Array::create(js, 100);
     store.asArrayPtr().fill(0xAA);
-    auto ab = jsg::BufferSource(js, kj::mv(store)).getHandle(js);
-    queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(ab.As<v8::Value>()), 100));
+    queue.push(js, kj::rc<ValueQueue::Entry>(js, store, 100));
 
     // Default maxRead (kj::maxValue) should drain buffer normally
-    MustCall<DrainingReadContinuation> readContinuation(
-        [&](jsg::Lock& js, DrainingReadResult&& result) {
+    MustCall<DrainingReadContinuation> readContinuation([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       KJ_ASSERT(result.chunks.size() == 1);
       KJ_ASSERT(result.chunks[0].size() == 100);
@@ -1820,16 +1823,15 @@ KJ_TEST("ValueQueue draining read maxRead bounds multiple iterations") {
 
     // Buffer 400 bytes: four 100-byte chunks
     for (int i = 0; i < 4; i++) {
-      auto store = jsg::BackingStore::alloc(js, 100);
+      auto store = jsg::JsUint8Array::create(js, 100);
       store.asArrayPtr().fill(0x10 * (i + 1));
-      auto ab = jsg::BufferSource(js, kj::mv(store)).getHandle(js);
-      queue.push(js, kj::rc<ValueQueue::Entry>(js.v8Ref(ab.As<v8::Value>()), 100));
+      queue.push(js, kj::rc<ValueQueue::Entry>(js, store, 100));
     }
     KJ_ASSERT(consumer.size() == 400);
 
     // First read with maxRead=150: drains first chunk (100 bytes, now totalRead=100 < 150),
     // then drains second chunk (200 bytes total, now >= 150), stops.
-    MustCall<DrainingReadContinuation> read1([&](jsg::Lock& js, DrainingReadResult&& result) {
+    MustCall<DrainingReadContinuation> read1([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       KJ_ASSERT(result.chunks.size() == 2);
       KJ_ASSERT(consumer.size() == 200);
@@ -1839,7 +1841,7 @@ KJ_TEST("ValueQueue draining read maxRead bounds multiple iterations") {
     js.runMicrotasks();
 
     // Second read with maxRead=150: drains next two chunks similarly
-    MustCall<DrainingReadContinuation> read2([&](jsg::Lock& js, DrainingReadResult&& result) {
+    MustCall<DrainingReadContinuation> read2([&](jsg::Lock& js, auto result) {
       KJ_ASSERT(!result.done);
       KJ_ASSERT(result.chunks.size() == 2);
       KJ_ASSERT(consumer.size() == 0);
@@ -1911,9 +1913,9 @@ KJ_TEST("ByteQueue destroyed before consumer doesn't crash") {
     auto queue = kj::heap<ByteQueue>(2);
     auto consumer = kj::heap<ByteQueue::Consumer>(*queue);
 
-    auto store = jsg::BackingStore::alloc(js, 4);
+    auto store = jsg::JsUint8Array::create(js, 4);
     store.asArrayPtr().fill('a');
-    queue->push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store))));
+    queue->push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store)));
     KJ_ASSERT(consumer->size() == 4);
 
     // Destroy queue before consumer
@@ -1965,7 +1967,7 @@ KJ_TEST("ValueQueue error then destroy before consumer doesn't crash") {
     auto consumer = kj::heap<ValueQueue::Consumer>(*queue);
 
     // Error the queue first
-    queue->error(js, js.v8Ref(js.v8Error("boom"_kj)));
+    queue->error(js, js.error("boom"_kj));
 
     // Then destroy it
     queue = nullptr;
@@ -2003,9 +2005,9 @@ KJ_TEST("ByteQueue push skips consumer removed from queue during iteration") {
 
     // Push data - should not crash even though consumer2 was in the queue
     // when it was created but is now destroyed.
-    auto store = jsg::BackingStore::alloc(js, 4);
+    auto store = jsg::JsUint8Array::create(js, 4);
     store.asArrayPtr().fill('x');
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store)));
 
     // consumer1 should have received the data
     KJ_ASSERT(consumer1->size() == 4);
@@ -2037,10 +2039,11 @@ KJ_TEST("ByteQueue push handles consumer destroyed by microtask between pushes")
 
     // Set up a pending read on consumer1
     auto prp = js.newPromiseAndResolver<ReadResult>();
+    auto u8 = jsg::JsUint8Array::create(js, 4);
     consumer1->read(js,
         ByteQueue::ReadRequest(kj::mv(prp.resolver),
             {
-              .store = jsg::BufferSource(js, jsg::BackingStore::alloc(js, 4)),
+              .store = jsg::JsArrayBufferView(u8).addRef(js),
             }));
 
     // The continuation destroys consumer2
@@ -2051,17 +2054,17 @@ KJ_TEST("ByteQueue push handles consumer destroyed by microtask between pushes")
     prp.promise.then(js, readContinuation);
 
     // First push - resolves consumer1's read, schedules microtask that will destroy consumer2
-    auto store1 = jsg::BackingStore::alloc(js, 4);
+    auto store1 = jsg::JsUint8Array::create(js, 4);
     store1.asArrayPtr().fill('x');
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store1))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store1)));
 
     // Run microtasks - this destroys consumer2
     js.runMicrotasks();
 
     // Second push - consumer2 is now destroyed, should not crash
-    auto store2 = jsg::BackingStore::alloc(js, 4);
+    auto store2 = jsg::JsUint8Array::create(js, 4);
     store2.asArrayPtr().fill('y');
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store2))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store2)));
 
     // consumer1 should have the second push's data buffered
     KJ_ASSERT(consumer1->size() == 4);
@@ -2076,9 +2079,9 @@ KJ_TEST("ByteQueue maybeUpdateBackpressure skips destroyed consumers") {
     auto consumer2 = kj::heap<ByteQueue::Consumer>(queue);
 
     // Push some data so consumers have size
-    auto store = jsg::BackingStore::alloc(js, 4);
+    auto store = jsg::JsUint8Array::create(js, 4);
     store.asArrayPtr().fill('x');
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store)));
 
     KJ_ASSERT(consumer1->size() == 4);
     KJ_ASSERT(consumer2->size() == 4);
@@ -2088,9 +2091,9 @@ KJ_TEST("ByteQueue maybeUpdateBackpressure skips destroyed consumers") {
     consumer2 = nullptr;
 
     // Trigger backpressure recalculation by pushing more data
-    auto store2 = jsg::BackingStore::alloc(js, 4);
+    auto store2 = jsg::JsUint8Array::create(js, 4);
     store2.asArrayPtr().fill('y');
-    queue.push(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, kj::mv(store2))));
+    queue.push(js, kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(store2)));
 
     // Should not crash, and size should reflect only consumer1
     KJ_ASSERT(consumer1->size() == 8);

--- a/src/workerd/api/streams/queue.c++
+++ b/src/workerd/api/streams/queue.c++
@@ -23,25 +23,31 @@ void ValueQueue::ReadRequest::resolveAsDone(jsg::Lock& js) {
   resolver.resolve(js, ReadResult{.done = true});
 }
 
-void ValueQueue::ReadRequest::resolve(jsg::Lock& js, jsg::Value value) {
-  resolver.resolve(js, ReadResult{.value = kj::mv(value), .done = false});
+void ValueQueue::ReadRequest::resolve(jsg::Lock& js, jsg::JsValue value) {
+  resolver.resolve(js,
+      ReadResult{
+        .value = value.addRef(js),
+        .done = false,
+      });
 }
 
-void ValueQueue::ReadRequest::reject(jsg::Lock& js, jsg::Value& value) {
-  resolver.reject(js, value.getHandle(js));
+void ValueQueue::ReadRequest::reject(jsg::Lock& js, jsg::JsValue value) {
+  resolver.reject(js, value);
 }
 
 #pragma endregion ValueQueue::ReadRequest
 
 #pragma region ValueQueue::Entry
 
-ValueQueue::Entry::Entry(jsg::Value value, size_t size): value(kj::mv(value)), size(size) {}
+ValueQueue::Entry::Entry(jsg::Lock& js, jsg::JsValue value, size_t size)
+    : value(value.addRef(js)),
+      size(size) {}
 
-jsg::Value ValueQueue::Entry::getValue(jsg::Lock& js) {
-  return value.addRef(js);
+jsg::JsValue ValueQueue::Entry::getValue(jsg::Lock& js) {
+  return value.getHandle(js);
 }
 
-size_t ValueQueue::Entry::getSize() const {
+size_t ValueQueue::Entry::getSize(jsg::Lock&) const {
   return size;
 }
 
@@ -76,7 +82,7 @@ ValueQueue::Consumer::Consumer(
 ValueQueue::Consumer::Consumer(kj::Maybe<ConsumerImpl::StateListener&> stateListener)
     : impl(stateListener) {}
 
-void ValueQueue::Consumer::cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+void ValueQueue::Consumer::cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   impl.cancel(js, maybeReason);
 }
 
@@ -88,8 +94,8 @@ bool ValueQueue::Consumer::empty() {
   return impl.empty();
 }
 
-void ValueQueue::Consumer::error(jsg::Lock& js, jsg::Value reason) {
-  impl.error(js, kj::mv(reason));
+void ValueQueue::Consumer::error(jsg::Lock& js, jsg::JsValue reason) {
+  impl.error(js, reason);
 };
 
 void ValueQueue::Consumer::read(jsg::Lock& js, ReadRequest request) {
@@ -133,23 +139,21 @@ bool ValueQueue::Consumer::hasPendingDrainingRead() {
 
 namespace {
 // Helper to convert a JS value to bytes. Returns kj::none if the value cannot be converted.
-kj::Maybe<kj::Array<kj::byte>> valueToBytes(jsg::Lock& js, jsg::Value& value) {
-  auto jsval = jsg::JsValue(value.getHandle(js));
-
+kj::Maybe<kj::Array<kj::byte>> valueToBytes(jsg::Lock& js, const jsg::JsValue& value) {
   // Try ArrayBuffer first.
-  KJ_IF_SOME(ab, jsval.tryCast<jsg::JsArrayBuffer>()) {
+  KJ_IF_SOME(ab, value.tryCast<jsg::JsArrayBuffer>()) {
     auto src = ab.asArrayPtr();
     return kj::heapArray(src);
   }
 
   // Try ArrayBufferView.
-  KJ_IF_SOME(abView, jsval.tryCast<jsg::JsArrayBufferView>()) {
+  KJ_IF_SOME(abView, value.tryCast<jsg::JsArrayBufferView>()) {
     auto src = abView.asArrayPtr();
     return kj::heapArray(src);
   }
 
   // Try string - convert to UTF-8.
-  KJ_IF_SOME(str, jsval.tryCast<jsg::JsString>()) {
+  KJ_IF_SOME(str, value.tryCast<jsg::JsString>()) {
     auto data = str.toUSVString(js);
     return kj::heapArray(data.asBytes());
   }
@@ -206,12 +210,12 @@ jsg::Promise<DrainingReadResult> ValueQueue::Consumer::drainingRead(jsg::Lock& j
           KJ_IF_SOME(bytes, valueToBytes(js, value)) {
             totalRead += bytes.size();
             chunks.add(kj::mv(bytes));
-            ready.queueTotalSize -= entry.entry->getSize();
+            ready.queueTotalSize -= entry.entry->getSize(js);
             ready.buffer.pop_front();
           } else {
             auto error = js.typeError(
                 "Draining read encountered a value that cannot be converted to bytes"_kj);
-            impl.error(js, jsg::Value(js.v8Isolate, error));
+            impl.error(js, error);
             return js.rejectedPromise<DrainingReadResult>(error);
           }
         }
@@ -328,7 +332,7 @@ jsg::Promise<DrainingReadResult> ValueQueue::Consumer::drainingRead(jsg::Lock& j
     // Convert the value to bytes.
     kj::Vector<kj::Array<kj::byte>> chunks;
     KJ_IF_SOME(val, result.value) {
-      KJ_IF_SOME(bytes, valueToBytes(js, val)) {
+      KJ_IF_SOME(bytes, valueToBytes(js, val.getHandle(js))) {
         chunks.add(kj::mv(bytes));
       }
       // If valueToBytes returned kj::none, we just return empty chunks.
@@ -367,8 +371,8 @@ ssize_t ValueQueue::desiredSize() const {
   return impl.desiredSize();
 }
 
-void ValueQueue::error(jsg::Lock& js, jsg::Value reason) {
-  impl.error(js, kj::mv(reason));
+void ValueQueue::error(jsg::Lock& js, jsg::JsValue reason) {
+  impl.error(js, reason);
 }
 
 void ValueQueue::maybeUpdateBackpressure() {
@@ -388,7 +392,7 @@ void ValueQueue::handlePush(
   // If there are no pending reads, just add the entry to the buffer and return, adjusting
   // the size of the queue in the process.
   if (state.readRequests.empty()) {
-    state.queueTotalSize += entry->getSize();
+    state.queueTotalSize += entry->getSize(js);
     state.buffer.push_back(QueueEntry{.entry = kj::mv(entry)});
     return;
   }
@@ -436,7 +440,7 @@ void ValueQueue::handleRead(jsg::Lock& js,
         auto freed = kj::mv(entry);
         state.buffer.pop_front();
         request.resolve(js, freed.entry->getValue(js));
-        state.queueTotalSize -= freed.entry->getSize();
+        state.queueTotalSize -= freed.entry->getSize(js);
         return;
       }
     }
@@ -473,7 +477,7 @@ bool ValueQueue::wantsRead() const {
   return impl.wantsRead();
 }
 
-bool ValueQueue::hasPartiallyFulfilledRead() {
+bool ValueQueue::hasPartiallyFulfilledRead(jsg::Lock&) {
   // A ValueQueue can never have a partially fulfilled read.
   return false;
 }
@@ -511,26 +515,33 @@ void ByteQueue::ReadRequest::resolveAsDone(jsg::Lock& js) {
   if (pullInto.filled > 0) {
     // There's been at least some data written, we need to respond but not
     // set done to true since that's what the streams spec requires.
-    pullInto.store.trim(js, pullInto.store.size() - pullInto.filled);
-    resolver.resolve(
-        js, ReadResult{.value = js.v8Ref(pullInto.store.getHandle(js)), .done = false});
+    return resolve(js);
   } else {
+    auto handle = pullInto.store.getHandle(js).clone(js);
     // Otherwise, we set the length to zero
-    pullInto.store.trim(js, pullInto.store.size());
-    KJ_ASSERT(pullInto.store.size() == 0);
-    resolver.resolve(js, ReadResult{.value = js.v8Ref(pullInto.store.getHandle(js)), .done = true});
+    handle = handle.slice(js, 0, 0);
+    resolver.resolve(js,
+        ReadResult{
+          .value = jsg::JsValue(handle).addRef(js),
+          .done = true,
+        });
   }
   maybeInvalidateByobRequest(byobReadRequest);
 }
 
 void ByteQueue::ReadRequest::resolve(jsg::Lock& js) {
-  pullInto.store.trim(js, pullInto.store.size() - pullInto.filled);
-  resolver.resolve(js, ReadResult{.value = js.v8Ref(pullInto.store.getHandle(js)), .done = false});
+  auto handle = pullInto.store.getHandle(js).clone(js);
+  // We need to create a new handle over the same underlying data
+  resolver.resolve(js,
+      ReadResult{
+        .value = jsg::JsValue(handle.slice(js, 0, pullInto.filled)).addRef(js),
+        .done = false,
+      });
   maybeInvalidateByobRequest(byobReadRequest);
 }
 
-void ByteQueue::ReadRequest::reject(jsg::Lock& js, jsg::Value& value) {
-  resolver.reject(js, value.getHandle(js));
+void ByteQueue::ReadRequest::reject(jsg::Lock& js, jsg::JsValue value) {
+  resolver.reject(js, value);
   maybeInvalidateByobRequest(byobReadRequest);
 }
 
@@ -545,14 +556,14 @@ kj::Own<ByteQueue::ByobRequest> ByteQueue::ReadRequest::makeByobReadRequest(
 
 #pragma region ByteQueue::Entry
 
-ByteQueue::Entry::Entry(jsg::BufferSource store): store(kj::mv(store)) {}
+ByteQueue::Entry::Entry(jsg::Lock& js, jsg::JsBufferSource store): store(store.addRef(js)) {}
 
-kj::ArrayPtr<kj::byte> ByteQueue::Entry::toArrayPtr() {
-  return store.asArrayPtr();
+kj::ArrayPtr<kj::byte> ByteQueue::Entry::toArrayPtr(jsg::Lock& js) {
+  return store.getHandle(js).asArrayPtr();
 }
 
-size_t ByteQueue::Entry::getSize() const {
-  return store.size();
+size_t ByteQueue::Entry::getSize(jsg::Lock& js) const {
+  return store.getHandle(js).size();
 }
 
 kj::Rc<ByteQueue::Entry> ByteQueue::Entry::clone(jsg::Lock& js) {
@@ -587,7 +598,7 @@ ByteQueue::Consumer::Consumer(
 ByteQueue::Consumer::Consumer(kj::Maybe<ConsumerImpl::StateListener&> stateListener)
     : impl(stateListener) {}
 
-void ByteQueue::Consumer::cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+void ByteQueue::Consumer::cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   impl.cancel(js, maybeReason);
 }
 
@@ -599,8 +610,8 @@ bool ByteQueue::Consumer::empty() const {
   return impl.empty();
 }
 
-void ByteQueue::Consumer::error(jsg::Lock& js, jsg::Value reason) {
-  impl.error(js, kj::mv(reason));
+void ByteQueue::Consumer::error(jsg::Lock& js, jsg::JsValue reason) {
+  impl.error(js, reason);
 }
 
 void ByteQueue::Consumer::read(jsg::Lock& js, ReadRequest request) {
@@ -672,7 +683,7 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
 
   // Drains buffered byte data into chunks. Stops draining when totalRead reaches
   // or exceeds maxRead (after finishing the current item).
-  static const auto drainBuffer = [](ConsumerImpl::Ready& ready,
+  static const auto drainBuffer = [](jsg::Lock& js, ConsumerImpl::Ready& ready,
                                       kj::Vector<kj::Array<kj::byte>>& chunks, size_t& totalRead,
                                       bool& isClosing, size_t maxRead) {
     while (!ready.buffer.empty() && !isClosing && totalRead < maxRead) {
@@ -683,7 +694,7 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
           break;
         }
         KJ_CASE_ONEOF(entry, QueueEntry) {
-          auto ptr = entry.entry->toArrayPtr();
+          auto ptr = entry.entry->toArrayPtr(js);
           auto offset = entry.offset;
           auto size = ptr.size() - offset;
           totalRead += size;
@@ -696,7 +707,7 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
   };
 
   // Drain the buffer up to maxRead bytes, then pump for more if under the limit.
-  drainBuffer(ready, chunks, totalRead, isClosing, maxRead);
+  drainBuffer(js, ready, chunks, totalRead, isClosing, maxRead);
 
   // Pump the controller for more synchronously available data.
   // maxRead is checked here: we only proceed with pumping if we haven't exceeded it.
@@ -711,7 +722,7 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
       if (!impl.state.isActive()) break;
 
       // Drain buffered data that was added by the pull, respecting maxRead.
-      drainBuffer(ready, chunks, totalRead, isClosing, maxRead);
+      drainBuffer(js, ready, chunks, totalRead, isClosing, maxRead);
 
       // If pull is async or no new data was added, stop pumping.
       if (!pullCompletedSync || chunks.size() == prevChunkCount) {
@@ -741,7 +752,7 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
   if (impl.queue == kj::none) {
     // Drain remaining buffer up to maxRead. If there's still more, the caller
     // will loop back and we'll drain the rest on subsequent calls.
-    drainBuffer(ready, chunks, totalRead, isClosing, maxRead);
+    drainBuffer(js, ready, chunks, totalRead, isClosing, maxRead);
     ready.hasPendingDrainingRead = false;
     bool done = ready.buffer.empty() || isClosing;
     // If isClosing, finalize the consumer so onConsumerClose fires promptly.
@@ -773,11 +784,11 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
   // We allocate a buffer for the read - the data will be copied into it.
   // The flag remains set (was set at the start) and will be cleared by the promise callbacks.
   constexpr size_t kDefaultReadSize = 16384;  // 16KB default buffer
-  KJ_IF_SOME(store, jsg::BufferSource::tryAllocUnsafe(js, kDefaultReadSize)) {
+  KJ_IF_SOME(store, jsg::JsUint8Array::tryCreate(js, kDefaultReadSize)) {
     auto prp = js.newPromiseAndResolver<ReadResult>();
 
     ReadRequest::PullInto pullInto{
-      .store = kj::mv(store),
+      .store = jsg::JsArrayBufferView(store).addRef(js),
       .filled = 0,
       .atLeast = 1,
       .type = ReadRequest::Type::DEFAULT,
@@ -802,7 +813,7 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
 
       kj::Vector<kj::Array<kj::byte>> chunks;
       KJ_IF_SOME(val, result.value) {
-        auto jsval = jsg::JsValue(val.getHandle(js));
+        auto jsval = val.getHandle(js);
         KJ_IF_SOME(ab, jsval.tryCast<jsg::JsArrayBuffer>()) {
           chunks.add(kj::heapArray(ab.asArrayPtr()));
         } else KJ_IF_SOME(abView, jsval.tryCast<jsg::JsArrayBufferView>()) {
@@ -849,9 +860,10 @@ void ByteQueue::ByobRequest::invalidate() {
   }
 }
 
-bool ByteQueue::ByobRequest::isPartiallyFulfilled() {
-  return !isInvalidated() && getRequest().pullInto.filled > 0 &&
-      getRequest().pullInto.store.getElementSize() > 1;
+bool ByteQueue::ByobRequest::isPartiallyFulfilled(jsg::Lock& js) {
+  if (isInvalidated()) return false;
+  auto handle = getRequest().pullInto.store.getHandle(js);
+  return getRequest().pullInto.filled > 0 && handle.getElementSize() > 1;
 }
 
 bool ByteQueue::ByobRequest::respond(jsg::Lock& js, size_t amount) {
@@ -866,22 +878,23 @@ bool ByteQueue::ByobRequest::respond(jsg::Lock& js, size_t amount) {
   // rejected already.
   auto& req = KJ_REQUIRE_NONNULL(request, "the pending byob read request was already invalidated");
 
+  auto handle = req.pullInto.store.getHandle(js);
   // The amount cannot be more than the total space in the request store.
-  JSG_REQUIRE(req.pullInto.filled + amount <= req.pullInto.store.size(), RangeError,
+  JSG_REQUIRE(req.pullInto.filled + amount <= handle.size(), RangeError,
       kj::str("Too many bytes [", amount, "] in response to a BYOB read request."));
 
-  auto sourcePtr = req.pullInto.store.asArrayPtr();
+  auto sourcePtr = handle.asArrayPtr();
 
   if (queue.getConsumerCount() > 1) {
     // Allocate the entry into which we will be copying the provided data for the
     // other consumers of the queue.
-    KJ_IF_SOME(store, jsg::BufferSource::tryAllocUnsafe(js, amount)) {
-      auto entry = kj::rc<Entry>(kj::mv(store));
+    KJ_IF_SOME(store, jsg::JsUint8Array::tryCreate(js, amount)) {
+      auto entry = kj::rc<Entry>(js, jsg::JsBufferSource(store));
 
       auto start = sourcePtr.slice(req.pullInto.filled);
 
       // Safely copy the data over into the entry.
-      entry->toArrayPtr().first(amount).copyFrom(start.first(amount));
+      entry->toArrayPtr(js).first(amount).copyFrom(start.first(amount));
 
       // Push the entry into the other consumers.
       queue.push(js, kj::mv(entry), consumer);
@@ -911,7 +924,7 @@ bool ByteQueue::ByobRequest::respond(jsg::Lock& js, size_t amount) {
   // There is no need to adjust the pullInto.atLeast here because we are resolving
   // the read immediately.
 
-  auto unaligned = req.pullInto.filled % req.pullInto.store.getElementSize();
+  auto unaligned = req.pullInto.filled % handle.getElementSize();
   // It is possible that the request was partially filled already.
   req.pullInto.filled -= unaligned;
 
@@ -921,9 +934,9 @@ bool ByteQueue::ByobRequest::respond(jsg::Lock& js, size_t amount) {
   if (unaligned > 0) {
     auto start = sourcePtr.slice(amount - unaligned);
 
-    KJ_IF_SOME(store, jsg::BufferSource::tryAllocUnsafe(js, unaligned)) {
-      auto excess = kj::rc<Entry>(kj::mv(store));
-      excess->toArrayPtr().first(unaligned).copyFrom(start.first(unaligned));
+    KJ_IF_SOME(store, jsg::JsUint8Array::tryCreate(js, unaligned)) {
+      auto excess = kj::rc<Entry>(js, jsg::JsBufferSource(store));
+      excess->toArrayPtr(js).first(unaligned).copyFrom(start.first(unaligned));
       consumer.push(js, kj::mv(excess));
     } else {
       js.throwException(js.error("Failed to allocate memory for the byob read response."_kj));
@@ -933,7 +946,7 @@ bool ByteQueue::ByobRequest::respond(jsg::Lock& js, size_t amount) {
   return true;
 }
 
-bool ByteQueue::ByobRequest::respondWithNewView(jsg::Lock& js, jsg::BufferSource view) {
+bool ByteQueue::ByobRequest::respondWithNewView(jsg::Lock& js, jsg::JsBufferSource view) {
   // The idea here is that rather than filling the view that the controller was given,
   // it chose to create its own view and fill that, likely over the same ArrayBuffer.
   // What we do here is perform some basic validations on what we were given, and if
@@ -942,15 +955,24 @@ bool ByteQueue::ByobRequest::respondWithNewView(jsg::Lock& js, jsg::BufferSource
   auto& req = KJ_REQUIRE_NONNULL(request, "the pending byob read request was already invalidated");
   auto amount = view.size();
 
-  JSG_REQUIRE(view.canDetach(js), TypeError, "Unable to use non-detachable ArrayBuffer.");
-  JSG_REQUIRE(req.pullInto.store.getOffset() + req.pullInto.filled == view.getOffset(), RangeError,
+  auto handle = req.pullInto.store.getHandle(js);
+  JSG_REQUIRE(view.isDetachable(), TypeError, "Unable to use non-detachable ArrayBuffer.");
+  JSG_REQUIRE(handle.getOffset() + req.pullInto.filled == view.getOffset(), RangeError,
       "The given view has an invalid byte offset.");
-  JSG_REQUIRE(req.pullInto.store.size() == view.underlyingArrayBufferSize(js), RangeError,
+  JSG_REQUIRE(handle.size() == view.underlyingArrayBufferSize(js), RangeError,
       "The underlying ArrayBuffer is not the correct length.");
-  JSG_REQUIRE(req.pullInto.filled + amount <= req.pullInto.store.size(), RangeError,
+  JSG_REQUIRE(req.pullInto.filled + amount <= handle.size(), RangeError,
       "The view is not the correct length.");
 
-  req.pullInto.store = jsg::BufferSource(js, view.detach(js));
+  KJ_IF_SOME(actualView, jsg::JsValue(view).tryCast<jsg::JsArrayBufferView>()) {
+    req.pullInto.store = actualView.addRef(js);
+  } else KJ_IF_SOME(sab, jsg::JsValue(view).tryCast<jsg::JsSharedArrayBuffer>()) {
+    req.pullInto.store = jsg::JsArrayBufferView(jsg::JsUint8Array::create(js, sab)).addRef(js);
+  } else {
+    auto ab = KJ_ASSERT_NONNULL(jsg::JsValue(view).tryCast<jsg::JsArrayBuffer>());
+    req.pullInto.store = jsg::JsArrayBufferView(jsg::JsUint8Array::create(js, ab)).addRef(js);
+  }
+
   return respond(js, amount);
 }
 
@@ -961,28 +983,26 @@ size_t ByteQueue::ByobRequest::getAtLeast() const {
   return 0;
 }
 
-v8::Local<v8::Uint8Array> ByteQueue::ByobRequest::getView(jsg::Lock& js) {
+kj::Maybe<jsg::JsUint8Array> ByteQueue::ByobRequest::getView(jsg::Lock& js) {
   KJ_IF_SOME(req, request) {
-    return req.pullInto.store
-        .getTypedViewSlice<v8::Uint8Array>(js, req.pullInto.filled, req.pullInto.store.size())
-        .getHandle(js)
-        .As<v8::Uint8Array>();
+    jsg::JsUint8Array handle = req.pullInto.store.getHandle(js).clone(js);
+    return handle.slice(js, req.pullInto.filled, handle.size() - req.pullInto.filled);
   }
-  return v8::Local<v8::Uint8Array>();
+  return kj::none;
 }
 
 size_t ByteQueue::ByobRequest::getOriginalBufferByteLength(jsg::Lock& js) const {
   KJ_IF_SOME(req, request) {
-    KJ_IF_SOME(size, req.pullInto.store.underlyingArrayBufferSize(js)) {
-      return size;
-    }
+    auto handle = req.pullInto.store.getHandle(js);
+    return handle.getBuffer().size();
   }
   return 0;
 }
 
-size_t ByteQueue::ByobRequest::getOriginalByteOffsetPlusBytesFilled() const {
+size_t ByteQueue::ByobRequest::getOriginalByteOffsetPlusBytesFilled(jsg::Lock& js) const {
   KJ_IF_SOME(req, request) {
-    return req.pullInto.store.getOffset() + req.pullInto.filled;
+    auto handle = req.pullInto.store.getHandle(js);
+    return handle.getOffset() + req.pullInto.filled;
   }
   return 0;
 }
@@ -1012,8 +1032,8 @@ ssize_t ByteQueue::desiredSize() const {
   return impl.desiredSize();
 }
 
-void ByteQueue::error(jsg::Lock& js, jsg::Value reason) {
-  impl.error(js, kj::mv(reason));
+void ByteQueue::error(jsg::Lock& js, jsg::JsValue reason) {
+  impl.error(js, reason);
 }
 
 void ByteQueue::maybeUpdateBackpressure() {
@@ -1047,7 +1067,7 @@ void ByteQueue::handlePush(jsg::Lock& js,
     kj::Maybe<QueueImpl&> queue,
     kj::Rc<Entry> newEntry) {
   const auto bufferData = [&](size_t offset) {
-    state.queueTotalSize += newEntry->getSize() - offset;
+    state.queueTotalSize += newEntry->getSize(js) - offset;
     state.buffer.emplace_back(QueueEntry{
       .entry = kj::mv(newEntry),
       .offset = offset,
@@ -1064,7 +1084,7 @@ void ByteQueue::handlePush(jsg::Lock& js,
   // are >= the pending reads atLeast, then we will fulfill the pending
   // read, and keep fulfilling pending reads as long as they are available.
   // Once we are out of pending reads, we will buffer the remaining data.
-  auto entrySize = newEntry->getSize();
+  auto entrySize = newEntry->getSize(js);
   auto amountAvailable = state.queueTotalSize + entrySize;
   size_t entryOffset = 0;
 
@@ -1095,11 +1115,12 @@ void ByteQueue::handlePush(jsg::Lock& js,
           KJ_FAIL_ASSERT("The consumer is closed.");
         }
         KJ_CASE_ONEOF(entry, QueueEntry) {
-          auto sourcePtr = entry.entry->toArrayPtr();
+          auto sourcePtr = entry.entry->toArrayPtr(js);
           auto sourceSize = sourcePtr.size() - entry.offset;
 
-          auto destPtr = pending.pullInto.store.asArrayPtr().slice(pending.pullInto.filled);
-          auto destAmount = pending.pullInto.store.size() - pending.pullInto.filled;
+          auto handle = pending.pullInto.store.getHandle(js);
+          auto destPtr = handle.asArrayPtr().slice(pending.pullInto.filled);
+          auto destAmount = handle.size() - pending.pullInto.filled;
 
           // sourceSize is the amount of data remaining in the current entry to copy.
           // destAmount is the amount of space remaining to be filled in the pending read.
@@ -1131,8 +1152,10 @@ void ByteQueue::handlePush(jsg::Lock& js,
     // At this point, there shouldn't be any data remaining in the buffer.
     KJ_REQUIRE(state.queueTotalSize == 0);
 
+    auto handle = pending.pullInto.store.getHandle(js);
+
     // And there should be data remaining in the pending pullInto destination.
-    KJ_REQUIRE(pending.pullInto.filled < pending.pullInto.store.size());
+    KJ_REQUIRE(pending.pullInto.filled < handle.size());
 
     // And the amountAvailable should be equal to the current push size.
     KJ_REQUIRE(amountAvailable == entrySize - entryOffset);
@@ -1141,8 +1164,7 @@ void ByteQueue::handlePush(jsg::Lock& js,
     // destination pullInto by taking the lesser of amountAvailable and
     // destination pullInto size - filled (which gives us the amount of space
     // remaining in the destination).
-    auto amountToCopy =
-        kj::min(amountAvailable, pending.pullInto.store.size() - pending.pullInto.filled);
+    auto amountToCopy = kj::min(amountAvailable, handle.size() - pending.pullInto.filled);
 
     // The amountToCopy should not be more than the entry size minus the entryOffset
     // (which is the amount of data remaining to be consumed in the current entry).
@@ -1151,14 +1173,14 @@ void ByteQueue::handlePush(jsg::Lock& js,
     // The amountToCopy plus pending.pullInto.filled should be more than or equal to atLeast
     // and less than or equal pending.pullInto.store.size().
     KJ_REQUIRE(amountToCopy + pending.pullInto.filled >= pending.pullInto.atLeast &&
-        amountToCopy + pending.pullInto.filled <= pending.pullInto.store.size());
+        amountToCopy + pending.pullInto.filled <= handle.size());
 
     // Awesome, so now we safely copy amountToCopy bytes from the current entry into
     // the remaining space in pending.pullInto.store, being careful to account for
     // the entryOffset and pending.pullInto.filled offsets to determine the range
     // where we start copying.
-    auto entryPtr = newEntry->toArrayPtr();
-    auto destPtr = pending.pullInto.store.asArrayPtr().slice(pending.pullInto.filled);
+    auto entryPtr = newEntry->toArrayPtr(js);
+    auto destPtr = handle.asArrayPtr().slice(pending.pullInto.filled);
     destPtr.first(amountToCopy).copyFrom(entryPtr.slice(entryOffset).first(amountToCopy));
 
     // Yay! this pending read has been fulfilled. There might be more tho. Let's adjust
@@ -1221,7 +1243,7 @@ void ByteQueue::handleRead(jsg::Lock& js,
       KJ_REQUIRE(!state.buffer.empty());
       // There must be at least one item in the buffer.
       auto& item = state.buffer.front();
-
+      auto handle = request.pullInto.store.getHandle(js);
       KJ_SWITCH_ONEOF(item) {
         KJ_CASE_ONEOF(c, ConsumerImpl::Close) {
           // We reached the end of the buffer! All data has been consumed.
@@ -1230,10 +1252,10 @@ void ByteQueue::handleRead(jsg::Lock& js,
         KJ_CASE_ONEOF(entry, QueueEntry) {
           // The amount to copy is the lesser of the current entry size minus
           // offset and the data remaining in the destination to fill.
-          auto entrySize = entry.entry->getSize();
-          auto amountToCopy = kj::min(
-              entrySize - entry.offset, request.pullInto.store.size() - request.pullInto.filled);
-          auto elementSize = request.pullInto.store.getElementSize();
+          auto entrySize = entry.entry->getSize(js);
+          auto amountToCopy =
+              kj::min(entrySize - entry.offset, handle.size() - request.pullInto.filled);
+          auto elementSize = handle.getElementSize();
           if (amountToCopy > elementSize) {
             amountToCopy -= amountToCopy % elementSize;
           }
@@ -1243,8 +1265,8 @@ void ByteQueue::handleRead(jsg::Lock& js,
 
           // Once we have the amount, we safely copy amountToCopy bytes from the
           // entry into the destination request, accounting properly for the offsets.
-          auto sourcePtr = entry.entry->toArrayPtr().slice(entry.offset);
-          auto destPtr = request.pullInto.store.asArrayPtr().slice(request.pullInto.filled);
+          auto sourcePtr = entry.entry->toArrayPtr(js).slice(entry.offset);
+          auto destPtr = handle.asArrayPtr().slice(request.pullInto.filled);
 
           destPtr.first(amountToCopy).copyFrom(sourcePtr.first(amountToCopy));
 
@@ -1302,7 +1324,8 @@ void ByteQueue::handleRead(jsg::Lock& js,
     // to minimally fill this read request! The amount to copy is the lesser
     // of the queue total size and the maximum amount of space in the request
     // pull into.
-    if (consume(kj::min(state.queueTotalSize, request.pullInto.store.size()))) {
+    auto handle = request.pullInto.store.getHandle(js);
+    if (consume(kj::min(state.queueTotalSize, handle.size()))) {
 
       // If consume returns true, the consumer hit the end and we need to
       // just resolve the request as done and return.
@@ -1370,11 +1393,12 @@ bool ByteQueue::handleMaybeClose(jsg::Lock& js,
           return true;
         }
         KJ_CASE_ONEOF(entry, QueueEntry) {
-          auto sourcePtr = entry.entry->toArrayPtr();
+          auto sourcePtr = entry.entry->toArrayPtr(js);
           auto sourceSize = sourcePtr.size() - entry.offset;
 
-          auto destPtr = pending.pullInto.store.asArrayPtr().slice(pending.pullInto.filled);
-          auto destAmount = pending.pullInto.store.size() - pending.pullInto.filled;
+          auto handle = pending.pullInto.store.getHandle(js);
+          auto destPtr = handle.asArrayPtr().slice(pending.pullInto.filled);
+          auto destAmount = handle.size() - pending.pullInto.filled;
 
           // There should be space available to copy into and data to copy from, or
           // something else went wrong.
@@ -1499,11 +1523,11 @@ kj::Maybe<kj::Own<ByteQueue::ByobRequest>> ByteQueue::nextPendingByobReadRequest
   return kj::none;
 }
 
-bool ByteQueue::hasPartiallyFulfilledRead() {
+bool ByteQueue::hasPartiallyFulfilledRead(jsg::Lock& js) {
   KJ_IF_SOME(state, impl.getState()) {
     if (!state.pendingByobReadRequests.empty()) {
       auto& pending = state.pendingByobReadRequests.front();
-      if (pending->isPartiallyFulfilled()) {
+      if (pending->isPartiallyFulfilled(js)) {
         return true;
       }
     }

--- a/src/workerd/api/streams/queue.h
+++ b/src/workerd/api/streams/queue.h
@@ -42,7 +42,7 @@ namespace workerd::api {
 //    entries are freed. The underlying data is freed once the last
 //    reference is released.
 //
-//  - Every consumer has an remaining buffer size, which is the sum of the sizes
+//  - Every consumer has a remaining buffer size, which is the sum of the sizes
 //    of all entries remaining to be consumed in its internal buffer.
 //
 //  - A queue has a total queue size, which is the remaining buffer size of the
@@ -194,14 +194,14 @@ class QueueImpl final {
   // which will, in turn, reset their internal buffers and reject
   // all pending consume promises.
   // If we are already closed or errored, do nothing here.
-  void error(jsg::Lock& js, jsg::Value reason) {
+  void error(jsg::Lock& js, jsg::JsValue reason) {
     if (state.isActive()) {
 #ifdef KJ_DEBUG
       isClosingOrErroring = true;
       KJ_DEFER(isClosingOrErroring = false);
 #endif
-      allConsumers.forEach([&](ConsumerImpl& consumer) { consumer.error(js, reason.addRef(js)); });
-      state.template transitionTo<Errored>(kj::mv(reason));
+      allConsumers.forEach([&](ConsumerImpl& consumer) { consumer.error(js, reason); });
+      state.template transitionTo<Errored>(reason.addRef(js));
     }
   }
 
@@ -274,7 +274,7 @@ class QueueImpl final {
   };
   struct Errored {
     static constexpr kj::StringPtr NAME KJ_UNUSED = "errored"_kj;
-    jsg::Value reason;
+    jsg::JsRef<jsg::JsValue> reason;
   };
 
   struct Ready final: public State {
@@ -337,7 +337,7 @@ class ConsumerImpl final {
  public:
   struct StateListener {
     virtual void onConsumerClose(jsg::Lock& js) = 0;
-    virtual void onConsumerError(jsg::Lock& js, jsg::Value reason) = 0;
+    virtual void onConsumerError(jsg::Lock& js, jsg::JsValue reason) = 0;
     // Called when the consumer has a pending read and needs data.
     // Returns true if the pull algorithm completed synchronously (meaning
     // more pumping might yield additional synchronous data), false if the
@@ -400,7 +400,7 @@ class ConsumerImpl final {
     queue = kj::none;
   }
 
-  void cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+  void cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue>) {
     // Already closed or errored - nothing to do.
     KJ_IF_SOME(ready, state.tryGetActiveUnsafe()) {
       for (auto& request: ready.readRequests) {
@@ -428,11 +428,11 @@ class ConsumerImpl final {
     return size() == 0;
   }
 
-  void error(jsg::Lock& js, jsg::Value reason) {
+  void error(jsg::Lock& js, jsg::JsValue reason) {
     // If we are already closed or errored, then we do nothing here.
     // The new error doesn't matter.
     if (state.isActive()) {
-      maybeDrainAndSetState(js, kj::mv(reason));
+      maybeDrainAndSetState(js, reason);
     }
   }
 
@@ -444,7 +444,7 @@ class ConsumerImpl final {
     KJ_IF_SOME(ready, state.tryGetActiveUnsafe()) {
       // If the consumer is already closing or the entry is empty, do nothing.
       // Also skip if queue is none (consumer cloned from closed stream).
-      if (isClosing() || entry->getSize() == 0 || queue == kj::none) {
+      if (isClosing() || entry->getSize(js) == 0 || queue == kj::none) {
         return;
       }
 
@@ -458,13 +458,12 @@ class ConsumerImpl final {
       return request.resolveAsDone(js);
     }
     KJ_IF_SOME(errored, state.tryGetErrorUnsafe()) {
-      return request.reject(js, errored.reason);
+      return request.reject(js, errored.reason.getHandle(js));
     }
     auto& ready = state.requireActiveUnsafe();
     // Mutual exclusion with draining reads.
     if (ready.hasPendingDrainingRead) {
-      auto error = jsg::Value(
-          js.v8Isolate, js.typeError("Cannot call read while there is a pending draining read"_kj));
+      auto error = js.typeError("Cannot call read while there is a pending draining read"_kj);
       return request.reject(js, error);
     }
     Self::handleRead(js, ready, *this, queue, kj::mv(request));
@@ -573,7 +572,7 @@ class ConsumerImpl final {
   };
   struct Errored {
     static constexpr kj::StringPtr NAME KJ_UNUSED = "errored"_kj;
-    jsg::Value reason;
+    jsg::JsRef<jsg::JsValue> reason;
   };
   struct Ready {
     static constexpr kj::StringPtr NAME KJ_UNUSED = "ready"_kj;
@@ -636,7 +635,7 @@ class ConsumerImpl final {
     return result;
   }
 
-  void maybeDrainAndSetState(jsg::Lock& js, kj::Maybe<jsg::Value> maybeReason = kj::none) {
+  void maybeDrainAndSetState(jsg::Lock& js, kj::Maybe<jsg::JsValue> maybeReason = kj::none) {
     // If the state is already errored or closed then there is nothing to drain.
     KJ_IF_SOME(ready, state.tryGetActiveUnsafe()) {
       UpdateBackpressureScope scope(*this);
@@ -667,7 +666,7 @@ class ConsumerImpl final {
         weak->runIfAlive([&](ConsumerImpl& self) {
           self.state.template transitionTo<Errored>(reason.addRef(js));
           KJ_IF_SOME(listener, self.stateListener) {
-            listener.onConsumerError(js, kj::mv(reason));
+            listener.onConsumerError(js, reason);
             // After this point, we should not assume that this consumer can
             // be safely used at all. It's most likely the stateListener has
             // released it.
@@ -730,8 +729,8 @@ class ValueQueue final {
     jsg::Promise<ReadResult>::Resolver resolver;
 
     void resolveAsDone(jsg::Lock& js);
-    void resolve(jsg::Lock& js, jsg::Value value);
-    void reject(jsg::Lock& js, jsg::Value& value);
+    void resolve(jsg::Lock& js, jsg::JsValue value);
+    void reject(jsg::Lock& js, jsg::JsValue value);
 
     JSG_MEMORY_INFO(ValueQueue::ReadRequest) {
       tracker.trackField("resolver", resolver);
@@ -742,12 +741,12 @@ class ValueQueue final {
   // calculated by the size algorithm function provided in the stream constructor.
   class Entry: public kj::Refcounted {
    public:
-    explicit Entry(jsg::Value value, size_t size);
+    explicit Entry(jsg::Lock&, jsg::JsValue value, size_t size);
     KJ_DISALLOW_COPY_AND_MOVE(Entry);
 
-    jsg::Value getValue(jsg::Lock& js);
+    jsg::JsValue getValue(jsg::Lock& js);
 
-    size_t getSize() const;
+    size_t getSize(jsg::Lock& js) const;
 
     void visitForGc(jsg::GcVisitor& visitor);
 
@@ -758,7 +757,7 @@ class ValueQueue final {
     }
 
    private:
-    jsg::Value value;
+    jsg::JsRef<jsg::JsValue> value;
     size_t size;
   };
 
@@ -767,7 +766,8 @@ class ValueQueue final {
     QueueEntry clone(jsg::Lock& js);
 
     JSG_MEMORY_INFO(ValueQueue::QueueEntry) {
-      tracker.trackFieldWithSize("entry", entry->getSize());
+      // TODO(soon): Add support for kj::Rc types in memory tracker
+      //tracker.trackFieldWithSize("entry", entry->getSize());
     }
   };
 
@@ -782,13 +782,13 @@ class ValueQueue final {
     Consumer& operator=(Consumer&&) = delete;
     Consumer& operator=(Consumer&) = delete;
 
-    void cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason);
+    void cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason);
 
     void close(jsg::Lock& js);
 
     bool empty();
 
-    void error(jsg::Lock& js, jsg::Value reason);
+    void error(jsg::Lock& js, jsg::JsValue reason);
 
     void read(jsg::Lock& js, ReadRequest request);
 
@@ -832,7 +832,7 @@ class ValueQueue final {
 
   ssize_t desiredSize() const;
 
-  void error(jsg::Lock& js, jsg::Value reason);
+  void error(jsg::Lock& js, jsg::JsValue reason);
 
   void maybeUpdateBackpressure();
 
@@ -844,7 +844,7 @@ class ValueQueue final {
 
   bool wantsRead() const;
 
-  bool hasPartiallyFulfilledRead();
+  bool hasPartiallyFulfilledRead(jsg::Lock& js);
 
   void visitForGc(jsg::GcVisitor& visitor);
 
@@ -889,7 +889,7 @@ class ByteQueue final {
     kj::Maybe<ByobRequest&> byobReadRequest;
 
     struct PullInto {
-      jsg::BufferSource store;
+      jsg::JsRef<jsg::JsArrayBufferView> store;
       size_t filled = 0;
       size_t atLeast = 1;
       Type type = Type::DEFAULT;
@@ -905,7 +905,7 @@ class ByteQueue final {
     ~ReadRequest() noexcept(false);
     void resolveAsDone(jsg::Lock& js);
     void resolve(jsg::Lock& js);
-    void reject(jsg::Lock& js, jsg::Value& value);
+    void reject(jsg::Lock& js, jsg::JsValue value);
 
     kj::Own<ByobRequest> makeByobReadRequest(ConsumerImpl& consumer, QueueImpl& queue);
 
@@ -938,7 +938,7 @@ class ByteQueue final {
 
     bool respond(jsg::Lock& js, size_t amount);
 
-    bool respondWithNewView(jsg::Lock& js, jsg::BufferSource view);
+    bool respondWithNewView(jsg::Lock& js, jsg::JsBufferSource view);
 
     // Disconnects this ByobRequest instance from the associated ByteQueue::ReadRequest.
     // The term "invalidate" is adopted from the streams spec for handling BYOB requests.
@@ -948,17 +948,17 @@ class ByteQueue final {
       return request == kj::none;
     }
 
-    bool isPartiallyFulfilled();
+    bool isPartiallyFulfilled(jsg::Lock& js);
 
     size_t getAtLeast() const;
 
-    v8::Local<v8::Uint8Array> getView(jsg::Lock& js);
+    kj::Maybe<jsg::JsUint8Array> getView(jsg::Lock& js);
 
     // Returns the byte length of the original underlying ArrayBuffer.
     size_t getOriginalBufferByteLength(jsg::Lock& js) const;
 
     // Returns the byte offset of the original view plus bytes filled.
-    size_t getOriginalByteOffsetPlusBytesFilled() const;
+    size_t getOriginalByteOffsetPlusBytesFilled(jsg::Lock& js) const;
 
     JSG_MEMORY_INFO(ByteQueue::ByobRequest) {}
 
@@ -980,15 +980,15 @@ class ByteQueue final {
     }
   };
 
-  // A byte queue entry consists of a jsg::BufferSource containing a non-zero-length
+  // A byte queue entry consists of a JsBufferSource containing a non-zero-length
   // sequence of bytes. The size is determined by the number of bytes in the entry.
   class Entry: public kj::Refcounted {
    public:
-    explicit Entry(jsg::BufferSource store);
+    explicit Entry(jsg::Lock& js, jsg::JsBufferSource store);
 
-    kj::ArrayPtr<kj::byte> toArrayPtr();
+    kj::ArrayPtr<kj::byte> toArrayPtr(jsg::Lock& js);
 
-    size_t getSize() const;
+    size_t getSize(jsg::Lock& js) const;
 
     void visitForGc(jsg::GcVisitor& visitor);
 
@@ -999,7 +999,7 @@ class ByteQueue final {
     }
 
    private:
-    jsg::BufferSource store;
+    jsg::JsRef<jsg::JsBufferSource> store;
   };
 
   struct QueueEntry {
@@ -1009,7 +1009,8 @@ class ByteQueue final {
     QueueEntry clone(jsg::Lock& js);
 
     JSG_MEMORY_INFO(ByteQueue::QueueEntry) {
-      tracker.trackFieldWithSize("entry", entry->getSize());
+      // TODO(soon): Add support for kj::Rc<T> types to memory tracker
+      //tracker.trackFieldWithSize("entry", entry->getSize());
     }
   };
 
@@ -1024,13 +1025,13 @@ class ByteQueue final {
     Consumer& operator=(Consumer&&) = delete;
     Consumer& operator=(Consumer&) = delete;
 
-    void cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason);
+    void cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason);
 
     void close(jsg::Lock& js);
 
     bool empty() const;
 
-    void error(jsg::Lock& js, jsg::Value reason);
+    void error(jsg::Lock& js, jsg::JsValue reason);
 
     void read(jsg::Lock& js, ReadRequest request);
 
@@ -1070,7 +1071,7 @@ class ByteQueue final {
 
   ssize_t desiredSize() const;
 
-  void error(jsg::Lock& js, jsg::Value reason);
+  void error(jsg::Lock& js, jsg::JsValue reason);
 
   void maybeUpdateBackpressure();
 
@@ -1082,7 +1083,7 @@ class ByteQueue final {
 
   bool wantsRead() const;
 
-  bool hasPartiallyFulfilledRead();
+  bool hasPartiallyFulfilledRead(jsg::Lock& js);
 
   // nextPendingByobReadRequest will be used to support the ReadableStreamBYOBRequest interface
   // that is part of ReadableByteStreamController. When user code calls the `controller.byobRequest`

--- a/src/workerd/api/streams/readable-source-adapter-test.c++
+++ b/src/workerd/api/streams/readable-source-adapter-test.c++
@@ -838,10 +838,10 @@ KJ_TEST("Read all bytes") {
 
     return env.context
         .awaitJs(env.js,
-            adapter->readAllBytes(env.js).then(
-                env.js, [&adapter = *adapter](jsg::Lock& js, jsg::BufferSource result) {
+            adapter->readAllBytes(env.js).then(env.js,
+                [&adapter = *adapter](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> result) {
       // With exponential growth strategy: 1024 + 2048 + 4096 + 8192 = 15360
-      KJ_ASSERT(result.size() == 15360);
+      KJ_ASSERT(result.getHandle(js).size() == 15360);
       KJ_ASSERT(adapter.isClosed(), "Adapter should be closed after readAllText()");
     })).attach(kj::mv(adapter));
   });

--- a/src/workerd/api/streams/readable-source-adapter-test.c++
+++ b/src/workerd/api/streams/readable-source-adapter-test.c++
@@ -114,9 +114,10 @@ KJ_TEST("Adapter shutdown with no reads") {
     adapter->shutdown(env.js);  // second call is no-op
 
     // Read after shutdown should be resolved immediate
+    auto u8 = jsg::JsUint8Array::create(env.js, 10);
     auto read = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, 10)),
+          .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
         });
     KJ_ASSERT(read.getState(env.js) ==
             jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult>::State::FULFILLED,
@@ -144,9 +145,10 @@ KJ_TEST("Adapter cancel with no reads") {
 
     adapter->cancel(env.js, env.js.error("boom"));
 
+    auto u8 = jsg::JsUint8Array::create(env.js, 10);
     auto read = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, 10)),
+          .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
         });
     KJ_ASSERT(read.getState(env.js) ==
             jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult>::State::REJECTED,
@@ -200,25 +202,21 @@ KJ_TEST("Adapter with single read (ArrayBuffer)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 10;
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, bufferSize);
+    auto u8 = jsg::JsUint8Array::create(env.js, 10);
 
     return env.context
         .awaitJs(env.js,
             adapter
                 ->read(env.js,
                     ReadableStreamSourceJsAdapter::ReadOptions{
-                      .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                      .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
                       .minBytes = 5,
                     })
                 .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 10, "Read buffer should be full size");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaaaaaaaaa"_kjb);
-
-      // BufferSource should be an ArrayBuffer
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsArrayBuffer());
+      KJ_ASSERT(!result.done, "Stream should not be done yet");
+      KJ_ASSERT(handle.asArrayPtr().size() == 10, "Read buffer should be full size");
+      KJ_ASSERT(handle.asArrayPtr() == "aaaaaaaaaa"_kjb);
     })).attach(kj::mv(adapter));
   });
 }
@@ -236,25 +234,22 @@ KJ_TEST("Adapter with single read (Uint8Array)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 10;
-    auto backing = jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize);
+    auto u8 = jsg::JsUint8Array::create(env.js, 10);
 
     return env.context
         .awaitJs(env.js,
             adapter
                 ->read(env.js,
                     ReadableStreamSourceJsAdapter::ReadOptions{
-                      .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                      .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
                       .minBytes = 5,
                     })
                 .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 10, "Read buffer should be full size");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaaaaaaaaa"_kjb);
-
-      // BufferSource should be an ArrayBuffer
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsUint8Array());
+      KJ_ASSERT(!result.done, "Stream should not be done yet");
+      KJ_ASSERT(handle.asArrayPtr().size() == 10, "Read buffer should be full size");
+      KJ_ASSERT(handle.asArrayPtr() == "aaaaaaaaaa"_kjb);
+      KJ_ASSERT(handle.isUint8Array());
     })).attach(kj::mv(adapter));
   });
 }
@@ -272,25 +267,24 @@ KJ_TEST("Adapter with single read (Int32Array)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 16;
-    auto backing = jsg::BackingStore::alloc<v8::Int32Array>(env.js, bufferSize);
+    auto ab = jsg::JsArrayBuffer::create(env.js, 16);
+    auto i32 = v8::Int32Array::New(ab, 0, 4);
+    auto i32View = jsg::JsArrayBufferView(i32);
 
     return env.context
         .awaitJs(env.js,
             adapter
                 ->read(env.js,
                     ReadableStreamSourceJsAdapter::ReadOptions{
-                      .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                      .buffer = i32View.addRef(env.js),
                       .minBytes = 5,
                     })
                 .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 16, "Read buffer should be full size");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaaaaaaaaaaaaaaa"_kjb);
-
-      // BufferSource should be an ArrayBuffer
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsInt32Array());
+      KJ_ASSERT(!result.done, "Stream should not be done yet");
+      KJ_ASSERT(handle.asArrayPtr().size() == 16, "Read buffer should be full size");
+      KJ_ASSERT(handle.asArrayPtr() == "aaaaaaaaaaaaaaaa"_kjb);
+      KJ_ASSERT(handle.isInt32Array());
     })).attach(kj::mv(adapter));
   });
 }
@@ -308,24 +302,21 @@ KJ_TEST("Adapter with single large read (ArrayBuffer)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 16 * 1024;
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, bufferSize);
+    auto u8 = jsg::JsUint8Array::create(env.js, 16 * 1024);
 
     return env.context
         .awaitJs(env.js,
             adapter
                 ->read(env.js,
                     ReadableStreamSourceJsAdapter::ReadOptions{
-                      .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                      .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
                       .minBytes = 5,
                     })
                 .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 16 * 1024, "Read buffer should be full size");
-
-      // BufferSource should be an ArrayBuffer
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsArrayBuffer());
+      KJ_ASSERT(!result.done, "Stream should not be done yet");
+      KJ_ASSERT(handle.asArrayPtr().size() == 16 * 1024, "Read buffer should be full size");
+      KJ_ASSERT(handle.isUint8Array());
     })).attach(kj::mv(adapter));
   });
 }
@@ -343,24 +334,21 @@ KJ_TEST("Adapter with single small read (ArrayBuffer)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 1;
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, bufferSize);
+    auto u8 = jsg::JsUint8Array::create(env.js, 1);
 
     return env.context
         .awaitJs(env.js,
             adapter
                 ->read(env.js,
                     ReadableStreamSourceJsAdapter::ReadOptions{
-                      .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                      .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
                       .minBytes = 5,
                     })
                 .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 1, "Read buffer should be full size");
-
-      // BufferSource should be an ArrayBuffer
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsArrayBuffer());
+      KJ_ASSERT(!result.done, "Stream should not be done yet");
+      KJ_ASSERT(handle.asArrayPtr().size() == 1, "Read buffer should be full size");
+      KJ_ASSERT(handle.isUint8Array());
     })).attach(kj::mv(adapter));
   });
 }
@@ -378,23 +366,20 @@ KJ_TEST("Adapter with minimal reads (Uint8Array)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 10;
-    auto backing = jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize);
+    auto u8 = jsg::JsUint8Array::create(env.js, 10);
 
     auto promise = adapter
                        ->read(env.js,
                            ReadableStreamSourceJsAdapter::ReadOptions{
-                             .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                             .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
                              .minBytes = 3,
                            })
                        .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 3, "Read buffer should be three bytes");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaa"_kjb);
-
-      // BufferSource should be an ArrayBuffer
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsUint8Array());
+      KJ_ASSERT(!result.done, "Stream should not be done yet");
+      KJ_ASSERT(handle.asArrayPtr().size() == 3, "Read buffer should be three bytes");
+      KJ_ASSERT(handle.asArrayPtr() == "aaa"_kjb);
+      KJ_ASSERT(handle.isUint8Array());
     });
 
     return env.context.awaitJs(env.js, kj::mv(promise)).attach(kj::mv(adapter));
@@ -414,23 +399,22 @@ KJ_TEST("Adapter with minimal reads (Uint32Array)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 16;
-    auto backing = jsg::BackingStore::alloc<v8::Uint32Array>(env.js, bufferSize);
+    auto ab = jsg::JsArrayBuffer::create(env.js, 16);
+    auto u32 = v8::Uint32Array::New(ab, 0, 4);
+    auto u32View = jsg::JsArrayBufferView(u32);
 
     auto promise = adapter
                        ->read(env.js,
                            ReadableStreamSourceJsAdapter::ReadOptions{
-                             .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                             .buffer = u32View.addRef(env.js),
                              .minBytes = 3,  // Impl with round up to 4
                            })
                        .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 4, "Read buffer should be four bytes");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaaa"_kjb);
-
-      // BufferSource should be an ArrayBuffer
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsUint32Array());
+      KJ_ASSERT(!result.done, "Stream should not be done yet");
+      KJ_ASSERT(handle.asArrayPtr().size() == 4, "Read buffer should be four bytes");
+      KJ_ASSERT(handle.asArrayPtr() == "aaaa"_kjb);
+      KJ_ASSERT(handle.isUint32Array());
     });
 
     return env.context.awaitJs(env.js, kj::mv(promise)).attach(kj::mv(adapter));
@@ -450,23 +434,22 @@ KJ_TEST("Adapter with over large min reads (Uint32Array)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 16;
-    auto backing = jsg::BackingStore::alloc<v8::Uint32Array>(env.js, bufferSize);
+    auto ab = jsg::JsArrayBuffer::create(env.js, 16);
+    auto u32 = v8::Uint32Array::New(ab, 0, 4);
+    auto u32View = jsg::JsArrayBufferView(u32);
 
     auto promise = adapter
                        ->read(env.js,
                            ReadableStreamSourceJsAdapter::ReadOptions{
-                             .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                             .buffer = u32View.addRef(env.js),
                              .minBytes = 24,  // Impl with round up to 4
                            })
                        .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 16, "Read buffer should be four bytes");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaaaaaaaaaaaaaaa"_kjb);
-
-      // BufferSource should be an ArrayBuffer
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsUint32Array());
+      KJ_ASSERT(!result.done, "Stream should not be done yet");
+      KJ_ASSERT(handle.asArrayPtr().size() == 16, "Read buffer should be four bytes");
+      KJ_ASSERT(handle.asArrayPtr() == "aaaaaaaaaaaaaaaa"_kjb);
+      KJ_ASSERT(handle.isUint32Array());
     });
 
     return env.context.awaitJs(env.js, kj::mv(promise)).attach(kj::mv(adapter));
@@ -484,19 +467,18 @@ KJ_TEST("Adapter with over large min reads (Uint32Array)") {
     KJ_ASSERT(
         adapter->isCanceled() == kj::none, "Adapter should not be canceled upon construction");
 
-    const size_t bufferSize = 1;
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, bufferSize);
+    auto u8 = jsg::JsUint8Array::create(env.js, 1);
 
     auto promise = adapter
                        ->read(env.js,
                            ReadableStreamSourceJsAdapter::ReadOptions{
-                             .buffer = jsg::BufferSource(env.js, kj::mv(backing)),
+                             .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
                            })
                        .then(env.js, [](jsg::Lock& js, auto result) {
-      KJ_ASSERT(result.done, "Stream should be done");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 0, "Read buffer should be 0 bytes");
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsArrayBuffer());
+      KJ_ASSERT(result.done, "Stream should be done");
+      KJ_ASSERT(handle.asArrayPtr().size() == 0, "Read buffer should be 0 bytes");
+      KJ_ASSERT(handle.isUint8Array());
     });
 
     return env.context.awaitJs(env.js, kj::mv(promise)).attach(kj::mv(adapter));
@@ -518,20 +500,21 @@ KJ_TEST("Adapter with multiple reads (Uint8Array)") {
 
     const size_t bufferSize = 10;
 
+    auto u81 = jsg::JsUint8Array::create(env.js, bufferSize);
+    auto u82 = jsg::JsUint8Array::create(env.js, bufferSize);
+    auto u83 = jsg::JsUint8Array::create(env.js, bufferSize);
+
     auto read1 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u81).addRef(env.js),
         });
     auto read2 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u82).addRef(env.js),
         });
     auto read3 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u83).addRef(env.js),
         });
 
     return env.context
@@ -539,20 +522,23 @@ KJ_TEST("Adapter with multiple reads (Uint8Array)") {
             read1
                 .then(env.js,
                     [read2 = kj::mv(read2)](jsg::Lock& js, auto result) mutable {
+      auto handle = result.buffer.getHandle(js);
       KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 10, "Read buffer should be full size");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaaaaaaaaa"_kjb);
+      KJ_ASSERT(handle.asArrayPtr().size() == 10, "Read buffer should be full size");
+      KJ_ASSERT(handle.asArrayPtr() == "aaaaaaaaaa"_kjb);
       return kj::mv(read2);
     })
                 .then(env.js, [read3 = kj::mv(read3)](jsg::Lock& js, auto result) mutable {
+      auto handle = result.buffer.getHandle(js);
       KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 10, "Read buffer should be full size");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaaaaaaaaa"_kjb);
+      KJ_ASSERT(handle.asArrayPtr().size() == 10, "Read buffer should be full size");
+      KJ_ASSERT(handle.asArrayPtr() == "aaaaaaaaaa"_kjb);
       return kj::mv(read3);
     }).then(env.js, [](jsg::Lock& js, auto result) mutable {
+      auto handle = result.buffer.getHandle(js);
       KJ_ASSERT(!result.done, "Stream should not be done yet");
-      KJ_ASSERT(result.buffer.asArrayPtr().size() == 10, "Read buffer should be full size");
-      KJ_ASSERT(result.buffer.asArrayPtr() == "aaaaaaaaaa"_kjb);
+      KJ_ASSERT(handle.asArrayPtr().size() == 10, "Read buffer should be full size");
+      KJ_ASSERT(handle.asArrayPtr() == "aaaaaaaaaa"_kjb);
       return js.resolvedPromise();
     })).attach(kj::mv(adapter));
   });
@@ -573,20 +559,21 @@ KJ_TEST("Adapter with multiple reads shutdown") {
 
     const size_t bufferSize = 10;
 
+    auto u81 = jsg::JsUint8Array::create(env.js, bufferSize);
+    auto u82 = jsg::JsUint8Array::create(env.js, bufferSize);
+    auto u83 = jsg::JsUint8Array::create(env.js, bufferSize);
+
     auto read1 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u81).addRef(env.js),
         });
     auto read2 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u82).addRef(env.js),
         });
     auto read3 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u83).addRef(env.js),
         });
 
     adapter->shutdown(env.js);
@@ -634,20 +621,21 @@ KJ_TEST("Adapter with multiple reads cancel") {
 
     const size_t bufferSize = 10;
 
+    auto u81 = jsg::JsUint8Array::create(env.js, bufferSize);
+    auto u82 = jsg::JsUint8Array::create(env.js, bufferSize);
+    auto u83 = jsg::JsUint8Array::create(env.js, bufferSize);
+
     auto read1 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u81).addRef(env.js),
         });
     auto read2 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u82).addRef(env.js),
         });
     auto read3 = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(
-              env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, bufferSize)),
+          .buffer = jsg::JsArrayBufferView(u83).addRef(env.js),
         });
 
     adapter->cancel(env.js, env.js.error("boom"));
@@ -699,9 +687,11 @@ KJ_TEST("Adapter close after read") {
     auto adapter = kj::heap<ReadableStreamSourceJsAdapter>(
         env.js, env.context, newReadableSource(kj::mv(fake)));
 
+    auto u8 = jsg::JsUint8Array::create(env.js, 10);
+
     auto read = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, 10)),
+          .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
         });
 
     auto closePromise = adapter->close(env.js);
@@ -731,9 +721,11 @@ KJ_TEST("Adapter close") {
     auto closePromise = adapter->close(env.js);
 
     // reads after close should be resoved immediately.
+    auto u8 = jsg::JsUint8Array::create(env.js, 10);
+
     auto read = adapter->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = jsg::BufferSource(env.js, jsg::BackingStore::alloc<v8::Uint8Array>(env.js, 10)),
+          .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
         });
     KJ_ASSERT(read.getState(env.js) ==
             jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult>::State::FULFILLED,
@@ -784,22 +776,22 @@ KJ_TEST("After read BackingStore maintains identity") {
     std::unique_ptr<v8::BackingStore> backing =
         v8::ArrayBuffer::NewBackingStore(env.js.v8Isolate, 10);
     auto* backingPtr = backing.get();
-    v8::Local<v8::ArrayBuffer> originalArrayBuffer =
-        v8::ArrayBuffer::New(env.js.v8Isolate, kj::mv(backing));
-    jsg::BufferSource source(env.js, originalArrayBuffer);
+    auto ab = jsg::JsArrayBuffer::create(env.js, kj::mv(backing));
+    auto u8 = jsg::JsUint8Array::create(env.js, ab);
 
     return env.context
         .awaitJs(env.js,
             adapter
                 ->read(env.js,
                     ReadableStreamSourceJsAdapter::ReadOptions{
-                      .buffer = jsg::BufferSource(env.js, originalArrayBuffer),
+                      .buffer = jsg::JsArrayBufferView(u8).addRef(env.js),
                       .minBytes = 5,
                     })
                 .then(env.js, [backingPtr](jsg::Lock& js, auto result) {
       auto handle = result.buffer.getHandle(js);
-      KJ_ASSERT(handle->IsArrayBuffer());
-      auto backing = handle.template As<v8::ArrayBuffer>()->GetBackingStore();
+      KJ_ASSERT(handle.isUint8Array());
+      v8::Local<v8::ArrayBuffer> buf = handle.getBuffer();
+      auto backing = buf->GetBackingStore();
       KJ_ASSERT(backing.get() == backingPtr);
       return js.resolvedPromise();
     })).attach(kj::mv(adapter));
@@ -926,31 +918,31 @@ KJ_TEST("tee successful") {
     KJ_ASSERT(!branch2->isClosed(), "Branch2 should not be closed after tee");
     KJ_ASSERT(branch2->isCanceled() == kj::none, "Branch2 should not be canceled after tee");
 
-    auto backing1 = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, 11);
-    auto buffer1 = jsg::BufferSource(env.js, kj::mv(backing1));
+    auto u81 = jsg::JsUint8Array::create(env.js, 11);
+    auto u82 = jsg::JsUint8Array::create(env.js, 11);
     auto read1 = branch1->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = kj::mv(buffer1),
+          .buffer = jsg::JsArrayBufferView(u81).addRef(env.js),
         });
-    auto backing2 = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, 11);
-    auto buffer2 = jsg::BufferSource(env.js, kj::mv(backing2));
     auto read2 = branch2->read(env.js,
         ReadableStreamSourceJsAdapter::ReadOptions{
-          .buffer = kj::mv(buffer2),
+          .buffer = jsg::JsArrayBufferView(u82).addRef(env.js),
         });
 
     return env.context
         .awaitJs(env.js,
             kj::mv(read1)
                 .then(env.js, [read2 = kj::mv(read2)](jsg::Lock& js, auto result1) mutable {
+      auto handle = result1.buffer.getHandle(js);
       KJ_ASSERT(!result1.done, "Stream should not be done yet");
-      KJ_ASSERT(result1.buffer.asArrayPtr().size() == 11);
-      KJ_ASSERT(result1.buffer.asArrayPtr() == "hello world"_kjb);
+      KJ_ASSERT(handle.asArrayPtr().size() == 11);
+      KJ_ASSERT(handle.asArrayPtr() == "hello world"_kjb);
       return kj::mv(read2);
     }).then(env.js, [](jsg::Lock& js, auto result2) {
+      auto handle = result2.buffer.getHandle(js);
       KJ_ASSERT(!result2.done, "Stream should not be done yet");
-      KJ_ASSERT(result2.buffer.asArrayPtr().size() == 11);
-      KJ_ASSERT(result2.buffer.asArrayPtr() == "hello world"_kjb);
+      KJ_ASSERT(handle.asArrayPtr().size() == 11);
+      KJ_ASSERT(handle.asArrayPtr() == "hello world"_kjb);
       return js.resolvedPromise();
     })).attach(kj::mv(branch1), kj::mv(branch2));
   });
@@ -974,10 +966,9 @@ jsg::Ref<ReadableStream> createFiniteBytesReadableStream(
         KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableStreamDefaultController>>()));
     auto& counter = *count;
     if (counter++ < 10) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-      jsg::BufferSource buffer(js, kj::mv(backing));
-      buffer.asArrayPtr().fill(96 + counter);  // fill with 'a'...'j'
-      c->enqueue(js, buffer.getHandle(js));
+      auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+      ab.asArrayPtr().fill(96 + counter);  // fill with 'a'...'j'
+      c->enqueue(js, ab);
     }
     if (counter == 10) {
       c->close(js);
@@ -1001,9 +992,8 @@ jsg::Ref<ReadableStream> createFiniteByobReadableStream(jsg::Lock& js, size_t ch
         KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableByteStreamController>>()));
     static int count = 0;
     if (count++ < 10) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-      jsg::BufferSource buffer(js, kj::mv(backing));
-      c->enqueue(js, kj::mv(buffer));
+      auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+      c->enqueue(js, jsg::BufferSource(js, ab));
     }
     if (count == 10) {
       c->close(js);
@@ -1587,10 +1577,9 @@ KJ_TEST("KjAdapter MinReadPolicy IMMEDIATE behavior") {
           controller.template tryGet<jsg::Ref<ReadableStreamDefaultController>>());
       if (counter < 8) {
         // Return 256 bytes per chunk, 8 chunks total (2048 bytes)
-        auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 256);
-        jsg::BufferSource buffer(js, kj::mv(backing));
-        buffer.asArrayPtr().fill(97 + counter);  // 'a', 'b', 'c', etc.
-        c->enqueue(js, buffer.getHandle(js));
+        auto ab = jsg::JsArrayBuffer::create(js, 256);
+        ab.asArrayPtr().fill(97 + counter);  // 'a', 'b', 'c', etc.
+        c->enqueue(js, ab);
         counter++;
       } else {
         c->close(js);
@@ -1643,10 +1632,9 @@ KJ_TEST("KjAdapter MinReadPolicy OPPORTUNISTIC behavior") {
 
       if (counter < 8) {
         // Return 256 bytes per chunk, 8 chunks total (2048 bytes)
-        auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 256);
-        jsg::BufferSource buffer(js, kj::mv(backing));
-        buffer.asArrayPtr().fill(97 + counter);  // 'a', 'b', 'c', etc.
-        c->enqueue(js, buffer.getHandle(js));
+        auto ab = jsg::JsArrayBuffer::create(js, 256);
+        ab.asArrayPtr().fill(97 + counter);  // 'a', 'b', 'c', etc.
+        c->enqueue(js, ab);
         counter++;
       } else {
         c->close(js);

--- a/src/workerd/api/streams/readable-source-adapter-test.c++
+++ b/src/workerd/api/streams/readable-source-adapter-test.c++
@@ -992,8 +992,7 @@ jsg::Ref<ReadableStream> createFiniteByobReadableStream(jsg::Lock& js, size_t ch
         KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableByteStreamController>>()));
     static int count = 0;
     if (count++ < 10) {
-      auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
-      c->enqueue(js, jsg::BufferSource(js, ab));
+      c->enqueue(js, jsg::JsArrayBuffer::create(js, chunkSize));
     }
     if (count == 10) {
       c->close(js);

--- a/src/workerd/api/streams/readable-source-adapter.c++
+++ b/src/workerd/api/streams/readable-source-adapter.c++
@@ -15,13 +15,10 @@ namespace {
 // does that. It takes the original allocation and wraps it into a new ArrayBuffer
 // instance that is wrapped by a zero-length view of the same type as the original
 // TypedArray we were given.
-jsg::BufferSource transferToEmptyBuffer(jsg::Lock& js, jsg::BufferSource buffer) {
-  KJ_DASSERT(!buffer.isDetached() && buffer.canDetach(js));
-  auto backing = buffer.detach(js);
-  backing.limit(0);
-  auto buf = jsg::BufferSource(js, kj::mv(backing));
-  KJ_DASSERT(buf.size() == 0);
-  return kj::mv(buf);
+jsg::JsArrayBufferView transferToEmptyBuffer(jsg::Lock& js, jsg::JsArrayBufferView buffer) {
+  KJ_DASSERT(!buffer.isDetached() && buffer.isDetachable());
+  auto backing = buffer.detachAndTake(js);
+  return backing.slice(js, 0, 0);
 }
 }  // namespace
 
@@ -168,11 +165,12 @@ jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult> ReadableStreamSourceJsAd
     return js.rejectedPromise<ReadResult>(js.exceptionToJs(exception.clone()));
   }
 
+  auto buffer = options.buffer.getHandle(js);
   if (state.is<Closed>()) {
     // We are already in a closed state. This is a no-op, just return
     // an empty buffer.
     return js.resolvedPromise(ReadResult{
-      .buffer = transferToEmptyBuffer(js, kj::mv(options.buffer)),
+      .buffer = transferToEmptyBuffer(js, buffer).addRef(js),
       .done = true,
     });
   }
@@ -185,7 +183,7 @@ jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult> ReadableStreamSourceJsAd
   // Treat them as if the stream is closed.
   if (active.closePending) {
     return js.resolvedPromise(ReadResult{
-      .buffer = transferToEmptyBuffer(js, kj::mv(options.buffer)),
+      .buffer = transferToEmptyBuffer(js, buffer).addRef(js),
       .done = true,
     });
   }
@@ -193,14 +191,10 @@ jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult> ReadableStreamSourceJsAd
   // Ok, we are in a readable state, there are no pending closes.
   // Let's enqueue our read request.
   auto& ioContext = IoContext::current();
-
-  auto buffer = kj::mv(options.buffer);
   auto elementSize = buffer.getElementSize();
 
   // The buffer size should always be a multiple of the element size and should
-  // always be at least as large as minBytes. This should be handled for us by
-  // the jsg::BufferSource, but just to be safe, we will double-check with a
-  // debug assert here.
+  // always be at least as large as minBytes.
   KJ_DASSERT(buffer.size() % elementSize == 0);
 
   auto minBytes = kj::min(options.minBytes.orDefault(elementSize), buffer.size());
@@ -231,41 +225,43 @@ jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult> ReadableStreamSourceJsAd
   }));
   return ioContext
       .awaitIo(js, kj::mv(promise),
-          [buffer = kj::mv(buffer), self = selfRef.addRef()](jsg::Lock& js,
-              size_t bytesRead) mutable -> jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult> {
-    // If the bytesRead is 0, that indicates the stream is closed. We will
-    // move the stream to a closed state and return the empty buffer.
-    if (bytesRead == 0) {
-      self->runIfAlive([](ReadableStreamSourceJsAdapter& self) {
-        KJ_IF_SOME(open, self.state.tryGetActiveUnsafe()) {
-          open.active->closePending = true;
-        }
-      });
-      return js.resolvedPromise(ReadResult{
-        .buffer = transferToEmptyBuffer(js, kj::mv(buffer)),
-        .done = true,
-      });
-    }
-    KJ_DASSERT(bytesRead <= buffer.size());
+          JSG_VISITABLE_LAMBDA((buffer = buffer.addRef(js), self = selfRef.addRef()), (buffer),
+              (jsg::Lock & js, size_t bytesRead) mutable
+                  ->jsg::Promise<ReadableStreamSourceJsAdapter::ReadResult> {
+                    // If the bytesRead is 0, that indicates the stream is closed. We will
+                    // move the stream to a closed state and return the empty buffer.
+                    auto handle = buffer.getHandle(js);
+                    if (bytesRead == 0) {
+                    self->runIfAlive([](ReadableStreamSourceJsAdapter& self) {
+                      KJ_IF_SOME(open, self.state.tryGetActiveUnsafe()) {
+                      open.active->closePending = true;
+                      } else {
+                      }
+                    });
+                    return js.resolvedPromise(ReadResult{
+                      .buffer = transferToEmptyBuffer(js, handle).addRef(js),
+                      .done = true,
+                    });
+                    }
+                    KJ_DASSERT(bytesRead <= handle.size());
 
-    // If bytesRead is not a multiple of the element size, that indicates
-    // that the source either read less than minBytes (and ended), or is
-    // simply unable to satisfy the element size requirement. We cannot
-    // provide a partial element to the caller, so reject the read.
-    if (bytesRead % buffer.getElementSize() != 0) {
-      return js.rejectedPromise<ReadResult>(
-          js.typeError(kj::str("The underlying stream failed to provide a multiple of the "
-                               "target element size ",
-              buffer.getElementSize())));
-    }
+                    // If bytesRead is not a multiple of the element size, that indicates
+                    // that the source either read less than minBytes (and ended), or is
+                    // simply unable to satisfy the element size requirement. We cannot
+                    // provide a partial element to the caller, so reject the read.
+                    if (bytesRead % handle.getElementSize() != 0) {
+                    return js.rejectedPromise<ReadResult>(js.typeError(
+                        kj::str("The underlying stream failed to provide a multiple of the "
+                                "target element size ",
+                            handle.getElementSize())));
+                    }
 
-    auto backing = buffer.detach(js);
-    backing.limit(bytesRead);
-    return js.resolvedPromise(ReadResult{
-      .buffer = jsg::BufferSource(js, kj::mv(backing)),
-      .done = false,
-    });
-  })
+                    auto backing = handle.detachAndTake(js);
+                    return js.resolvedPromise(ReadResult{
+                      .buffer = backing.slice(js, 0, bytesRead).addRef(js),
+                      .done = false,
+                    });
+                  }))
       .catch_(js,
           [self = selfRef.addRef()](
               jsg::Lock& js, jsg::Value exception) -> ReadableStreamSourceJsAdapter::ReadResult {

--- a/src/workerd/api/streams/readable-source-adapter.c++
+++ b/src/workerd/api/streams/readable-source-adapter.c++
@@ -377,20 +377,20 @@ jsg::Promise<jsg::JsRef<jsg::JsString>> ReadableStreamSourceJsAdapter::readAllTe
   });
 }
 
-jsg::Promise<jsg::BufferSource> ReadableStreamSourceJsAdapter::readAllBytes(
+jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> ReadableStreamSourceJsAdapter::readAllBytes(
     jsg::Lock& js, uint64_t limit) {
   KJ_IF_SOME(exception, state.tryGetErrorUnsafe()) {
     // Really should not have been called if errored but just in case,
     // return a rejected promise.
-    return js.rejectedPromise<jsg::BufferSource>(js.exceptionToJs(exception.clone()));
+    return js.rejectedPromise<jsg::JsRef<jsg::JsArrayBuffer>>(js.exceptionToJs(exception.clone()));
   }
 
   if (state.is<Closed>()) {
     // We are already in a closed state. This is a no-op. This really
     // should not have been called if closed but just in case, return
     // a resolved promise.
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 0);
-    return js.resolvedPromise(jsg::BufferSource(js, kj::mv(backing)));
+    auto ab = jsg::JsArrayBuffer::create(js, 0);
+    return js.resolvedPromise(ab.addRef(js));
   }
 
   auto& open = state.requireActiveUnsafe();
@@ -398,7 +398,7 @@ jsg::Promise<jsg::BufferSource> ReadableStreamSourceJsAdapter::readAllBytes(
   auto& active = *open.active;
 
   if (active.closePending) {
-    return js.rejectedPromise<jsg::BufferSource>(
+    return js.rejectedPromise<jsg::JsRef<jsg::JsArrayBuffer>>(
         js.typeError("Close already pending, cannot read."));
   }
   active.closePending = true;
@@ -424,16 +424,16 @@ jsg::Promise<jsg::BufferSource> ReadableStreamSourceJsAdapter::readAllBytes(
       KJ_DASSERT(result.size() == amount);
       // We have to copy the data into the backing store because of the
       // v8 sandboxing rules.
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, amount);
-      backing.asArrayPtr().copyFrom(result);
-      return jsg::BufferSource(js, kj::mv(backing));
+      auto ab = jsg::JsArrayBuffer::create(js, result);
+      return ab.addRef(js);
     } else {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 0);
-      return jsg::BufferSource(js, kj::mv(backing));
+      auto ab = jsg::JsArrayBuffer::create(js, 0);
+      return ab.addRef(js);
     }
   })
       .catch_(js,
-          [self = selfRef.addRef()](jsg::Lock& js, jsg::Value&& exception) -> jsg::BufferSource {
+          [self = selfRef.addRef()](
+              jsg::Lock& js, jsg::Value&& exception) -> jsg::JsRef<jsg::JsArrayBuffer> {
     // Likewise, while nothing should be waiting on the ready promise, we
     // should still reject it just in case.
     auto error = jsg::JsValue(exception.getHandle(js));

--- a/src/workerd/api/streams/readable-source-adapter.c++
+++ b/src/workerd/api/streams/readable-source-adapter.c++
@@ -325,7 +325,7 @@ jsg::Promise<jsg::JsRef<jsg::JsString>> ReadableStreamSourceJsAdapter::readAllTe
     // We are already in a closed state. This is a no-op. This really
     // should not have been called if closed but just in case, return
     // a resolved promise.
-    return js.resolvedPromise(jsg::JsRef(js, js.str()));
+    return js.resolvedPromise(js.str().addRef(js));
   }
 
   auto& open = state.requireActiveUnsafe();
@@ -357,9 +357,9 @@ jsg::Promise<jsg::JsRef<jsg::JsString>> ReadableStreamSourceJsAdapter::readAllTe
         [&](ReadableStreamSourceJsAdapter& self) { self.state.transitionTo<Closed>(); });
     KJ_IF_SOME(result, holder->result) {
       KJ_DASSERT(result.size() == amount);
-      return jsg::JsRef(js, js.str(result));
+      return js.str(result).addRef(js);
     } else {
-      return jsg::JsRef(js, js.str());
+      return js.str().addRef(js);
     }
   })
       .catch_(js,
@@ -585,11 +585,11 @@ using JsByteSource = kj::OneOf<jsg::JsRef<jsg::JsString>,
 
 kj::Maybe<JsByteSource> tryExtractJsByteSource(jsg::Lock& js, const jsg::JsValue& jsval) {
   KJ_IF_SOME(abView, jsval.tryCast<jsg::JsArrayBuffer>()) {
-    return kj::Maybe(jsg::JsRef(js, abView));
+    return kj::Maybe(abView.addRef(js));
   } else KJ_IF_SOME(ab, jsval.tryCast<jsg::JsArrayBufferView>()) {
-    return kj::Maybe(jsg::JsRef(js, ab));
+    return kj::Maybe(ab.addRef(js));
   } else KJ_IF_SOME(str, jsval.tryCast<jsg::JsString>()) {
-    return kj::Maybe(jsg::JsRef(js, str));
+    return kj::Maybe(str.addRef(js));
   }
   return kj::none;
 }
@@ -749,7 +749,7 @@ jsg::Promise<kj::Own<ReadableSourceKjAdapter::ReadContext>> ReadableSourceKjAdap
 
     // Ok, we have some data. Let's make sure it is bytes.
     // We accept either an ArrayBuffer, ArrayBufferView, or string.
-    auto jsval = jsg::JsValue(value.getHandle(js));
+    auto jsval = value.getHandle(js);
     KJ_IF_SOME(result, tryExtractJsByteSource(js, jsval)) {
       // Process the resulting data.
       KJ_IF_SOME(leftOver, copyFromSource(js, *context, result)) {
@@ -1326,8 +1326,7 @@ jsg::Promise<kj::Array<T>> ReadableSourceKjAdapter::readAllReadImpl(jsg::Lock& j
     auto leftover = readable.view.asBytes();
     if (leftover.size() > limit) {
       auto error = js.rangeError("Memory limit would be exceeded before EOF.");
-      return active->reader->cancel(js, error).then(
-          js, [ex = jsg::JsRef(js, error)](jsg::Lock& js) {
+      return active->reader->cancel(js, error).then(js, [ex = error.addRef(js)](jsg::Lock& js) {
         return js.rejectedPromise<kj::Array<T>>(ex.getHandle(js));
       });
     }
@@ -1358,7 +1357,7 @@ jsg::Promise<kj::Array<T>> ReadableSourceKjAdapter::readAllReadImpl(jsg::Lock& j
     }
 
     auto& value = KJ_ASSERT_NONNULL(result.value);
-    auto jsval = jsg::JsValue(value.getHandle(js));
+    auto jsval = value.getHandle(js);
 
     kj::ArrayPtr<const kj::byte> bytes;
     kj::Maybe<kj::String> maybeOwnedString;
@@ -1374,16 +1373,14 @@ jsg::Promise<kj::Array<T>> ReadableSourceKjAdapter::readAllReadImpl(jsg::Lock& j
     } else {
       auto error = js.typeError("ReadableStream provided a non-bytes value. Only ArrayBuffer, "
                                 "ArrayBufferView, or string are supported.");
-      return active->reader->cancel(js, error).then(
-          js, [err = jsg::JsRef(js, error)](jsg::Lock& js) {
+      return active->reader->cancel(js, error).then(js, [err = error.addRef(js)](jsg::Lock& js) {
         return js.rejectedPromise<kj::Array<T>>(err.getHandle(js));
       });
     }
 
     if (accumulated.size() + bytes.size() > limit) {
       auto error = js.rangeError("Memory limit would be exceeded before EOF.");
-      return active->reader->cancel(js, error).then(
-          js, [err = jsg::JsRef(js, error)](jsg::Lock& js) {
+      return active->reader->cancel(js, error).then(js, [err = error.addRef(js)](jsg::Lock& js) {
         return js.rejectedPromise<kj::Array<T>>(err.getHandle(js));
       });
     }

--- a/src/workerd/api/streams/readable-source-adapter.h
+++ b/src/workerd/api/streams/readable-source-adapter.h
@@ -159,7 +159,7 @@ class ReadableStreamSourceJsAdapter final {
     // is equal to the length of this buffer. The actual number of
     // bytes read is indicated by the resolved value of the promise
     // but will never exceed the length of this buffer.
-    jsg::BufferSource buffer;
+    jsg::JsRef<jsg::JsArrayBufferView> buffer;
 
     // The optional minimum number of bytes to read. If not provided,
     // the read will complete as soon as at least the mininum number
@@ -179,7 +179,7 @@ class ReadableStreamSourceJsAdapter final {
     // of the same type as that provided in ReadOptions.
     // If the read produced no data because the stream is
     // closed, the type array will be zero length.
-    jsg::BufferSource buffer;
+    jsg::JsRef<jsg::JsArrayBufferView> buffer;
 
     // True if the stream is now closed and no further reads
     // are possible. If this is true, the buffer will be zero

--- a/src/workerd/api/streams/readable-source-adapter.h
+++ b/src/workerd/api/streams/readable-source-adapter.h
@@ -210,7 +210,8 @@ class ReadableStreamSourceJsAdapter final {
   // If there are pending reads when this is called, those reads
   // will be allowed to complete first, and then the stream will
   // be read to the end.
-  jsg::Promise<jsg::BufferSource> readAllBytes(jsg::Lock& js, uint64_t limit = kj::maxValue);
+  jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> readAllBytes(
+      jsg::Lock& js, uint64_t limit = kj::maxValue);
 
   // If the stream is still active, tries to get the total length,
   // if known. If the length is not known, the encoding does not

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -74,36 +74,35 @@ jsg::Promise<ReadResult> ReaderImpl::read(
   assertAttachedOrTerminal();
   if (state.is<Released>()) {
     return js.rejectedPromise<ReadResult>(
-        js.v8TypeError("This ReadableStream reader has been released."_kj));
+        js.typeError("This ReadableStream reader has been released."_kj));
   }
   if (state.is<Closed>()) {
-    return js.rejectedPromise<ReadResult>(
-        js.v8TypeError("This ReadableStream has been closed."_kj));
+    return js.rejectedPromise<ReadResult>(js.typeError("This ReadableStream has been closed."_kj));
   }
   auto& attached = state.requireActiveUnsafe();
   KJ_IF_SOME(options, byobOptions) {
     // Per the spec, we must perform these checks before disturbing the stream.
     size_t atLeast = options.atLeast.orDefault(1);
+    auto view = options.bufferView.getHandle(js);
 
-    if (options.byteLength == 0) {
+    if (view.size() == 0) {
       return js.rejectedPromise<ReadResult>(
-          js.v8TypeError("You must call read() on a \"byob\" reader with a positive-sized "
-                         "TypedArray object."_kj));
+          js.typeError("You must call read() on a \"byob\" reader with a positive-sized "
+                       "TypedArray object."_kj));
     }
     if (atLeast == 0) {
-      return js.rejectedPromise<ReadResult>(js.v8TypeError(
+      return js.rejectedPromise<ReadResult>(js.typeError(
           kj::str("Requested invalid minimum number of bytes to read (", atLeast, ").")));
     }
 
     // Both read() and readAtLeast() pass atLeast in element count.
     // Convert to bytes before validation and forwarding to the controller.
-    jsg::BufferSource source(js, options.bufferView.getHandle(js));
-    auto elementSize = source.getElementSize();
+    auto elementSize = view.getElementSize();
     atLeast = atLeast * elementSize;
 
-    if (atLeast > options.byteLength) {
-      return js.rejectedPromise<ReadResult>(js.v8TypeError(kj::str("Minimum bytes to read (",
-          atLeast, ") exceeds size of buffer (", options.byteLength, ").")));
+    if (atLeast > view.size()) {
+      return js.rejectedPromise<ReadResult>(js.typeError(kj::str(
+          "Minimum bytes to read (", atLeast, ") exceeds size of buffer (", view.size(), ").")));
     }
 
     options.atLeast = atLeast;
@@ -224,13 +223,11 @@ void ReadableStreamBYOBReader::lockToStream(jsg::Lock& js, ReadableStream& strea
 }
 
 jsg::Promise<ReadResult> ReadableStreamBYOBReader::read(jsg::Lock& js,
-    v8::Local<v8::ArrayBufferView> byobBuffer,
+    jsg::JsArrayBufferView byobBuffer,
     jsg::Optional<ReadableStreamBYOBReaderReadOptions> maybeOptions) {
   static const ReadableStreamBYOBReaderReadOptions defaultOptions{};
   auto options = ReadableStreamController::ByobOptions{
-    .bufferView = js.v8Ref(byobBuffer),
-    .byteOffset = byobBuffer->ByteOffset(),
-    .byteLength = byobBuffer->ByteLength(),
+    .bufferView = byobBuffer.addRef(js),
     .atLeast = maybeOptions.orDefault(defaultOptions).min.orDefault(1),
     .detachBuffer = FeatureFlags::get(js).getStreamsByobReaderDetachesBuffer(),
   };
@@ -238,11 +235,9 @@ jsg::Promise<ReadResult> ReadableStreamBYOBReader::read(jsg::Lock& js,
 }
 
 jsg::Promise<ReadResult> ReadableStreamBYOBReader::readAtLeast(
-    jsg::Lock& js, int minElements, v8::Local<v8::ArrayBufferView> byobBuffer) {
+    jsg::Lock& js, int minElements, jsg::JsArrayBufferView byobBuffer) {
   auto options = ReadableStreamController::ByobOptions{
-    .bufferView = js.v8Ref(byobBuffer),
-    .byteOffset = byobBuffer->ByteOffset(),
-    .byteLength = byobBuffer->ByteLength(),
+    .bufferView = byobBuffer.addRef(js),
     .atLeast = minElements,
     .detachBuffer = true,
   };

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -39,12 +39,11 @@ void ReaderImpl::detach() {
   }
 }
 
-jsg::Promise<void> ReaderImpl::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+jsg::Promise<void> ReaderImpl::cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   assertAttachedOrTerminal();
   if (state.is<Released>()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This ReadableStream reader has been released."_kj));
+        js.typeError("This ReadableStream reader has been released."_kj));
   }
   if (state.is<Closed>()) {
     return js.resolvedPromise();
@@ -153,8 +152,8 @@ void ReadableStreamDefaultReader::attach(
 }
 
 jsg::Promise<void> ReadableStreamDefaultReader::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
-  return impl.cancel(js, kj::mv(maybeReason));
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
+  return impl.cancel(js, maybeReason);
 }
 
 void ReadableStreamDefaultReader::detach() {
@@ -206,8 +205,8 @@ void ReadableStreamBYOBReader::attach(
 }
 
 jsg::Promise<void> ReadableStreamBYOBReader::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
-  return impl.cancel(js, kj::mv(maybeReason));
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
+  return impl.cancel(js, maybeReason);
 }
 
 void ReadableStreamBYOBReader::detach() {
@@ -311,11 +310,11 @@ jsg::Promise<DrainingReadResult> DrainingReader::read(jsg::Lock& js, size_t maxR
         return kj::mv(result);
       }
       return js.rejectedPromise<DrainingReadResult>(
-          js.v8TypeError("Unable to perform draining read on this stream."_kj));
+          js.typeError("Unable to perform draining read on this stream."_kj));
     }
     KJ_CASE_ONEOF(r, Released) {
       return js.rejectedPromise<DrainingReadResult>(
-          js.v8TypeError("This ReadableStream reader has been released."_kj));
+          js.typeError("This ReadableStream reader has been released."_kj));
     }
     KJ_CASE_ONEOF(c, StreamStates::Closed) {
       return js.resolvedPromise(DrainingReadResult{
@@ -327,8 +326,7 @@ jsg::Promise<DrainingReadResult> DrainingReader::read(jsg::Lock& js, size_t maxR
   KJ_UNREACHABLE;
 }
 
-jsg::Promise<void> DrainingReader::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+jsg::Promise<void> DrainingReader::cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(i, Initial) {
       KJ_FAIL_ASSERT("this reader was never attached");
@@ -339,7 +337,7 @@ jsg::Promise<void> DrainingReader::cancel(
     }
     KJ_CASE_ONEOF(r, Released) {
       return js.rejectedPromise<void>(
-          js.v8TypeError("This ReadableStream reader has been released."_kj));
+          js.typeError("This ReadableStream reader has been released."_kj));
     }
     KJ_CASE_ONEOF(c, StreamStates::Closed) {
       return js.resolvedPromise();
@@ -426,11 +424,10 @@ ReadableStreamController& ReadableStream::getController() {
   return *controller;
 }
 
-jsg::Promise<void> ReadableStream::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+jsg::Promise<void> ReadableStream::cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   if (isLocked()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This ReadableStream is currently locked to a reader."_kj));
+        js.typeError("This ReadableStream is currently locked to a reader."_kj));
   }
   return getController().cancel(js, maybeReason);
 }
@@ -491,12 +488,12 @@ jsg::Promise<void> ReadableStream::pipeTo(jsg::Lock& js,
     jsg::Optional<PipeToOptions> maybeOptions) {
   if (isLocked()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This ReadableStream is currently locked to a reader."_kj));
+        js.typeError("This ReadableStream is currently locked to a reader."_kj));
   }
 
   if (destination->getController().isLockedToWriter()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream is currently locked to a writer"_kj));
+        js.typeError("This WritableStream is currently locked to a writer"_kj));
   }
 
   auto options = kj::mv(maybeOptions).orDefault({});
@@ -598,24 +595,28 @@ jsg::Ref<ReadableStream> ReadableStream::constructor(jsg::Lock& js,
 }
 
 jsg::Optional<uint32_t> ByteLengthQueuingStrategy::size(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeValue) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeValue) {
   KJ_IF_SOME(value, maybeValue) {
-    if ((value)->IsArrayBuffer()) {
-      auto buffer = value.As<v8::ArrayBuffer>();
-      return buffer->ByteLength();
-    } else if ((value)->IsArrayBufferView()) {
-      auto view = value.As<v8::ArrayBufferView>();
-      return view->ByteLength();
-    } else {
-      // Per the WHATWG Streams spec, ByteLengthQueuingStrategy.size should return
-      // GetV(chunk, "byteLength"), which means getting the byteLength property
-      // from any object, not just ArrayBuffer/ArrayBufferView.
-      KJ_IF_SOME(obj, jsg::JsValue(value).tryCast<jsg::JsObject>()) {
-        auto byteLength = obj.get(js, "byteLength"_kj);
-        KJ_IF_SOME(num, byteLength.tryCast<jsg::JsNumber>()) {
-          KJ_IF_SOME(val, num.value(js)) {
-            return static_cast<uint32_t>(val);
-          }
+    KJ_IF_SOME(ab, value.tryCast<jsg::JsArrayBuffer>()) {
+      return ab.size();
+    }
+    KJ_IF_SOME(sab, value.tryCast<jsg::JsSharedArrayBuffer>()) {
+      return sab.size();
+    }
+    KJ_IF_SOME(view, value.tryCast<jsg::JsArrayBufferView>()) {
+      return view.size();
+    }
+    KJ_IF_SOME(str, value.tryCast<jsg::JsString>()) {
+      return str.utf8Length(js);
+    }
+    // Per the WHATWG Streams spec, ByteLengthQueuingStrategy.size should return
+    // GetV(chunk, "byteLength"), which means getting the byteLength property
+    // from any object, not just ArrayBuffer/ArrayBufferView.
+    KJ_IF_SOME(obj, value.tryCast<jsg::JsObject>()) {
+      auto byteLength = obj.get(js, "byteLength"_kj);
+      KJ_IF_SOME(num, byteLength.tryCast<jsg::JsNumber>()) {
+        KJ_IF_SOME(val, num.value(js)) {
+          return static_cast<uint32_t>(val);
         }
       }
     }

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -22,7 +22,7 @@ public:
 
   void attach(ReadableStreamController& controller, jsg::Promise<void> closedPromise);
 
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason);
 
   void detach();
 
@@ -105,7 +105,7 @@ public:
       jsg::Lock& js, jsg::Ref<ReadableStream> stream);
 
   jsg::MemoizedIdentity<jsg::Promise<void>>& getClosed();
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason);
   jsg::Promise<ReadResult> read(jsg::Lock& js);
   void releaseLock(jsg::Lock& js);
 
@@ -156,7 +156,7 @@ public:
       jsg::Ref<ReadableStream> stream);
 
   jsg::MemoizedIdentity<jsg::Promise<void>>& getClosed();
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason);
 
   struct ReadableStreamBYOBReaderReadOptions {
     jsg::Optional<int> min;
@@ -238,7 +238,7 @@ class DrainingReader: public ReadableStreamController::Reader {
   jsg::Promise<DrainingReadResult> read(jsg::Lock& js, size_t maxRead = kj::maxValue);
 
   // Cancels the stream.
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason);
 
   // Releases the lock on the stream.
   void releaseLock(jsg::Lock& js);
@@ -312,7 +312,7 @@ public:
   // results. `reason` will be passed to the underlying source's cancel algorithm -- if this
   // readable stream is one side of a transform stream, then its cancel algorithm causes the
   // transform's writable side to become errored with `reason`.
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason);
 
   using Reader = kj::OneOf<jsg::Ref<ReadableStreamDefaultReader>,
                            jsg::Ref<ReadableStreamBYOBReader>>;
@@ -492,7 +492,7 @@ struct QueuingStrategyInit {
 };
 
 using QueuingStrategySizeFunction =
-    jsg::Optional<uint32_t>(jsg::Optional<v8::Local<v8::Value>>);
+    jsg::Optional<uint32_t>(jsg::Optional<jsg::JsValue>);
 
 // Utility class defined by the streams spec that uses byteLength to calculate
 // backpressure changes.
@@ -519,7 +519,7 @@ public:
   }
 
 private:
-  static jsg::Optional<uint32_t> size(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>>);
+  static jsg::Optional<uint32_t> size(jsg::Lock& js, jsg::Optional<jsg::JsValue>);
 
   QueuingStrategyInit init;
 };
@@ -549,7 +549,7 @@ public:
   }
 
 private:
-  static jsg::Optional<uint32_t> size(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>>) {
+  static jsg::Optional<uint32_t> size(jsg::Lock& js, jsg::Optional<jsg::JsValue>) {
     return 1;
   }
 

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -163,7 +163,7 @@ public:
     JSG_STRUCT(min);
   };
 
-  jsg::Promise<ReadResult> read(jsg::Lock& js, v8::Local<v8::ArrayBufferView> byobBuffer,
+  jsg::Promise<ReadResult> read(jsg::Lock& js, jsg::JsArrayBufferView byobBuffer,
       jsg::Optional<ReadableStreamBYOBReaderReadOptions> options = kj::none);
 
   // Non-standard extension so that reads can specify a minimum number of elements to read. It's a
@@ -175,7 +175,7 @@ public:
   // TODO(soon): Like fetch() and Cache.match(), readAtLeast() returns a promise for a V8 object.
   jsg::Promise<ReadResult> readAtLeast(jsg::Lock& js,
                                         int minElements,
-                                        v8::Local<v8::ArrayBufferView> byobBuffer);
+                                        jsg::JsArrayBufferView byobBuffer);
 
   void releaseLock(jsg::Lock& js);
 

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -230,8 +230,8 @@ KJ_TEST("ReadableStream read all bytes (value readable)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
-        js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
-      KJ_ASSERT(text.asArrayPtr() == "Hello, world!"_kjb);
+        js, [&](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> text) {
+      KJ_ASSERT(text.getHandle(js).asArrayPtr() == "Hello, world!"_kjb);
       checked++;
     });
 
@@ -287,8 +287,8 @@ KJ_TEST("ReadableStream read all bytes (byte readable)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
-        js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
-      KJ_ASSERT(text.asArrayPtr() == "Hello, world!"_kjb);
+        js, [&](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> text) {
+      KJ_ASSERT(text.getHandle(js).asArrayPtr() == "Hello, world!"_kjb);
       checked++;
     });
 
@@ -349,8 +349,8 @@ KJ_TEST("ReadableStream read all bytes (value readable, more reads)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
-        js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
-      KJ_ASSERT(text.asArrayPtr() == "Hello, world!"_kjb);
+        js, [&](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> text) {
+      KJ_ASSERT(text.getHandle(js).asArrayPtr() == "Hello, world!"_kjb);
       checked++;
     });
 
@@ -412,8 +412,8 @@ KJ_TEST("ReadableStream read all bytes (byte readable, more reads)") {
 
     // Starts a read loop of javascript promises.
     auto promise = rs->getController().readAllBytes(js, 20).then(
-        js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
-      KJ_ASSERT(text.asArrayPtr() == "Hello, world!"_kjb);
+        js, [&](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> text) {
+      KJ_ASSERT(text.getHandle(js).asArrayPtr() == "Hello, world!"_kjb);
       checked++;
     });
 
@@ -479,8 +479,9 @@ KJ_TEST("ReadableStream read all bytes (byte readable, large data)") {
     // Starts a read loop of javascript promises.
     auto promise = rs->getController()
                        .readAllBytes(js, (BASE * 7) + 1)
-                       .then(js, [&](jsg::Lock& js, jsg::BufferSource&& text) {
+                       .then(js, [&](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> buf) {
       kj::byte check[BASE * 7]{};
+      auto text = buf.getHandle(js);
       kj::arrayPtr(check).first(BASE).fill('A');
       kj::arrayPtr(check).slice(BASE).first(BASE * 2).fill('B');
       kj::arrayPtr(check).slice(BASE * 3).fill('C');
@@ -545,9 +546,8 @@ KJ_TEST("ReadableStream read all bytes (value readable, wrong type)") {
     // clang-format on
 
     // Starts a read loop of javascript promises.
-    auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
-        [&](jsg::Lock& js, jsg::Value&& exception) {
+    auto promise = rs->getController().readAllBytes(js, 20).then(
+        js, [](auto&, auto) { KJ_UNREACHABLE; }, [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) ==
           "TypeError: This ReadableStream did not return bytes.");
       checked++;
@@ -600,9 +600,8 @@ KJ_TEST("ReadableStream read all bytes (value readable, to many bytes)") {
     // clang-format on
 
     // Starts a read loop of javascript promises.
-    auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
-        [&](jsg::Lock& js, jsg::Value&& exception) {
+    auto promise = rs->getController().readAllBytes(js, 20).then(
+        js, [](auto&, auto) { KJ_UNREACHABLE; }, [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "TypeError: Memory limit exceeded before EOF.");
       checked++;
     });
@@ -655,9 +654,8 @@ KJ_TEST("ReadableStream read all bytes (byte readable, to many bytes)") {
     // clang-format on
 
     // Starts a read loop of javascript promises.
-    auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
-        [&](jsg::Lock& js, jsg::Value&& exception) {
+    auto promise = rs->getController().readAllBytes(js, 20).then(
+        js, [](auto&, auto) { KJ_UNREACHABLE; }, [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "TypeError: Memory limit exceeded before EOF.");
       checked++;
     });
@@ -697,9 +695,8 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed read)") {
     // clang-format on
 
     // Starts a read loop of javascript promises.
-    auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
-        [&](jsg::Lock& js, jsg::Value&& exception) {
+    auto promise = rs->getController().readAllBytes(js, 20).then(
+        js, [](auto&, auto) { KJ_UNREACHABLE; }, [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
       checked++;
     });
@@ -738,9 +735,8 @@ KJ_TEST("ReadableStream read all bytes (value readable, failed read)") {
     // clang-format on
 
     // Starts a read loop of javascript promises.
-    auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
-        [&](jsg::Lock& js, jsg::Value&& exception) {
+    auto promise = rs->getController().readAllBytes(js, 20).then(
+        js, [](auto&, auto) { KJ_UNREACHABLE; }, [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
       checked++;
     });
@@ -780,9 +776,8 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed start)") {
     // clang-format on
 
     // Starts a read loop of javascript promises.
-    auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
-        [&](jsg::Lock& js, jsg::Value&& exception) {
+    auto promise = rs->getController().readAllBytes(js, 20).then(
+        js, [](auto&, auto) { KJ_UNREACHABLE; }, [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
       checked++;
     });
@@ -822,9 +817,8 @@ KJ_TEST("ReadableStream read all bytes (byte readable, failed start 2)") {
     // clang-format on
 
     // Starts a read loop of javascript promises.
-    auto promise = rs->getController().readAllBytes(js, 20).then(js,
-        [](jsg::Lock& js, jsg::BufferSource&& text) { KJ_UNREACHABLE; },
-        [&](jsg::Lock& js, jsg::Value&& exception) {
+    auto promise = rs->getController().readAllBytes(js, 20).then(
+        js, [](auto&, auto) { KJ_UNREACHABLE; }, [&](jsg::Lock& js, jsg::Value&& exception) {
       KJ_ASSERT(kj::str(exception.getHandle(js)) == "Error: boom");
       checked++;
     });

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -15,18 +15,16 @@ void preamble(auto callback) {
   fixture.runInIoContext([&](const TestFixture::Environment& env) { callback(env.js); });
 }
 
-v8::Local<v8::Value> toBytes(jsg::Lock& js, kj::String str) {
-  return jsg::BackingStore::from(js, str.asBytes().attach(kj::mv(str))).createHandle(js);
+jsg::JsUint8Array toBytes(jsg::Lock& js, kj::String str) {
+  return jsg::JsUint8Array::create(js, str.asBytes().slice(0, str.size()));
 }
 
-jsg::BufferSource toBufferSource(jsg::Lock& js, kj::String str) {
-  auto backing = jsg::BackingStore::from(js, str.asBytes().attach(kj::mv(str))).createHandle(js);
-  return jsg::BufferSource(js, kj::mv(backing));
+jsg::JsBufferSource toBufferSource(jsg::Lock& js, kj::String str) {
+  return jsg::JsBufferSource(jsg::JsUint8Array::create(js, str.asBytes().slice(0, str.size())));
 }
 
-jsg::BufferSource toBufferSource(jsg::Lock& js, kj::Array<kj::byte> bytes) {
-  auto backing = jsg::BackingStore::from(js, kj::mv(bytes)).createHandle(js);
-  return jsg::BufferSource(js, kj::mv(backing));
+jsg::JsBufferSource toBufferSource(jsg::Lock& js, kj::Array<kj::byte> bytes) {
+  return jsg::JsBufferSource(jsg::JsUint8Array::create(js, bytes));
 }
 
 // ======================================================================================
@@ -522,11 +520,8 @@ KJ_TEST("ReadableStream read all bytes (value readable, wrong type)") {
         // require at least three reads to complete: one for the first chunk, 'hello, ',
         // one for the second chunk, 'world!', and one to signal close.
         KJ_SWITCH_ONEOF(controller) {
-          // Because we're using a value-based stream, two enqueue operations will
-          // require at least three reads to complete: one for the first chunk, 'hello, ',
-          // one for the second chunk, 'world!', and one to signal close.
           KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-            c->enqueue(js, js.str("wrong type"_kjc));
+            c->enqueue(js, js.num(1));
             checked++;
             return js.resolvedPromise();
           }
@@ -2116,7 +2111,7 @@ KJ_TEST("DrainingReader: pull that synchronously errors does not UAF (value stre
       .pull = [&](jsg::Lock& js, UnderlyingSource::Controller controller) {
         KJ_SWITCH_ONEOF(controller) {
           KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {
-            c->error(js, js.v8TypeError("test error"_kj));
+            c->error(js, js.typeError("test error"_kj));
             return js.resolvedPromise();
           }
           KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
@@ -2354,7 +2349,7 @@ KJ_TEST("DrainingReader: pending error in endOperation rejects read (value strea
             // and calls doError(), which defers the error because beginOperation() is
             // active. When wrapDrainingRead's endOperation() fires, it applies the
             // pending error and should throw rather than returning the data.
-            return js.rejectedPromise<void>(js.v8TypeError("pull failed"_kj));
+            return js.rejectedPromise<void>(js.typeError("pull failed"_kj));
           }
           KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {}
         }
@@ -2390,7 +2385,7 @@ KJ_TEST("DrainingReader: pending error in endOperation rejects read (byte stream
           KJ_CASE_ONEOF(c, jsg::Ref<ReadableStreamDefaultController>) {}
           KJ_CASE_ONEOF(c, jsg::Ref<ReadableByteStreamController>) {
             c->enqueue(js, toBufferSource(js, kj::str("should-be-discarded")));
-            return js.rejectedPromise<void>(js.v8TypeError("pull failed"_kj));
+            return js.rejectedPromise<void>(js.typeError("pull failed"_kj));
           }
         }
         KJ_UNREACHABLE;

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -796,7 +796,7 @@ class ReadableStreamJsController final: public ReadableStreamController {
 
   kj::Maybe<kj::OneOf<DefaultController, ByobController>> getController();
 
-  jsg::Promise<jsg::BufferSource> readAllBytes(jsg::Lock& js, uint64_t limit) override;
+  jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> readAllBytes(jsg::Lock& js, uint64_t limit) override;
   jsg::Promise<kj::String> readAllText(jsg::Lock& js, uint64_t limit) override;
 
   kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) override;
@@ -3223,11 +3223,12 @@ class AllReader {
         limit(limit) {}
   KJ_DISALLOW_COPY_AND_MOVE(AllReader);
 
-  jsg::Promise<jsg::BufferSource> allBytes(jsg::Lock& js) {
-    return loop(js).then(js, [this](auto& js, PartList&& partPtrs) -> jsg::BufferSource {
-      auto out = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, runningTotal);
+  jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> allBytes(jsg::Lock& js) {
+    return loop(js).then(
+        js, [this](auto& js, PartList&& partPtrs) -> jsg::JsRef<jsg::JsArrayBuffer> {
+      auto out = jsg::JsArrayBuffer::create(js, runningTotal);
       copyInto(out.asArrayPtr(), partPtrs.asPtr());
-      return jsg::BufferSource(js, kj::mv(out));
+      return out.addRef(js);
     });
   }
 
@@ -3267,13 +3268,13 @@ class AllReader {
       jsg::Ref<ReadableStream>>;
   State state;
   uint64_t limit;
-  kj::Vector<jsg::BufferSource> parts;
+  kj::Vector<jsg::JsRef<jsg::JsBufferSource>> parts;
   uint64_t runningTotal = 0;
 
   jsg::Promise<PartList> loop(jsg::Lock& js) {
     KJ_SWITCH_ONEOF(state) {
       KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-        return js.resolvedPromise(KJ_MAP(p, parts) { return p.asArrayPtr(); });
+        return js.resolvedPromise(KJ_MAP(p, parts) { return p.getHandle(js).asArrayPtr(); });
       }
       KJ_CASE_ONEOF(errored, StreamStates::Errored) {
         return js.template rejectedPromise<PartList>(errored.getHandle(js));
@@ -3300,7 +3301,7 @@ class AllReader {
                   js, [&](jsg::Lock& js) { return loop(js); });
               }
 
-              jsg::BufferSource bufferSource(js, handle);
+              jsg::JsBufferSource bufferSource(handle);
 
               if (bufferSource.size() == 0) {
               // Weird but allowed, we'll skip it.
@@ -3315,7 +3316,7 @@ class AllReader {
               }
 
               runningTotal += bufferSource.size();
-              parts.add(bufferSource.copy(js));
+              parts.add(bufferSource.addRef(js));
               return loop(js);
             });
 
@@ -3618,7 +3619,7 @@ jsg::Promise<T> ReadableStreamJsController::readAll(jsg::Lock& js, uint64_t limi
     auto reader = kj::heap<AllReader>(addRef(), limit);
 
     auto promise = ([&js, &reader, stripBom]() -> jsg::Promise<T> {
-      if constexpr (kj::isSameType<T, jsg::BufferSource>()) {
+      if constexpr (kj::isSameType<T, jsg::JsRef<jsg::JsArrayBuffer>>()) {
         (void)stripBom;  // Unused in this branch.
         return reader->allBytes(js);
       } else {
@@ -3647,17 +3648,17 @@ jsg::Promise<T> ReadableStreamJsController::readAll(jsg::Lock& js, uint64_t limi
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(initial, Initial) {
       // Stream not yet set up, treat as closed.
-      if constexpr (kj::isSameType<T, jsg::BufferSource>()) {
-        auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 0);
-        return js.resolvedPromise(jsg::BufferSource(js, kj::mv(backing)));
+      if constexpr (kj::isSameType<T, jsg::JsRef<jsg::JsArrayBuffer>>()) {
+        auto ab = jsg::JsArrayBuffer::create(js, 0);
+        return js.resolvedPromise(ab.addRef(js));
       } else {
         return js.resolvedPromise(T());
       }
     }
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-      if constexpr (kj::isSameType<T, jsg::BufferSource>()) {
-        auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, 0);
-        return js.resolvedPromise(jsg::BufferSource(js, kj::mv(backing)));
+      if constexpr (kj::isSameType<T, jsg::JsRef<jsg::JsArrayBuffer>>()) {
+        auto ab = jsg::JsArrayBuffer::create(js, 0);
+        return js.resolvedPromise(ab.addRef(js));
       } else {
         return js.resolvedPromise(T());
       }
@@ -3675,9 +3676,9 @@ jsg::Promise<T> ReadableStreamJsController::readAll(jsg::Lock& js, uint64_t limi
   KJ_UNREACHABLE;
 }
 
-jsg::Promise<jsg::BufferSource> ReadableStreamJsController::readAllBytes(
+jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> ReadableStreamJsController::readAllBytes(
     jsg::Lock& js, uint64_t limit) {
-  return readAll<jsg::BufferSource>(js, limit);
+  return readAll<jsg::JsRef<jsg::JsArrayBuffer>>(js, limit);
 }
 
 jsg::Promise<kj::String> ReadableStreamJsController::readAllText(jsg::Lock& js, uint64_t limit) {

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -62,7 +62,7 @@ class ReadableLockImpl {
   bool lock();
 
   void onClose(jsg::Lock& js);
-  void onError(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void onError(jsg::Lock& js, jsg::JsValue reason);
 
   kj::Maybe<PipeController&> tryPipeLock(Controller& self);
 
@@ -95,14 +95,14 @@ class ReadableLockImpl {
       return inner.state.template is<StreamStates::Closed>();
     }
 
-    kj::Maybe<v8::Local<v8::Value>> tryGetErrored(jsg::Lock& js) override {
+    kj::Maybe<jsg::JsValue> tryGetErrored(jsg::Lock& js) override {
       KJ_IF_SOME(errored, inner.state.template tryGetUnsafe<StreamStates::Errored>()) {
         return errored.getHandle(js);
       }
       return kj::none;
     }
 
-    void cancel(jsg::Lock& js, v8::Local<v8::Value> reason) override {
+    void cancel(jsg::Lock& js, jsg::JsValue reason) override {
       // Cancel here returns a Promise but we do not need to propagate it.
       // We can safely drop it on the floor here.
       auto promise KJ_UNUSED = inner.cancel(js, reason);
@@ -112,11 +112,11 @@ class ReadableLockImpl {
       inner.doClose(js);
     }
 
-    void error(jsg::Lock& js, v8::Local<v8::Value> reason) override {
+    void error(jsg::Lock& js, jsg::JsValue reason) override {
       inner.doError(js, reason);
     }
 
-    void release(jsg::Lock& js, kj::Maybe<v8::Local<v8::Value>> maybeError = kj::none) override {
+    void release(jsg::Lock& js, kj::Maybe<jsg::JsValue> maybeError = kj::none) override {
       KJ_IF_SOME(error, maybeError) {
         cancel(js, error);
       }
@@ -334,7 +334,7 @@ void ReadableLockImpl<Controller>::onClose(jsg::Lock& js) {
 }
 
 template <typename Controller>
-void ReadableLockImpl<Controller>::onError(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void ReadableLockImpl<Controller>::onError(jsg::Lock& js, jsg::JsValue reason) {
   KJ_IF_SOME(locked, state.template tryGetUnsafe<ReaderLocked>()) {
     try {
       maybeRejectPromise<void>(js, locked.getClosedFulfiller(), reason);
@@ -429,7 +429,7 @@ void WritableLockImpl<Controller>::releaseWriter(
 
       // Per spec (WritableStreamDefaultWriterRelease), both the ready and closed
       // promises must be rejected when the writer is released.
-      auto releaseReason = js.v8TypeError("This WritableStream writer has been released."_kjc);
+      auto releaseReason = js.typeError("This WritableStream writer has been released."_kjc);
       if (FeatureFlags::get(js).getWritableStreamSpecCompliantWriter()) {
         if (locked.getReadyFulfiller() != kj::none) {
           maybeRejectPromise<void>(js, locked.getReadyFulfiller(), releaseReason);
@@ -515,7 +515,7 @@ kj::Maybe<jsg::Promise<void>> WritableLockImpl<Controller>::PipeLocked::checkSig
     if (signal->getAborted(js)) {
       auto reason = signal->getReason(js);
       if (!flags.preventCancel) {
-        source.release(js, v8::Local<v8::Value>(reason));
+        source.release(js, reason);
       } else {
         source.release(js);
       }
@@ -611,21 +611,33 @@ jsg::Promise<void> maybeRunAlgorithmAsync(
     // rare cases. For those we return a rejected promise but do not call the
     // onFailure case since such errors are generally indicative of a fatal
     // condition in the isolate (e.g. out of memory, other fatal exception, etc).
-    return js.tryCatch([&] {
+    JSG_TRY(js) {
       KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
-        return js
-            .tryCatch([&] { return algorithm(js, kj::fwd<decltype(args)>(args)...); },
-                [&](jsg::Value&& exception) { return js.rejectedPromise<void>(kj::mv(exception)); })
-            .then(js, ioContext.addFunctor(kj::mv(onSuccess)),
-                ioContext.addFunctor(kj::mv(onFailure)));
+        auto getInnerPromise = [&]() -> jsg::Promise<void> {
+          JSG_TRY(js) {
+            return algorithm(js, kj::fwd<decltype(args)>(args)...);
+          }
+          JSG_CATCH(exception) {
+            return js.rejectedPromise<void>(kj::mv(exception));
+          }
+        };
+        return getInnerPromise().then(
+            js, ioContext.addFunctor(kj::mv(onSuccess)), ioContext.addFunctor(kj::mv(onFailure)));
       } else {
-        return js
-            .tryCatch([&] { return algorithm(js, kj::fwd<decltype(args)>(args)...); },
-                [&](jsg::Value&& exception) {
-          return js.rejectedPromise<void>(kj::mv(exception));
-        }).then(js, kj::mv(onSuccess), kj::mv(onFailure));
+        auto getInnerPromise = [&]() -> jsg::Promise<void> {
+          JSG_TRY(js) {
+            return algorithm(js, kj::fwd<decltype(args)>(args)...);
+          }
+          JSG_CATCH(exception) {
+            return js.rejectedPromise<void>(kj::mv(exception));
+          }
+        };
+        return getInnerPromise().then(js, kj::mv(onSuccess), kj::mv(onFailure));
       }
-    }, [&](jsg::Value&& exception) { return js.rejectedPromise<void>(kj::mv(exception)); });
+    }
+    JSG_CATCH(exception) {
+      return js.rejectedPromise<void>(kj::mv(exception));
+    };
   }
 
   // If the algorithm does not exist, we handle it as a success but ensure
@@ -688,8 +700,9 @@ jsg::Promise<ReadResult> deferControllerStateChange(jsg::Lock& js,
       controller.state.clearPendingState();
       (void)controller.state.endOperation();
     }
-    controller.doError(js, exception.getHandle(js));
-    return js.rejectedPromise<ReadResult>(kj::mv(exception));
+    auto handle = jsg::JsValue(exception.getHandle(js));
+    controller.doError(js, handle);
+    return js.rejectedPromise<ReadResult>(handle);
   });
 }
 
@@ -746,11 +759,11 @@ class ReadableStreamJsController final: public ReadableStreamController {
   // is still pending, the ReadableStream will be no longer usable and any
   // data still in the queue will be dropped. Pending read requests will be
   // rejected if a reason is given, or resolved with no data otherwise.
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) override;
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason) override;
 
   void doClose(jsg::Lock& js);
 
-  void doError(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void doError(jsg::Lock& js, jsg::JsValue reason);
 
   bool canCloseOrEnqueue();
   bool hasBackpressure();
@@ -767,7 +780,7 @@ class ReadableStreamJsController final: public ReadableStreamController {
 
   bool lockReader(jsg::Lock& js, Reader& reader) override;
 
-  kj::Maybe<v8::Local<v8::Value>> isErrored(jsg::Lock& js);
+  kj::Maybe<jsg::JsValue> isErrored(jsg::Lock& js);
 
   kj::Maybe<int> getDesiredSize();
 
@@ -886,7 +899,7 @@ class WritableStreamJsController final: public WritableStreamController {
 
   KJ_DISALLOW_COPY_AND_MOVE(WritableStreamJsController);
 
-  jsg::Promise<void> abort(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) override;
+  jsg::Promise<void> abort(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason) override;
 
   jsg::Ref<WritableStream> addRef() override;
 
@@ -898,16 +911,16 @@ class WritableStreamJsController final: public WritableStreamController {
 
   void doClose(jsg::Lock& js);
 
-  void doError(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void doError(jsg::Lock& js, jsg::JsValue reason);
 
   // Error through the underlying controller if available, going through the proper
   // error transition (Erroring -> Errored).
-  void errorIfNeeded(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void errorIfNeeded(jsg::Lock& js, jsg::JsValue reason);
 
   kj::Maybe<int> getDesiredSize() override;
 
-  kj::Maybe<v8::Local<v8::Value>> isErroring(jsg::Lock& js) override;
-  kj::Maybe<v8::Local<v8::Value>> isErroredOrErroring(jsg::Lock& js);
+  kj::Maybe<jsg::JsValue> isErroring(jsg::Lock& js) override;
+  kj::Maybe<jsg::JsValue> isErroredOrErroring(jsg::Lock& js);
 
   bool isLocked() const;
 
@@ -923,7 +936,7 @@ class WritableStreamJsController final: public WritableStreamController {
 
   bool lockWriter(jsg::Lock& js, Writer& writer) override;
 
-  void maybeRejectReadyPromise(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void maybeRejectReadyPromise(jsg::Lock& js, jsg::JsValue reason);
 
   void maybeResolveReadyPromise(jsg::Lock& js);
 
@@ -944,7 +957,7 @@ class WritableStreamJsController final: public WritableStreamController {
 
   void updateBackpressure(jsg::Lock& js, bool backpressure);
 
-  jsg::Promise<void> write(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> value) override;
+  jsg::Promise<void> write(jsg::Lock& js, jsg::Optional<jsg::JsValue> value) override;
 
   void visitForGc(jsg::GcVisitor& visitor) override;
 
@@ -1028,7 +1041,7 @@ void ReadableImpl<Self>::start(jsg::Lock& js, jsg::Ref<Self> self) {
       (this, self = self.addRef()), (self), (jsg::Lock& js, jsg::Value reason) {
         flags.started = true;
         flags.starting = false;
-        doError(js, kj::mv(reason));
+        doError(js, jsg::JsValue(reason.getHandle(js)));
       });
 
   maybeRunAlgorithm(js, algorithms.start, kj::mv(onSuccess), kj::mv(onFailure), kj::mv(self));
@@ -1042,7 +1055,7 @@ size_t ReadableImpl<Self>::consumerCount() {
 
 template <typename Self>
 jsg::Promise<void> ReadableImpl<Self>::cancel(
-    jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason) {
+    jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason) {
   if (state.template is<StreamStates::Closed>()) {
     // We are already closed. There's nothing to cancel.
     // This shouldn't happen but we handle the case anyway, just to be safe.
@@ -1095,7 +1108,7 @@ bool ReadableImpl<Self>::canCloseOrEnqueue() {
 // that they called cancel. What we do want to do here, tho, is close the implementation
 // and trigger the cancel algorithm.
 template <typename Self>
-void ReadableImpl<Self>::doCancel(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason) {
+void ReadableImpl<Self>::doCancel(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason) {
   state.template transitionTo<StreamStates::Closed>();
 
   auto onSuccess = JSG_VISITABLE_LAMBDA((this, self = self.addRef()), (self), (jsg::Lock& js) {
@@ -1113,7 +1126,7 @@ void ReadableImpl<Self>::doCancel(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<
         // no longer cares and has gone away.
         doClose(js);
         KJ_IF_SOME(pendingCancel, maybePendingCancel) {
-        maybeRejectPromise<void>(js, pendingCancel.fulfiller, reason.getHandle(js));
+        maybeRejectPromise<void>(js, pendingCancel.fulfiller, jsg::JsValue(reason.getHandle(js)));
         } else {
         // Else block to avert dangling else compiler warning.
         }
@@ -1135,11 +1148,10 @@ void ReadableImpl<Self>::close(jsg::Lock& js) {
   JSG_REQUIRE(canCloseOrEnqueue(), TypeError, "This ReadableStream is closed.");
   auto& queue = state.template getUnsafe<Queue>();
 
-  if (queue.hasPartiallyFulfilledRead()) {
-    auto error =
-        js.v8Ref(js.v8TypeError("This ReadableStream was closed with a partial read pending."));
-    doError(js, error.addRef(js));
-    js.throwException(kj::mv(error));
+  if (queue.hasPartiallyFulfilledRead(js)) {
+    auto error = js.typeError("This ReadableStream was closed with a partial read pending.");
+    doError(js, error);
+    js.throwException(error);
     return;
   }
 
@@ -1157,15 +1169,15 @@ void ReadableImpl<Self>::doClose(jsg::Lock& js) {
 }
 
 template <typename Self>
-void ReadableImpl<Self>::doError(jsg::Lock& js, jsg::Value reason) {
+void ReadableImpl<Self>::doError(jsg::Lock& js, jsg::JsValue reason) {
   // If already closed or errored, do nothing
   if (state.isInactive()) {
     return;
   }
 
   auto& queue = state.template getUnsafe<Queue>();
-  queue.error(js, reason.addRef(js));
-  state.template transitionTo<StreamStates::Errored>(kj::mv(reason));
+  queue.error(js, reason);
+  state.template transitionTo<StreamStates::Errored>(reason.addRef(js));
   algorithms.clear();
 }
 
@@ -1214,7 +1226,7 @@ void ReadableImpl<Self>::pullIfNeeded(jsg::Lock& js, jsg::Ref<Self> self) {
   auto onFailure = JSG_VISITABLE_LAMBDA(
       (this, self = self.addRef()), (self), (jsg::Lock& js, jsg::Value reason) {
         flags.pulling = false;
-        doError(js, kj::mv(reason));
+        doError(js, jsg::JsValue(reason.getHandle(js)));
       });
 
   maybeRunAlgorithm(js, algorithms.pull, kj::mv(onSuccess), kj::mv(onFailure), self.addRef());
@@ -1247,7 +1259,7 @@ void ReadableImpl<Self>::forcePullIfNeeded(jsg::Lock& js, jsg::Ref<Self> self) {
   auto onFailure = JSG_VISITABLE_LAMBDA(
       (this, self = self.addRef()), (self), (jsg::Lock& js, jsg::Value reason) {
         flags.pulling = false;
-        doError(js, kj::mv(reason));
+        doError(js, jsg::JsValue(reason.getHandle(js)));
       });
 
   maybeRunAlgorithm(js, algorithms.pull, kj::mv(onSuccess), kj::mv(onFailure), self.addRef());
@@ -1281,16 +1293,16 @@ WritableImpl<Self>::WritableImpl(
 
 template <typename Self>
 jsg::Promise<void> WritableImpl<Self>::abort(
-    jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason) {
+    jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason) {
   // Per the spec, the signal.reason should be a DOMException with name 'AbortError'
   // when no reason is provided, but the stored error should remain as the original reason.
   auto signalReason = [&]() -> jsg::JsValue {
-    if (reason->IsUndefined() && FeatureFlags::get(js).getPedanticWpt()) {
+    if (reason.isUndefined() && FeatureFlags::get(js).getPedanticWpt()) {
       auto ex = js.domException(
           kj::str("AbortError"), kj::str("This writable stream has been aborted."), kj::none);
       return jsg::JsValue(KJ_ASSERT_NONNULL(ex.tryGetHandle(js)));
     }
-    return jsg::JsValue(reason);
+    return reason;
   }();
   signal->triggerAbort(js, signalReason);
 
@@ -1308,7 +1320,7 @@ jsg::Promise<void> WritableImpl<Self>::abort(
   bool wasAlreadyErroring = false;
   if (state.template is<StreamStates::Erroring>()) {
     wasAlreadyErroring = true;
-    reason = js.v8Undefined();
+    reason = js.undefined();
   }
 
   KJ_DEFER(if (!wasAlreadyErroring) { startErroring(js, kj::mv(self), reason); });
@@ -1354,7 +1366,7 @@ void WritableImpl<Self>::advanceQueueIfNeeded(jsg::Lock& js, jsg::Ref<Self> self
 
       auto onFailure = JSG_VISITABLE_LAMBDA(
           (this, self = self.addRef()), (self), (jsg::Lock& js, jsg::Value reason) {
-            finishInFlightClose(js, kj::mv(self), reason.getHandle(js));
+            finishInFlightClose(js, kj::mv(self), jsg::JsValue(reason.getHandle(js)));
           });
 
       // Per the spec, the close algorithm should always run asynchronously, even if
@@ -1405,7 +1417,7 @@ void WritableImpl<Self>::advanceQueueIfNeeded(jsg::Lock& js, jsg::Ref<Self> self
   auto onFailure = JSG_VISITABLE_LAMBDA(
       (this, self = self.addRef(), size), (self), (jsg::Lock& js, jsg::Value reason) {
         amountBuffered -= size;
-        finishInFlightWrite(js, kj::mv(self), reason.getHandle(js));
+        finishInFlightWrite(js, kj::mv(self), jsg::JsValue(reason.getHandle(js)));
         return js.resolvedPromise();
       });
 
@@ -1425,7 +1437,7 @@ void WritableImpl<Self>::advanceQueueIfNeeded(jsg::Lock& js, jsg::Ref<Self> self
 template <typename Self>
 jsg::Promise<void> WritableImpl<Self>::close(jsg::Lock& js, jsg::Ref<Self> self) {
   if (state.template is<StreamStates::Closed>()) {
-    return js.rejectedPromise<void>(js.v8TypeError("This WritableStream has been closed."_kj));
+    return js.rejectedPromise<void>(js.typeError("This WritableStream has been closed."_kj));
   }
   KJ_IF_SOME(errored, state.template tryGetUnsafe<StreamStates::Errored>()) {
     return js.rejectedPromise<void>(errored.addRef(js));
@@ -1449,7 +1461,7 @@ jsg::Promise<void> WritableImpl<Self>::close(jsg::Lock& js, jsg::Ref<Self> self)
 
 template <typename Self>
 void WritableImpl<Self>::dealWithRejection(
-    jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason) {
+    jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason) {
   if (isWritable()) {
     return startErroring(js, kj::mv(self), reason);
   }
@@ -1481,7 +1493,7 @@ void WritableImpl<Self>::doClose(jsg::Lock& js) {
 }
 
 template <typename Self>
-void WritableImpl<Self>::doError(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void WritableImpl<Self>::doError(jsg::Lock& js, jsg::JsValue reason) {
   KJ_ASSERT(closeRequest == kj::none);
   KJ_ASSERT(inFlightClose == kj::none);
   KJ_ASSERT(inFlightWrite == kj::none);
@@ -1497,7 +1509,7 @@ void WritableImpl<Self>::doError(jsg::Lock& js, v8::Local<v8::Value> reason) {
 }
 
 template <typename Self>
-void WritableImpl<Self>::error(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason) {
+void WritableImpl<Self>::error(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason) {
   if (isWritable()) {
     algorithms.clear();
     startErroring(js, kj::mv(self), reason);
@@ -1533,7 +1545,7 @@ void WritableImpl<Self>::finishErroring(jsg::Lock& js, jsg::Ref<Self> self) {
     auto onFailure = JSG_VISITABLE_LAMBDA(
         (this, self = self.addRef()), (self), (jsg::Lock& js, jsg::Value reason) {
           auto& pendingAbort = KJ_ASSERT_NONNULL(maybePendingAbort);
-          pendingAbort->fail(js, reason.getHandle(js));
+          pendingAbort->fail(js, jsg::JsValue(reason.getHandle(js)));
           rejectCloseAndClosedPromiseIfNeeded(js);
         });
 
@@ -1545,7 +1557,7 @@ void WritableImpl<Self>::finishErroring(jsg::Lock& js, jsg::Ref<Self> self) {
 
 template <typename Self>
 void WritableImpl<Self>::finishInFlightClose(
-    jsg::Lock& js, jsg::Ref<Self> self, kj::Maybe<v8::Local<v8::Value>> maybeReason) {
+    jsg::Lock& js, jsg::Ref<Self> self, kj::Maybe<jsg::JsValue> maybeReason) {
   algorithms.clear();
   KJ_ASSERT_NONNULL(inFlightClose);
   KJ_ASSERT(isWritable() || state.template is<StreamStates::Erroring>());
@@ -1576,7 +1588,7 @@ void WritableImpl<Self>::finishInFlightClose(
 
 template <typename Self>
 void WritableImpl<Self>::finishInFlightWrite(
-    jsg::Lock& js, jsg::Ref<Self> self, kj::Maybe<v8::Local<v8::Value>> maybeReason) {
+    jsg::Lock& js, jsg::Ref<Self> self, kj::Maybe<jsg::JsValue> maybeReason) {
   auto& write = KJ_ASSERT_NONNULL(inFlightWrite);
 
   KJ_IF_SOME(reason, maybeReason) {
@@ -1645,7 +1657,7 @@ void WritableImpl<Self>::setup(jsg::Lock& js,
 
   auto onFailure = JSG_VISITABLE_LAMBDA(
       (this, self = self.addRef()), (self), (jsg::Lock& js, jsg::Value reason) {
-        auto handle = reason.getHandle(js);
+        auto handle = jsg::JsValue(reason.getHandle(js));
         KJ_ASSERT(isWritable() || state.template is<StreamStates::Erroring>());
         KJ_IF_SOME(owner, tryGetOwner()) {
         owner.maybeRejectReadyPromise(js, handle);
@@ -1663,13 +1675,12 @@ void WritableImpl<Self>::setup(jsg::Lock& js,
 }
 
 template <typename Self>
-void WritableImpl<Self>::startErroring(
-    jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason) {
+void WritableImpl<Self>::startErroring(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason) {
   KJ_ASSERT(isWritable());
   KJ_IF_SOME(owner, tryGetOwner()) {
     owner.maybeRejectReadyPromise(js, reason);
   }
-  state.template transitionTo<StreamStates::Erroring>(js.v8Ref(reason));
+  state.template transitionTo<StreamStates::Erroring>(js, reason);
   if (inFlightWrite == kj::none && inFlightClose == kj::none && flags.started) {
     finishErroring(js, kj::mv(self));
   }
@@ -1691,20 +1702,21 @@ void WritableImpl<Self>::updateBackpressure(jsg::Lock& js) {
 
 template <typename Self>
 jsg::Promise<void> WritableImpl<Self>::write(
-    jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> value) {
+    jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue value) {
 
   size_t size = 1;
   KJ_IF_SOME(sizeFunc, algorithms.size) {
-    kj::Maybe<jsg::Value> failure;
+    kj::Maybe<jsg::JsValue> failure;
     JSG_TRY(js) {
       size = sizeFunc(js, value);
     }
     JSG_CATCH(exception) {
-      startErroring(js, self.addRef(), exception.getHandle(js));
-      failure = kj::mv(exception);
+      auto handle = jsg::JsValue(exception.getHandle(js));
+      startErroring(js, self.addRef(), handle);
+      failure = handle;
     }
     KJ_IF_SOME(exception, failure) {
-      return js.rejectedPromise<void>(kj::mv(exception));
+      return js.rejectedPromise<void>(exception);
     }
   }
 
@@ -1717,7 +1729,7 @@ jsg::Promise<void> WritableImpl<Self>::write(
     KJ_IF_SOME(owner, tryGetOwner()) {
       if (!owner.isLockedToWriter()) {
         return js.rejectedPromise<void>(
-            js.v8TypeError("This WritableStream writer has been released."_kjc));
+            js.typeError("This WritableStream writer has been released."_kjc));
       }
     }
   }
@@ -1727,7 +1739,7 @@ jsg::Promise<void> WritableImpl<Self>::write(
   }
 
   if (isCloseQueuedOrInFlight() || state.template is<StreamStates::Closed>()) {
-    return js.rejectedPromise<void>(js.v8TypeError("This ReadableStream is closed."_kj));
+    return js.rejectedPromise<void>(js.typeError("This ReadableStream is closed."_kj));
   }
 
   KJ_IF_SOME(erroring, state.template tryGetUnsafe<StreamStates::Erroring>()) {
@@ -1739,7 +1751,7 @@ jsg::Promise<void> WritableImpl<Self>::write(
   auto prp = js.newPromiseAndResolver<void>();
   writeRequests.push_back(WriteRequest{
     .resolver = kj::mv(prp.resolver),
-    .value = js.v8Ref(value),
+    .value = value.addRef(js),
     .size = size,
   });
   amountBuffered += size;
@@ -1883,7 +1895,7 @@ struct ValueReadable final: private api::ValueQueue::ConsumerImpl::StateListener
     });
   }
 
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
     // When a ReadableStream is canceled, the expected behavior is that the underlying
     // controller is notified and the cancel algorithm on the underlying source is
     // called. When there are multiple ReadableStreams sharing consumption of a
@@ -1923,13 +1935,13 @@ struct ValueReadable final: private api::ValueQueue::ConsumerImpl::StateListener
     }
   }
 
-  void onConsumerError(jsg::Lock& js, jsg::Value reason) override {
+  void onConsumerError(jsg::Lock& js, jsg::JsValue reason) override {
     // Called by the consumer when a state change to errored happens.
     // We need to notify the owner. Note that the owner may drop this
     // readable in doClose so it is not safe to access anything on this
     // after calling doError.
     KJ_IF_SOME(s, state) {
-      s.owner.doError(js, reason.getHandle(js));
+      s.owner.doError(js, reason);
     }
   }
 
@@ -2056,39 +2068,39 @@ struct ByteReadable final: private api::ByteQueue::ConsumerImpl::StateListener {
         s.consumer->read(js,
             ByteQueue::ReadRequest(kj::mv(prp.resolver),
                 {
-                  .store = jsg::BufferSource(js, view.detachAndTake(js)),
+                  .store = view.detachAndTake(js).addRef(js),
                   .atLeast = atLeast,
                   .type = ByteQueue::ReadRequest::Type::BYOB,
                 }));
       } else KJ_IF_SOME(chunkSize, autoAllocateChunkSize) {
         // autoAllocateChunkSize is set, so we allocate a buffer and do a BYOB read.
         // This makes the buffer available to the underlying source via controller.byobRequest.
-        KJ_IF_SOME(store, jsg::BufferSource::tryAlloc(js, chunkSize)) {
+        KJ_IF_SOME(store, jsg::JsUint8Array::tryCreate(js, chunkSize)) {
           // Ensure that the handle is created here so that the size of the buffer
           // is accounted for in the isolate memory tracking.
           s.consumer->read(js,
               ByteQueue::ReadRequest(kj::mv(prp.resolver),
                   {
-                    .store = kj::mv(store),
+                    .store = jsg::JsArrayBufferView(store).addRef(js),
                     .type = ByteQueue::ReadRequest::Type::BYOB,
                   }));
         } else {
-          prp.resolver.reject(js, js.v8Error("Failed to allocate buffer for read."));
+          prp.resolver.reject(js, js.error("Failed to allocate buffer for read."));
         }
       } else {
         // autoAllocateChunkSize is not set. Per spec, we do a DEFAULT read which means
         // the underlying source's pull method won't get a byobRequest. It must use
         // controller.enqueue() to provide data instead.
         constexpr size_t kDefaultReadSize = 16384;  // 16KB default buffer
-        KJ_IF_SOME(store, jsg::BufferSource::tryAlloc(js, kDefaultReadSize)) {
+        KJ_IF_SOME(store, jsg::JsUint8Array::tryCreate(js, kDefaultReadSize)) {
           s.consumer->read(js,
               ByteQueue::ReadRequest(kj::mv(prp.resolver),
                   {
-                    .store = kj::mv(store),
+                    .store = jsg::JsArrayBufferView(store).addRef(js),
                     .type = ByteQueue::ReadRequest::Type::DEFAULT,
                   }));
         } else {
-          prp.resolver.reject(js, js.v8Error("Failed to allocate buffer for read."));
+          prp.resolver.reject(js, js.error("Failed to allocate buffer for read."));
         }
       }
 
@@ -2099,9 +2111,9 @@ struct ByteReadable final: private api::ByteQueue::ConsumerImpl::StateListener {
     KJ_IF_SOME(byob, byobOptions) {
       // If a BYOB buffer was given, we need to give it back wrapped in a TypedArray
       // whose size is set to zero.
-      auto view = byob.bufferView.getHandle(js);
+      auto view = byob.bufferView.getHandle(js).detachAndTake(js);
       return js.resolvedPromise(ReadResult{
-        .value = js.v8Ref(v8::Local<v8::Value>(view.slice(js, 0, 0))),
+        .value = jsg::JsValue(view.slice(js, 0, 0)).addRef(js),
         .done = true,
       });
     } else {
@@ -2132,7 +2144,7 @@ struct ByteReadable final: private api::ByteQueue::ConsumerImpl::StateListener {
   // the underlying controller only when the last reader is canceled.
   // Here, we rely on the controller implementing the correct behavior since it owns
   // the queue that knows about all of the attached consumers.
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
     if (pendingCancel) return js.resolvedPromise();
     KJ_IF_SOME(s, state) {
       // Check if there's a pending draining read before calling cancel, since cancel
@@ -2163,11 +2175,11 @@ struct ByteReadable final: private api::ByteQueue::ConsumerImpl::StateListener {
     }
   }
 
-  void onConsumerError(jsg::Lock& js, jsg::Value reason) override {
+  void onConsumerError(jsg::Lock& js, jsg::JsValue reason) override {
     // Note that the owner may drop this readable in doClose so it
     // is not safe to access anything on this after calling doError.
     KJ_IF_SOME(s, state) {
-      s.owner.doError(js, reason.getHandle(js));
+      s.owner.doError(js, reason);
     };
   }
 
@@ -2268,16 +2280,15 @@ void ReadableStreamDefaultController::visitForGc(jsg::GcVisitor& visitor) {
 }
 
 jsg::Promise<void> ReadableStreamDefaultController::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
-  return impl.cancel(js, JSG_THIS, maybeReason.orDefault([&] { return js.v8Undefined(); }));
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
+  return impl.cancel(js, JSG_THIS, maybeReason.orDefault([&] { return js.undefined(); }));
 }
 
 void ReadableStreamDefaultController::close(jsg::Lock& js) {
   impl.close(js);
 }
 
-void ReadableStreamDefaultController::enqueue(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> chunk) {
+void ReadableStreamDefaultController::enqueue(jsg::Lock& js, jsg::Optional<jsg::JsValue> chunk) {
   // Hold a strong reference to prevent this controller from being freed if the
   // user-provided size algorithm (below) re-enters JS and errors the controller
   // through a side-channel (e.g. TransformStreamDefaultController::error()
@@ -2291,7 +2302,7 @@ void ReadableStreamDefaultController::enqueue(
   bool errored = false;
   KJ_IF_SOME(sizeFunc, impl.algorithms.size) {
     js.tryCatch([&] { size = sizeFunc(js, value); }, [&](jsg::Value exception) {
-      impl.doError(js, kj::mv(exception));
+      impl.doError(js, jsg::JsValue(exception.getHandle(js)));
       errored = true;
     });
   }
@@ -2300,12 +2311,12 @@ void ReadableStreamDefaultController::enqueue(
   // throwing (e.g. by calling transformController.error()), in which case
   // `errored` is still false but the impl state has transitioned to Errored.
   if (!errored && impl.canCloseOrEnqueue()) {
-    impl.enqueue(js, kj::rc<ValueQueue::Entry>(js.v8Ref(value), size), kj::mv(self));
+    impl.enqueue(js, kj::rc<ValueQueue::Entry>(js, value, size), kj::mv(self));
   }
 }
 
-void ReadableStreamDefaultController::error(jsg::Lock& js, v8::Local<v8::Value> reason) {
-  impl.doError(js, js.v8Ref(reason));
+void ReadableStreamDefaultController::error(jsg::Lock& js, jsg::JsValue reason) {
+  impl.doError(js, reason);
 }
 
 // When a consumer receives a read request, but does not have the data available to
@@ -2326,19 +2337,28 @@ kj::Own<ValueQueue::Consumer> ReadableStreamDefaultController::getConsumer(
 
 // ======================================================================================
 
+namespace {
+jsg::JsRef<jsg::JsUint8Array> getViewRef(jsg::Lock& js, kj::Maybe<jsg::JsUint8Array> maybeView) {
+  KJ_IF_SOME(view, maybeView) {
+    return view.addRef(js);
+  }
+  KJ_FAIL_ASSERT("BYOB read request's view is expected to be present when updating the view");
+}
+}  // namespace
+
 ReadableStreamBYOBRequest::Impl::Impl(jsg::Lock& js,
     kj::Own<ByteQueue::ByobRequest> readRequest,
     kj::Rc<WeakRef<ReadableByteStreamController>> controller)
     : readRequest(kj::mv(readRequest)),
       controller(kj::mv(controller)),
-      view(js.v8Ref(this->readRequest->getView(js))),
+      view(getViewRef(js, this->readRequest->getView(js))),
       originalBufferByteLength(this->readRequest->getOriginalBufferByteLength(js)),
-      originalByteOffsetPlusBytesFilled(this->readRequest->getOriginalByteOffsetPlusBytesFilled()) {
-}
+      originalByteOffsetPlusBytesFilled(
+          this->readRequest->getOriginalByteOffsetPlusBytesFilled(js)) {}
 
 void ReadableStreamBYOBRequest::Impl::updateView(jsg::Lock& js) {
-  jsg::check(view.getHandle(js)->Buffer()->Detach(v8::Local<v8::Value>()));
-  view = js.v8Ref(readRequest->getView(js));
+  view.getHandle(js).detachInPlace(js);
+  view = getViewRef(js, readRequest->getView(js));
 }
 
 void ReadableStreamBYOBRequest::visitForGc(jsg::GcVisitor& visitor) {
@@ -2360,9 +2380,9 @@ kj::Maybe<int> ReadableStreamBYOBRequest::getAtLeast() {
   return kj::none;
 }
 
-kj::Maybe<jsg::V8Ref<v8::Uint8Array>> ReadableStreamBYOBRequest::getView(jsg::Lock& js) {
+kj::Maybe<jsg::JsUint8Array> ReadableStreamBYOBRequest::getView(jsg::Lock& js) {
   KJ_IF_SOME(impl, maybeImpl) {
-    return impl.view.addRef(js);
+    return impl.view.getHandle(js);
   }
   return kj::none;
 }
@@ -2372,7 +2392,7 @@ void ReadableStreamBYOBRequest::invalidate(jsg::Lock& js) {
     // If the user code happened to have retained a reference to the view or
     // the buffer, we need to detach it so that those references cannot be used
     // to modify or observe modifications.
-    jsg::check(impl.view.getHandle(js)->Buffer()->Detach(v8::Local<v8::Value>()));
+    impl.view.getHandle(js).detachInPlace(js);
     impl.controller->runIfAlive(
         [](ReadableByteStreamController& controller) { controller.maybeByobRequest = kj::none; });
   }
@@ -2382,9 +2402,9 @@ void ReadableStreamBYOBRequest::invalidate(jsg::Lock& js) {
 void ReadableStreamBYOBRequest::respond(jsg::Lock& js, int bytesWritten) {
   auto& impl = JSG_REQUIRE_NONNULL(
       maybeImpl, TypeError, "This ReadableStreamBYOBRequest has been invalidated.");
+  auto handle = impl.view.getHandle(js);
   JSG_REQUIRE(impl.controller->isValid(), Error, "The ReadableStreamBYOBRequest is invalid.");
-  JSG_REQUIRE(impl.view.getHandle(js)->ByteLength() > 0, TypeError,
-      "Cannot respond with a zero-length or detached view");
+  JSG_REQUIRE(handle.size() > 0, TypeError, "Cannot respond with a zero-length or detached view");
   impl.controller->runIfAlive([&](ReadableByteStreamController& controller) {
     if (!controller.canCloseOrEnqueue()) {
       JSG_REQUIRE(bytesWritten == 0, TypeError,
@@ -2396,8 +2416,7 @@ void ReadableStreamBYOBRequest::respond(jsg::Lock& js, int bytesWritten) {
       if (impl.readRequest->isInvalidated() && controller.impl.consumerCount() >= 1) {
         // While this particular request may be invalidated, there are still
         // other branches we can push the data to. Let's do so.
-        jsg::BufferSource source(js, impl.view.getHandle(js));
-        auto entry = kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, source.detach(js)));
+        auto entry = kj::rc<ByteQueue::Entry>(js, jsg::JsBufferSource(handle.detachAndTake(js)));
         controller.impl.enqueue(js, kj::mv(entry), controller.getSelf());
       } else {
         JSG_REQUIRE(bytesWritten > 0, TypeError,
@@ -2420,7 +2439,7 @@ void ReadableStreamBYOBRequest::respond(jsg::Lock& js, int bytesWritten) {
   });
 }
 
-void ReadableStreamBYOBRequest::respondWithNewView(jsg::Lock& js, jsg::BufferSource view) {
+void ReadableStreamBYOBRequest::respondWithNewView(jsg::Lock& js, jsg::JsBufferSource view) {
   auto& impl = JSG_REQUIRE_NONNULL(
       maybeImpl, TypeError, "This ReadableStreamBYOBRequest has been invalidated.");
   JSG_REQUIRE(impl.controller->isValid(), Error, "The ReadableStreamBYOBRequest is invalid.");
@@ -2435,22 +2454,16 @@ void ReadableStreamBYOBRequest::respondWithNewView(jsg::Lock& js, jsg::BufferSou
         // 2. The underlying buffer must not be detached (TypeError)
         // 3. The buffer byte length must not be zero (RangeError)
         // 4. The buffer byte length must match the original (RangeError)
-        auto handle = view.getHandle(js);
-        auto buffer = handle->IsArrayBuffer() ? handle.As<v8::ArrayBuffer>()
-                                              : handle.As<v8::ArrayBufferView>()->Buffer();
-        JSG_REQUIRE(
-            !buffer->WasDetached(), TypeError, "The underlying ArrayBuffer has been detached.");
-
-        JSG_REQUIRE(view.canDetach(js), TypeError, "Unable to use non-detachable ArrayBuffer.");
+        JSG_REQUIRE(!view.isDetached(), TypeError, "The underlying ArrayBuffer has been detached.");
+        JSG_REQUIRE(view.isDetachable(), TypeError, "Unable to use non-detachable ArrayBuffer.");
         // Use the stored values since the ByobRequest may have been invalidated during close.
-        auto actualBufferByteLength = buffer->ByteLength();
+        auto actualBufferByteLength = view.underlyingArrayBufferSize(js);
         JSG_REQUIRE(
             actualBufferByteLength != 0, RangeError, "The underlying ArrayBuffer is zero-length.");
         JSG_REQUIRE(actualBufferByteLength == impl.originalBufferByteLength, RangeError,
             "The underlying ArrayBuffer is not the correct length.");
         // The view's byte offset must match the original byte offset plus bytes filled.
-        auto viewByteOffset =
-            handle->IsArrayBuffer() ? 0 : handle.As<v8::ArrayBufferView>()->ByteOffset();
+        auto viewByteOffset = view.getOffset();
         JSG_REQUIRE(viewByteOffset == impl.originalByteOffsetPlusBytesFilled, RangeError,
             "The view has an invalid byte offset.");
       } else {
@@ -2463,12 +2476,12 @@ void ReadableStreamBYOBRequest::respondWithNewView(jsg::Lock& js, jsg::BufferSou
       if (impl.readRequest->isInvalidated() && controller.impl.consumerCount() >= 1) {
         // While this particular request may be invalidated, there are still
         // other branches we can push the data to. Let's do so.
-        auto entry = kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, view.detach(js)));
+        auto entry = kj::rc<ByteQueue::Entry>(js, view.detachAndTake(js));
         controller.impl.enqueue(js, kj::mv(entry), controller.getSelf());
       } else {
         JSG_REQUIRE(view.size() > 0, TypeError,
             "The view byte length must be more than zero while the stream is open.");
-        if (impl.readRequest->respondWithNewView(js, kj::mv(view))) {
+        if (impl.readRequest->respondWithNewView(js, view)) {
           // The read request was fulfilled, we need to invalidate.
           shouldInvalidate = true;
         } else {
@@ -2487,9 +2500,9 @@ void ReadableStreamBYOBRequest::respondWithNewView(jsg::Lock& js, jsg::BufferSou
   });
 }
 
-bool ReadableStreamBYOBRequest::isPartiallyFulfilled() {
+bool ReadableStreamBYOBRequest::isPartiallyFulfilled(jsg::Lock& js) {
   KJ_IF_SOME(impl, maybeImpl) {
-    return impl.readRequest->isPartiallyFulfilled();
+    return impl.readRequest->isPartiallyFulfilled(js);
   }
   return false;
 }
@@ -2528,7 +2541,7 @@ void ReadableByteStreamController::visitForGc(jsg::GcVisitor& visitor) {
 }
 
 jsg::Promise<void> ReadableByteStreamController::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   KJ_IF_SOME(byobRequest, maybeByobRequest) {
     if (impl.consumerCount() == 1) {
       byobRequest->invalidate(js);
@@ -2539,7 +2552,7 @@ jsg::Promise<void> ReadableByteStreamController::cancel(
 
 void ReadableByteStreamController::close(jsg::Lock& js) {
   KJ_IF_SOME(byobRequest, maybeByobRequest) {
-    JSG_REQUIRE(!byobRequest->isPartiallyFulfilled(), TypeError,
+    JSG_REQUIRE(!byobRequest->isPartiallyFulfilled(js), TypeError,
         "This ReadableStream was closed with a partial read pending.");
   } else if (FeatureFlags::get(js).getPedanticWpt()) {
     // If maybeByobRequest is not set, check if there's a pending byob request.
@@ -2548,7 +2561,7 @@ void ReadableByteStreamController::close(jsg::Lock& js) {
     // respondWithNewView() error handling in the closed state.
     // Only do this if the queue doesn't have a partially fulfilled read.
     KJ_IF_SOME(queue, impl.state.tryGetUnsafe<ByteQueue>()) {
-      if (!queue.hasPartiallyFulfilledRead()) {
+      if (!queue.hasPartiallyFulfilledRead(js)) {
         getByobRequest(js);
       }
     }
@@ -2556,29 +2569,29 @@ void ReadableByteStreamController::close(jsg::Lock& js) {
   impl.close(js);
 }
 
-void ReadableByteStreamController::enqueue(jsg::Lock& js, jsg::BufferSource chunk) {
+void ReadableByteStreamController::enqueue(jsg::Lock& js, jsg::JsBufferSource chunk) {
   // Hold a strong reference up front. Operations below (invalidate, detach) touch
   // the JS heap and C++ argument evaluation order is unspecified, so JSG_THIS as a
   // function argument would not reliably precede chunk.detach(js).
   auto self = JSG_THIS;
 
   JSG_REQUIRE(chunk.size() > 0, TypeError, "Cannot enqueue a zero-length ArrayBuffer.");
-  JSG_REQUIRE(chunk.canDetach(js), TypeError, "The provided ArrayBuffer must be detachable.");
+  JSG_REQUIRE(chunk.isDetachable(), TypeError, "The provided ArrayBuffer must be detachable.");
   JSG_REQUIRE(impl.canCloseOrEnqueue(), TypeError, "This ReadableByteStreamController is closed.");
 
   KJ_IF_SOME(byobRequest, maybeByobRequest) {
     KJ_IF_SOME(view, byobRequest->getView(js)) {
-      JSG_REQUIRE(view.getHandle(js)->ByteLength() > 0, TypeError,
-          "The byobRequest.view is zero-length or was detached");
+      JSG_REQUIRE(
+          view.size() > 0, TypeError, "The byobRequest.view is zero-length or was detached");
     }
     byobRequest->invalidate(js);
   }
 
-  impl.enqueue(js, kj::rc<ByteQueue::Entry>(jsg::BufferSource(js, chunk.detach(js))), kj::mv(self));
+  impl.enqueue(js, kj::rc<ByteQueue::Entry>(js, chunk.detachAndTake(js)), kj::mv(self));
 }
 
-void ReadableByteStreamController::error(jsg::Lock& js, v8::Local<v8::Value> reason) {
-  impl.doError(js, js.v8Ref(reason));
+void ReadableByteStreamController::error(jsg::Lock& js, jsg::JsValue reason) {
+  impl.doError(js, reason);
 }
 
 kj::Maybe<jsg::Ref<ReadableStreamBYOBRequest>> ReadableByteStreamController::getByobRequest(
@@ -2643,13 +2656,13 @@ jsg::Ref<ReadableStream> ReadableStreamJsController::addRef() {
 }
 
 jsg::Promise<void> ReadableStreamJsController::cancel(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   disturbed = true;
 
   const auto doCancel = [&](auto& consumer) {
-    auto reason = js.v8Ref(maybeReason.orDefault([&] { return js.v8Undefined(); }));
+    auto reason = maybeReason.orDefault([&] { return js.undefined(); });
     KJ_DEFER(doClose(js));
-    return consumer->cancel(js, reason.getHandle(js));
+    return consumer->cancel(js, reason);
   };
 
   // Check for pending state first (deferred close/error during a read operation)
@@ -2711,13 +2724,13 @@ void ReadableStreamJsController::doClose(jsg::Lock& js) {
 // erroring. We detach ourselves from the underlying controller by releasing the ValueReadable
 // or ByteReadable in the state and changing that to errored.
 // We also clean up other state here.
-void ReadableStreamJsController::doError(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void ReadableStreamJsController::doError(jsg::Lock& js, jsg::JsValue reason) {
   // If already in a terminal state, nothing to do.
   if (state.isTerminal()) return;
 
   // deferTransitionTo will defer if an operation is in progress, otherwise transition immediately.
   // Returns true if transition happened immediately.
-  if (state.deferTransitionTo<StreamStates::Errored>(js.v8Ref(reason))) {
+  if (state.deferTransitionTo<StreamStates::Errored>(reason.addRef(js))) {
     lock.onError(js, reason);
   }
   // If deferred, lock.onError will be called when the pending state is applied
@@ -2762,7 +2775,7 @@ jsg::Promise<void> ReadableStreamJsController::pipeTo(
   }
 
   return js.rejectedPromise<void>(
-      js.v8TypeError("This ReadableStream cannot be piped to this WritableStream"_kj));
+      js.typeError("This ReadableStream cannot be piped to this WritableStream"_kj));
 }
 
 kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamJsController::read(
@@ -2793,7 +2806,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamJsController::read(
       // as that provided, but with zero-length.
       auto view = byobOptions.bufferView.getHandle(js).detachAndTake(js);
       return js.resolvedPromise(ReadResult{
-        .value = js.v8Ref(v8::Local<v8::Value>(view.slice(js, 0, 0))),
+        .value = jsg::JsValue(view.slice(js, 0, 0)).addRef(js),
         .done = true,
       });
     }
@@ -2918,8 +2931,9 @@ kj::Maybe<jsg::Promise<DrainingReadResult>> ReadableStreamJsController::draining
       JSG_CATCH(exception) {
         state.clearPendingState();
         (void)state.endOperation();
-        doError(js, exception.getHandle(js));
-        return js.rejectedPromise<DrainingReadResult>(kj::mv(exception));
+        auto handle = jsg::JsValue(exception.getHandle(js));
+        doError(js, handle);
+        return js.rejectedPromise<DrainingReadResult>(handle);
       };
     }
     KJ_CASE_ONEOF(consumer, kj::Own<ByteReadable>) {
@@ -2931,8 +2945,9 @@ kj::Maybe<jsg::Promise<DrainingReadResult>> ReadableStreamJsController::draining
       JSG_CATCH(exception) {
         state.clearPendingState();
         (void)state.endOperation();
-        doError(js, exception.getHandle(js));
-        return js.rejectedPromise<DrainingReadResult>(kj::mv(exception));
+        auto handle = jsg::JsValue(exception.getHandle(js));
+        doError(js, handle);
+        return js.rejectedPromise<DrainingReadResult>(handle);
       };
     }
   }
@@ -3139,14 +3154,17 @@ kj::Maybe<int> ReadableStreamJsController::getDesiredSize() {
   KJ_UNREACHABLE;
 }
 
-kj::Maybe<v8::Local<v8::Value>> ReadableStreamJsController::isErrored(jsg::Lock& js) {
+kj::Maybe<jsg::JsValue> ReadableStreamJsController::isErrored(jsg::Lock& js) {
   // Check for pending error first
   KJ_IF_SOME(pendingError, state.tryGetPendingStateUnsafe<StreamStates::Errored>()) {
     return pendingError.getHandle(js);
   }
   // Pending Closed means not errored, so we can just check current state
-  return state.tryGetUnsafe<StreamStates::Errored>().map(
-      [&](jsg::Value& reason) { return reason.getHandle(js); });
+  KJ_IF_SOME(err, state.tryGetUnsafe<StreamStates::Errored>()) {
+    return err.getHandle(js);
+  }
+
+  return kj::none;
 }
 
 bool ReadableStreamJsController::canCloseOrEnqueue() {
@@ -3265,13 +3283,23 @@ class AllReader {
       jsg::Ref<ReadableStream>>;
   State state;
   uint64_t limit;
-  kj::Vector<jsg::JsRef<jsg::JsBufferSource>> parts;
+  kj::Vector<kj::OneOf<jsg::JsRef<jsg::JsBufferSource>, jsg::DOMString>> parts;
   uint64_t runningTotal = 0;
 
   jsg::Promise<PartList> loop(jsg::Lock& js) {
     KJ_SWITCH_ONEOF(state) {
       KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-        return js.resolvedPromise(KJ_MAP(p, parts) { return p.getHandle(js).asArrayPtr(); });
+        return js.resolvedPromise(KJ_MAP(p, parts) {
+          KJ_SWITCH_ONEOF(p) {
+            KJ_CASE_ONEOF(str, jsg::DOMString) {
+              return str.asBytes().slice(0, str.size());
+            }
+            KJ_CASE_ONEOF(buf, jsg::JsRef<jsg::JsBufferSource>) {
+              return buf.getHandle(js).asArrayPtr();
+            }
+          }
+          KJ_UNREACHABLE;
+        });
       }
       KJ_CASE_ONEOF(errored, StreamStates::Errored) {
         return js.template rejectedPromise<PartList>(errored.getHandle(js));
@@ -3291,9 +3319,27 @@ class AllReader {
               // If we're not done, the result value must be interpretable as
               // bytes for the read to make any sense.
               auto handle = KJ_ASSERT_NONNULL(result.value).getHandle(js);
-              if (!handle->IsArrayBufferView() && !handle->IsArrayBuffer()) {
-              auto error = js.v8TypeError("This ReadableStream did not return bytes.");
-              state.template transitionTo<StreamStates::Errored>(js.v8Ref(error));
+
+              KJ_IF_SOME(str, handle.tryCast<jsg::JsString>()) {
+              auto kjstr = str.toDOMString(js);
+              if (kjstr.size() == 0) return loop(js);
+              if ((runningTotal + kjstr.size()) > limit) {
+              auto error = js.typeError("Memory limit exceeded before EOF.");
+              state.template transitionTo<StreamStates::Errored>(error.addRef(js));
+              return readable->getController().cancel(js, error).then(
+                  js, [&](jsg::Lock& js) { return loop(js); });
+              }
+
+              runningTotal += kjstr.size();
+              parts.add(kj::mv(kjstr));
+              return loop(js);
+              } else {
+              }
+
+              if (!handle.isArrayBufferView() && !handle.isSharedArrayBuffer() &&
+                  !handle.isArrayBuffer()) {
+              auto error = js.typeError("This ReadableStream did not return bytes.");
+              state.template transitionTo<StreamStates::Errored>(error.addRef(js));
               return readable->getController().cancel(js, error).then(
                   js, [&](jsg::Lock& js) { return loop(js); });
               }
@@ -3306,8 +3352,8 @@ class AllReader {
               }
 
               if ((runningTotal + bufferSource.size()) > limit) {
-              auto error = js.v8TypeError("Memory limit exceeded before EOF.");
-              state.template transitionTo<StreamStates::Errored>(js.v8Ref(error));
+              auto error = js.typeError("Memory limit exceeded before EOF.");
+              state.template transitionTo<StreamStates::Errored>(error.addRef(js));
               return readable->getController().cancel(js, error).then(
                   js, [&](jsg::Lock& js) { return loop(js); });
               }
@@ -3319,7 +3365,8 @@ class AllReader {
 
         auto onFailure = [this](auto& js, jsg::Value exception) -> jsg::Promise<PartList> {
           // In this case the stream should already be errored.
-          state.template transitionTo<StreamStates::Errored>(js.v8Ref(exception.getHandle(js)));
+          auto handle = jsg::JsValue(exception.getHandle(js));
+          state.template transitionTo<StreamStates::Errored>(handle.addRef(js));
           return loop(js);
         };
 
@@ -3425,7 +3472,8 @@ class PumpToReader {
         return js.rejectedPromise<void>(errored.clone());
       }
       KJ_CASE_ONEOF(pumping, Pumping) {
-        using Result = kj::OneOf<Pumping, kj::Array<kj::byte>, StreamStates::Closed, jsg::Value>;
+        using Result =
+            kj::OneOf<Pumping, kj::Array<kj::byte>, StreamStates::Closed, jsg::JsRef<jsg::JsValue>>;
 
         return KJ_ASSERT_NONNULL(readable->getController().read(js, kj::none))
             .then(js,
@@ -3436,22 +3484,25 @@ class PumpToReader {
           }
 
           auto handle = KJ_ASSERT_NONNULL(result.value).getHandle(js);
-          if (!handle->IsArrayBufferView() && !handle->IsArrayBuffer()) {
-            return js.v8Ref(js.v8TypeError("This ReadableStream did not return bytes."));
+          if (!isByteSource(handle)) {
+            return js.typeError("This ReadableStream did not return bytes.").addRef(js);
           }
 
-          jsg::BufferSource bufferSource(js, handle);
-          if (bufferSource.size() == 0) {
+          KJ_IF_SOME(str, handle.template tryCast<jsg::JsString>()) {
+            auto kjstr = str.toDOMString(js);
+            return kjstr.asBytes().slice(0, kjstr.size()).attach(kj::mv(kjstr));
+          }
+
+          jsg::JsBufferSource source(handle);
+          if (source.size() == 0) {
             return Pumping{};
           }
 
-          if (byteStream) {
-            jsg::BackingStore backing = bufferSource.detach(js);
-            return backing.asArrayPtr().attach(kj::mv(backing));
-          }
-          return bufferSource.asArrayPtr().attach(kj::mv(bufferSource));
+          return kj::heapArray<kj::byte>(source.asArrayPtr());
         }),
-                [](auto& js, jsg::Value exception) mutable -> Result { return kj::mv(exception); })
+                [](auto& js, jsg::Value exception) mutable -> Result {
+          return jsg::JsValue(exception.getHandle(js)).addRef(js);
+        })
             .then(js, ioContext.addFunctor( JSG_VISITABLE_LAMBDA((readable = kj::mv(readable), pumpToReader = kj::mv(pumpToReader)), (readable), (jsg::Lock & js, Result result) mutable {
               KJ_IF_SOME(reader, pumpToReader->tryGet()) {
               reader.ioContext.requireCurrentOrThrowJs();
@@ -3461,17 +3512,19 @@ class PumpToReader {
               auto promise = reader.sink->write(bytes).attach(kj::mv(bytes));
               return ioContext.awaitIo(js, reader.canceler.wrap(kj::mv(promise)))
                   .then(js,
-                      [](jsg::Lock& js) -> kj::Maybe<jsg::Value> {
-                return kj::Maybe<jsg::Value>(kj::none);
+                      [](jsg::Lock& js) mutable -> kj::Maybe<jsg::JsRef<jsg::JsValue>> {
+                return kj::Maybe<jsg::JsRef<jsg::JsValue>>(kj::none);
               },
-                      [](jsg::Lock& js, jsg::Value exception) mutable -> kj::Maybe<jsg::Value> {
-                return kj::mv(exception);
+                      [](jsg::Lock& js,
+                          jsg::Value exception) mutable -> kj::Maybe<jsg::JsRef<jsg::JsValue>> {
+                return jsg::JsValue(exception.getHandle(js)).addRef(js);
               })
                   .then(js,
                       ioContext.addFunctor(JSG_VISITABLE_LAMBDA(
                           (readable = readable.addRef(), pumpToReader = kj::mv(pumpToReader)),
                           (readable),
-                          (jsg::Lock & js, kj::Maybe<jsg::Value> maybeException) mutable {
+                          (jsg::Lock & js,
+                              kj::Maybe<jsg::JsRef<jsg::JsValue>> maybeException) mutable {
                             KJ_IF_SOME(reader, pumpToReader->tryGet()) {
                             auto& ioContext = reader.ioContext;
                             ioContext.requireCurrentOrThrowJs();
@@ -3486,9 +3539,10 @@ class PumpToReader {
                             return reader.pumpLoop(
                                 js, ioContext, readable.addRef(), kj::mv(pumpToReader));
                             } else {
-                            return readable->getController().cancel(js,
-                                maybeException.map(
-                                    [&](jsg::Value& ex) { return ex.getHandle(js); }));
+                            return readable->getController().cancel(
+                                js, maybeException.map([&](jsg::JsRef<jsg::JsValue>& ex) {
+                              return ex.getHandle(js);
+                            }));
                             }
                           })));
               }
@@ -3498,9 +3552,9 @@ class PumpToReader {
               reader.state.transitionTo<StreamStates::Closed>();
               }
               }
-              KJ_CASE_ONEOF(exception, jsg::Value) {
+              KJ_CASE_ONEOF(exception, jsg::JsRef<jsg::JsValue>) {
               if (!reader.isErroredOrClosed()) {
-              reader.state.transitionTo<kj::Exception>(js.exceptionToKj(kj::mv(exception)));
+              reader.state.transitionTo<kj::Exception>(js.exceptionToKj(exception.getHandle(js)));
               }
               }
               }
@@ -3516,7 +3570,7 @@ class PumpToReader {
               KJ_CASE_ONEOF(closed, StreamStates::Closed) {
               return js.resolvedPromise();
               }
-              KJ_CASE_ONEOF(exception, jsg::Value) {
+              KJ_CASE_ONEOF(exception, jsg::JsRef<jsg::JsValue>) {
               return readable->getController().cancel(js, exception.getHandle(js));
               }
               }
@@ -3783,8 +3837,7 @@ WritableStreamDefaultController::WritableStreamDefaultController(
     : ioContext(tryGetIoContext()),
       impl(js, owner, kj::mv(abortSignal)) {}
 
-jsg::Promise<void> WritableStreamDefaultController::abort(
-    jsg::Lock& js, v8::Local<v8::Value> reason) {
+jsg::Promise<void> WritableStreamDefaultController::abort(jsg::Lock& js, jsg::JsValue reason) {
   return impl.abort(js, JSG_THIS, reason);
 }
 
@@ -3796,8 +3849,7 @@ jsg::Promise<void> WritableStreamDefaultController::close(jsg::Lock& js) {
   return impl.close(js, JSG_THIS);
 }
 
-void WritableStreamDefaultController::error(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) {
+void WritableStreamDefaultController::error(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason) {
   impl.error(js, JSG_THIS, reason.orDefault(js.undefined()));
 }
 
@@ -3813,7 +3865,7 @@ jsg::Ref<AbortSignal> WritableStreamDefaultController::getSignal() {
   return impl.signal.addRef();
 }
 
-kj::Maybe<v8::Local<v8::Value>> WritableStreamDefaultController::isErroring(jsg::Lock& js) {
+kj::Maybe<jsg::JsValue> WritableStreamDefaultController::isErroring(jsg::Lock& js) {
   KJ_IF_SOME(erroring, impl.state.tryGetUnsafe<StreamStates::Erroring>()) {
     return erroring.reason.getHandle(js);
   }
@@ -3825,8 +3877,7 @@ void WritableStreamDefaultController::setup(
   impl.setup(js, JSG_THIS, kj::mv(underlyingSink), kj::mv(queuingStrategy));
 }
 
-jsg::Promise<void> WritableStreamDefaultController::write(
-    jsg::Lock& js, v8::Local<v8::Value> value) {
+jsg::Promise<void> WritableStreamDefaultController::write(jsg::Lock& js, jsg::JsValue value) {
   return impl.write(js, JSG_THIS, value);
 }
 
@@ -3871,7 +3922,7 @@ WritableStreamJsController::WritableStreamJsController(StreamStates::Errored err
 }
 
 jsg::Promise<void> WritableStreamJsController::abort(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> reason) {
   // The spec requires that if abort is called multiple times, it is supposed to return the same
   // promise each time. That's a bit cumbersome here with jsg::Promise so we intentionally just
   // return a continuation branch off the same promise.
@@ -3917,16 +3968,16 @@ jsg::Promise<void> WritableStreamJsController::close(jsg::Lock& js, bool markAsH
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(initial, Initial) {
       return rejectedMaybeHandledPromise<void>(
-          js, js.v8TypeError("This WritableStream has been closed."_kj), markAsHandled);
+          js, js.typeError("This WritableStream has been closed."_kj), markAsHandled);
     }
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
       return rejectedMaybeHandledPromise<void>(
-          js, js.v8TypeError("This WritableStream has been closed."_kj), markAsHandled);
+          js, js.typeError("This WritableStream has been closed."_kj), markAsHandled);
     }
     KJ_CASE_ONEOF(errored, StreamStates::Errored) {
       if (FeatureFlags::get(js).getPedanticWpt()) {
         return rejectedMaybeHandledPromise<void>(
-            js, js.v8TypeError("This WritableStream has been errored."_kj), markAsHandled);
+            js, js.typeError("This WritableStream has been errored."_kj), markAsHandled);
       }
       return rejectedMaybeHandledPromise<void>(js, errored.getHandle(js), markAsHandled);
     }
@@ -3955,7 +4006,7 @@ void WritableStreamJsController::doClose(jsg::Lock& js) {
   }
 }
 
-void WritableStreamJsController::doError(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void WritableStreamJsController::doError(jsg::Lock& js, jsg::JsValue reason) {
   // If already in a terminal state, nothing to do.
   if (state.isTerminal()) return;
 
@@ -3964,7 +4015,7 @@ void WritableStreamJsController::doError(jsg::Lock& js, v8::Local<v8::Value> rea
     controller->clearAlgorithms();
   }
 
-  state.transitionTo<StreamStates::Errored>(js.v8Ref(reason));
+  state.transitionTo<StreamStates::Errored>(reason.addRef(js));
   KJ_IF_SOME(locked, lock.state.tryGetUnsafe<WriterLocked>()) {
     maybeRejectPromise<void>(js, locked.getClosedFulfiller(), reason);
     maybeResolvePromise(js, locked.getReadyFulfiller());
@@ -3981,7 +4032,7 @@ void WritableStreamJsController::doError(jsg::Lock& js, v8::Local<v8::Value> rea
   }
 }
 
-void WritableStreamJsController::errorIfNeeded(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void WritableStreamJsController::errorIfNeeded(jsg::Lock& js, jsg::JsValue reason) {
   // Error through the underlying controller if available, which goes through the proper
   // error transition (Erroring -> Errored). This allows close() to be called while the
   // stream is "erroring" and reject with the stored error.
@@ -4009,7 +4060,7 @@ kj::Maybe<int> WritableStreamJsController::getDesiredSize() {
   KJ_UNREACHABLE;
 }
 
-kj::Maybe<v8::Local<v8::Value>> WritableStreamJsController::isErroring(jsg::Lock& js) {
+kj::Maybe<jsg::JsValue> WritableStreamJsController::isErroring(jsg::Lock& js) {
   KJ_IF_SOME(controller, state.tryGetUnsafe<Controller>()) {
     return controller->isErroring(js);
   }
@@ -4020,7 +4071,7 @@ bool WritableStreamDefaultController::isErroring() const {
   return impl.state.is<StreamStates::Erroring>();
 }
 
-kj::Maybe<v8::Local<v8::Value>> WritableStreamJsController::isErroredOrErroring(jsg::Lock& js) {
+kj::Maybe<jsg::JsValue> WritableStreamJsController::isErroredOrErroring(jsg::Lock& js) {
   KJ_IF_SOME(err, state.tryGetErrorUnsafe()) {
     return err.getHandle(js);
   }
@@ -4064,8 +4115,7 @@ bool WritableStreamJsController::lockWriter(jsg::Lock& js, Writer& writer) {
   return lock.lockWriter(js, *this, writer);
 }
 
-void WritableStreamJsController::maybeRejectReadyPromise(
-    jsg::Lock& js, v8::Local<v8::Value> reason) {
+void WritableStreamJsController::maybeRejectReadyPromise(jsg::Lock& js, jsg::JsValue reason) {
   KJ_IF_SOME(writerLock, lock.state.tryGetUnsafe<WriterLocked>()) {
     if (writerLock.getReadyFulfiller() != kj::none) {
       maybeRejectPromise<void>(js, writerLock.getReadyFulfiller(), reason);
@@ -4163,7 +4213,7 @@ jsg::Promise<void> WritableStreamJsController::pipeLoop(jsg::Lock& js) {
     lock.releasePipeLock();
     if (!preventAbort) {
       auto onSuccess = JSG_VISITABLE_LAMBDA(
-          (pipeThrough, reason = js.v8Ref(errored)), (reason), (jsg::Lock& js) {
+          (pipeThrough, reason = errored.addRef(js)), (reason), (jsg::Lock& js) {
             return rejectedMaybeHandledPromise<void>(js, reason.getHandle(js), pipeThrough);
           });
       auto promise = abort(js, errored);
@@ -4212,7 +4262,7 @@ jsg::Promise<void> WritableStreamJsController::pipeLoop(jsg::Lock& js) {
 
   if (state.is<StreamStates::Closed>()) {
     lock.releasePipeLock();
-    auto reason = js.v8TypeError("This destination writable stream is closed."_kj);
+    auto reason = js.typeError("This destination writable stream is closed."_kj);
     if (!preventCancel) {
       source.release(js, reason);
     } else {
@@ -4258,7 +4308,7 @@ jsg::Promise<void> WritableStreamJsController::pipeLoop(jsg::Lock& js) {
         (this, ref=addRef(), preventCancel, pipeThrough),
         (ref) , (jsg::Lock& js, jsg::Value value) {
       // The write failed. We need to release the source if the pipe lock still exists.
-      auto reason = value.getHandle(js);
+      auto reason = jsg::JsValue(value.getHandle(js));
       KJ_IF_SOME(pipeLock, lock.tryGetPipe()) {
         if (!preventCancel) {
           pipeLock.source.release(js, reason);
@@ -4269,8 +4319,8 @@ jsg::Promise<void> WritableStreamJsController::pipeLoop(jsg::Lock& js) {
       return rejectedMaybeHandledPromise<void>(js, reason, pipeThrough);
     } );
 
-        auto promise =
-            write(js, result.value.map([&](jsg::Value& value) { return value.getHandle(js); }));
+        auto promise = write(js,
+            result.value.map([&](jsg::JsRef<jsg::JsValue>& value) { return value.getHandle(js); }));
 
         return maybeAddFunctor(js, kj::mv(promise), kj::mv(onSuccess), kj::mv(onFailure));
       });
@@ -4301,13 +4351,13 @@ void WritableStreamJsController::updateBackpressure(jsg::Lock& js, bool backpres
 }
 
 jsg::Promise<void> WritableStreamJsController::write(
-    jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> value) {
+    jsg::Lock& js, jsg::Optional<jsg::JsValue> value) {
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(initial, Initial) {
-      return js.rejectedPromise<void>(js.v8TypeError("This WritableStream has been closed."_kj));
+      return js.rejectedPromise<void>(js.typeError("This WritableStream has been closed."_kj));
     }
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
-      return js.rejectedPromise<void>(js.v8TypeError("This WritableStream has been closed."_kj));
+      return js.rejectedPromise<void>(js.typeError("This WritableStream has been closed."_kj));
     }
     KJ_CASE_ONEOF(errored, StreamStates::Errored) {
       return js.rejectedPromise<void>(errored.addRef(js));
@@ -4337,7 +4387,7 @@ kj::Maybe<int> TransformStreamDefaultController::getDesiredSize() {
   return kj::none;
 }
 
-void TransformStreamDefaultController::enqueue(jsg::Lock& js, v8::Local<v8::Value> chunk) {
+void TransformStreamDefaultController::enqueue(jsg::Lock& js, jsg::JsValue chunk) {
   auto& readableController = JSG_REQUIRE_NONNULL(tryGetReadableController(), TypeError,
       "The readable side of this TransformStream is no longer readable.");
   // Hold a strong reference to the readable controller for the duration of this
@@ -4352,8 +4402,9 @@ void TransformStreamDefaultController::enqueue(jsg::Lock& js, v8::Local<v8::Valu
   JSG_REQUIRE(readableController.canCloseOrEnqueue(), TypeError,
       "The readable side of this TransformStream is no longer readable.");
   js.tryCatch([&] { readableController.enqueue(js, chunk); }, [&](jsg::Value exception) {
-    errorWritableAndUnblockWrite(js, exception.getHandle(js));
-    js.throwException(kj::mv(exception));
+    auto handle = jsg::JsValue(exception.getHandle(js));
+    errorWritableAndUnblockWrite(js, handle);
+    js.throwException(handle);
   });
 
   // If the controller was errored during the enqueue (e.g. by the size callback
@@ -4375,7 +4426,7 @@ void TransformStreamDefaultController::enqueue(jsg::Lock& js, v8::Local<v8::Valu
   }
 }
 
-void TransformStreamDefaultController::error(jsg::Lock& js, v8::Local<v8::Value> reason) {
+void TransformStreamDefaultController::error(jsg::Lock& js, jsg::JsValue reason) {
   KJ_IF_SOME(readableController, tryGetReadableController()) {
     readableController.error(js, reason);
     readable = kj::none;
@@ -4388,11 +4439,10 @@ void TransformStreamDefaultController::terminate(jsg::Lock& js) {
     readableController.close(js);
     readable = kj::none;
   }
-  errorWritableAndUnblockWrite(js, js.v8TypeError("The transform stream has been terminated"_kj));
+  errorWritableAndUnblockWrite(js, js.typeError("The transform stream has been terminated"_kj));
 }
 
-jsg::Promise<void> TransformStreamDefaultController::write(
-    jsg::Lock& js, v8::Local<v8::Value> chunk) {
+jsg::Promise<void> TransformStreamDefaultController::write(jsg::Lock& js, jsg::JsValue chunk) {
   KJ_IF_SOME(writableController, tryGetWritableController()) {
     KJ_IF_SOME(error, writableController.isErroredOrErroring(js)) {
       return js.rejectedPromise<void>(error);
@@ -4401,9 +4451,8 @@ jsg::Promise<void> TransformStreamDefaultController::write(
     KJ_ASSERT(writableController.isWritable());
 
     if (backpressure) {
-      auto chunkRef = js.v8Ref(chunk);
       return KJ_ASSERT_NONNULL(maybeBackpressureChange).promise.whenResolved(js).then(js,
-          JSG_VISITABLE_LAMBDA((chunkRef = kj::mv(chunkRef), ref=JSG_THIS),
+          JSG_VISITABLE_LAMBDA((chunkRef = chunk.addRef(js), ref=JSG_THIS),
                               (chunkRef, ref), (jsg::Lock& js) mutable -> jsg::Promise<void> {
         KJ_IF_SOME(writableController, ref->tryGetWritableController()) {
           KJ_IF_SOME(error, writableController.isErroring(js)) {
@@ -4424,8 +4473,7 @@ jsg::Promise<void> TransformStreamDefaultController::write(
   }
 }
 
-jsg::Promise<void> TransformStreamDefaultController::abort(
-    jsg::Lock& js, v8::Local<v8::Value> reason) {
+jsg::Promise<void> TransformStreamDefaultController::abort(jsg::Lock& js, jsg::JsValue reason) {
   if (FeatureFlags::get(js).getPedanticWpt()) {
     // If a finish operation is already in progress, return the existing promise
     // or handle the case where we're being called synchronously from within another
@@ -4439,7 +4487,7 @@ jsg::Promise<void> TransformStreamDefaultController::abort(
       // We need to error the stream with the abort reason so that both the current
       // operation and this abort reject with the abort reason.
       error(js, reason);
-      return js.rejectedPromise<void>(js.v8Ref(reason));
+      return js.rejectedPromise<void>(reason);
     }
 
     // Mark that we're starting a finish operation before running the algorithm.
@@ -4452,8 +4500,7 @@ jsg::Promise<void> TransformStreamDefaultController::abort(
 
   return algorithms.maybeFinish
       .emplace(maybeRunAlgorithm(js, algorithms.cancel,
-          JSG_VISITABLE_LAMBDA(
-              (this, ref = JSG_THIS, reason = jsg::JsRef(js, jsg::JsValue(reason))), (ref, reason),
+          JSG_VISITABLE_LAMBDA((this, ref = JSG_THIS, reason = reason.addRef(js)), (ref, reason),
               (jsg::Lock & js)->jsg::Promise<void> {
                 // If the readable side is errored, return a rejected promise with the stored error
                 {
@@ -4469,10 +4516,11 @@ jsg::Promise<void> TransformStreamDefaultController::abort(
               }),
           JSG_VISITABLE_LAMBDA((this, ref = JSG_THIS), (ref),
               (jsg::Lock & js, jsg::Value reason)->jsg::Promise<void> {
-                error(js, reason.getHandle(js));
-                return js.rejectedPromise<void>(kj::mv(reason));
+                auto handle = jsg::JsValue(reason.getHandle(js));
+                error(js, handle);
+                return js.rejectedPromise<void>(handle);
               }),
-          jsg::JsValue(reason)))
+          reason))
       .whenResolved(js);
 }
 
@@ -4534,8 +4582,9 @@ jsg::Promise<void> TransformStreamDefaultController::close(jsg::Lock& js) {
 
   auto onFailure = JSG_VISITABLE_LAMBDA(
       (ref = JSG_THIS), (ref), (jsg::Lock & js, jsg::Value reason)->jsg::Promise<void> {
-        ref->error(js, reason.getHandle(js));
-        return js.rejectedPromise<void>(kj::mv(reason));
+        auto handle = jsg::JsValue(reason.getHandle(js));
+        ref->error(js, handle);
+        return js.rejectedPromise<void>(handle);
       });
 
   if (flags.getPedanticWpt()) {
@@ -4554,8 +4603,7 @@ jsg::Promise<void> TransformStreamDefaultController::pull(jsg::Lock& js) {
   return KJ_ASSERT_NONNULL(maybeBackpressureChange).promise.whenResolved(js);
 }
 
-jsg::Promise<void> TransformStreamDefaultController::cancel(
-    jsg::Lock& js, v8::Local<v8::Value> reason) {
+jsg::Promise<void> TransformStreamDefaultController::cancel(jsg::Lock& js, jsg::JsValue reason) {
   if (FeatureFlags::get(js).getPedanticWpt()) {
     // If a finish operation is already in progress, return the existing promise
     // or check for errors if we're being called synchronously from within another
@@ -4578,8 +4626,7 @@ jsg::Promise<void> TransformStreamDefaultController::cancel(
 
   return algorithms.maybeFinish
       .emplace(maybeRunAlgorithm(js, algorithms.cancel,
-          JSG_VISITABLE_LAMBDA(
-              (this, ref = JSG_THIS, reason = jsg::JsRef(js, jsg::JsValue(reason))), (ref, reason),
+          JSG_VISITABLE_LAMBDA((this, ref = JSG_THIS, reason = reason.addRef(js)), (ref, reason),
               (jsg::Lock & js)->jsg::Promise<void> {
                 // If the stream was errored during the cancel algorithm (e.g., by controller.error()
                 // or by a parallel abort()), we should reject with that error.
@@ -4599,22 +4646,24 @@ jsg::Promise<void> TransformStreamDefaultController::cancel(
           JSG_VISITABLE_LAMBDA((this, ref = JSG_THIS), (ref),
               (jsg::Lock & js, jsg::Value reason)->jsg::Promise<void> {
                 readable = kj::none;
-                errorWritableAndUnblockWrite(js, reason.getHandle(js));
-                return js.rejectedPromise<void>(kj::mv(reason));
+                auto handle = jsg::JsValue(reason.getHandle(js));
+                errorWritableAndUnblockWrite(js, handle);
+                return js.rejectedPromise<void>(handle);
               }),
-          jsg::JsValue(reason)))
+          reason))
       .whenResolved(js);
 }
 
 jsg::Promise<void> TransformStreamDefaultController::performTransform(
-    jsg::Lock& js, v8::Local<v8::Value> chunk) {
+    jsg::Lock& js, jsg::JsValue chunk) {
   if (algorithms.transform != kj::none) {
     return maybeRunAlgorithm(js, algorithms.transform,
         [](jsg::Lock& js) -> jsg::Promise<void> { return js.resolvedPromise(); },
         JSG_VISITABLE_LAMBDA((ref = JSG_THIS), (ref),
             (jsg::Lock & js, jsg::Value reason)->jsg::Promise<void> {
-              ref->error(js, reason.getHandle(js));
-              return js.rejectedPromise<void>(kj::mv(reason));
+              auto handle = jsg::JsValue(reason.getHandle(js));
+              ref->error(js, handle);
+              return js.rejectedPromise<void>(handle);
             }),
         chunk, JSG_THIS);
   }
@@ -4637,7 +4686,7 @@ void TransformStreamDefaultController::setBackpressure(jsg::Lock& js, bool newBa
 }
 
 void TransformStreamDefaultController::errorWritableAndUnblockWrite(
-    jsg::Lock& js, v8::Local<v8::Value> reason) {
+    jsg::Lock& js, jsg::JsValue reason) {
   algorithms.clear();
   KJ_IF_SOME(writableController, tryGetWritableController()) {
     if (FeatureFlags::get(js).getPedanticWpt()) {
@@ -4729,9 +4778,11 @@ kj::Maybe<WritableStreamJsController&> TransformStreamDefaultController::
   return kj::none;
 }
 
-kj::Maybe<jsg::Value> TransformStreamDefaultController::getReadableErrorState(jsg::Lock& js) {
+kj::Maybe<jsg::JsValue> TransformStreamDefaultController::getReadableErrorState(jsg::Lock& js) {
   KJ_IF_SOME(controller, tryGetReadableController()) {
-    return controller.getMaybeErrorState(js);
+    KJ_IF_SOME(err, controller.getMaybeErrorState(js)) {
+      return err.getHandle(js);
+    }
   }
   return kj::none;
 }
@@ -4910,11 +4961,11 @@ jsg::Ref<ReadableStream> ReadableStream::from(
                             (controller=controller.addRef()),
                             (controller),
                             (jsg::Lock& js, jsg::Value val) mutable {
-                      controller->enqueue(js, val.getHandle(js));
+                      controller->enqueue(js, jsg::JsValue(val.getHandle(js)));
                       return js.resolvedPromise();
                     }));
                   }
-                  controller->enqueue(js, v.getHandle(js));
+                  controller->enqueue(js, jsg::JsValue(v.getHandle(js)));
                 } else {
                   controller->close(js);
                 }
@@ -4922,12 +4973,13 @@ jsg::Ref<ReadableStream> ReadableStream::from(
               }),
           JSG_VISITABLE_LAMBDA((controller = c.addRef(), generator = generator.addRef()),
               (controller), (jsg::Lock& js, jsg::Value reason) {
-                controller->error(js, reason.getHandle(js));
-                return js.rejectedPromise<void>(kj::mv(reason));
+                auto handle = jsg::JsValue(reason.getHandle(js));
+                controller->error(js, handle);
+                return js.rejectedPromise<void>(handle);
               }));
     },
     .cancel = [generator = rcGenerator.addRef()](jsg::Lock& js, auto reason) mutable {
-      return generator->getWrapped().return_(js, js.v8Ref(reason))
+      return generator->getWrapped().return_(js, js.v8Ref(v8::Local<v8::Value>(reason)))
           .then(js, [generator = kj::mv(generator)](auto& lock, auto) {
         // The generator might produce a value on return and might even want to continue,
         // but the stream has been canceled at this point, so we stop here.

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -2046,16 +2046,17 @@ struct ByteReadable final: private api::ByteQueue::ConsumerImpl::StateListener {
       auto prp = js.newPromiseAndResolver<ReadResult>();
 
       KJ_IF_SOME(byob, byobOptions) {
-        jsg::BufferSource source(js, byob.bufferView.getHandle(js));
+        auto view = byob.bufferView.getHandle(js);
+        auto elementSize = view.getElementSize();
         // If atLeast is not given, then by default it is the element size of the view
         // that we were given. If atLeast is given, we make sure that it is aligned
         // with the element size. No matter what, atLeast cannot be less than 1.
-        auto atLeast = kj::max(source.getElementSize(), byob.atLeast.orDefault(1));
-        atLeast = kj::max(1, atLeast - (atLeast % source.getElementSize()));
+        auto atLeast = kj::max(elementSize, byob.atLeast.orDefault(1));
+        atLeast = kj::max(1, atLeast - (atLeast % elementSize));
         s.consumer->read(js,
             ByteQueue::ReadRequest(kj::mv(prp.resolver),
                 {
-                  .store = jsg::BufferSource(js, source.detach(js)),
+                  .store = jsg::BufferSource(js, view.detachAndTake(js)),
                   .atLeast = atLeast,
                   .type = ByteQueue::ReadRequest::Type::BYOB,
                 }));
@@ -2098,11 +2099,9 @@ struct ByteReadable final: private api::ByteQueue::ConsumerImpl::StateListener {
     KJ_IF_SOME(byob, byobOptions) {
       // If a BYOB buffer was given, we need to give it back wrapped in a TypedArray
       // whose size is set to zero.
-      jsg::BufferSource source(js, byob.bufferView.getHandle(js));
-      auto store = source.detach(js);
-      store.consume(store.size());
+      auto view = byob.bufferView.getHandle(js);
       return js.resolvedPromise(ReadResult{
-        .value = js.v8Ref(store.createHandle(js)),
+        .value = js.v8Ref(v8::Local<v8::Value>(view.slice(js, 0, 0))),
         .done = true,
       });
     } else {
@@ -2773,14 +2772,14 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamJsController::read(
   KJ_IF_SOME(byobOptions, maybeByobOptions) {
     byobOptions.detachBuffer = true;
     auto view = byobOptions.bufferView.getHandle(js);
-    if (!view->Buffer()->IsDetachable()) {
+    if (!view.isDetachable()) {
       return js.rejectedPromise<ReadResult>(
-          js.v8TypeError("Unabled to use non-detachable ArrayBuffer."_kj));
+          js.typeError("Unabled to use non-detachable ArrayBuffer."_kj));
     }
 
-    if (view->ByteLength() == 0 || view->Buffer()->ByteLength() == 0) {
+    if (view.size() == 0) {
       return js.rejectedPromise<ReadResult>(
-          js.v8TypeError("Unable to use a zero-length ArrayBuffer."_kj));
+          js.typeError("Unable to use a zero-length ArrayBuffer."_kj));
     }
 
     // Check for pending error first (deferred error during a prior read operation)
@@ -2792,11 +2791,9 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamJsController::read(
       // If it is a BYOB read, then the spec requires that we return an empty
       // view of the same type provided, that uses the same backing memory
       // as that provided, but with zero-length.
-      auto source = jsg::BufferSource(js, byobOptions.bufferView.getHandle(js));
-      auto store = source.detach(js);
-      store.consume(store.size());
+      auto view = byobOptions.bufferView.getHandle(js).detachAndTake(js);
       return js.resolvedPromise(ReadResult{
-        .value = js.v8Ref(store.createHandle(js)),
+        .value = js.v8Ref(v8::Local<v8::Value>(view.slice(js, 0, 0))),
         .done = true,
       });
     }

--- a/src/workerd/api/streams/standard.h
+++ b/src/workerd/api/streams/standard.h
@@ -143,14 +143,14 @@ class ReadableImpl {
   void start(jsg::Lock& js, jsg::Ref<Self> self);
 
   // If the readable is not already closed or errored, initiates a cancellation.
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> maybeReason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue maybeReason);
 
   // True if the readable is not closed, not errored, and close has not already been requested.
   bool canCloseOrEnqueue();
 
   // Invokes the cancel algorithm to let the underlying source know that the
   // readable has been canceled.
-  void doCancel(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason);
+  void doCancel(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason);
 
   // Close the queue if we are in a state where we can be closed.
   void close(jsg::Lock& js);
@@ -162,7 +162,7 @@ class ReadableImpl {
 
   // If it isn't already errored or closed, errors the queue, causing all consumers to be errored
   // and detached.
-  void doError(jsg::Lock& js, jsg::Value reason);
+  void doError(jsg::Lock& js, jsg::JsValue reason);
 
   // When a negative number is returned, indicates that we are above the highwatermark
   // and backpressure should be signaled.
@@ -277,7 +277,7 @@ class WritableImpl {
 
   struct WriteRequest {
     jsg::Promise<void>::Resolver resolver;
-    jsg::Value value;
+    jsg::JsRef<jsg::JsValue> value;
     size_t size;
 
     void visitForGc(jsg::GcVisitor& visitor) {
@@ -292,29 +292,29 @@ class WritableImpl {
 
   WritableImpl(jsg::Lock& js, WritableStream& owner, jsg::Ref<AbortSignal> abortSignal);
 
-  jsg::Promise<void> abort(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason);
+  jsg::Promise<void> abort(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason);
 
   void advanceQueueIfNeeded(jsg::Lock& js, jsg::Ref<Self> self);
 
   jsg::Promise<void> close(jsg::Lock& js, jsg::Ref<Self> self);
 
-  void dealWithRejection(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason);
+  void dealWithRejection(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason);
 
   WriteRequest dequeueWriteRequest();
 
   void doClose(jsg::Lock& js);
 
-  void doError(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void doError(jsg::Lock& js, jsg::JsValue reason);
 
-  void error(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason);
+  void error(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason);
 
   void finishErroring(jsg::Lock& js, jsg::Ref<Self> self);
 
   void finishInFlightClose(
-      jsg::Lock& js, jsg::Ref<Self> self, kj::Maybe<v8::Local<v8::Value>> reason = kj::none);
+      jsg::Lock& js, jsg::Ref<Self> self, kj::Maybe<jsg::JsValue> reason = kj::none);
 
   void finishInFlightWrite(
-      jsg::Lock& js, jsg::Ref<Self> self, kj::Maybe<v8::Local<v8::Value>> reason = kj::none);
+      jsg::Lock& js, jsg::Ref<Self> self, kj::Maybe<jsg::JsValue> reason = kj::none);
 
   ssize_t getDesiredSize();
 
@@ -331,7 +331,7 @@ class WritableImpl {
 
   // Puts the writable into an erroring state. This allows any in flight write or
   // close to complete before actually transitioning the writable.
-  void startErroring(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> reason);
+  void startErroring(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue reason);
 
   // Notifies the Writer of the current backpressure state. If the amount of data queued
   // is equal to or above the highwatermark, then backpressure is applied.
@@ -339,7 +339,7 @@ class WritableImpl {
 
   // Writes a chunk to the Writable, possibly queuing the chunk in the internal buffer
   // if there are already other writes pending.
-  jsg::Promise<void> write(jsg::Lock& js, jsg::Ref<Self> self, v8::Local<v8::Value> value);
+  jsg::Promise<void> write(jsg::Lock& js, jsg::Ref<Self> self, jsg::JsValue value);
 
   // True if the writable is in a state where new chunks can be written
   bool isWritable() const;
@@ -446,7 +446,7 @@ class ReadableStreamDefaultController: public jsg::Object {
 
   void start(jsg::Lock& js);
 
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason);
 
   void close(jsg::Lock& js);
 
@@ -454,9 +454,9 @@ class ReadableStreamDefaultController: public jsg::Object {
   bool hasBackpressure();
   kj::Maybe<int> getDesiredSize();
 
-  void enqueue(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> chunk);
+  void enqueue(jsg::Lock& js, jsg::Optional<jsg::JsValue> chunk);
 
-  void error(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void error(jsg::Lock& js, jsg::JsValue reason);
 
   void pull(jsg::Lock& js);
 
@@ -522,13 +522,13 @@ class ReadableStreamBYOBRequest: public jsg::Object {
   // added to support the readAtLeast extension on the ReadableStreamBYOBReader.
   kj::Maybe<int> getAtLeast();
 
-  kj::Maybe<jsg::V8Ref<v8::Uint8Array>> getView(jsg::Lock& js);
+  kj::Maybe<jsg::JsUint8Array> getView(jsg::Lock& js);
 
   void invalidate(jsg::Lock& js);
 
   void respond(jsg::Lock& js, int bytesWritten);
 
-  void respondWithNewView(jsg::Lock& js, jsg::BufferSource view);
+  void respondWithNewView(jsg::Lock& js, jsg::JsBufferSource view);
 
   JSG_RESOURCE_TYPE(ReadableStreamBYOBRequest) {
     JSG_READONLY_PROTOTYPE_PROPERTY(view, getView);
@@ -540,7 +540,7 @@ class ReadableStreamBYOBRequest: public jsg::Object {
     JSG_READONLY_PROTOTYPE_PROPERTY(atLeast, getAtLeast);
   }
 
-  bool isPartiallyFulfilled();
+  bool isPartiallyFulfilled(jsg::Lock& js);
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
@@ -548,7 +548,7 @@ class ReadableStreamBYOBRequest: public jsg::Object {
   struct Impl {
     kj::Own<ByteQueue::ByobRequest> readRequest;
     kj::Rc<WeakRef<ReadableByteStreamController>> controller;
-    jsg::V8Ref<v8::Uint8Array> view;
+    jsg::JsRef<jsg::JsUint8Array> view;
 
     size_t originalBufferByteLength;
     size_t originalByteOffsetPlusBytesFilled;
@@ -584,13 +584,13 @@ class ReadableByteStreamController: public jsg::Object {
 
   void start(jsg::Lock& js);
 
-  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> maybeReason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason);
 
   void close(jsg::Lock& js);
 
-  void enqueue(jsg::Lock& js, jsg::BufferSource chunk);
+  void enqueue(jsg::Lock& js, jsg::JsBufferSource chunk);
 
-  void error(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void error(jsg::Lock& js, jsg::JsValue reason);
 
   bool canCloseOrEnqueue();
   bool hasBackpressure();
@@ -652,17 +652,17 @@ class WritableStreamDefaultController: public jsg::Object {
 
   ~WritableStreamDefaultController() noexcept(false);
 
-  jsg::Promise<void> abort(jsg::Lock& js, v8::Local<v8::Value> reason);
+  jsg::Promise<void> abort(jsg::Lock& js, jsg::JsValue reason);
 
   jsg::Promise<void> close(jsg::Lock& js);
 
-  void error(jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason);
+  void error(jsg::Lock& js, jsg::Optional<jsg::JsValue> reason);
 
   kj::Maybe<ssize_t> getDesiredSize();
 
   jsg::Ref<AbortSignal> getSignal();
 
-  kj::Maybe<v8::Local<v8::Value>> isErroring(jsg::Lock& js);
+  kj::Maybe<jsg::JsValue> isErroring(jsg::Lock& js);
 
   // Returns true if the stream is in the erroring state. Unlike the overload
   // that takes a lock, this method does not require a lock since it doesn't
@@ -679,7 +679,7 @@ class WritableStreamDefaultController: public jsg::Object {
 
   void setup(jsg::Lock& js, UnderlyingSink underlyingSink, StreamQueuingStrategy queuingStrategy);
 
-  jsg::Promise<void> write(jsg::Lock& js, v8::Local<v8::Value> value);
+  jsg::Promise<void> write(jsg::Lock& js, jsg::JsValue value);
 
   JSG_RESOURCE_TYPE(WritableStreamDefaultController) {
     JSG_READONLY_PROTOTYPE_PROPERTY(signal, getSignal);
@@ -728,9 +728,9 @@ class TransformStreamDefaultController: public jsg::Object {
 
   kj::Maybe<int> getDesiredSize();
 
-  void enqueue(jsg::Lock& js, v8::Local<v8::Value> chunk);
+  void enqueue(jsg::Lock& js, jsg::JsValue chunk);
 
-  void error(jsg::Lock& js, v8::Local<v8::Value> reason);
+  void error(jsg::Lock& js, jsg::JsValue reason);
 
   void terminate(jsg::Lock& js);
 
@@ -745,11 +745,11 @@ class TransformStreamDefaultController: public jsg::Object {
     });
   }
 
-  jsg::Promise<void> write(jsg::Lock& js, v8::Local<v8::Value> chunk);
-  jsg::Promise<void> abort(jsg::Lock& js, v8::Local<v8::Value> reason);
+  jsg::Promise<void> write(jsg::Lock& js, jsg::JsValue chunk);
+  jsg::Promise<void> abort(jsg::Lock& js, jsg::JsValue reason);
   jsg::Promise<void> close(jsg::Lock& js);
   jsg::Promise<void> pull(jsg::Lock& js);
-  jsg::Promise<void> cancel(jsg::Lock& js, v8::Local<v8::Value> reason);
+  jsg::Promise<void> cancel(jsg::Lock& js, jsg::JsValue reason);
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const;
 
@@ -781,8 +781,8 @@ class TransformStreamDefaultController: public jsg::Object {
     }
   };
 
-  void errorWritableAndUnblockWrite(jsg::Lock& js, v8::Local<v8::Value> reason);
-  jsg::Promise<void> performTransform(jsg::Lock& js, v8::Local<v8::Value> chunk);
+  void errorWritableAndUnblockWrite(jsg::Lock& js, jsg::JsValue reason);
+  jsg::Promise<void> performTransform(jsg::Lock& js, jsg::JsValue chunk);
   void setBackpressure(jsg::Lock& js, bool newBackpressure);
 
   kj::Maybe<IoContext&> ioContext;
@@ -791,7 +791,7 @@ class TransformStreamDefaultController: public jsg::Object {
   kj::Maybe<ReadableStreamDefaultController&> tryGetReadableController();
   kj::Maybe<WritableStreamJsController&> tryGetWritableController();
 
-  kj::Maybe<jsg::Value> getReadableErrorState(jsg::Lock& js);
+  kj::Maybe<jsg::JsValue> getReadableErrorState(jsg::Lock& js);
 
   // Currently, JS-backed transform streams only support value-oriented streams.
   // In the future, that may change and this will need to become a kj::OneOf

--- a/src/workerd/api/streams/writable-sink-adapter-test.c++
+++ b/src/workerd/api/streams/writable-sink-adapter-test.c++
@@ -612,11 +612,7 @@ KJ_TEST("zero-length writes are a non-op (ArrayBuffer)") {
     auto adapter = kj::heap<WritableStreamSinkJsAdapter>(
         env.js, env.context, newWritableSink(kj::mv(recordingSink)));
 
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, 0);
-    jsg::BufferSource source(env.js, kj::mv(backing));
-    jsg::JsValue handle(source.getHandle(env.js));
-
-    auto writePromise = adapter->write(env.js, handle);
+    auto writePromise = adapter->write(env.js, jsg::JsArrayBuffer::create(env.js, 0));
     KJ_ASSERT(state.writeCalled == 0, "Underlying sink's write() should not have been called");
 
     return env.context
@@ -638,11 +634,7 @@ KJ_TEST("writing small ArrayBuffer") {
           .highWaterMark = 10,
         });
 
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, 10);
-    jsg::BufferSource source(env.js, kj::mv(backing));
-    jsg::JsValue handle(source.getHandle(env.js));
-
-    auto writePromise = adapter->write(env.js, handle);
+    auto writePromise = adapter->write(env.js, jsg::JsArrayBuffer::create(env.js, 10));
     KJ_ASSERT(state.writeCalled == 1, "Underlying sink's write() should not have been called");
     KJ_ASSERT(KJ_ASSERT_NONNULL(adapter->getDesiredSize()) == 0,
         "Adapter's desired size should be 0 after writing highWaterMark bytes");
@@ -668,11 +660,7 @@ KJ_TEST("writing medium ArrayBuffer") {
           .highWaterMark = 5 * 1024,
         });
 
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, 4 * 1024);
-    jsg::BufferSource source(env.js, kj::mv(backing));
-    jsg::JsValue handle(source.getHandle(env.js));
-
-    auto writePromise = adapter->write(env.js, handle);
+    auto writePromise = adapter->write(env.js, jsg::JsArrayBuffer::create(env.js, 4 * 1024));
     KJ_ASSERT(state.writeCalled == 1, "Underlying sink's write() should not have been called");
     KJ_ASSERT(KJ_ASSERT_NONNULL(adapter->getDesiredSize()) == 1024,
         "Adapter's desired size should be 1024 after writing 4 * 1024 bytes");
@@ -698,11 +686,7 @@ KJ_TEST("writing large ArrayBuffer") {
           .highWaterMark = 8 * 1024,
         });
 
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, 16 * 1024);
-    jsg::BufferSource source(env.js, kj::mv(backing));
-    jsg::JsValue handle(source.getHandle(env.js));
-
-    auto writePromise = adapter->write(env.js, handle);
+    auto writePromise = adapter->write(env.js, jsg::JsArrayBuffer::create(env.js, 16 * 1024));
     KJ_ASSERT(state.writeCalled == 1, "Underlying sink's write() should not have been called");
     KJ_ASSERT(KJ_ASSERT_NONNULL(adapter->getDesiredSize()) == -(8 * 1024),
         "Adapter's desired size should be negative after writing 16 * 1024 bytes");
@@ -756,11 +740,7 @@ KJ_TEST("large number of large writes") {
         kj::heap<WritableStreamSinkJsAdapter>(env.js, env.context, newWritableSink(kj::mv(fake)));
 
     for (int i = 0; i < 1000; i++) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, 16 * 1024);
-      jsg::BufferSource source(env.js, kj::mv(backing));
-      jsg::JsValue handle(source.getHandle(env.js));
-
-      adapter->write(env.js, handle);
+      adapter->write(env.js, jsg::JsArrayBuffer::create(env.js, 16 * 1024));
     }
     auto endPromise = adapter->end(env.js);
 
@@ -813,15 +793,9 @@ KJ_TEST("detachOnWrite option detaches ArrayBuffer before write") {
           .detachOnWrite = true,
         });
 
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(env.js, 10);
-    jsg::BufferSource source(env.js, kj::mv(backing));
-    KJ_ASSERT(!source.isDetached());
-    jsg::JsValue handle(source.getHandle(env.js));
-
+    auto handle = jsg::JsArrayBuffer::create(env.js, 10);
     auto writePromise = adapter->write(env.js, handle);
-
-    jsg::BufferSource source2(env.js, handle);
-    KJ_ASSERT(source2.size() == 0);
+    KJ_ASSERT(handle.size() == 0);
 
     return env.context.awaitJs(env.js, kj::mv(writePromise)).attach(kj::mv(adapter));
   });
@@ -838,15 +812,10 @@ KJ_TEST("detachOnWrite option detaches Uint8Array before write") {
           .detachOnWrite = true,
         });
 
-    auto backing = jsg::BackingStore::alloc<v8::Uint8Array>(env.js, 10);
-    jsg::BufferSource source(env.js, kj::mv(backing));
-    KJ_ASSERT(!source.isDetached());
-    jsg::JsValue handle(source.getHandle(env.js));
-
+    auto handle = jsg::JsUint8Array::create(env.js, 10);
     auto writePromise = adapter->write(env.js, handle);
 
-    jsg::BufferSource source2(env.js, handle);
-    KJ_ASSERT(source2.size() == 0);
+    KJ_ASSERT(handle.size() == 0);
 
     return env.context.awaitJs(env.js, kj::mv(writePromise)).attach(kj::mv(adapter));
   });
@@ -911,9 +880,7 @@ jsg::Ref<WritableStream> createSimpleWritableStream(jsg::Lock& js, WritableStrea
       UnderlyingSink{
         .write =
             [&context](jsg::Lock& js, auto chunk, auto) {
-    jsg::BufferSource source(js, chunk);
-    auto data = kj::heapArray<kj::byte>(source.asArrayPtr());
-    context.chunks.add(kj::mv(data));
+    context.chunks.add(jsg::JsBufferSource(chunk).copy());
     return js.resolvedPromise();
   },
         .abort =

--- a/src/workerd/api/streams/writable-sink-adapter.c++
+++ b/src/workerd/api/streams/writable-sink-adapter.c++
@@ -204,12 +204,11 @@ jsg::Promise<void> WritableStreamSinkJsAdapter::write(jsg::Lock& js, const jsg::
   // types: ArrayBuffer, ArrayBufferView, and String. If it is a string,
   // we convert it to UTF-8 bytes. Anything else is an error.
   if (value.isArrayBufferView() || value.isArrayBuffer() || value.isSharedArrayBuffer()) {
-    // We can just wrap the value with a jsg::BufferSource and write it.
-    jsg::BufferSource source(js, value);
-    if (active.options.detachOnWrite && source.canDetach(js)) {
+    jsg::JsBufferSource source(value);
+    if (active.options.detachOnWrite && source.isDetachable()) {
       // Detach from the original ArrayBuffer...
-      // ... and re-wrap it with a new BufferSource that we own.
-      source = jsg::BufferSource(js, source.detach(js));
+      // ... and re-wrap it with a new view that we own.
+      source = source.detachAndTake(js);
     }
 
     // Zero-length writes are a no-op.
@@ -240,10 +239,11 @@ jsg::Promise<void> WritableStreamSinkJsAdapter::write(jsg::Lock& js, const jsg::
     // held by the write queue, which is itself held by Active. If active
     // is destroyed, the write queue is destroyed along with the lambda.
     auto promise =
-        active.enqueue(kj::coCapture([&active, source = kj::mv(source)]() -> kj::Promise<void> {
-      co_await active.sink->write(source.asArrayPtr());
+        active
+            .enqueue(kj::coCapture([&active, source = source.asArrayPtr()]() -> kj::Promise<void> {
+      co_await active.sink->write(source);
       active.bytesInFlight -= source.size();
-    }));
+    })).attach(source.addRef(js));
     return ioContext
         .awaitIo(js, kj::mv(promise), [self = selfRef.addRef()](jsg::Lock& js) {
       // Why do we need a weak ref here? Well, because this is a JavaScript
@@ -608,17 +608,16 @@ kj::Promise<void> WritableStreamSinkKjAdapter::write(
     // WritableStream API has no concept of a vector write, so each write
     // would incur the overhead of a separate promise and microtask checkpoint.
     // By collapsing into a single write we reduce that overhead.
-    auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, totalAmount);
-    auto ptr = backing.asArrayPtr();
+    auto source = jsg::JsArrayBuffer::create(js, totalAmount);
+    auto ptr = source.asArrayPtr();
     for (auto piece: pieces) {
       ptr.first(piece.size()).copyFrom(piece);
       ptr = ptr.slice(piece.size());
     }
-    jsg::BufferSource source(js, kj::mv(backing));
 
     auto ready = KJ_ASSERT_NONNULL(writer->isReady(js));
-    auto promise =
-        ready.then(js, [writer = writer.addRef(), source = kj::mv(source)](jsg::Lock& js) mutable {
+    auto promise = ready.then(
+        js, [writer = writer.addRef(), source = source.addRef(js)](jsg::Lock& js) mutable {
       return writer->write(js, source.getHandle(js));
     });
     return IoContext::current().awaitJs(js, kj::mv(promise));

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -409,9 +409,8 @@ class WritableStreamJsRpcAdapter final: public capnp::ExplicitEndOutputStream {
     if (buffer == nullptr) return kj::READY_NOW;
     return canceler.wrap(context.run([this, buffer](Worker::Lock& lock) mutable {
       auto& writer = getInner();
-      auto source = KJ_ASSERT_NONNULL(jsg::BufferSource::tryAlloc(lock, buffer.size()));
-      source.asArrayPtr().copyFrom(buffer);
-      return context.awaitJs(lock, writer.write(lock, source.getHandle(lock)));
+      auto source = jsg::JsArrayBuffer::create(lock, buffer);
+      return context.awaitJs(lock, writer.write(lock, source));
     }));
   }
 
@@ -430,7 +429,7 @@ class WritableStreamJsRpcAdapter final: public capnp::ExplicitEndOutputStream {
       // guaranteed to live until the returned promise is resolved, but the application code
       // may hold onto the ArrayBuffer for longer. We need to make sure that the backing store
       // for the ArrayBuffer remains valid.
-      auto source = KJ_ASSERT_NONNULL(jsg::BufferSource::tryAlloc(lock, amount));
+      auto source = jsg::JsArrayBuffer::create(lock, amount);
       auto ptr = source.asArrayPtr();
       for (auto& piece: pieces) {
         KJ_DASSERT(ptr.size() > 0);
@@ -440,7 +439,7 @@ class WritableStreamJsRpcAdapter final: public capnp::ExplicitEndOutputStream {
         ptr = ptr.slice(piece.size());
       }
 
-      return context.awaitJs(lock, writer.write(lock, source.getHandle(lock)));
+      return context.awaitJs(lock, writer.write(lock, source));
     }));
   }
 

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -34,7 +34,7 @@ jsg::Promise<void> WritableStreamDefaultWriter::abort(
   assertAttachedOrTerminal();
   if (state.is<Released>()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream writer has been released."_kj));
+        js.typeError("This WritableStream writer has been released."_kj));
   }
   if (state.is<Closed>()) {
     return js.resolvedPromise();
@@ -62,10 +62,10 @@ jsg::Promise<void> WritableStreamDefaultWriter::close(jsg::Lock& js) {
   assertAttachedOrTerminal();
   if (state.is<Released>()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream writer has been released."_kj));
+        js.typeError("This WritableStream writer has been released."_kj));
   }
   if (state.is<Closed>()) {
-    return js.rejectedPromise<void>(js.v8TypeError("This WritableStream has been closed."_kj));
+    return js.rejectedPromise<void>(js.typeError("This WritableStream has been closed."_kj));
   }
   auto& attached = state.requireActiveUnsafe();
   // In some edge cases, this writer is the last thing holding a strong
@@ -139,10 +139,10 @@ jsg::Promise<void> WritableStreamDefaultWriter::write(
   assertAttachedOrTerminal();
   if (state.is<Released>()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream writer has been released."_kj));
+        js.typeError("This WritableStream writer has been released."_kj));
   }
   if (state.is<Closed>()) {
-    return js.rejectedPromise<void>(js.v8TypeError("This WritableStream has been closed."_kj));
+    return js.rejectedPromise<void>(js.typeError("This WritableStream has been closed."_kj));
   }
   auto& attached = state.requireActiveUnsafe();
   return attached.stream->getController().write(js, chunk);
@@ -219,7 +219,7 @@ jsg::Promise<void> WritableStream::abort(
     jsg::Lock& js, jsg::Optional<v8::Local<v8::Value>> reason) {
   if (isLocked()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream is currently locked to a writer."_kj));
+        js.typeError("This WritableStream is currently locked to a writer."_kj));
   }
   return getController().abort(js, reason);
 }
@@ -227,7 +227,7 @@ jsg::Promise<void> WritableStream::abort(
 jsg::Promise<void> WritableStream::close(jsg::Lock& js) {
   if (isLocked()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream is currently locked to a writer."_kj));
+        js.typeError("This WritableStream is currently locked to a writer."_kj));
   }
   return getController().close(js);
 }
@@ -235,7 +235,7 @@ jsg::Promise<void> WritableStream::close(jsg::Lock& js) {
 jsg::Promise<void> WritableStream::flush(jsg::Lock& js) {
   if (isLocked()) {
     return js.rejectedPromise<void>(
-        js.v8TypeError("This WritableStream is currently locked to a writer."_kj));
+        js.typeError("This WritableStream is currently locked to a writer."_kj));
   }
   return getController().flush(js);
 }

--- a/src/workerd/api/tests/pipe-streams-test.js
+++ b/src/workerd/api/tests/pipe-streams-test.js
@@ -10,7 +10,7 @@ export const pipeThroughJsToInternal = {
   async test() {
     const enc = new TextEncoder();
     const dec = new TextDecoder();
-    const chunks = [enc.encode('hello'), enc.encode('there'), 'hello'];
+    const chunks = [enc.encode('hello'), enc.encode('there'), '!', 1];
     const rs = new ReadableStream({
       pull(c) {
         c.enqueue(chunks.shift());
@@ -26,12 +26,13 @@ export const pipeThroughJsToInternal = {
         output.push(dec.decode(chunk));
       }
     }
-    // The 'hello' string at the end of chunks will cause an error to be thrown.
-    await rejects(consumeStream, {
+    // The 1 number at the end of chunks will cause an error to be thrown.
+    await rejects(consumeStream(), {
       message: 'This WritableStream only supports writing byte types.',
     });
 
-    deepStrictEqual(output, ['hello', 'there']);
+    // But we should have received the valid chunks before the error.
+    deepStrictEqual(output, ['hello', 'there', '!']);
   },
 };
 

--- a/src/workerd/api/tests/streams-byob-edge-cases-test.js
+++ b/src/workerd/api/tests/streams-byob-edge-cases-test.js
@@ -109,6 +109,7 @@ export const byobFloat32Array = {
 
     ok(!done);
     ok(value instanceof Float32Array);
+
     strictEqual(value.length, 2);
     ok(Math.abs(value[0] - 3.14) < 0.001);
     ok(Math.abs(value[1] - 2.71) < 0.001);

--- a/src/workerd/api/tests/streams-js-test.js
+++ b/src/workerd/api/tests/streams-js-test.js
@@ -2352,7 +2352,8 @@ export const queuingStrategies = {
 
       ok(startRan);
       strictEqual(highWaterMark, 10);
-      strictEqual(size('nothing'), undefined);
+      // Non-standard, but strings are interpreted as UTF-8 length...
+      strictEqual(size('nothing'), 7);
       strictEqual(size(123), undefined);
       strictEqual(size(undefined), undefined);
       strictEqual(size(null), undefined);

--- a/src/workerd/api/tests/streams-respond-test.js
+++ b/src/workerd/api/tests/streams-respond-test.js
@@ -621,7 +621,7 @@ export const jsNotBytesInPull = {
   async test() {
     const rs = new ReadableStream({
       pull(c) {
-        c.enqueue('hello');
+        c.enqueue(12);
         c.close();
       },
     });
@@ -635,7 +635,7 @@ export const jsNotBytesInStart = {
   async test() {
     const rs = new ReadableStream({
       start(c) {
-        c.enqueue('hello');
+        c.enqueue(1);
         c.close();
       },
     });

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -1076,8 +1076,8 @@ kj::Promise<kj::Maybe<kj::Exception>> WebSocket::readLoop(
               auto blob = js.alloc<Blob>(js, jsg::JsBufferSource(ab), kj::str());
               dispatchEventImpl(js, js.alloc<MessageEvent>(js, kj::str("message"), kj::mv(blob)));
             } else {
-              auto ab = js.arrayBuffer(kj::mv(data)).getHandle(js);
-              dispatchEventImpl(js, js.alloc<MessageEvent>(js, jsg::JsValue(ab)));
+              auto ab = js.arrayBuffer(data);
+              dispatchEventImpl(js, js.alloc<MessageEvent>(js, ab));
             }
           }
           KJ_CASE_ONEOF(close, kj::WebSocket::Close) {

--- a/src/workerd/io/bundle-fs-test.c++
+++ b/src/workerd/io/bundle-fs-test.c++
@@ -81,7 +81,7 @@ KJ_TEST("The BundleDirectoryDelegate works") {
     auto readText = file->readAllText(env.js).get<jsg::JsString>();
     KJ_EXPECT(readText == env.js.str("this is a commonjs module"_kj));
 
-    auto readBytes = file->readAllBytes(env.js).get<jsg::BufferSource>();
+    auto readBytes = file->readAllBytes(env.js).get<jsg::JsUint8Array>();
     KJ_EXPECT(readBytes.asArrayPtr() == "this is a commonjs module"_kjb);
 
     // Reading five bytes from offset 20 should return "odule".

--- a/src/workerd/io/worker-fs.c++
+++ b/src/workerd/io/worker-fs.c++
@@ -1153,14 +1153,14 @@ kj::OneOf<FsError, jsg::JsString> File::readAllText(jsg::Lock& js) {
   return js.str(data);
 }
 
-kj::OneOf<FsError, jsg::BufferSource> File::readAllBytes(jsg::Lock& js) {
+kj::OneOf<FsError, jsg::JsUint8Array> File::readAllBytes(jsg::Lock& js) {
   auto info = stat(js);
   KJ_DASSERT(info.type == FsType::FILE);
-  auto backing = jsg::BackingStore::alloc<v8::Uint8Array>(js, info.size);
+  auto u8 = jsg::JsUint8Array::create(js, info.size);
   if (info.size > 0) {
-    KJ_ASSERT(read(js, 0, backing) == info.size);
+    KJ_ASSERT(read(js, 0, u8.asArrayPtr()) == info.size);
   }
-  return jsg::BufferSource(js, kj::mv(backing));
+  return u8;
 }
 
 void Directory::Builder::add(

--- a/src/workerd/io/worker-fs.h
+++ b/src/workerd/io/worker-fs.h
@@ -220,7 +220,7 @@ class File: public kj::Refcounted {
   kj::OneOf<FsError, jsg::JsString> readAllText(jsg::Lock& js) KJ_WARN_UNUSED_RESULT;
 
   // Reads all the contents of the file as a Uint8Array.
-  kj::OneOf<FsError, jsg::BufferSource> readAllBytes(jsg::Lock& js) KJ_WARN_UNUSED_RESULT;
+  kj::OneOf<FsError, jsg::JsUint8Array> readAllBytes(jsg::Lock& js) KJ_WARN_UNUSED_RESULT;
 
   // Reads data from the file at the given offset into the given buffer.
   virtual uint32_t read(jsg::Lock& js, uint32_t offset, kj::ArrayPtr<kj::byte> buffer) const = 0;

--- a/src/workerd/jsg/buffersource.h
+++ b/src/workerd/jsg/buffersource.h
@@ -492,8 +492,4 @@ class BufferSourceWrapper {
   }
 };
 
-inline BufferSource Lock::arrayBuffer(kj::Array<kj::byte> data) {
-  return BufferSource(*this, BackingStore::from<v8::ArrayBuffer>(*this, kj::mv(data)));
-}
-
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2774,13 +2774,8 @@ class Lock {
   template <typename T>
   JsObject opaque(T&& inner) KJ_WARN_UNUSED_RESULT;
 
-  // Returns a jsg::BufferSource whose underlying JavaScript handle is a Uint8Array.
-  BufferSource bytes(kj::Array<kj::byte> data) KJ_WARN_UNUSED_RESULT;
-
-  // Returns a jsg::BufferSource whose underlying JavaScript handle is an ArrayBuffer
-  // as opposed to the default Uint8Array.  May copy and move the bytes if they are
-  // not in the right sandbox.
-  BufferSource arrayBuffer(kj::Array<kj::byte> data) KJ_WARN_UNUSED_RESULT;
+  JsUint8Array bytes(kj::ArrayPtr<const kj::byte> data) KJ_WARN_UNUSED_RESULT;
+  JsArrayBuffer arrayBuffer(kj::ArrayPtr<const kj::byte> data) KJ_WARN_UNUSED_RESULT;
 
   enum class AllocOption { ZERO_INITIALIZED, UNINITIALIZED };
 

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2200,7 +2200,8 @@ class JsMessage;
   V(Function)                                                                                      \
   V(Uint8Array)                                                                                    \
   V(ArrayBuffer)                                                                                   \
-  V(ArrayBufferView)
+  V(ArrayBufferView)                                                                               \
+  V(SharedArrayBuffer)
 
 #define V(Name) class Js##Name;
 JS_TYPE_CLASSES(V)

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -1145,23 +1145,32 @@ JsArrayBufferView JsArrayBufferView::slice(Lock& js, size_t offset, size_t lengt
   } else if (inner->IsUint8ClampedArray()) {
     return JsArrayBufferView(v8::Uint8ClampedArray::New(inner->Buffer(), offset, length));
   } else if (inner->IsUint16Array()) {
-    return JsArrayBufferView(v8::Uint16Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::Uint16Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsInt16Array()) {
-    return JsArrayBufferView(v8::Int16Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::Int16Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsUint32Array()) {
-    return JsArrayBufferView(v8::Uint32Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::Uint32Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsInt32Array()) {
-    return JsArrayBufferView(v8::Int32Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::Int32Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsFloat16Array()) {
-    return JsArrayBufferView(v8::Float16Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::Float16Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsFloat32Array()) {
-    return JsArrayBufferView(v8::Float32Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::Float32Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsFloat64Array()) {
-    return JsArrayBufferView(v8::Float64Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::Float64Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsBigInt64Array()) {
-    return JsArrayBufferView(v8::BigInt64Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::BigInt64Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsBigUint64Array()) {
-    return JsArrayBufferView(v8::BigUint64Array::New(inner->Buffer(), offset, length));
+    return JsArrayBufferView(
+        v8::BigUint64Array::New(inner->Buffer(), offset, length / getElementSize()));
   } else if (inner->IsDataView()) {
     return JsArrayBufferView(v8::DataView::New(inner->Buffer(), offset, length));
   }

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -26,7 +26,7 @@ bool JsValue::strictEquals(const JsValue& other) const {
 }
 
 JsMap::operator JsObject() {
-  return JsObject(inner);
+  return jsg::JsObject(inner);
 }
 
 void JsMap::set(Lock& js, const JsValue& name, const JsValue& value) {
@@ -211,7 +211,7 @@ size_t JsSet::size() const {
 }
 
 JsSet::operator JsArray() const {
-  return JsArray(inner->AsArray());
+  return jsg::JsArray(inner->AsArray());
 }
 
 kj::Maybe<int32_t> JsInt32::value(Lock& js) const {
@@ -343,7 +343,7 @@ void JsArray::add(Lock& js, const JsValue& value) {
 }
 
 JsArray::operator JsObject() const {
-  return JsObject(inner.As<v8::Object>());
+  return jsg::JsObject(inner.As<v8::Object>());
 }
 
 kj::String JsString::toString(jsg::Lock& js) const {
@@ -666,6 +666,15 @@ BufferSource Lock::bytes(kj::Array<kj::byte> data) {
 // ======================================================================================
 // JsArrayBuffer
 
+kj::Maybe<JsArrayBuffer> JsArrayBuffer::tryCreate(Lock& js, size_t length) {
+  JSG_REQUIRE(length < v8::ArrayBuffer::kMaxByteLength, RangeError, "The length is too large");
+  auto backing = v8::ArrayBuffer::NewBackingStore(js.v8Isolate, length,
+      v8::BackingStoreInitializationMode::kZeroInitialized,
+      v8::BackingStoreOnFailureMode::kReturnNull);
+  if (backing == nullptr) return kj::none;
+  return create(js, kj::mv(backing));
+}
+
 JsArrayBuffer JsArrayBuffer::create(Lock& js, size_t length) {
   JSG_REQUIRE(length < v8::ArrayBuffer::kMaxByteLength, RangeError, "The length is too large");
   auto backing = v8::ArrayBuffer::NewBackingStore(js.v8Isolate, length,
@@ -682,6 +691,10 @@ JsArrayBuffer JsArrayBuffer::create(Lock& js, kj::ArrayPtr<const kj::byte> data)
 }
 
 JsArrayBuffer JsArrayBuffer::create(Lock& js, std::unique_ptr<v8::BackingStore> backingStore) {
+  return JsArrayBuffer(v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backingStore)));
+}
+
+JsArrayBuffer JsArrayBuffer::create(Lock& js, std::shared_ptr<v8::BackingStore> backingStore) {
   return JsArrayBuffer(v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backingStore)));
 }
 
@@ -707,15 +720,9 @@ kj::ArrayPtr<const kj::byte> JsArrayBuffer::asArrayPtr() const {
 
 JsArrayBuffer JsArrayBuffer::slice(Lock& js, size_t newLength) const {
   JSG_REQUIRE(newLength <= size(), RangeError, "New length exceeds buffer length");
-  auto backing = v8::ArrayBuffer::NewBackingStore(js.v8Isolate, newLength,
-      v8::BackingStoreInitializationMode::kUninitialized,
-      v8::BackingStoreOnFailureMode::kReturnNull);
-  JSG_REQUIRE(backing != nullptr, RangeError, "Failed to allocate memory for ArrayBuffer");
-  auto dest = kj::ArrayPtr(static_cast<kj::byte*>(backing->Data()), newLength);
-  v8::Local<v8::ArrayBuffer> inner = *this;
-  dest.copyFrom(
-      kj::ArrayPtr(static_cast<const kj::byte*>(inner->GetBackingStore()->Data()), newLength));
-  return JsArrayBuffer(v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backing)));
+  auto dest = create(js, newLength);
+  dest.asArrayPtr().copyFrom(asArrayPtr().slice(0, newLength));
+  return dest;
 }
 
 size_t JsArrayBuffer::size() const {
@@ -728,6 +735,246 @@ kj::Array<kj::byte> JsArrayBuffer::copy() {
   return kj::heapArray(ptr);
 }
 
+JsArrayBuffer::operator JsBufferSource() const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return jsg::JsBufferSource(inner);
+}
+
+bool JsArrayBuffer::isDetachable() const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return inner->IsDetachable();
+}
+
+bool JsArrayBuffer::isDetached() const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return inner->WasDetached();
+}
+
+void JsArrayBuffer::detachInPlace(Lock& js) {
+  JSG_REQUIRE(isDetachable(), TypeError, "ArrayBuffer is not detachable");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  check(inner->Detach({}));
+}
+
+JsArrayBuffer JsArrayBuffer::detachAndTake(Lock& js) {
+  JSG_REQUIRE(isDetachable(), TypeError, "ArrayBuffer is not detachable");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  auto backing = inner->GetBackingStore();
+  check(inner->Detach({}));
+  return JsArrayBuffer(v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backing)));
+}
+
+JsUint8Array JsArrayBuffer::newUint8View(size_t offset, size_t numElements) const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsUint8Array(v8::Uint8Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newInt8View(size_t offset, size_t numElements) const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Int8Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newUint8ClampedView(size_t offset, size_t numElements) const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Uint8ClampedArray::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newUint16View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 2 == 0, TypeError, "ArrayBuffer size is not a multiple of 2");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Uint16Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newInt16View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 2 == 0, TypeError, "ArrayBuffer size is not a multiple of 2");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Int16Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newUint32View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 4 == 0, TypeError, "ArrayBuffer size is not a multiple of 4");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Uint32Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newInt32View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 4 == 0, TypeError, "ArrayBuffer size is not a multiple of 4");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Int32Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newFloat16View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 2 == 0, TypeError, "ArrayBuffer size is not a multiple of 2");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Float16Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newFloat32View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 4 == 0, TypeError, "ArrayBuffer size is not a multiple of 4");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Float32Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newFloat64View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 8 == 0, TypeError, "ArrayBuffer size is not a multiple of 8");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Float64Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newBigInt64View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 8 == 0, TypeError, "ArrayBuffer size is not a multiple of 8");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::BigInt64Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newBigUint64View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 8 == 0, TypeError, "ArrayBuffer size is not a multiple of 8");
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::BigUint64Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsArrayBuffer::newDataView(size_t offset, size_t numElements) const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::DataView::New(inner, offset, numElements));
+}
+
+bool JsArrayBuffer::isResizable() const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return inner->IsResizableByUserJavaScript();
+}
+
+JsArrayBuffer::operator JsUint8Array() const {
+  return newUint8View(0, size());
+}
+
+// ======================================================================================
+// JsSharedArrayBuffer
+
+kj::Maybe<JsSharedArrayBuffer> JsSharedArrayBuffer::tryCreate(Lock& js, size_t length) {
+  JSG_REQUIRE(length < v8::ArrayBuffer::kMaxByteLength, RangeError, "The length is too large");
+  auto backing = v8::SharedArrayBuffer::NewBackingStore(js.v8Isolate, length,
+      v8::BackingStoreInitializationMode::kZeroInitialized,
+      v8::BackingStoreOnFailureMode::kReturnNull);
+  if (backing == nullptr) return kj::none;
+  return create(js, kj::mv(backing));
+}
+
+JsSharedArrayBuffer JsSharedArrayBuffer::create(Lock& js, size_t length) {
+  JSG_REQUIRE(length < v8::ArrayBuffer::kMaxByteLength, RangeError, "The length is too large");
+  auto backing = v8::SharedArrayBuffer::NewBackingStore(js.v8Isolate, length,
+      v8::BackingStoreInitializationMode::kZeroInitialized,
+      v8::BackingStoreOnFailureMode::kReturnNull);
+  JSG_REQUIRE(backing != nullptr, RangeError, "Failed to allocate memory for ArrayBuffer");
+  return create(js, kj::mv(backing));
+}
+
+JsSharedArrayBuffer JsSharedArrayBuffer::create(Lock& js, kj::ArrayPtr<const kj::byte> data) {
+  auto buf = create(js, data.size());
+  buf.asArrayPtr().copyFrom(data);
+  return buf;
+}
+
+JsSharedArrayBuffer JsSharedArrayBuffer::create(
+    Lock& js, std::unique_ptr<v8::BackingStore> backingStore) {
+  return JsSharedArrayBuffer(v8::SharedArrayBuffer::New(js.v8Isolate, kj::mv(backingStore)));
+}
+
+JsSharedArrayBuffer JsSharedArrayBuffer::create(
+    Lock& js, std::shared_ptr<v8::BackingStore> backingStore) {
+  return JsSharedArrayBuffer(v8::SharedArrayBuffer::New(js.v8Isolate, kj::mv(backingStore)));
+}
+
+kj::ArrayPtr<kj::byte> JsSharedArrayBuffer::asArrayPtr() {
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  void* data = inner->GetBackingStore()->Data();
+  size_t length = inner->ByteLength();
+  return kj::ArrayPtr(static_cast<kj::byte*>(data), length);
+}
+
+kj::ArrayPtr<const kj::byte> JsSharedArrayBuffer::asArrayPtr() const {
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  const void* data = inner->GetBackingStore()->Data();
+  size_t length = inner->ByteLength();
+  return kj::ArrayPtr(static_cast<const kj::byte*>(data), length);
+}
+
+JsSharedArrayBuffer JsSharedArrayBuffer::slice(Lock& js, size_t newLength) const {
+  JSG_REQUIRE(newLength <= size(), RangeError, "New length exceeds buffer length");
+  auto dest = create(js, newLength);
+  dest.asArrayPtr().copyFrom(asArrayPtr().slice(0, newLength));
+  return dest;
+}
+
+size_t JsSharedArrayBuffer::size() const {
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return inner->ByteLength();
+}
+
+kj::Array<kj::byte> JsSharedArrayBuffer::copy() {
+  auto ptr = asArrayPtr();
+  return kj::heapArray(ptr);
+}
+
+JsSharedArrayBuffer::operator JsBufferSource() const {
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return jsg::JsBufferSource(inner);
+}
+
+JsUint8Array JsSharedArrayBuffer::newUint8View(size_t offset, size_t numElements) const {
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsUint8Array(v8::Uint8Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newInt8View(size_t offset, size_t numElements) const {
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Int8Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newUint8ClampedView(
+    size_t offset, size_t numElements) const {
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Uint8ClampedArray::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newUint16View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 2 == 0, TypeError, "ArrayBuffer size is not a multiple of 2");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Uint16Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newInt16View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 2 == 0, TypeError, "ArrayBuffer size is not a multiple of 2");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Int16Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newUint32View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 4 == 0, TypeError, "ArrayBuffer size is not a multiple of 4");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Uint32Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newInt32View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 4 == 0, TypeError, "ArrayBuffer size is not a multiple of 4");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Int32Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newFloat16View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 2 == 0, TypeError, "ArrayBuffer size is not a multiple of 2");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Float16Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newFloat32View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 4 == 0, TypeError, "ArrayBuffer size is not a multiple of 4");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Float32Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newFloat64View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 8 == 0, TypeError, "ArrayBuffer size is not a multiple of 8");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::Float64Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newBigInt64View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 8 == 0, TypeError, "ArrayBuffer size is not a multiple of 8");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::BigInt64Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newBigUint64View(size_t offset, size_t numElements) const {
+  JSG_REQUIRE(size() % 8 == 0, TypeError, "ArrayBuffer size is not a multiple of 8");
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::BigUint64Array::New(inner, offset, numElements));
+}
+JsArrayBufferView JsSharedArrayBuffer::newDataView(size_t offset, size_t numElements) const {
+  v8::Local<v8::SharedArrayBuffer> inner = *this;
+  return JsArrayBufferView(v8::DataView::New(inner, offset, numElements));
+}
+
+JsSharedArrayBuffer::operator JsUint8Array() const {
+  return newUint8View(0, size());
+}
+
 // ======================================================================================
 // JsArrayBufferView
 
@@ -736,11 +983,210 @@ size_t JsArrayBufferView::size() const {
   return inner->ByteLength();
 }
 
+size_t JsArrayBufferView::getOffset() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->ByteOffset();
+}
+
 bool JsArrayBufferView::isIntegerType() const {
   v8::Local<v8::ArrayBufferView> inner = *this;
   return inner->IsUint8Array() || inner->IsUint8ClampedArray() || inner->IsInt8Array() ||
       inner->IsUint16Array() || inner->IsInt16Array() || inner->IsUint32Array() ||
       inner->IsInt32Array() || inner->IsBigInt64Array() || inner->IsBigUint64Array();
+}
+
+bool JsArrayBufferView::isUint8Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsUint8Array();
+}
+
+bool JsArrayBufferView::isInt8Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsInt8Array();
+}
+
+bool JsArrayBufferView::isUint8ClampedArray() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsUint8ClampedArray();
+}
+
+bool JsArrayBufferView::isUint16Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsUint16Array();
+}
+
+bool JsArrayBufferView::isInt16Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsInt16Array();
+}
+
+bool JsArrayBufferView::isUint32Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsUint32Array();
+}
+
+bool JsArrayBufferView::isInt32Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsInt32Array();
+}
+
+bool JsArrayBufferView::isFloat16Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsFloat16Array();
+}
+
+bool JsArrayBufferView::isFloat32Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsFloat32Array();
+}
+
+bool JsArrayBufferView::isFloat64Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsFloat64Array();
+}
+
+bool JsArrayBufferView::isBigInt64Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsBigInt64Array();
+}
+
+bool JsArrayBufferView::isBigUint64Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsBigUint64Array();
+}
+
+bool JsArrayBufferView::isDataView() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->IsDataView();
+}
+
+size_t JsArrayBufferView::getElementSize() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  if (inner->IsUint8Array() || inner->IsInt8Array() || inner->IsUint8ClampedArray()) {
+    return 1;
+  } else if (inner->IsUint16Array() || inner->IsInt16Array()) {
+    return 2;
+  } else if (inner->IsUint32Array() || inner->IsInt32Array() || inner->IsFloat32Array()) {
+    return 4;
+  } else if (inner->IsFloat64Array() || inner->IsBigInt64Array() || inner->IsBigUint64Array()) {
+    return 8;
+  } else if (inner->IsDataView()) {
+    return 1;  // DataView is byte-addressable
+  }
+  KJ_UNREACHABLE;  // Not a valid ArrayBufferView type
+}
+
+JsArrayBuffer JsArrayBufferView::getBuffer() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return JsArrayBuffer(inner->Buffer());
+}
+
+bool JsArrayBufferView::isDetachable() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->Buffer()->IsDetachable();
+}
+
+bool JsArrayBufferView::isDetached() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->Buffer()->WasDetached();
+}
+
+void JsArrayBufferView::detachInPlace(Lock& js) {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  check(inner->Buffer()->Detach({}));
+}
+
+JsArrayBufferView JsArrayBufferView::detachAndTake(Lock& js) {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  auto length = inner->ByteLength();
+  auto offset = inner->ByteOffset();
+  auto ab = getBuffer().detachAndTake(js);
+
+  // We have to return the same type of vie
+  if (inner->IsUint8Array()) {
+    return ab.newUint8View(offset, length);
+  } else if (inner->IsInt8Array()) {
+    return ab.newInt8View(offset, length);
+  } else if (inner->IsUint8ClampedArray()) {
+    return ab.newUint8ClampedView(offset, length);
+  } else if (inner->IsUint16Array()) {
+    return ab.newUint16View(offset, length / getElementSize());
+  } else if (inner->IsInt16Array()) {
+    return ab.newInt16View(offset, length / getElementSize());
+  } else if (inner->IsUint32Array()) {
+    return ab.newUint32View(offset, length / getElementSize());
+  } else if (inner->IsInt32Array()) {
+    return ab.newInt32View(offset, length / getElementSize());
+  } else if (inner->IsFloat16Array()) {
+    return ab.newFloat16View(offset, length / getElementSize());
+  } else if (inner->IsFloat32Array()) {
+    return ab.newFloat32View(offset, length / getElementSize());
+  } else if (inner->IsFloat64Array()) {
+    return ab.newFloat64View(offset, length / getElementSize());
+  } else if (inner->IsBigInt64Array()) {
+    return ab.newBigInt64View(offset, length / getElementSize());
+  } else if (inner->IsBigUint64Array()) {
+    return ab.newBigUint64View(offset, length / getElementSize());
+  } else if (inner->IsDataView()) {
+    return ab.newDataView(offset, length);
+  }
+
+  KJ_UNREACHABLE;
+}
+
+JsArrayBufferView JsArrayBufferView::slice(Lock& js, size_t offset, size_t length) const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  offset = inner->ByteOffset() + offset;
+
+  if (inner->IsUint8Array()) {
+    return JsArrayBufferView(v8::Uint8Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsInt8Array()) {
+    return JsArrayBufferView(v8::Int8Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsUint8ClampedArray()) {
+    return JsArrayBufferView(v8::Uint8ClampedArray::New(inner->Buffer(), offset, length));
+  } else if (inner->IsUint16Array()) {
+    return JsArrayBufferView(v8::Uint16Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsInt16Array()) {
+    return JsArrayBufferView(v8::Int16Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsUint32Array()) {
+    return JsArrayBufferView(v8::Uint32Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsInt32Array()) {
+    return JsArrayBufferView(v8::Int32Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsFloat16Array()) {
+    return JsArrayBufferView(v8::Float16Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsFloat32Array()) {
+    return JsArrayBufferView(v8::Float32Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsFloat64Array()) {
+    return JsArrayBufferView(v8::Float64Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsBigInt64Array()) {
+    return JsArrayBufferView(v8::BigInt64Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsBigUint64Array()) {
+    return JsArrayBufferView(v8::BigUint64Array::New(inner->Buffer(), offset, length));
+  } else if (inner->IsDataView()) {
+    return JsArrayBufferView(v8::DataView::New(inner->Buffer(), offset, length));
+  }
+
+  KJ_UNREACHABLE;
+}
+
+bool JsArrayBufferView::isResizable() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return inner->Buffer()->IsResizableByUserJavaScript();
+}
+
+JsArrayBufferView::operator JsBufferSource() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  return jsg::JsBufferSource(inner);
+}
+
+JsArrayBufferView::operator JsUint8Array() const {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  if (inner->IsUint8Array()) {
+    return jsg::JsUint8Array(inner.As<v8::Uint8Array>());
+  }
+
+  auto buf = inner->Buffer();
+  return jsg::JsUint8Array(v8::Uint8Array::New(buf, inner->ByteOffset(), inner->ByteLength()));
 }
 
 // ======================================================================================
@@ -828,6 +1274,77 @@ bool JsBufferSource::isResizable() const {
   return false;
 }
 
+bool JsBufferSource::isDetachable() const {
+  v8::Local<v8::Value> inner = *this;
+  if (inner->IsArrayBuffer()) {
+    return inner.As<v8::ArrayBuffer>()->IsDetachable();
+  } else if (inner->IsSharedArrayBuffer()) {
+    return false;  // SharedArrayBuffers are never detachable
+  } else {
+    KJ_DASSERT(inner->IsArrayBufferView());
+    return inner.As<v8::ArrayBufferView>()->Buffer()->IsDetachable();
+  }
+}
+
+bool JsBufferSource::isDetached() const {
+  v8::Local<v8::Value> inner = *this;
+  if (inner->IsArrayBuffer()) {
+    return inner.As<v8::ArrayBuffer>()->WasDetached();
+  } else if (inner->IsSharedArrayBuffer()) {
+    return false;  // SharedArrayBuffers are never detachable
+  } else {
+    KJ_DASSERT(inner->IsArrayBufferView());
+    return inner.As<v8::ArrayBufferView>()->Buffer()->WasDetached();
+  }
+}
+
+void JsBufferSource::detachInPlace(Lock& js) {
+  JSG_REQUIRE(isDetachable(), TypeError, "BufferSource is not detachable");
+  v8::Local<v8::Value> inner = *this;
+  if (inner->IsArrayBuffer()) {
+    auto buf = inner.As<v8::ArrayBuffer>();
+    check(buf->Detach({}));
+  } else if (inner->IsSharedArrayBuffer()) {
+    KJ_UNREACHABLE;  // SharedArrayBuffers are never detachable
+  } else {
+    KJ_DASSERT(inner->IsArrayBufferView());
+    auto view = inner.As<v8::ArrayBufferView>();
+    check(view->Buffer()->Detach({}));
+  }
+}
+
+JsBufferSource JsBufferSource::detachAndTake(Lock& js) {
+  JSG_REQUIRE(isDetachable(), TypeError, "BufferSource is not detachable");
+  v8::Local<v8::Value> inner = *this;
+  if (inner->IsArrayBuffer()) {
+    JsArrayBuffer ab(inner.As<v8::ArrayBuffer>());
+    return ab.detachAndTake(js);
+  } else if (inner->IsSharedArrayBuffer()) {
+    KJ_UNREACHABLE;  // SharedArrayBuffers are never detachable
+  }
+
+  KJ_DASSERT(inner->IsArrayBufferView());
+  JsArrayBufferView view(inner.As<v8::ArrayBufferView>());
+  return view.detachAndTake(js);
+}
+
+JsBufferSource::operator JsUint8Array() const {
+  v8::Local<v8::Value> inner = *this;
+  if (inner->IsArrayBuffer()) {
+    JsArrayBuffer ab(inner.As<v8::ArrayBuffer>());
+    return ab;
+  }
+  if (inner->IsSharedArrayBuffer()) {
+    JsSharedArrayBuffer ab(inner.As<v8::SharedArrayBuffer>());
+    return ab;
+  }
+  if (inner->IsUint8Array()) {
+    return jsg::JsUint8Array(inner.As<v8::Uint8Array>());
+  }
+  JsArrayBufferView view(inner.As<v8::ArrayBufferView>());
+  return view;
+}
+
 // ======================================================================================
 // JsUint8Array
 
@@ -859,8 +1376,7 @@ JsUint8Array JsUint8Array::create(
 
 JsUint8Array JsUint8Array::slice(Lock& js, size_t newLength) const {
   JSG_REQUIRE(newLength <= size(), RangeError, "New length exceeds array length");
-  auto u8 = v8::Uint8Array::New(inner->Buffer(), inner->ByteOffset(), newLength);
-  return JsUint8Array(u8);
+  return slice(js, 0, newLength);
 }
 
 kj::ArrayPtr<const kj::byte> JsUint8Array::asArrayPtr() const {
@@ -880,6 +1396,54 @@ size_t JsUint8Array::size() const {
 kj::Array<kj::byte> JsUint8Array::copy() {
   auto ptr = asArrayPtr();
   return kj::heapArray(ptr);
+}
+
+JsArrayBuffer JsUint8Array::getBuffer() const {
+  auto buf = inner->Buffer();
+  return JsArrayBuffer(buf);
+}
+
+bool JsUint8Array::isDetachable() const {
+  auto buf = inner->Buffer();
+  return buf->IsDetachable();
+}
+
+bool JsUint8Array::isDetached() const {
+  auto buf = inner->Buffer();
+  return buf->WasDetached();
+}
+
+void JsUint8Array::detachInPlace(Lock& js) {
+  auto buf = inner->Buffer();
+  check(buf->Detach({}));
+}
+
+JsUint8Array JsUint8Array::detachAndTake(Lock& js) {
+  v8::Local<v8::Uint8Array> inner = *this;
+  auto length = inner->ByteLength();
+  auto offset = inner->ByteOffset();
+  auto ab = getBuffer().detachAndTake(js);
+  return JsUint8Array(v8::Uint8Array::New(ab, offset, length));
+}
+
+JsUint8Array JsUint8Array::slice(Lock& js, size_t offset, size_t length) const {
+  auto buf = inner->Buffer();
+  return JsUint8Array(v8::Uint8Array::New(buf, inner->ByteOffset() + offset, length));
+}
+
+bool JsUint8Array::isResizable() const {
+  auto buf = inner->Buffer();
+  return buf->IsResizableByUserJavaScript();
+}
+
+JsUint8Array::operator JsArrayBufferView() const {
+  v8::Local<v8::Uint8Array> inner = *this;
+  return jsg::JsArrayBufferView(inner);
+}
+
+JsUint8Array::operator JsBufferSource() const {
+  v8::Local<v8::Uint8Array> inner = *this;
+  return jsg::JsBufferSource(inner);
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -1348,6 +1348,15 @@ JsBufferSource::operator JsUint8Array() const {
 // ======================================================================================
 // JsUint8Array
 
+kj::Maybe<JsUint8Array> JsUint8Array::tryCreate(Lock& js, size_t length) {
+  JSG_REQUIRE(length < v8::ArrayBuffer::kMaxByteLength, RangeError, "The length is too large");
+  auto backing = v8::ArrayBuffer::NewBackingStore(js.v8Isolate, length,
+      v8::BackingStoreInitializationMode::kZeroInitialized,
+      v8::BackingStoreOnFailureMode::kReturnNull);
+  if (backing == nullptr) return kj::none;
+  return create(js, kj::mv(backing), 0, length);
+}
+
 JsUint8Array JsUint8Array::create(Lock& js, size_t length) {
   JSG_REQUIRE(length < v8::ArrayBuffer::kMaxByteLength, RangeError, "The length is too large");
   auto backing = v8::ArrayBuffer::NewBackingStore(js.v8Isolate, length,

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -154,7 +154,7 @@ JsValue JsObject::getPrototype(Lock& js) {
       return JsObject(target.As<v8::Object>()).getPrototype(js);
     }
     JSG_REQUIRE(trap.isFunction(), TypeError, "Proxy getPrototypeOf trap is not a function");
-    v8::Local<v8::Function> fn = ((v8::Local<v8::Value>)trap).As<v8::Function>();
+    v8::Local<v8::Function> fn = (v8::Local<v8::Value>(trap)).As<v8::Function>();
     v8::Local<v8::Value> args[] = {target};
     auto ret = JsValue(check(fn->Call(js.v8Context(), jsHandler.inner, 1, args)));
     JSG_REQUIRE(ret.isObject() || ret.isNull(), TypeError,
@@ -659,8 +659,12 @@ uint JsFunction::hashCode() const {
   return kj::hashCode(obj->GetIdentityHash());
 }
 
-BufferSource Lock::bytes(kj::Array<kj::byte> data) {
-  return BufferSource(*this, BackingStore::from(*this, kj::mv(data)));
+JsUint8Array Lock::bytes(kj::ArrayPtr<const kj::byte> data) {
+  return JsUint8Array::create(*this, data);
+}
+
+JsArrayBuffer Lock::arrayBuffer(kj::ArrayPtr<const kj::byte> data) {
+  return JsArrayBuffer::create(*this, data);
 }
 
 // ======================================================================================
@@ -1064,7 +1068,7 @@ size_t JsArrayBufferView::getElementSize() const {
   v8::Local<v8::ArrayBufferView> inner = *this;
   if (inner->IsUint8Array() || inner->IsInt8Array() || inner->IsUint8ClampedArray()) {
     return 1;
-  } else if (inner->IsUint16Array() || inner->IsInt16Array()) {
+  } else if (inner->IsUint16Array() || inner->IsInt16Array() || inner->IsFloat16Array()) {
     return 2;
   } else if (inner->IsUint32Array() || inner->IsInt32Array() || inner->IsFloat32Array()) {
     return 4;
@@ -1196,6 +1200,44 @@ JsArrayBufferView::operator JsUint8Array() const {
 
   auto buf = inner->Buffer();
   return jsg::JsUint8Array(v8::Uint8Array::New(buf, inner->ByteOffset(), inner->ByteLength()));
+}
+
+JsArrayBufferView JsArrayBufferView::clone(jsg::Lock& js) {
+  v8::Local<v8::ArrayBufferView> inner = *this;
+  auto backing = inner->Buffer()->GetBackingStore();
+  auto ab = jsg::JsArrayBuffer::create(js, kj::mv(backing));
+
+  auto offset = getOffset();
+  auto length = size();
+
+  if (inner->IsUint8Array()) {
+    return ab.newUint8View(offset, length);
+  } else if (inner->IsInt8Array()) {
+    return ab.newInt8View(offset, length / getElementSize());
+  } else if (inner->IsUint8ClampedArray()) {
+    return ab.newUint8ClampedView(offset, length / getElementSize());
+  } else if (inner->IsUint16Array()) {
+    return ab.newUint16View(offset, length / getElementSize());
+  } else if (inner->IsInt16Array()) {
+    return ab.newInt16View(offset, length / getElementSize());
+  } else if (inner->IsUint32Array()) {
+    return ab.newUint32View(offset, length / getElementSize());
+  } else if (inner->IsInt32Array()) {
+    return ab.newInt32View(offset, length / getElementSize());
+  } else if (inner->IsFloat16Array()) {
+    return ab.newFloat16View(offset, length / getElementSize());
+  } else if (inner->IsFloat32Array()) {
+    return ab.newFloat32View(offset, length / getElementSize());
+  } else if (inner->IsFloat64Array()) {
+    return ab.newFloat64View(offset, length / getElementSize());
+  } else if (inner->IsBigInt64Array()) {
+    return ab.newBigInt64View(offset, length / getElementSize());
+  } else if (inner->IsBigUint64Array()) {
+    return ab.newBigUint64View(offset, length / getElementSize());
+  } else if (inner->IsDataView()) {
+    return ab.newDataView(offset, length);
+  }
+  KJ_UNREACHABLE;
 }
 
 // ======================================================================================
@@ -1354,6 +1396,38 @@ JsBufferSource::operator JsUint8Array() const {
   return view;
 }
 
+size_t JsBufferSource::getOffset() const {
+  v8::Local<v8::Value> inner = *this;
+  if (inner->IsArrayBuffer() || inner->IsSharedArrayBuffer()) {
+    return 0;
+  }
+  KJ_DASSERT(inner->IsArrayBufferView());
+  auto view = inner.As<v8::ArrayBufferView>();
+  return view->ByteOffset();
+}
+
+size_t JsBufferSource::underlyingArrayBufferSize(Lock& js) const {
+  v8::Local<v8::Value> inner = *this;
+  if (inner->IsArrayBuffer()) {
+    auto buf = inner.As<v8::ArrayBuffer>();
+    if (buf->WasDetached()) [[unlikely]] {
+      return 0;
+    }
+    return buf->ByteLength();
+  } else if (inner->IsSharedArrayBuffer()) {
+    auto buf = inner.As<v8::SharedArrayBuffer>();
+    return buf->ByteLength();
+  } else {
+    KJ_DASSERT(inner->IsArrayBufferView());
+    auto view = inner.As<v8::ArrayBufferView>();
+    auto buf = view->Buffer();
+    if (buf->WasDetached()) [[unlikely]] {
+      return 0;
+    }
+    return buf->ByteLength();
+  }
+}
+
 // ======================================================================================
 // JsUint8Array
 
@@ -1383,6 +1457,11 @@ JsUint8Array JsUint8Array::create(Lock& js, kj::ArrayPtr<const kj::byte> data) {
 
 JsUint8Array JsUint8Array::create(Lock& js, JsArrayBuffer& buffer) {
   v8::Local<v8::ArrayBuffer> ab = buffer;
+  return JsUint8Array(v8::Uint8Array::New(ab, 0, ab->ByteLength()));
+}
+
+JsUint8Array JsUint8Array::create(Lock& js, JsSharedArrayBuffer& buffer) {
+  v8::Local<v8::SharedArrayBuffer> ab = buffer;
   return JsUint8Array(v8::Uint8Array::New(ab, 0, ab->ByteLength()));
 }
 
@@ -1462,6 +1541,13 @@ JsUint8Array::operator JsArrayBufferView() const {
 JsUint8Array::operator JsBufferSource() const {
   v8::Local<v8::Uint8Array> inner = *this;
   return jsg::JsBufferSource(inner);
+}
+
+JsUint8Array JsUint8Array::clone(jsg::Lock& js) {
+  auto buf = inner->Buffer();
+  auto backing = buf->GetBackingStore();
+  auto ab = jsg::JsArrayBuffer::create(js, kj::mv(backing));
+  return JsUint8Array(v8::Uint8Array::New(ab, inner->ByteOffset(), inner->ByteLength()));
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -390,6 +390,8 @@ class JsArrayBufferView final: public JsBase<v8::ArrayBufferView, JsArrayBufferV
   // Regardless of what kind of typed array view this is, we can always get it as a Uint8Array
   operator JsUint8Array() const;
 
+  JsArrayBufferView clone(jsg::Lock& js);
+
   using JsBase<v8::ArrayBufferView, JsArrayBufferView>::JsBase;
 };
 
@@ -403,6 +405,8 @@ class JsUint8Array final: public JsBase<v8::Uint8Array, JsUint8Array> {
 
   // Create a Uint8Array view over the given ArrayBuffer.
   static JsUint8Array create(Lock& js, JsArrayBuffer& buffer);
+
+  static JsUint8Array create(Lock& js, JsSharedArrayBuffer& buffer);
 
   static JsUint8Array create(
       Lock& js, std::unique_ptr<v8::BackingStore> backingStore, size_t byteOffset, size_t length);
@@ -445,6 +449,8 @@ class JsUint8Array final: public JsBase<v8::Uint8Array, JsUint8Array> {
   operator JsArrayBufferView() const;
   operator JsBufferSource() const;
 
+  JsUint8Array clone(jsg::Lock& js);
+
   using JsBase<v8::Uint8Array, JsUint8Array>::JsBase;
 };
 
@@ -466,6 +472,8 @@ class JsBufferSource final: public JsBase<v8::Value, JsBufferSource> {
   kj::ArrayPtr<kj::byte> asArrayPtr();
 
   size_t size() const;
+  size_t getOffset() const;
+  size_t underlyingArrayBufferSize(Lock& js) const;
 
   // Returns true if the underlying value is an integer-typed TypedArray.
   bool isIntegerType() const;

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -58,7 +58,6 @@ inline void requireOnStack(void* self) {
   V(BigInt64Array)                                                                                 \
   V(BigUint64Array)                                                                                \
   V(DataView)                                                                                      \
-  V(SharedArrayBuffer)                                                                             \
   V(WasmMemoryObject)                                                                              \
   V(WasmModuleObject)                                                                              \
   JS_TYPE_CLASSES(V)
@@ -234,12 +233,16 @@ class JsArray final: public JsBase<v8::Array, JsArray> {
 
 class JsArrayBuffer final: public JsBase<v8::ArrayBuffer, JsArrayBuffer> {
  public:
+  static kj::Maybe<JsArrayBuffer> tryCreate(Lock& js, size_t length);
+
   static JsArrayBuffer create(Lock& js, size_t length);
 
   // Allocate and copy data from the given ArrayPtr in a single step.
   static JsArrayBuffer create(Lock& js, kj::ArrayPtr<const kj::byte> data);
 
+  // Take ownership of the given backing store.
   static JsArrayBuffer create(Lock& js, std::unique_ptr<v8::BackingStore> backingStore);
+  static JsArrayBuffer create(Lock& js, std::shared_ptr<v8::BackingStore> backingStore);
 
   JsArrayBuffer slice(Lock& js, size_t newLength) const;
 
@@ -251,7 +254,83 @@ class JsArrayBuffer final: public JsBase<v8::ArrayBuffer, JsArrayBuffer> {
   // Return a copy of this buffer's data as a kj::Array.
   kj::Array<kj::byte> copy();
 
+  // A JsArrayBuffer can be used as a JsBufferSource, which is a more general type that
+  // also includes JsArrayBufferView.
+  operator JsBufferSource() const;
+
+  // A JsArrayBuffer might be detachable.
+  bool isDetachable() const;
+  bool isDetached() const;
+  void detachInPlace(Lock& js);
+  JsArrayBuffer detachAndTake(Lock& js) KJ_WARN_UNUSED_RESULT;
+
+  // Return a view over this buffer
+  JsUint8Array newUint8View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newInt8View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newUint8ClampedView(size_t offset, size_t numElements) const;
+  JsArrayBufferView newUint16View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newInt16View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newUint32View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newInt32View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newFloat16View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newFloat32View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newFloat64View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newBigInt64View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newBigUint64View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newDataView(size_t offset, size_t numElements) const;
+
+  bool isResizable() const;
+
+  operator JsUint8Array() const;
+
   using JsBase<v8::ArrayBuffer, JsArrayBuffer>::JsBase;
+};
+
+class JsSharedArrayBuffer final: public JsBase<v8::SharedArrayBuffer, JsSharedArrayBuffer> {
+ public:
+  static kj::Maybe<JsSharedArrayBuffer> tryCreate(Lock& js, size_t length);
+
+  static JsSharedArrayBuffer create(Lock& js, size_t length);
+
+  // Allocate and copy data from the given ArrayPtr in a single step.
+  static JsSharedArrayBuffer create(Lock& js, kj::ArrayPtr<const kj::byte> data);
+
+  // Take ownership of the given backing store.
+  static JsSharedArrayBuffer create(Lock& js, std::unique_ptr<v8::BackingStore> backingStore);
+  static JsSharedArrayBuffer create(Lock& js, std::shared_ptr<v8::BackingStore> backingStore);
+
+  JsSharedArrayBuffer slice(Lock& js, size_t newLength) const;
+
+  kj::ArrayPtr<kj::byte> asArrayPtr();
+  kj::ArrayPtr<const kj::byte> asArrayPtr() const;
+
+  size_t size() const;
+
+  // Return a copy of this buffer's data as a kj::Array.
+  kj::Array<kj::byte> copy();
+
+  // A JsArrayBuffer can be used as a JsBufferSource, which is a more general type that
+  // also includes JsArrayBufferView.
+  operator JsBufferSource() const;
+
+  // Return a view over this buffer
+  JsUint8Array newUint8View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newInt8View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newUint8ClampedView(size_t offset, size_t numElements) const;
+  JsArrayBufferView newUint16View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newInt16View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newUint32View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newInt32View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newFloat16View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newFloat32View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newFloat64View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newBigInt64View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newBigUint64View(size_t offset, size_t numElements) const;
+  JsArrayBufferView newDataView(size_t offset, size_t numElements) const;
+
+  operator JsUint8Array() const;
+
+  using JsBase<v8::SharedArrayBuffer, JsSharedArrayBuffer>::JsBase;
 };
 
 class JsArrayBufferView final: public JsBase<v8::ArrayBufferView, JsArrayBufferView> {
@@ -269,17 +348,54 @@ class JsArrayBufferView final: public JsBase<v8::ArrayBufferView, JsArrayBufferV
   }
 
   size_t size() const;
+  size_t getOffset() const;
 
   // Returns true if the underlying view is an integer-typed TypedArray
   // (e.g. Uint8Array, Int32Array, BigUint64Array) as opposed to a float-typed
   // TypedArray or DataView.
   bool isIntegerType() const;
 
+  bool isUint8Array() const;
+  bool isInt8Array() const;
+  bool isUint8ClampedArray() const;
+  bool isUint16Array() const;
+  bool isInt16Array() const;
+  bool isUint32Array() const;
+  bool isInt32Array() const;
+  bool isFloat16Array() const;
+  bool isFloat32Array() const;
+  bool isFloat64Array() const;
+  bool isBigInt64Array() const;
+  bool isBigUint64Array() const;
+  bool isDataView() const;
+
+  size_t getElementSize() const;
+
+  JsArrayBuffer getBuffer() const;
+
+  bool isDetachable() const;
+  bool isDetached() const;
+  void detachInPlace(Lock& js);
+  JsArrayBufferView detachAndTake(Lock& js) KJ_WARN_UNUSED_RESULT;
+
+  // Get a new view of the same type over the same buffer with the given offset and length.
+  // The offset is relative to the start of this view, not the start of the underlying buffer.
+  // The length is the number of elements (not bytes).
+  JsArrayBufferView slice(Lock& js, size_t offset, size_t length) const;
+
+  bool isResizable() const;
+
+  operator JsBufferSource() const;
+
+  // Regardless of what kind of typed array view this is, we can always get it as a Uint8Array
+  operator JsUint8Array() const;
+
   using JsBase<v8::ArrayBufferView, JsArrayBufferView>::JsBase;
 };
 
 class JsUint8Array final: public JsBase<v8::Uint8Array, JsUint8Array> {
  public:
+  static kj::Maybe<JsUint8Array> tryCreate(Lock& js, size_t length);
   static JsUint8Array create(Lock& js, size_t length);
 
   // Allocate and copy data from the given ArrayPtr in a single step.
@@ -312,6 +428,23 @@ class JsUint8Array final: public JsBase<v8::Uint8Array, JsUint8Array> {
   // Return a copy of this buffer's data as a kj::Array.
   kj::Array<kj::byte> copy();
 
+  JsArrayBuffer getBuffer() const;
+
+  bool isDetachable() const;
+  bool isDetached() const;
+  void detachInPlace(Lock& js);
+  JsUint8Array detachAndTake(Lock& js) KJ_WARN_UNUSED_RESULT;
+
+  // Get a new view of the same type over the same buffer with the given offset and length.
+  // The offset is relative to the start of this view, not the start of the underlying buffer.
+  // The length is the number of elements (not bytes).
+  JsUint8Array slice(Lock& js, size_t offset, size_t length) const;
+
+  bool isResizable() const;
+
+  operator JsArrayBufferView() const;
+  operator JsBufferSource() const;
+
   using JsBase<v8::Uint8Array, JsUint8Array>::JsBase;
 };
 
@@ -342,8 +475,16 @@ class JsBufferSource final: public JsBase<v8::Value, JsBufferSource> {
   bool isArrayBufferView() const;
   bool isResizable() const;
 
+  bool isDetachable() const;
+  bool isDetached() const;
+  void detachInPlace(Lock& js);
+  JsBufferSource detachAndTake(Lock& js) KJ_WARN_UNUSED_RESULT;
+
   // Return a copy of this buffer's data as a kj::Array.
   kj::Array<kj::byte> copy();
+
+  // Regardless of what kind of typed array view this is, we can always get it as a Uint8Array
+  operator JsUint8Array() const;
 
   using JsBase<v8::Value, JsBufferSource>::JsBase;
 };

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -1984,10 +1984,7 @@ Module::EvaluateCallback Module::newDataModuleHandler(kj::ArrayPtr<const kj::byt
   return [data](Lock& js, const Url& id, const ModuleNamespace& ns,
              const CompilationObserver&) -> bool {
     JSG_TRY(js) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, data.size());
-      backing.asArrayPtr().copyFrom(data);
-      auto buffer = jsg::BufferSource(js, kj::mv(backing));
-      return ns.setDefault(js, JsValue(buffer.getHandle(js)));
+      return ns.setDefault(js, jsg::JsArrayBuffer::create(js, data));
     }
     JSG_CATCH(exception) {
       js.v8Isolate->ThrowException(exception.getHandle(js));

--- a/src/workerd/tests/bench-pumpto.c++
+++ b/src/workerd/tests/bench-pumpto.c++
@@ -100,10 +100,9 @@ jsg::Ref<ReadableStream> createValueStream(
         KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableStreamDefaultController>>());
 
     if ((*counter)++ < numChunks) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-      jsg::BufferSource buffer(js, kj::mv(backing));
-      buffer.asArrayPtr().fill(0xAB);
-      c->enqueue(js, buffer.getHandle(js));
+      auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+      ab.asArrayPtr().fill(0xAB);
+      c->enqueue(js, ab);
     }
     if (*counter == numChunks) {
       c->close(js);
@@ -129,10 +128,9 @@ jsg::Ref<ReadableStream> createByteStream(
         KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableByteStreamController>>());
 
     if ((*counter)++ < numChunks) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-      jsg::BufferSource buffer(js, kj::mv(backing));
-      buffer.asArrayPtr().fill(0xAB);
-      c->enqueue(js, kj::mv(buffer));
+      auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+      ab.asArrayPtr().fill(0xAB);
+      c->enqueue(js, ab);
     }
     if (*counter == numChunks) {
       c->close(js);
@@ -171,10 +169,9 @@ jsg::Ref<ReadableStream> createIoLatencyValueStream(
         JSG_VISITABLE_LAMBDA(
             (cRef = kj::mv(cRef), chunkSize, numChunks, counter), (cRef), (jsg::Lock & js) mutable {
               if ((*counter)++ < numChunks) {
-              auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-              jsg::BufferSource buffer(js, kj::mv(backing));
-              buffer.asArrayPtr().fill(0xAB);
-              cRef->enqueue(js, buffer.getHandle(js));
+              auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+              ab.asArrayPtr().fill(0xAB);
+              cRef->enqueue(js, ab);
               }
               if (*counter == numChunks) {
               cRef->close(js);

--- a/src/workerd/tests/bench-stream-piping.c++
+++ b/src/workerd/tests/bench-stream-piping.c++
@@ -131,10 +131,9 @@ jsg::Ref<ReadableStream> createValueStream(
         KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableStreamDefaultController>>());
 
     if ((*counter)++ < numChunks) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-      jsg::BufferSource buffer(js, kj::mv(backing));
-      buffer.asArrayPtr().fill(0xAB);
-      c->enqueue(js, buffer.getHandle(js));
+      auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+      ab.asArrayPtr().fill(0xAB);
+      c->enqueue(js, ab);
     }
     if (*counter == numChunks) {
       c->close(js);
@@ -164,10 +163,9 @@ jsg::Ref<ReadableStream> createByteStream(jsg::Lock& js,
         KJ_ASSERT_NONNULL(controller.template tryGet<jsg::Ref<ReadableByteStreamController>>());
 
     if ((*counter)++ < numChunks) {
-      auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-      jsg::BufferSource buffer(js, kj::mv(backing));
-      buffer.asArrayPtr().fill(0xAB);
-      c->enqueue(js, kj::mv(buffer));
+      auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+      ab.asArrayPtr().fill(0xAB);
+      c->enqueue(js, ab);
     }
     if (*counter == numChunks) {
       c->close(js);
@@ -213,10 +211,9 @@ jsg::Ref<ReadableStream> createSlowValueStream(
         JSG_VISITABLE_LAMBDA(
             (cRef = kj::mv(cRef), chunkSize, numChunks, counter), (cRef), (jsg::Lock & js) mutable {
               if ((*counter)++ < numChunks) {
-              auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-              jsg::BufferSource buffer(js, kj::mv(backing));
-              buffer.asArrayPtr().fill(0xAB);
-              cRef->enqueue(js, buffer.getHandle(js));
+              auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+              ab.asArrayPtr().fill(0xAB);
+              cRef->enqueue(js, ab);
               }
               if (*counter == numChunks) {
               cRef->close(js);
@@ -261,10 +258,9 @@ jsg::Ref<ReadableStream> createIoLatencyValueStream(
         JSG_VISITABLE_LAMBDA(
             (cRef = kj::mv(cRef), chunkSize, numChunks, counter), (cRef), (jsg::Lock & js) mutable {
               if ((*counter)++ < numChunks) {
-              auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-              jsg::BufferSource buffer(js, kj::mv(backing));
-              buffer.asArrayPtr().fill(0xAB);
-              cRef->enqueue(js, buffer.getHandle(js));
+              auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+              ab.asArrayPtr().fill(0xAB);
+              cRef->enqueue(js, ab);
               }
               if (*counter == numChunks) {
               cRef->close(js);
@@ -301,10 +297,9 @@ jsg::Ref<ReadableStream> createIoLatencyByteStream(
         JSG_VISITABLE_LAMBDA(
             (cRef = kj::mv(cRef), chunkSize, numChunks, counter), (cRef), (jsg::Lock & js) mutable {
               if ((*counter)++ < numChunks) {
-              auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-              jsg::BufferSource buffer(js, kj::mv(backing));
-              buffer.asArrayPtr().fill(0xAB);
-              cRef->enqueue(js, kj::mv(buffer));
+              auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+              ab.asArrayPtr().fill(0xAB);
+              cRef->enqueue(js, ab);
               }
               if (*counter == numChunks) {
               cRef->close(js);
@@ -351,10 +346,9 @@ jsg::Ref<ReadableStream> createTimedValueStream(jsg::Lock& js,
         JSG_VISITABLE_LAMBDA(
             (cRef = kj::mv(cRef), chunkSize, numChunks, counter), (cRef), (jsg::Lock & js) mutable {
               if ((*counter)++ < numChunks) {
-              auto backing = jsg::BackingStore::alloc<v8::ArrayBuffer>(js, chunkSize);
-              jsg::BufferSource buffer(js, kj::mv(backing));
-              buffer.asArrayPtr().fill(0xAB);
-              cRef->enqueue(js, buffer.getHandle(js));
+              auto ab = jsg::JsArrayBuffer::create(js, chunkSize);
+              ab.asArrayPtr().fill(0xAB);
+              cRef->enqueue(js, ab);
               }
               if (*counter == numChunks) {
               cRef->close(js);

--- a/src/wpt/fetch/api-test.ts
+++ b/src/wpt/fetch/api-test.ts
@@ -836,7 +836,16 @@ export default {
       'Check response returned by static method redirect(), status = 308',
     ],
   },
-  'response/response-stream-bad-chunk.any.js': {},
+  'response/response-stream-bad-chunk.any.js': {
+    comment: 'Our impl is slightly more permissive in accepting strings',
+    expectedFailures: [
+      'ReadableStream with non-Uint8Array chunk passed to Response.arrayBuffer() causes TypeError',
+      'ReadableStream with non-Uint8Array chunk passed to Response.blob() causes TypeError',
+      'ReadableStream with non-Uint8Array chunk passed to Response.bytes() causes TypeError',
+      'ReadableStream with non-Uint8Array chunk passed to Response.json() causes TypeError',
+      'ReadableStream with non-Uint8Array chunk passed to Response.text() causes TypeError',
+    ],
+  },
   'response/response-stream-disturbed-1.any.js': {},
   'response/response-stream-disturbed-2.any.js': {},
   'response/response-stream-disturbed-3.any.js': {},

--- a/src/wpt/streams-test.ts
+++ b/src/wpt/streams-test.ts
@@ -207,7 +207,6 @@ export default {
       'ReadableStream with byte source: getReader(), read(view), then cancel()',
       'ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls',
       'ReadableStream with byte source: enqueue(), read(view) partially, then read()',
-      'ReadableStream with byte source: read(view), then respond() and close() in pull()',
       // TODO(conform): The spec expects the read to fail here. Instead, we end up cancelling
       // it with a zero-length result, with the subsequent read marked as done.
       'ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail',
@@ -287,7 +286,6 @@ export default {
       'ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array',
       'ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader',
       'ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches',
-      'ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other',
       'ReadableStream teeing with byte source: canceling branch1 should not impact branch2',
       'ReadableStream teeing with byte source: canceling branch2 should not impact branch1',
       'ReadableStream teeing with byte source: canceling both branches in sequence with delay',


### PR DESCRIPTION
The jsg::BufferSource will be fully replaced by the the
JsArrayBuffer/JsSharedArrayBuffer/JsBufferSource/JsUint8Array
APIs.

Most of this update is mechanical, replacing jsg::BufferSource/jsg::Value/jsg::V8Ref uses with jsg::Js* types. There are a couple small fixes and improvements along the way.

It's difficult to split this up into smaller Prs so I split up commits a bit. The last commit is larger simply because of how interconnected much of this is.