### PR TITLE
Tidy up python build script before 314 upgrade

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -158,6 +158,7 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
     },
     {
         "name": "0.28.2",
+        "released": True,
         "pyodide_version": "0.28.2",
         "pyodide_date": "2025-01-16",
         "packages": PACKAGES_20250808,
@@ -181,11 +182,6 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
                 "abi": "3.13",
                 "sha256": "955091f1bd2eb33255ff2633df990bedc96e2f6294e78f2b416078777394f942",
             },
-            # {
-            #     "name": "scipy",
-            #     "abi": "3.13",
-            #     "sha256": "4f1b6fc179bd5c6d3de68abc4aa9fca2aaecd09c5c8d357c2ecfedce7d621f3d",
-            # },
             {
                 "name": "shapely",
                 "abi": "3.13",

--- a/src/pyodide/helpers.bzl
+++ b/src/pyodide/helpers.bzl
@@ -284,6 +284,15 @@ def _python_bundle(version, *, pyodide_asm_wasm = None, pyodide_asm_js = None, p
     if emscripten_setup_override:
         _copy_to_generated(out_name = "emscriptenSetup.js", name = "emscriptenSetup", src = emscripten_setup_override, version = version)
     else:
+        expand_template(
+            name = "esbuild.config.mjs@" + version,
+            out = _out_path("esbuild.config.mjs", version),
+            substitutions = {
+                "%PYODIDE_VERSION%": version,
+            },
+            template = "internal/pool/esbuild.config.mjs",
+        )
+
         esbuild(
             name = "emscriptenSetup@" + version,
             # exclude emscriptenSetup from source set so that rules_ts won't also try to create a JS output
@@ -295,7 +304,7 @@ def _python_bundle(version, *, pyodide_asm_wasm = None, pyodide_asm_js = None, p
                 "internal/util.ts",
                 "internal/const.ts",
             ],
-            config = "internal/pool/esbuild.config.mjs",
+            config = _out_path("esbuild.config.mjs", version),
             entry_point = "internal/pool/emscriptenSetup.ts",
             external = [
                 "child_process",

--- a/src/pyodide/internal/pool/esbuild.config.mjs
+++ b/src/pyodide/internal/pool/esbuild.config.mjs
@@ -1,10 +1,12 @@
 import { dirname, join } from 'node:path';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'url';
 
 const pyodideRootDir = dirname(
   dirname(dirname(fileURLToPath(import.meta.url)))
 );
+
+const pyodideVersion = '%PYODIDE_VERSION%';
 
 let resolvePlugin = {
   name: 'pyodide-internal',
@@ -14,15 +16,13 @@ let resolvePlugin = {
       let rest = args.path.split(':')[1];
       let path;
       if (rest.startsWith('generated')) {
-        // I couldn't figure out how to pass down the version, so instead we'll look through the
-        // directories in `pyodideRootDir` and find one that starts with a 0. This will work until
-        // Pyodide has a 1.0 release.
-        const dir = readdirSync(pyodideRootDir).filter((x) =>
-          x.startsWith('0')
-        )[0];
-        path = join(pyodideRootDir, dir, rest);
+        path = join(pyodideRootDir, pyodideVersion, rest);
         if (!existsSync(path)) {
-          path += '.js';
+          if (existsSync(path + '.js')) {
+            path += '.js';
+          } else {
+            path += '.mjs';
+          }
         }
       } else {
         path = join(pyodideRootDir, 'internal', rest);

--- a/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
+++ b/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
@@ -14,7 +14,6 @@ const unitTests :Workerd.Config = (
           # This module below exercises a bug which caused our internal introspection.py
           # module to import it instead of the SDK module. See EW-9317 for more info.
           (name = "workers.py", pythonModule = embed "vendor/a.py"),
-          (name = "numpy", pythonRequirement = "")
         ],
         compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "disable_python_no_global_handlers"],
       )

--- a/src/workerd/server/tests/python/vendor_dir_compat_flag/vendor_dir_compat_flag.wd-test
+++ b/src/workerd/server/tests/python/vendor_dir_compat_flag/vendor_dir_compat_flag.wd-test
@@ -7,7 +7,6 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
           (name = "vendor/a.py", pythonModule = embed "vendor/a.py"),
-          (name = "numpy", pythonRequirement = "")
         ],
         compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workers_force_new_vendor_path", "disable_python_no_global_handlers"],
       )


### PR DESCRIPTION
Another split PR from #6683, this PR includes a few cleanups that are not directly related to 314 version up.

- Set 0.28.2 version as released.
- Fix esbuild script to find the correct Pyodide directory using the version number
- Update snapshot generation script to not output the numpy and fastapi snapshot anymore, regarding that we will drop supporting built-in packages.
- Removed numpy dependency from a few unittests that does not require numpy.