### PR TITLE
workers-sdk: Use Node 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,7 +188,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           # Match workers-sdk node version
-          node-version: 20.19.6
+          node-version: 22
           cache: 'pnpm'
       - name: Install workers-sdk dependencies
         run: pnpm install


### PR DESCRIPTION
To fix test failures due to warning about node 20 EOL