### PR TITLE
[build] Improve test parallelism through custom resource for socket tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,10 @@ test --test_tag_filters=-off-by-default,-requires-fuzzilli,-requires-container-e
 test:asan --test_tag_filters=-off-by-default,-no-asan,-requires-fuzzilli,-requires-container-engine
 # exclude enormous tests by default
 build --test_size_filters=-enormous
+# Don't run tests that set up TCP sockets in parallel since they may try to use the same ports. This
+# is less restrictive than marking such tests as "exclusive" since we can still run unrelated tests
+# at the same time.
+test --local_resources=socket=1
 
 # use lower test timeouts: https://bazel.build/reference/test-encyclopedia#role-test-runner
 # corresponds to small,medium,large,enormous tests (medium is default)

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -40,8 +40,10 @@ wd_test(
         "connect-handler-test-proxy.js",
     ],
     # Test uses TCP sockets for ports 8081-8083 and may fail when running concurrently with other
-    # tests that do so.
-    tags = ["exclusive"],
+    # tests that do so. Use the "socket" resource to model this behavior – this prevents other tests
+    # with this tag from running at the same time, but still allows for running at the same time as
+    # tests without the tag.
+    tags = ["resources:socket:1"],
 )
 
 wd_test(
@@ -71,7 +73,7 @@ wd_test(
         "connect-handler-test.js",
         "connect-handler-test-proxy.js",
     ],
-    tags = ["exclusive"],
+    tags = ["resources:socket:1"],
 )
 
 # Test to validate timing semantics for JSRPC streaming responses.
@@ -414,7 +416,7 @@ wd_test(
     src = "js-rpc-test.wd-test",
     args = ["--experimental"],
     data = ["js-rpc-test.js"],
-    tags = ["exclusive"],
+    tags = ["resources:socket:1"],
 )
 
 wd_test(
@@ -671,7 +673,7 @@ wd_test(
         "--no-verbose",
     ],
     data = ["js-rpc-test.js"],
-    tags = ["exclusive"],
+    tags = ["resources:socket:1"],
 )
 
 wd_test(


### PR DESCRIPTION
So far these tests were all running sequentially after all other tests, now we can run one of them at a time alongside other tests. This should make CI slightly faster.

Reviewers: This will require a downstream change so that the downstream build knows to limit the resource. It will also unlock some exciting optimizations there, stay tuned.

I have confirmed locally that this works as intended.