### PR TITLE
[types] add restart-from-step support to WorkflowInstance.restart()

### DIFF
--- a/src/cloudflare/internal/test/workflows/workflows-api-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-api-test.js
@@ -37,4 +37,21 @@ export const tests = {
       assert.deepStrictEqual(instances[1].id, 'bar');
     }
   },
+
+  async testRestartNoOptions(_, env) {
+    const instance = await env.workflow.get('restart-basic');
+    await instance.restart();
+  },
+
+  async testRestartFromStepNameOnly(_, env) {
+    const instance = await env.workflow.get('restart-step');
+    await instance.restart({ from: { name: 'fetch data' } });
+  },
+
+  async testRestartFromStepAllOptions(_, env) {
+    const instance = await env.workflow.get('restart-full');
+    await instance.restart({
+      from: { name: 'process item', count: 3, type: 'do' },
+    });
+  },
 };

--- a/src/cloudflare/internal/test/workflows/workflows-mock.js
+++ b/src/cloudflare/internal/test/workflows/workflows-mock.js
@@ -39,6 +39,10 @@ export default {
       );
     }
 
+    if (reqUrl.pathname === '/restart' && request.method === 'POST') {
+      return Response.json({}, { status: 200 });
+    }
+
     if (reqUrl.pathname === '/createBatch' && request.method === 'POST') {
       return Response.json(
         {

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -67,9 +67,10 @@ class InstanceImpl implements WorkflowInstance {
     });
   }
 
-  async restart(): Promise<void> {
+  async restart(options?: WorkflowInstanceRestartOptions): Promise<void> {
     await callFetcher(this.fetcher, '/restart', {
       id: this.id,
+      step: options?.from,
     });
   }
 

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -70,7 +70,7 @@ class InstanceImpl implements WorkflowInstance {
   async restart(options?: WorkflowInstanceRestartOptions): Promise<void> {
     await callFetcher(this.fetcher, '/restart', {
       id: this.id,
-      step: options?.from,
+      from: options?.from,
     });
   }
 

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -108,6 +108,21 @@ interface WorkflowError {
   message: string;
 }
 
+interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /** The step name as defined in your workflow code. */
+    name: string;
+    /** 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop). */
+    count?: number;
+    /** Step type filter. Use when different step types share the same name. */
+    type?: 'do' | 'sleep' | 'waitForEvent';
+  };
+}
+
 declare abstract class WorkflowInstance {
   id: string;
 
@@ -127,9 +142,11 @@ declare abstract class WorkflowInstance {
   terminate(): Promise<void>;
 
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  restart(): Promise<void>;
+  restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
 
   /**
    * Returns the current status of the instance.

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -93,6 +93,21 @@ interface WorkflowError {
   message: string;
 }
 
+interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /** The step name as defined in your workflow code. */
+    name: string;
+    /** 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop). */
+    count?: number;
+    /** Step type filter. Use when different step types share the same name. */
+    type?: 'do' | 'sleep' | 'waitForEvent';
+  };
+}
+
 declare abstract class WorkflowInstance {
   public id: string;
 
@@ -112,9 +127,11 @@ declare abstract class WorkflowInstance {
   public terminate(): Promise<void>;
 
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  public restart(): Promise<void>;
+  public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
 
   /**
    * Returns the current status of the instance.


### PR DESCRIPTION
Extends WorkflowInstance.restart() to accept an optional from parameter, allowing users to restart a workflow instance from a specific step instead of from the beginning.

> await instance.restart({ from: { name: 'aggregate' } });
> await instance.restart({ from: { name: 'process', count: 3 } });
> await instance.restart({ from: { name: 'checkpoint', type: 'do' } });