### PR TITLE
Move `jsRpcSession` span ownership into `JsRpcSessionCustomEvent`

### DIFF
--- a/src/cloudflare/internal/test/tracing/tracing-hierarchy-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-hierarchy-instrumentation-test.js
@@ -143,6 +143,23 @@ export const validateHierarchy = {
     // waitForCompletion() awaits them all. BaseTracer::WeakRef prevents the abandoned
     // SpanImpl from pinning the tracer past end-of-request.
 
+    // ---------- Case 7: jsRpcInsideEnterSpan ----------
+    // The jsRpcSession span created by an RPC binding call must be a child of the
+    // enterSpan it was called from, not the top-level onset span. This is the RPC
+    // equivalent of case 3 (fetchInsideEnterSpan).
+    {
+      const outer = findSpanByName(state, 'hierarchy-rpc-outer');
+      assert.strictEqual(outer.case, 'jsRpcInsideEnterSpan');
+      assert.ok(outer.closed);
+      const rpcSpan = findSpanByName(
+        state,
+        'jsRpcSession',
+        (s) => s.invocationId === outer.invocationId
+      );
+      assertParent(rpcSpan, outer, 'jsRpcInsideEnterSpan');
+      assertTopLevelParent(outer, 'jsRpcInsideEnterSpan');
+    }
+
     console.log('All tracing-hierarchy tests passed!');
   },
 };

--- a/src/cloudflare/internal/test/tracing/tracing-hierarchy-mock.js
+++ b/src/cloudflare/internal/test/tracing/tracing-hierarchy-mock.js
@@ -2,10 +2,17 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-// Minimal fetch target used by tracing-hierarchy-test. Just echoes the request path so
-// the runtime-generated "fetch" span has something to observe.
+// Minimal fetch + RPC target used by tracing-hierarchy-test.
+import { WorkerEntrypoint } from 'cloudflare:workers';
+
 export default {
   async fetch(request) {
     return new Response('ok', { status: 200 });
   },
 };
+
+export class RpcTarget extends WorkerEntrypoint {
+  async ping() {
+    return 'pong';
+  }
+}

--- a/src/cloudflare/internal/test/tracing/tracing-hierarchy-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-hierarchy-test.js
@@ -113,3 +113,17 @@ export const abandonedPromiseSpan = {
     });
   },
 };
+
+export const jsRpcInsideEnterSpan = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    // An RPC call inside enterSpan should produce a jsRpcSession user span whose
+    // parent is the enterSpan, not the top-level onset span. This is the RPC
+    // equivalent of fetchInsideEnterSpan.
+    await withSpan('hierarchy-rpc-outer', async (outer) => {
+      outer.setAttribute('case', 'jsRpcInsideEnterSpan');
+      const result = await env.rpcTarget.ping();
+      assert.strictEqual(result, 'pong');
+    });
+  },
+};

--- a/src/cloudflare/internal/test/tracing/tracing-hierarchy-test.wd-test
+++ b/src/cloudflare/internal/test/tracing/tracing-hierarchy-test.wd-test
@@ -11,12 +11,16 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "tracing-hierarchy-test.js"),
         ],
-        compatibilityFlags = ["experimental", "nodejs_compat"],
+        compatibilityFlags = ["experimental", "nodejs_compat", "rpc"],
         streamingTails = ["tail"],
         bindings = [
           (
             name = "fetchTarget",
             service = "tracing-hierarchy-mock"
+          ),
+          (
+            name = "rpcTarget",
+            service = (name = "tracing-hierarchy-mock", entrypoint = "RpcTarget")
           ),
           (
             name = "tracingTest",
@@ -29,7 +33,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "tracing-hierarchy-mock",
       worker = (
-        compatibilityFlags = ["experimental", "nodejs_compat"],
+        compatibilityFlags = ["experimental", "nodejs_compat", "rpc"],
         modules = [
           (name = "worker", esModule = embed "tracing-hierarchy-mock.js"),
         ],

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2121,9 +2121,9 @@ kj::Maybe<jsg::Ref<JsRpcProperty>> Fetcher::getRpcMethodInternal(jsg::Lock& js, 
 rpc::JsRpcTarget::Client Fetcher::getClientForOneCall(
     jsg::Lock& js, kj::Vector<kj::StringPtr>& path) {
   auto& ioContext = IoContext::current();
-  auto worker = getClient(ioContext, kj::none, "jsRpcSession"_kjc);
+  auto [worker, sessionSpan] = getJsRpcClient(ioContext);
   auto event = kj::heap<api::JsRpcSessionCustomEvent>(
-      JsRpcSessionCustomEvent::WORKER_RPC_EVENT_TYPE);
+      JsRpcSessionCustomEvent::WORKER_RPC_EVENT_TYPE, kj::mv(sessionSpan));
 
   auto result = event->getCap();
 
@@ -2405,6 +2405,51 @@ kj::Own<WorkerInterface> Fetcher::getClient(
     IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
   auto clientWithTracing = getClientWithTracing(ioContext, kj::mv(cfStr), kj::mv(operationName));
   return clientWithTracing.client.attach(kj::mv(clientWithTracing.traceContext));
+}
+
+Fetcher::JsRpcClient Fetcher::getJsRpcClient(IoContext& ioContext) {
+  // The jsRpcSession span is owned by JsRpcSessionCustomEvent and lives for the session.
+  // OutgoingFactory variants create their own outer span, so we skip jsRpcSession for them.
+  auto withSessionSpan = [&](auto startRequest) -> JsRpcClient {
+    auto sessionSpan = ioContext.getCurrentUserTraceSpan().newChild(
+        "jsRpcSession"_kjc, ioContext.now());
+    auto sessionSpanParent = SpanParent(sessionSpan);
+    auto worker = ioContext.getSubrequest(
+        [&](TraceContext& tracing, IoChannelFactory& channelFactory) {
+      return startRequest(channelFactory,
+          IoChannelFactory::SubrequestMetadata{
+            .parentSpan = tracing.getInternalSpanParent(),
+            .userSpanParent = sessionSpanParent.addRef(),
+          });
+    }, {.inHouse = isInHouse, .wrapMetrics = !isInHouse});
+    return {kj::mv(worker), kj::mv(sessionSpan)};
+  };
+
+  KJ_SWITCH_ONEOF(channelOrClientFactory) {
+    // Service binding (e.g. env.MyService) — create jsRpcSession span.
+    KJ_CASE_ONEOF(channel, uint) {
+      return withSessionSpan([&](IoChannelFactory& channelFactory,
+                                 IoChannelFactory::SubrequestMetadata metadata) {
+        return channelFactory.startSubrequest(channel, kj::mv(metadata));
+      });
+    }
+    // Direct in-process channel handle — create jsRpcSession span.
+    KJ_CASE_ONEOF(channel, IoOwn<IoChannelFactory::SubrequestChannel>) {
+      return withSessionSpan([&](IoChannelFactory&,
+                                 IoChannelFactory::SubrequestMetadata metadata) {
+        return channel->startRequest(kj::mv(metadata));
+      });
+    }
+    // DurableObject stub (env.MyActor.get(id)) — factory creates durable_object_subrequest, skip.
+    KJ_CASE_ONEOF(outgoingFactory, IoOwn<OutgoingFactory>) {
+      return {outgoingFactory->newSingleUseClient(kj::none), SpanBuilder(nullptr)};
+    }
+    // Cross-process actor — factory creates its own outer span, skip.
+    KJ_CASE_ONEOF(outgoingFactory, kj::Own<CrossContextOutgoingFactory>) {
+      return {outgoingFactory->newSingleUseClient(ioContext, kj::none), SpanBuilder(nullptr)};
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 Fetcher::ClientWithTracing Fetcher::getClientWithTracing(

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -338,6 +338,18 @@ class Fetcher: public JsRpcClientProvider {
   kj::Own<WorkerInterface> getClient(
       IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName);
 
+  // Worker interface plus the user span representing this jsRpc session, if any. The span is
+  // created for direct channel variants but not for OutgoingFactory variants (which create their
+  // own outer span). The span is intended to be transferred to JsRpcSessionCustomEvent.
+  struct JsRpcClient {
+    kj::Own<WorkerInterface> worker;
+    SpanBuilder sessionSpan;
+  };
+
+  // Get a worker interface for a jsRpc session call, along with the jsRpcSession span (if one
+  // should be created for this Fetcher variant).
+  JsRpcClient getJsRpcClient(IoContext& ioContext);
+
   // Result of getClient call that includes optional trace context
   struct ClientWithTracing {
     kj::Own<WorkerInterface> client;

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -467,12 +467,14 @@ class RpcStubDisposalGroup {
 class JsRpcSessionCustomEvent final: public WorkerInterface::CustomEvent {
  public:
   JsRpcSessionCustomEvent(uint16_t typeId,
+      SpanBuilder jsRpcSessionSpan = SpanBuilder(nullptr),
       kj::Maybe<kj::String> wrapperModule = kj::none,
       kj::PromiseFulfillerPair<rpc::JsRpcTarget::Client> paf =
           kj::newPromiseAndFulfiller<rpc::JsRpcTarget::Client>())
       : capFulfiller(kj::mv(paf.fulfiller)),
         clientCap(kj::mv(paf.promise)),
         typeId(typeId),
+        jsRpcSessionSpan(kj::mv(jsRpcSessionSpan)),
         wrapperModule(kj::mv(wrapperModule)) {}
 
   ~JsRpcSessionCustomEvent() noexcept(false) {
@@ -529,6 +531,10 @@ class JsRpcSessionCustomEvent final: public WorkerInterface::CustomEvent {
   // limited return type.
   kj::Maybe<rpc::JsRpcTarget::Client> clientCap;
   uint16_t typeId;
+  // Span representing this jsRpc session. Created before startRequest() so the callee can
+  // reference its ID for trace context propagation. Lives until this event is destroyed
+  // (i.e., until the session ends), which gives the correct span lifetime.
+  SpanBuilder jsRpcSessionSpan;
 
   kj::Maybe<kj::String> wrapperModule;
 


### PR DESCRIPTION
Today the span is buried in a `TraceContext` `.attach()`-ed to the `WorkerInterface` — the event can't reach it. This blocks runtime span enrichment from `callImpl`'s response continuation (e.g. AI Gateway binding tags, #6695).

1. Adds `Fetcher::getJsRpcClient()` returning `{worker, sessionSpan}`, and stores the `SpanBuilder` on `JsRpcSessionCustomEvent` for the session lifetime. 
2. Span ID is allocated before `startRequest()` so it works as `userSpanParent` for `USER_SPAN_CONTEXT_PROPAGATION`. 
3. `OutgoingFactory` variants keep their existing outer span — no `jsRpcSession` stacked on top.

### Unblocks #6695

With the span reachable from the event, `callImpl` can apply enrichment directly via `event->applyEnrichment(...)`. 

This lets #6695 delete:

- `currentEnrichmentTc_` raw pointer field on `Fetcher` (with its "safe because JS is single-threaded" comment)
- `getEnrichmentTraceContext()` virtual side-channel + every override
- The `KJ_IF_SOME(tc, clientWithTracing.traceContext)` branch + manual `kj::heap<TraceContext>` lifetime juggling

What stays in #6695: callee-side `setJsrpcSessionAttributes` API — i.e. the actual feature.