### PR TITLE
Refactor: Move setupPythonSearchPath to its own file

### DIFF
--- a/src/pyodide/internal/python.ts
+++ b/src/pyodide/internal/python.ts
@@ -32,12 +32,14 @@ import { default as UnsafeEval } from 'internal:unsafe-eval';
 import {
   PythonUserError,
   PythonWorkersInternalError,
+  loadPythonMod,
   reportError,
   setInternalErrorReporter,
   unreachable,
 } from 'pyodide-internal:util';
 import { loadPackages } from 'pyodide-internal:loadPackage';
 import { default as MetadataReader } from 'pyodide-internal:runtime-generated/metadata';
+import { default as setupPythonSearchPathSource } from 'pyodide-internal:setup_python_search_path.py';
 import { TRANSITIVE_REQUIREMENTS, IS_WORKERD } from 'pyodide-internal:metadata';
 import { getTrustedReadFunc } from 'pyodide-internal:readOnlyFS';
 import { PyodideVersion } from 'pyodide-internal:const';
@@ -79,55 +81,23 @@ function prepareWasmLinearMemory(
   }
 }
 
+type SetupPythonSearchPathMod = {
+  __dict__: PyDict;
+  setup_python_search_path: PyCallable;
+  destroy(): void;
+};
+
 function setupPythonSearchPath(pyodide: Pyodide): void {
-  const setup = pyodide.runPython(`
-    def _setup_python_search_path(*, LEGACY_VENDOR_PATH, PROCESS_PTH_FILES):
-      import sys
-      from site import addsitedir
-
-      VENDOR_PATH = "/session/metadata/vendor"
-      PYTHON_MODULES_PATH = "/session/metadata/python_modules"
-
-      # adjustSysPath adds the session path, but it is immortalised by the memory snapshot. This
-      # code runs irrespective of the memory snapshot.
-      if VENDOR_PATH in sys.path and LEGACY_VENDOR_PATH:
-        sys.path.remove(VENDOR_PATH)
-
-      if PYTHON_MODULES_PATH in sys.path:
-        sys.path.remove(PYTHON_MODULES_PATH)
-
-      # Insert vendor path after system paths but before site-packages
-      # System paths are typically: ['/session', '/lib/python312.zip', '/lib/python3.12', '/lib/python3.12/lib-dynload']
-      # We want to insert before '/lib/python3.12/site-packages' and other site-packages
-      #
-      # We also need the session path to be before the vendor path, if we don't do so then a local
-      # import will pick a module from the vendor path rather than the local path. We've got a test
-      # that reproduces this (vendor_dir).
-      for i, path in enumerate(sys.path):
-        if 'site-packages' in path:
-          if LEGACY_VENDOR_PATH:
-            sys.path.insert(i, VENDOR_PATH)
-          sys.path.insert(i, PYTHON_MODULES_PATH)
-          break
-      else:
-        # If no site-packages found, fail
-        raise ValueError("No site-packages found in sys.path")
-
-      if PROCESS_PTH_FILES:
-        # addsitedir processes any .pth files in PYTHON_MODULES_PATH, allowing
-        # packages to extend sys.path declaratively. It also re-adds the
-        # directory to sys.path, but it was already inserted above so this is a
-        # no-op for that purpose.
-        addsitedir(PYTHON_MODULES_PATH)
-
-    _setup_python_search_path
-  `) as PyCallable;
-  pyodide.runPython('del _setup_python_search_path');
-  setup.callKwargs({
+  const mod = loadPythonMod(
+    pyodide,
+    'setup_python_search_path',
+    setupPythonSearchPathSource
+  ) as SetupPythonSearchPathMod;
+  mod.setup_python_search_path.callKwargs({
     LEGACY_VENDOR_PATH,
     PROCESS_PTH_FILES,
   });
-  setup.destroy();
+  mod.destroy();
 }
 
 /**

--- a/src/pyodide/internal/setup_python_search_path.py
+++ b/src/pyodide/internal/setup_python_search_path.py
@@ -1,0 +1,39 @@
+import sys
+from site import addsitedir
+
+VENDOR_PATH = "/session/metadata/vendor"
+PYTHON_MODULES_PATH = "/session/metadata/python_modules"
+
+
+def setup_python_search_path(*, LEGACY_VENDOR_PATH, PROCESS_PTH_FILES):
+    # adjustSysPath adds the session path, but it is immortalised by the memory snapshot. This
+    # code runs irrespective of the memory snapshot.
+    if VENDOR_PATH in sys.path and LEGACY_VENDOR_PATH:
+        sys.path.remove(VENDOR_PATH)
+
+    if PYTHON_MODULES_PATH in sys.path:
+        sys.path.remove(PYTHON_MODULES_PATH)
+
+    # Insert vendor path after system paths but before site-packages
+    # System paths are typically: ['/session', '/lib/python312.zip', '/lib/python3.12', '/lib/python3.12/lib-dynload']
+    # We want to insert before '/lib/python3.12/site-packages' and other site-packages
+    #
+    # We also need the session path to be before the vendor path, if we don't do so then a local
+    # import will pick a module from the vendor path rather than the local path. We've got a test
+    # that reproduces this (vendor_dir).
+    for i, path in enumerate(sys.path):
+        if "site-packages" in path:
+            if LEGACY_VENDOR_PATH:
+                sys.path.insert(i, VENDOR_PATH)
+            sys.path.insert(i, PYTHON_MODULES_PATH)
+            break
+    else:
+        # If no site-packages found, fail
+        raise ValueError("No site-packages found in sys.path")
+
+    if PROCESS_PTH_FILES:
+        # addsitedir processes any .pth files in PYTHON_MODULES_PATH, allowing
+        # packages to extend sys.path declaratively. It also re-adds the
+        # directory to sys.path, but it was already inserted above so this is a
+        # no-op for that purpose.
+        addsitedir(PYTHON_MODULES_PATH)

--- a/src/pyodide/internal/util.ts
+++ b/src/pyodide/internal/util.ts
@@ -116,3 +116,27 @@ export function unreachable(obj: never, msg?: string): never {
   }
   throw new PythonWorkersInternalError(`Unreachable: ${msg}`);
 }
+
+/**
+ * Loads a Python source file (bundled as a Uint8Array) into a fresh anonymous
+ * module and returns it. This is used for internal Python helpers that need to
+ * be invoked from JS but should not pollute the global namespace.
+ *
+ * `moduleName` is the bare name of the module (e.g. "introspection"); typically
+ * the source is the default export from `pyodide-internal:<moduleName>.py`.
+ */
+export function loadPythonMod(
+  pyodide: Pyodide,
+  moduleName: string,
+  source: Uint8Array
+): { __dict__: PyDict } {
+  const mod = pyodide.runPython(
+    `from types import ModuleType; ModuleType('${moduleName}')`
+  ) as { __dict__: PyDict };
+  const decoder = new TextDecoder();
+  pyodide.runPython(decoder.decode(source), {
+    globals: mod.__dict__,
+    filename: `${moduleName}.py`,
+  });
+  return mod;
+}

--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -34,9 +34,11 @@ import {
 import {
   PythonUserError,
   PythonWorkersInternalError,
+  loadPythonMod,
   reportError,
 } from 'pyodide-internal:util';
 import { PyodideVersion } from 'pyodide-internal:const';
+import { default as introspectionSource } from 'pyodide-internal:introspection.py';
 export { createImportProxy } from 'pyodide-internal:serializeJsModule';
 
 type PyFuture<T> = Promise<T> & { copy(): PyFuture<T>; destroy(): void };
@@ -527,25 +529,16 @@ type IntrospectionMod = {
 };
 
 let introspectionModPromise: Promise<IntrospectionMod> | null = null;
-async function loadIntrospectionMod(
-  pyodide: Pyodide
-): Promise<IntrospectionMod> {
-  const introspectionSource = await import('pyodide-internal:introspection.py');
-  const introspectionMod = pyodide.runPython(
-    "from types import ModuleType; ModuleType('introspection')"
-  ) as IntrospectionMod;
-  const decoder = new TextDecoder();
-  pyodide.runPython(decoder.decode(introspectionSource.default), {
-    globals: introspectionMod.__dict__,
-    filename: 'introspection.py',
-  });
-
-  return introspectionMod;
-}
-
 async function getIntrospectionMod(): Promise<IntrospectionMod> {
   if (introspectionModPromise === null) {
-    introspectionModPromise = getPyodide().then(loadIntrospectionMod);
+    introspectionModPromise = (async (): Promise<IntrospectionMod> => {
+      const pyodide = await getPyodide();
+      return loadPythonMod(
+        pyodide,
+        'introspection',
+        introspectionSource
+      ) as IntrospectionMod;
+    })();
   }
 
   return introspectionModPromise;

--- a/src/pyodide/types/modules.d.ts
+++ b/src/pyodide/types/modules.d.ts
@@ -7,6 +7,11 @@ declare module 'pyodide-internal:introspection.py' {
   export default value;
 }
 
+declare module 'pyodide-internal:setup_python_search_path.py' {
+  const value: Uint8Array;
+  export default value;
+}
+
 declare module 'pyodideRuntime-internal:emscriptenSetup' {
   function instantiateEmscriptenModule(
     isWorkerd: boolean,


### PR DESCRIPTION
This function is long enough that I think it's more readable without having the code inline in python.ts