### PR TITLE
worker-loader: fix potential crash with JSON modules

### DIFF
--- a/src/workerd/api/worker-loader.c++
+++ b/src/workerd/api/worker-loader.c++
@@ -224,6 +224,9 @@ Worker::Script::Source WorkerLoader::extractSource(jsg::Lock& js, WorkerCode& co
           } else KJ_IF_SOME(json, module.json) {
             kj::StringPtr serialized =
                 module.serializedJson.emplace(js.serializeJson(kj::mv(json)));
+            // We moved out of `json`, making it an empty V8Ref, explicitly
+            // clear out the field as we don't intend to re-use this
+            module.json = kj::none;
             return Worker::Script::JsonModule{.body = serialized};
           } else KJ_IF_SOME(py, module.py) {
             return Worker::Script::PythonModule{.body = py};

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2427,7 +2427,10 @@ class Lock {
   }
   template <typename T>
   kj::String serializeJson(V8Ref<T>&& value) {
-    return serializeJson(value.getHandle(*this));
+    // Callers expect the rvalue-reference to be consumed, and to ensure
+    // that, explicitly move it into a local variable
+    auto moved = kj::mv(value);
+    return serializeJson(moved.getHandle(*this));
   }
 
   void recursivelyFreeze(Value& value);


### PR DESCRIPTION
https://jira.cfdata.org/browse/EW-10831

The `json` field was not actually moved from when passed to `serializeJson` in [worker-loader.c++](https://github.com/cloudflare/workerd/blob/37ff673e9df2b628533da9a221d97ca54436d9e2/src/workerd/api/worker-loader.c%2B%2B#L226), causing the dynamic worker script's `ownContent` to hold the `V8Ref` pointing to the parent isolate leading to a UaF in the `v8::Locker::isLocked` call in `jsg::Data::destroy` during destruction of `Module`, only if the parent isolate got GC'd before the dynamic isolate

With the fix, the `V8Ref`'s `isolate` will be set to `nullptr`, making the `jsg::Data::destroy` call a no-op