### PR TITLE
Tweak `jsRpcSession()` to avoid need for `ServerTopLevelMembrane`.

### DIFF
--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -2179,8 +2179,18 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::run(
 
   try {
     auto [donePromise, doneFulfiller] = kj::newPromiseAndFulfiller<void>();
-    capFulfiller->fulfill(capnp::membrane(
-        revcableTarget.getClient(), kj::refcounted<ServerTopLevelMembrane>(kj::mv(doneFulfiller))));
+
+    kj::Own<capnp::MembranePolicy> topMembrane;
+    if (util::Autogate::isEnabled(util::AutogateKey::JSRPC_SESSION_HANDLE)) {
+      // When using the session handle approach, we don't need the convoluted
+      // `ServerTopLevelMembrane` because the the top-level `JsRpcTarget` is not unnaturally held
+      // open, so it can be treated the same as any other capability in the session.
+      topMembrane = kj::refcounted<CompletionMembrane>(kj::mv(doneFulfiller));
+    } else {
+      topMembrane = kj::refcounted<ServerTopLevelMembrane>(kj::mv(doneFulfiller));
+    }
+
+    capFulfiller->fulfill(capnp::membrane(revcableTarget.getClient(), kj::mv(topMembrane)));
 
     // `donePromise` resolves once there are no longer any capabilities pointing between the client
     // and server as part of this session.
@@ -2237,8 +2247,24 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::sendR
 
   this->capFulfiller->fulfill(kj::mv(cap));
 
+  auto session = sent.getSession();
+
+  // We don't need to await the call itself as `session.whenResolved()` will already propagate any
+  // errors from it. So we can drop the call promise now.
+  //
+  // Note that it would NOT work to use `req.sendForPipeline()` above, since pipelined capabilities
+  // cannot resolve until the call returns, but `sendForPipeline()` explicitly inhibits the return
+  // message.
+  { auto drop = kj::mv(sent); }
+
   try {
-    co_await sent.ignoreResult().exclusiveJoin(kj::mv(completionPaf.promise));
+    // Wait for `session` to resolve to a null capability.
+    //
+    // Note that this works even if the server is using the "old approach" where it doesn't return
+    // a `session` at all, because in that case the return itself represents the end of the
+    // session, and the response contains a null pointer for `session`, so this does the expected
+    // thing: resolves `session` to null.
+    co_await session.whenResolved().exclusiveJoin(kj::mv(completionPaf.promise));
   } catch (...) {
     auto e = kj::getCaughtExceptionAsKj();
     if (revokePaf.fulfiller->isWaiting()) {
@@ -2248,6 +2274,39 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::sendR
   }
 
   co_return WorkerInterface::CustomEvent::Result{.outcome = EventOutcome::OK};
+}
+
+kj::Promise<void> JsRpcSessionCustomEvent::receiveRpc(JsRpcSessionContext context,
+    WorkerInterface& worker,
+    kj::Own<void> ownWorker,
+    kj::Maybe<kj::String> wrapperModule) {
+  // Client wants to start a JS RPC session, we'll dispatch to the WorkerEntrypoint
+  // here and read the capability off the event itself.
+  auto customEvent =
+      kj::heap<api::JsRpcSessionCustomEvent>(WORKER_RPC_EVENT_TYPE, kj::mv(wrapperModule));
+
+  auto cap = customEvent->getCap();
+
+  if (util::Autogate::isEnabled(util::AutogateKey::JSRPC_SESSION_HANDLE)) {
+    auto promise = worker.customEvent(kj::mv(customEvent));
+
+    auto results = context.getResults(capnp::MessageSize{4, 2});
+    results.setTopLevel(kj::mv(cap));
+
+    // Set the returned session capability to resolve to a null capability when the event is
+    // complete. This also neatly arranges that if the session is dropped early, the
+    // `customEvent()` promise is canceled, thus canceling the session.
+    results.setSession(promise.then([ownWorker = kj::mv(ownWorker)](auto outcome) {
+      return rpc::JsRpcSession::Client(nullptr);
+    }));
+  } else {
+    capnp::PipelineBuilder<rpc::EventDispatcher::JsRpcSessionResults> pipelineBuilder;
+    pipelineBuilder.setTopLevel(cap);
+    context.setPipeline(pipelineBuilder.build());
+    context.getResults().setTopLevel(kj::mv(cap));
+
+    co_await worker.customEvent(kj::mv(customEvent));
+  }
 }
 
 };  // namespace workerd::api

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -493,6 +493,24 @@ class JsRpcSessionCustomEvent final: public WorkerInterface::CustomEvent {
       capnp::ByteStreamFactory& byteStreamFactory,
       rpc::EventDispatcher::Client dispatcher) override;
 
+  // Same as `EventDispatcher::Server::JsRpcSessionContext` -- but that typedef is `protected`.
+  using JsRpcSessionContext = capnp::CallContext<rpc::EventDispatcher::JsRpcSessionParams,
+      rpc::EventDispatcher::JsRpcSessionResults>;
+
+  // Common implemnetation of EventDispatcher::jsRpcSession().
+  static kj::Promise<void> receiveRpc(JsRpcSessionContext context,
+      kj::Own<WorkerInterface> worker,
+      kj::Maybe<kj::String> wrapperModule = kj::none) {
+    auto& ref = *worker;
+    return receiveRpc(context, ref, kj::mv(worker), kj::mv(wrapperModule));
+  }
+
+  // Sometimes callers need to pass an `Own<void>` owning some parent object of `worker`.
+  static kj::Promise<void> receiveRpc(JsRpcSessionContext context,
+      WorkerInterface& worker,
+      kj::Own<void> ownWorker,
+      kj::Maybe<kj::String> wrapperModule = kj::none);
+
   uint16_t getType() override {
     return typeId;
   }

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -743,6 +743,15 @@ interface JsRpcTarget extends(JsValue.ExternalPusher) $Cxx.allowCancellation {
   # Runs a Worker/DO's RPC method.
 }
 
+interface JsRpcSession {
+  # Represents an ongoing JSRPC session. To cancel the session (revoking all capabilities), drop
+  # this object. The `JsRpcSession` object will resolve itself to a null capability when the
+  # session is complete (all stubs have been droppped); the caller can await `whenResolved()` to
+  # find out when this happens.
+
+  # Currently there are no methods. This handle exists solely to be dropped.
+}
+
 interface TailStreamTarget $Cxx.allowCancellation {
   # Interface used to deliver streaming tail events to a tail worker.
   struct TailStreamParams {
@@ -797,15 +806,28 @@ interface EventDispatcher @0xf20697475ec1752d {
   # should be retried. The optional metadata field carries queue metrics at the time the batch was
   # dispatched; it is safe for the sender to omit this field (the consumer sees it as absent).
 
-  jsRpcSession @9 () -> (topLevel :JsRpcTarget) $Cxx.allowCancellation;
+  jsRpcSession @9 () -> (topLevel :JsRpcTarget, session :JsRpcSession) $Cxx.allowCancellation;
   # Opens a JS rpc "session". The call does not return until the session is complete.
   #
   # `topLevel` is the top-level RPC target, on which exactly one method call can be made. This
-  # call must be made using pipelining since `jsRpcSession()` won't return until after the call
-  # completes.
+  # call should be made using pipelining to avoid a round trip at startup, and to properly handle
+  # the old semantics while they still exist in production (see below).
   #
-  # If, through the one top-level call, new capabilities are exchanged between the client and
-  # server, then `jsRpcSession()` won't return until all those capabilities have been dropped.
+  # The exact return semantics of this method are currently in flux. Both an old approach and a
+  # new approach may be live in production:
+  # * Old approach: `jsRpcSession()` does not return until (1) exactly one call has been made on
+  #   `topLevel`, and (2) any stubs passed over that call (in either direction) have been dropped.
+  #   The session can be canceled by cancelling the call. When the call returns, `session` is null,
+  #   which is consistent with the session being complete.
+  # * New approach: `jsRpcSession()` returns immediately. The returned `session` capability keeps
+  #   the session alive. Dropping `session` cancels the session. `session` resolves itself to a
+  #   null capability when `topLevel` and all stubs introduced through it have been dropped; the
+  #   caller may await `whenResolved()` to find out when this happens.
+  #
+  # The transition will take place in three phases:
+  # 1. Caller is adjusted to support both approaches.
+  # 2. Automate is rolled out to switch the callee to the new approach.
+  # 3. Remove code to support old approach.
   #
   # In C++, we use `WorkerInterface::customEvent()` to dispatch this event.
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -5277,17 +5277,7 @@ class Server::WorkerdBootstrapImpl final: public rpc::WorkerdBootstrap::Server {
     }
 
     kj::Promise<void> jsRpcSession(JsRpcSessionContext context) override {
-      auto customEvent = kj::heap<api::JsRpcSessionCustomEvent>(
-          api::JsRpcSessionCustomEvent::WORKER_RPC_EVENT_TYPE);
-
-      auto cap = customEvent->getCap();
-      capnp::PipelineBuilder<JsRpcSessionResults> pipelineBuilder;
-      pipelineBuilder.setTopLevel(cap);
-      context.setPipeline(pipelineBuilder.build());
-      context.getResults().setTopLevel(kj::mv(cap));
-
-      auto worker = getWorker();
-      return worker->customEvent(kj::mv(customEvent)).ignoreResult().attach(kj::mv(worker));
+      return api::JsRpcSessionCustomEvent::receiveRpc(context, getWorker());
     }
 
     kj::Promise<void> tailStreamSession(TailStreamSessionContext context) override {

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -47,6 +47,8 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "updated-auto-allocate-chunk-size"_kj;
     case AutogateKey::PYTHON_ABORT_ISOLATE_ON_FATAL_ERROR:
       return "python-abort-isolate-on-fatal-error"_kj;
+    case AutogateKey::JSRPC_SESSION_HANDLE:
+      return "jsrpc-session-handle"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -52,6 +52,9 @@ enum class AutogateKey {
   UPDATED_AUTO_ALLOCATE_CHUNK_SIZE,
   // Call abortIsolate() when a Python worker encounters a fatal error.
   PYTHON_ABORT_ISOLATE_ON_FATAL_ERROR,
+  // `jsRpcSession()` returns a session handle instead of having the call itself hang until the
+  // session is complete.
+  JSRPC_SESSION_HANDLE,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
Instead of having the `jsRpcSession()` "hang" until the session is done, we return a capability representing the session which can be dropped to effect cancellation.

This avoids the need for the rather-awkward `ServerTopLevelMembrane` on the receiving side.

Eliminating this membrane not just reduces complexity, but also fixes a problem where `ExternalPusher` methods had to be invoked strictly in advance of `call()`. I have features planned that will need to be able to call these methods later.

Unfortunately this will require a multi-step dance -- clients need to be updated first, then an autogate can update the server, then we can delete old code.