### PR TITLE
[Workflows] Add restart from step options

### DIFF
--- a/src/cloudflare/internal/test/workflows/workflows-api-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-api-test.js
@@ -4,6 +4,14 @@
 
 import * as assert from 'node:assert';
 
+async function getLastRestartBody(env, id) {
+  const res = await env.mock.fetch('http://placeholder/last-restart', {
+    method: 'POST',
+    body: JSON.stringify({ id }),
+  });
+  return (await res.json()).result;
+}
+
 export const tests = {
   async test(_, env) {
     {
@@ -36,5 +44,38 @@ export const tests = {
       assert.deepStrictEqual(instances[0].id, 'foo');
       assert.deepStrictEqual(instances[1].id, 'bar');
     }
+  },
+
+  async testRestartNoOptions(_, env) {
+    const instance = await env.workflow.get('restart-basic');
+    await instance.restart();
+
+    const body = await getLastRestartBody(env, 'restart-basic');
+    assert.deepStrictEqual(body.id, 'restart-basic');
+    assert.strictEqual(body.from, undefined);
+  },
+
+  async testRestartFromStepNameOnly(_, env) {
+    const instance = await env.workflow.get('restart-step');
+    await instance.restart({ from: { name: 'fetch data' } });
+
+    const body = await getLastRestartBody(env, 'restart-step');
+    assert.deepStrictEqual(body.id, 'restart-step');
+    assert.deepStrictEqual(body.from, { name: 'fetch data' });
+  },
+
+  async testRestartFromStepAllOptions(_, env) {
+    const instance = await env.workflow.get('restart-full');
+    await instance.restart({
+      from: { name: 'process item', count: 3, type: 'do' },
+    });
+
+    const body = await getLastRestartBody(env, 'restart-full');
+    assert.deepStrictEqual(body.id, 'restart-full');
+    assert.deepStrictEqual(body.from, {
+      name: 'process item',
+      count: 3,
+      type: 'do',
+    });
   },
 };

--- a/src/cloudflare/internal/test/workflows/workflows-api-test.wd-test
+++ b/src/cloudflare/internal/test/workflows/workflows-api-test.wd-test
@@ -18,6 +18,10 @@ const unitTests :Workerd.Config = (
               service = "workflows-mock"
             )],
           )
+        ),
+        (
+          name = "mock",
+          service = "workflows-mock"
         )
         ],
       )

--- a/src/cloudflare/internal/test/workflows/workflows-mock.js
+++ b/src/cloudflare/internal/test/workflows/workflows-mock.js
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+const restartBodies = new Map();
+
 export default {
   async fetch(request, env, ctx) {
     const data = await request.json();
@@ -50,6 +52,19 @@ export default {
             'content-type': 'application/json',
           },
         }
+      );
+    }
+
+    if (reqUrl.pathname === '/restart' && request.method === 'POST') {
+      restartBodies.set(data.id, data);
+      return Response.json({}, { status: 200 });
+    }
+
+    // Test-only: returns the body from the last /restart call for a given id
+    if (reqUrl.pathname === '/last-restart' && request.method === 'POST') {
+      return Response.json(
+        { result: restartBodies.get(data.id) ?? null },
+        { status: 200 }
       );
     }
   },

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -67,9 +67,10 @@ class InstanceImpl implements WorkflowInstance {
     });
   }
 
-  async restart(): Promise<void> {
+  async restart(options?: WorkflowInstanceRestartOptions): Promise<void> {
     await callFetcher(this.fetcher, '/restart', {
       id: this.id,
+      ...options,
     });
   }
 

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -69,8 +69,8 @@ class InstanceImpl implements WorkflowInstance {
 
   async restart(options?: WorkflowInstanceRestartOptions): Promise<void> {
     await callFetcher(this.fetcher, '/restart', {
-      id: this.id,
       ...options,
+      id: this.id,
     });
   }
 

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -119,7 +119,8 @@ interface WorkflowInstanceRestartOptions {
      */
     name: string;
     /**
-     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     * 1-indexed occurrence of this step name. Use when the same step name appears multiple times (e.g. in a loop).
+     * @default 1
      */
     count?: number;
     /**

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -108,6 +108,27 @@ interface WorkflowError {
   message: string;
 }
 
+interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /**
+     * The step name as defined in your workflow code.
+     */
+    name: string;
+    /**
+     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     */
+    count?: number;
+    /**
+     * Step type filter. Use when different step types share the same name.
+     */
+    type?: 'do' | 'sleep' | 'waitForEvent';
+  };
+}
+
 declare abstract class WorkflowInstance {
   id: string;
 
@@ -127,9 +148,11 @@ declare abstract class WorkflowInstance {
   terminate(): Promise<void>;
 
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  restart(): Promise<void>;
+  restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
 
   /**
    * Returns the current status of the instance.

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -104,7 +104,8 @@ interface WorkflowInstanceRestartOptions {
      */
     name: string;
     /**
-     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     * 1-indexed occurrence of this step name. Use when the same step name appears multiple times (e.g. in a loop).
+     * @default 1
      */
     count?: number;
     /**

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -93,6 +93,27 @@ interface WorkflowError {
   message: string;
 }
 
+interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /**
+     * The step name as defined in your workflow code.
+     */
+    name: string;
+    /**
+     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     */
+    count?: number;
+    /**
+     * Step type filter. Use when different step types share the same name.
+     */
+    type?: 'do' | 'sleep' | 'waitForEvent';
+  };
+}
+
 declare abstract class WorkflowInstance {
   public id: string;
 
@@ -112,9 +133,11 @@ declare abstract class WorkflowInstance {
   public terminate(): Promise<void>;
 
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  public restart(): Promise<void>;
+  public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
 
   /**
    * Returns the current status of the instance.

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -15902,7 +15902,8 @@ interface WorkflowInstanceRestartOptions {
      */
     name: string;
     /**
-     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     * 1-indexed occurrence of this step name. Use when the same step name appears multiple times (e.g. in a loop).
+     * @default 1
      */
     count?: number;
     /**

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3966,28 +3966,23 @@ interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
-  readonly __stdoutp: ArrayBuffer;
-  readonly __stderrp: ArrayBuffer;
 }
 interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  __stdinp?: ReadableStream | "pipe";
-  __stdoutp?: "pipe" | "ignore";
-  __stderrp?: "pipe" | "ignore" | "combined";
+  stdin?: ReadableStream | "pipe";
+  stdout?: "pipe" | "ignore";
+  stderr?: "pipe" | "ignore" | "combined";
 }
 interface ExecProcess {
-  get stdin(): WritableStream | undefined;
-  get stdout(): ReadableStream | undefined;
-  get stderr(): ReadableStream | undefined;
+  readonly stdin: WritableStream | null;
+  readonly stdout: ReadableStream | null;
+  readonly stderr: ReadableStream | null;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
-  readonly __stdinp: WritableStream | null;
-  readonly __stdoutp: ReadableStream | null;
-  readonly __stderrp: ReadableStream | null;
 }
 interface Container {
   get running(): boolean;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -3966,23 +3966,28 @@ interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
+  readonly __stdoutp: ArrayBuffer;
+  readonly __stderrp: ArrayBuffer;
 }
 interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  stdin?: ReadableStream | "pipe";
-  stdout?: "pipe" | "ignore";
-  stderr?: "pipe" | "ignore" | "combined";
+  __stdinp?: ReadableStream | "pipe";
+  __stdoutp?: "pipe" | "ignore";
+  __stderrp?: "pipe" | "ignore" | "combined";
 }
 interface ExecProcess {
-  readonly stdin: WritableStream | null;
-  readonly stdout: ReadableStream | null;
-  readonly stderr: ReadableStream | null;
+  get stdin(): WritableStream | undefined;
+  get stdout(): ReadableStream | undefined;
+  get stderr(): ReadableStream | undefined;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
+  readonly __stdinp: WritableStream | null;
+  readonly __stdoutp: ReadableStream | null;
+  readonly __stderrp: ReadableStream | null;
 }
 interface Container {
   get running(): boolean;
@@ -15891,6 +15896,26 @@ interface WorkflowError {
   code?: number;
   message: string;
 }
+interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /**
+     * The step name as defined in your workflow code.
+     */
+    name: string;
+    /**
+     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     */
+    count?: number;
+    /**
+     * Step type filter. Use when different step types share the same name.
+     */
+    type?: "do" | "sleep" | "waitForEvent";
+  };
+}
 declare abstract class WorkflowInstance {
   public id: string;
   /**
@@ -15906,9 +15931,11 @@ declare abstract class WorkflowInstance {
    */
   public terminate(): Promise<void>;
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  public restart(): Promise<void>;
+  public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
   /**
    * Returns the current status of the instance.
    */

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3972,28 +3972,23 @@ export interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
-  readonly __stdoutp: ArrayBuffer;
-  readonly __stderrp: ArrayBuffer;
 }
 export interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  __stdinp?: ReadableStream | "pipe";
-  __stdoutp?: "pipe" | "ignore";
-  __stderrp?: "pipe" | "ignore" | "combined";
+  stdin?: ReadableStream | "pipe";
+  stdout?: "pipe" | "ignore";
+  stderr?: "pipe" | "ignore" | "combined";
 }
 export interface ExecProcess {
-  get stdin(): WritableStream | undefined;
-  get stdout(): ReadableStream | undefined;
-  get stderr(): ReadableStream | undefined;
+  readonly stdin: WritableStream | null;
+  readonly stdout: ReadableStream | null;
+  readonly stderr: ReadableStream | null;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
-  readonly __stdinp: WritableStream | null;
-  readonly __stdoutp: ReadableStream | null;
-  readonly __stderrp: ReadableStream | null;
 }
 export interface Container {
   get running(): boolean;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -15854,7 +15854,8 @@ export interface WorkflowInstanceRestartOptions {
      */
     name: string;
     /**
-     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     * 1-indexed occurrence of this step name. Use when the same step name appears multiple times (e.g. in a loop).
+     * @default 1
      */
     count?: number;
     /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -3972,23 +3972,28 @@ export interface ExecOutput {
   readonly stdout: ArrayBuffer;
   readonly stderr: ArrayBuffer;
   readonly exitCode: number;
+  readonly __stdoutp: ArrayBuffer;
+  readonly __stderrp: ArrayBuffer;
 }
 export interface ContainerExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   user?: string;
-  stdin?: ReadableStream | "pipe";
-  stdout?: "pipe" | "ignore";
-  stderr?: "pipe" | "ignore" | "combined";
+  __stdinp?: ReadableStream | "pipe";
+  __stdoutp?: "pipe" | "ignore";
+  __stderrp?: "pipe" | "ignore" | "combined";
 }
 export interface ExecProcess {
-  readonly stdin: WritableStream | null;
-  readonly stdout: ReadableStream | null;
-  readonly stderr: ReadableStream | null;
+  get stdin(): WritableStream | undefined;
+  get stdout(): ReadableStream | undefined;
+  get stderr(): ReadableStream | undefined;
   readonly pid: number;
   readonly exitCode: Promise<number>;
   output(): Promise<ExecOutput>;
   kill(signal?: number): void;
+  readonly __stdinp: WritableStream | null;
+  readonly __stdoutp: ReadableStream | null;
+  readonly __stderrp: ReadableStream | null;
 }
 export interface Container {
   get running(): boolean;
@@ -15843,6 +15848,26 @@ export interface WorkflowError {
   code?: number;
   message: string;
 }
+export interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /**
+     * The step name as defined in your workflow code.
+     */
+    name: string;
+    /**
+     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     */
+    count?: number;
+    /**
+     * Step type filter. Use when different step types share the same name.
+     */
+    type?: "do" | "sleep" | "waitForEvent";
+  };
+}
 export declare abstract class WorkflowInstance {
   public id: string;
   /**
@@ -15858,9 +15883,11 @@ export declare abstract class WorkflowInstance {
    */
   public terminate(): Promise<void>;
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  public restart(): Promise<void>;
+  public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
   /**
    * Returns the current status of the instance.
    */

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -15234,7 +15234,8 @@ interface WorkflowInstanceRestartOptions {
      */
     name: string;
     /**
-     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     * 1-indexed occurrence of this step name. Use when the same step name appears multiple times (e.g. in a loop).
+     * @default 1
      */
     count?: number;
     /**

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -15223,6 +15223,26 @@ interface WorkflowError {
   code?: number;
   message: string;
 }
+interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /**
+     * The step name as defined in your workflow code.
+     */
+    name: string;
+    /**
+     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     */
+    count?: number;
+    /**
+     * Step type filter. Use when different step types share the same name.
+     */
+    type?: "do" | "sleep" | "waitForEvent";
+  };
+}
 declare abstract class WorkflowInstance {
   public id: string;
   /**
@@ -15238,9 +15258,11 @@ declare abstract class WorkflowInstance {
    */
   public terminate(): Promise<void>;
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  public restart(): Promise<void>;
+  public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
   /**
    * Returns the current status of the instance.
    */

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -15175,6 +15175,26 @@ export interface WorkflowError {
   code?: number;
   message: string;
 }
+export interface WorkflowInstanceRestartOptions {
+  /**
+   * Restart from a specific step. If omitted, the instance restarts from the beginning.
+   * The step must exist in the instance's execution history.
+   */
+  from?: {
+    /**
+     * The step name as defined in your workflow code.
+     */
+    name: string;
+    /**
+     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     */
+    count?: number;
+    /**
+     * Step type filter. Use when different step types share the same name.
+     */
+    type?: "do" | "sleep" | "waitForEvent";
+  };
+}
 export declare abstract class WorkflowInstance {
   public id: string;
   /**
@@ -15190,9 +15210,11 @@ export declare abstract class WorkflowInstance {
    */
   public terminate(): Promise<void>;
   /**
-   * Restart the instance.
+   * Restart the instance. Optionally restart from a specific step, preserving
+   * cached results for all steps before it.
+   * @param options Options for the restart, including an optional step to restart from.
    */
-  public restart(): Promise<void>;
+  public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
   /**
    * Returns the current status of the instance.
    */

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -15186,7 +15186,8 @@ export interface WorkflowInstanceRestartOptions {
      */
     name: string;
     /**
-     * 1-indexed occurrence of this step name. Defaults to 1. Use when the same step name appears multiple times (e.g. in a loop).
+     * 1-indexed occurrence of this step name. Use when the same step name appears multiple times (e.g. in a loop).
+     * @default 1
      */
     count?: number;
     /**


### PR DESCRIPTION
Extends WorkflowInstance.restart() to accept an optional from parameter, allowing users to restart a workflow instance from a specific step instead of from the beginning.

`await instance.restart({ from: { name: 'aggregate' } });`
`await instance.restart({ from: { name: 'process', count: 3 } });`
`await instance.restart({ from: { name: 'checkpoint', type: 'do' } });`