### PR TITLE
Allow channel tokens to be created asynchronously

### DIFF
--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -220,7 +220,8 @@ kj::Own<IoChannelFactory::ActorClassChannel> DurableObjectClass::getChannel(IoCo
 }
 
 void DurableObjectClass::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
-  auto channel = getChannel(IoContext::current());
+  auto& ioctx = IoContext::current();
+  auto channel = getChannel(ioctx);
   channel->requireAllowsTransfer();
 
   KJ_IF_SOME(handler, serializer.getExternalHandler()) {
@@ -232,10 +233,34 @@ void DurableObjectClass::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
       JSG_REQUIRE(FeatureFlags::get(js).getWorkerdExperimental(), DOMDataCloneError,
           "DurableObjectClass serialization requires the 'experimental' compat flag.");
 
-      auto token = channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
-      rpcHandler.write([token = kj::mv(token)](rpc::JsValue::External::Builder builder) {
-        builder.setActorClassChannelToken(token);
-      });
+      KJ_SWITCH_ONEOF(channel->getTokenMaybeSync(IoChannelFactory::ChannelTokenUsage::RPC)) {
+        KJ_CASE_ONEOF(token, kj::Array<byte>) {
+          rpcHandler.write([token = kj::mv(token)](rpc::JsValue::External::Builder builder) {
+            builder.setActorClassChannelToken(token);
+          });
+        }
+        KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+          // Token isn't available synchronously, so we have to send a promise.
+          auto paf = kj::newPromiseAndFulfiller<
+              rpc::JsValue::ExternalPusher::DelayedChannelToken::Client>();
+
+          // Arrange to send the token when it's ready.
+          ioctx.addTask(
+              promise.then([pusher = rpcHandler.getExternalPusher(),
+                               fulfiller = kj::mv(paf.fulfiller)](kj::Array<byte> token) mutable {
+            auto req = pusher.pushDelayedChannelTokenRequest(
+                capnp::MessageSize{4 + token.size() / sizeof(capnp::word), 0});
+            req.setToken(token);
+            fulfiller->fulfill(req.send().getCap());
+          }));
+
+          // Write the promise for now.
+          rpcHandler.write(
+              [promise = kj::mv(paf.promise)](rpc::JsValue::External::Builder builder) mutable {
+            builder.setDelayedActorClassChannelToken(kj::mv(promise));
+          });
+        }
+      }
       return;
     }
     // TODO(someday): structuredClone() should have special handling that just reproduces the same
@@ -246,7 +271,16 @@ void DurableObjectClass::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   // is temporary, anyone using this will lose their data later.
   JSG_REQUIRE(FeatureFlags::get(js).getAllowIrrevocableStubStorage(), DOMDataCloneError,
       "DurableObjectClass cannot be serialized in this context.");
-  serializer.writeLengthDelimited(channel->getToken(IoChannelFactory::ChannelTokenUsage::STORAGE));
+  KJ_SWITCH_ONEOF(channel->getTokenMaybeSync(IoChannelFactory::ChannelTokenUsage::STORAGE)) {
+    KJ_CASE_ONEOF(token, kj::Array<byte>) {
+      serializer.writeLengthDelimited(token);
+    }
+    KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+      // TODO(stub-storage): Eventually we'll serialize by pointing to an external table.
+      KJ_UNIMPLEMENTED(
+          "tried to store ActorClassChannel whose token is not synchronously available");
+    }
+  }
 }
 
 jsg::Ref<DurableObjectClass> DurableObjectClass::deserialize(
@@ -273,10 +307,21 @@ jsg::Ref<DurableObjectClass> DurableObjectClass::deserialize(
           "DurableObjectClass serialization requires the 'experimental' compat flag.");
 
       auto external = rpcHandler.read();
-      KJ_REQUIRE(external.isActorClassChannelToken());
       auto& ioctx = IoContext::current();
-      auto channel = ioctx.getIoChannelFactory().actorClassFromToken(
-          IoChannelFactory::ChannelTokenUsage::RPC, external.getActorClassChannelToken());
+      kj::Own<IoChannelFactory::ActorClassChannel> channel;
+
+      if (external.isDelayedActorClassChannelToken()) {
+        auto promise = ioctx.getExternalPusher()->unwrapDelayedChannelToken(
+            external.getDelayedActorClassChannelToken());
+        channel = ioctx.getIoChannelFactory().actorClassFromToken(
+            IoChannelFactory::ChannelTokenUsage::RPC, kj::mv(promise));
+      } else if (external.isActorClassChannelToken()) {
+        channel = ioctx.getIoChannelFactory().actorClassFromToken(
+            IoChannelFactory::ChannelTokenUsage::RPC, external.getActorClassChannelToken());
+      } else {
+        KJ_FAIL_REQUIRE("wrong external type for DurableObjectClass", external.which());
+      }
+
       return js.alloc<DurableObjectClass>(ioctx.addObject(kj::mv(channel)));
     }
   }

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -572,56 +572,6 @@ class AbortTriggerRpcClient final {
   rpc::AbortTrigger::Client client;
 };
 
-namespace {
-// The jsrpc handler that receives aborts from the remote and triggers them locally
-//
-// TODO(cleanup): This class has been copied to external-pusher.c++. The copy here can be
-//   deleted as soon as we've switched from StreamSink to ExternalPusher and can delete all the
-//   StreamSink-related code. For now I'm not trying to avoid duplication.
-class AbortTriggerRpcServer final: public rpc::AbortTrigger::Server {
- public:
-  AbortTriggerRpcServer(kj::Own<kj::PromiseFulfiller<void>> fulfiller,
-      kj::Own<AbortSignal::PendingReason>&& pendingReason)
-      : fulfiller(kj::mv(fulfiller)),
-        pendingReason(kj::mv(pendingReason)) {}
-
-  kj::Promise<void> abort(AbortContext abortCtx) override {
-    auto params = abortCtx.getParams();
-    auto reason = params.getReason().getV8Serialized();
-
-    pendingReason->getWrapped() = kj::heapArray(reason.asBytes());
-    fulfiller->fulfill();
-    return kj::READY_NOW;
-  }
-
-  kj::Promise<void> release(ReleaseContext releaseCtx) override {
-    released = true;
-    return kj::READY_NOW;
-  }
-
-  ~AbortTriggerRpcServer() noexcept(false) {
-    if (pendingReason->getWrapped() != nullptr) {
-      // Already triggered
-      return;
-    }
-
-    if (!released) {
-      pendingReason->getWrapped() = JSG_KJ_EXCEPTION(FAILED, DOMAbortError,
-          "An AbortSignal received over RPC was implicitly aborted because the connection back to "
-          "its trigger was lost.");
-    }
-
-    // Always fulfill the promise in case the AbortSignal was waiting
-    fulfiller->fulfill();
-  }
-
- private:
-  kj::Own<kj::PromiseFulfiller<void>> fulfiller;
-  kj::Own<AbortSignal::PendingReason> pendingReason;
-  bool released = false;
-};
-}  // namespace
-
 AbortSignal::AbortSignal(kj::Maybe<kj::Exception> exception,
     jsg::Optional<jsg::JsRef<jsg::JsValue>> maybeReason,
     Flag flag)
@@ -863,21 +813,16 @@ void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   }
 
   auto triggerCap = [&]() -> rpc::AbortTrigger::Client {
-    KJ_IF_SOME(pusher, externalHandler->getExternalPusher()) {
-      auto pipeline = pusher.pushAbortSignalRequest(capnp::MessageSize{2, 0}).sendForPipeline();
+    auto pipeline = externalHandler->getExternalPusher()
+                        .pushAbortSignalRequest(capnp::MessageSize{2, 0})
+                        .sendForPipeline();
 
-      externalHandler->write(
-          [signal = pipeline.getSignal()](rpc::JsValue::External::Builder builder) mutable {
-        builder.setAbortSignal(kj::mv(signal));
-      });
+    externalHandler->write(
+        [signal = pipeline.getSignal()](rpc::JsValue::External::Builder builder) mutable {
+      builder.setAbortSignal(kj::mv(signal));
+    });
 
-      return pipeline.getTrigger();
-    } else {
-      return externalHandler
-          ->writeStream([&](rpc::JsValue::External::Builder builder) mutable {
-        builder.setAbortTrigger();
-      }).castAs<rpc::AbortTrigger>();
-    }
+    return pipeline.getTrigger();
   }();
 
   auto& ioContext = IoContext::current();
@@ -914,24 +859,12 @@ jsg::Ref<AbortSignal> AbortSignal::deserialize(
   auto& ioctx = IoContext::current();
 
   auto reader = externalHandler->read();
-  if (reader.isAbortTrigger()) {
-    // Old-style StreamSink.
-    // TODO(cleanup): Remove this once the ExternalPusher autogate has rolled out.
-    auto paf = kj::newPromiseAndFulfiller<void>();
-    auto pendingReason = ioctx.addObject(kj::refcounted<PendingReason>());
+  KJ_REQUIRE(reader.isAbortSignal(), "external table slot type does't match serialization tag");
 
-    externalHandler->setLastStream(
-        kj::heap<AbortTriggerRpcServer>(kj::mv(paf.fulfiller), kj::addRef(*pendingReason)));
-    signal->rpcAbortPromise = ioctx.addObject(kj::heap(kj::mv(paf.promise)));
-    signal->pendingReason = kj::mv(pendingReason);
-  } else {
-    KJ_REQUIRE(reader.isAbortSignal(), "external table slot type does't match serialization tag");
+  auto resolvedSignal = ioctx.getExternalPusher()->unwrapAbortSignal(reader.getAbortSignal());
 
-    auto resolvedSignal = ioctx.getExternalPusher()->unwrapAbortSignal(reader.getAbortSignal());
-
-    signal->rpcAbortPromise = ioctx.addObject(kj::heap(kj::mv(resolvedSignal.signal)));
-    signal->pendingReason = ioctx.addObject(kj::mv(resolvedSignal.reason));
-  }
+  signal->rpcAbortPromise = ioctx.addObject(kj::heap(kj::mv(resolvedSignal.signal)));
+  signal->pendingReason = ioctx.addObject(kj::mv(resolvedSignal.reason));
 
   return signal;
 }

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -382,46 +382,65 @@ jsg::Promise<void> Container::interceptOutboundHttp(
     jsg::Lock& js, kj::String addr, jsg::Ref<Fetcher> binding) {
   auto& ioctx = IoContext::current();
   auto channel = binding->getSubrequestChannel(ioctx);
+  return ioctx.awaitIo(js, interceptOutboundHttpImpl(*rpcClient, kj::mv(addr), kj::mv(channel)));
+}
 
+kj::Promise<void> Container::interceptOutboundHttpImpl(rpc::Container::Client rpcClient,
+    kj::String addr,
+    kj::Own<IoChannelFactory::SubrequestChannel> channel) {
   // Get a channel token for RPC usage, the container runtime can use this
   // token later to redeem a Fetcher.
-  auto token = channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+  kj::Array<byte> token = co_await channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+  { auto drop = kj::mv(channel); }  // no longer needed
 
-  auto req = rpcClient->setEgressHttpRequest();
+  auto req = rpcClient.setEgressHttpRequest();
   req.setHostPort(addr);
   req.setChannelToken(token);
-  return ioctx.awaitIo(js, req.sendIgnoringResult());
+  co_await req.send();
 }
 
 jsg::Promise<void> Container::interceptAllOutboundHttp(jsg::Lock& js, jsg::Ref<Fetcher> binding) {
   auto& ioctx = IoContext::current();
   auto channel = binding->getSubrequestChannel(ioctx);
-  auto token = channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+  return ioctx.awaitIo(js, interceptAllOutboundHttpImpl(*rpcClient, kj::mv(channel)));
+}
+
+kj::Promise<void> Container::interceptAllOutboundHttpImpl(
+    rpc::Container::Client rpcClient, kj::Own<IoChannelFactory::SubrequestChannel> channel) {
+  auto token = co_await channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+  { auto drop = kj::mv(channel); }  // no longer needed
 
   // Register for all IPv4 and IPv6 addresses (on port 80)
-  auto reqV4 = rpcClient->setEgressHttpRequest();
+  auto reqV4 = rpcClient.setEgressHttpRequest();
   reqV4.setHostPort("0.0.0.0/0"_kj);
   reqV4.setChannelToken(token);
 
-  auto reqV6 = rpcClient->setEgressHttpRequest();
+  auto reqV6 = rpcClient.setEgressHttpRequest();
   reqV6.setHostPort("::/0"_kj);
   reqV6.setChannelToken(token);
 
-  return ioctx.awaitIo(js,
-      kj::joinPromisesFailFast(kj::arr(reqV4.sendIgnoringResult(), reqV6.sendIgnoringResult())));
+  co_await kj::joinPromisesFailFast(
+      kj::arr(reqV4.sendIgnoringResult(), reqV6.sendIgnoringResult()));
 }
 
 jsg::Promise<void> Container::interceptOutboundHttps(
     jsg::Lock& js, kj::String addr, jsg::Ref<Fetcher> binding) {
   auto& ioctx = IoContext::current();
   auto channel = binding->getSubrequestChannel(ioctx);
-  auto token = channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+  return ioctx.awaitIo(js, interceptOutboundHttpsImpl(*rpcClient, kj::mv(addr), kj::mv(channel)));
+}
 
-  auto req = rpcClient->setEgressHttpsRequest();
+kj::Promise<void> Container::interceptOutboundHttpsImpl(rpc::Container::Client rpcClient,
+    kj::String addr,
+    kj::Own<IoChannelFactory::SubrequestChannel> channel) {
+  auto token = co_await channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+  { auto drop = kj::mv(channel); }  // no longer needed
+
+  auto req = rpcClient.setEgressHttpsRequest();
   req.setHostPort(addr);
   req.setChannelToken(token);
 
-  return ioctx.awaitIo(js, req.sendIgnoringResult());
+  co_await req.send();
 }
 
 jsg::Promise<jsg::Ref<ExecProcess>> Container::exec(
@@ -557,15 +576,22 @@ jsg::Promise<void> Container::interceptOutboundTcp(
     jsg::Lock& js, kj::String addr, jsg::Ref<Fetcher> binding) {
   auto& ioctx = IoContext::current();
   auto channel = binding->getSubrequestChannel(ioctx);
+  return ioctx.awaitIo(js, interceptOutboundTcpImpl(*rpcClient, kj::mv(addr), kj::mv(channel)));
+}
+
+kj::Promise<void> Container::interceptOutboundTcpImpl(rpc::Container::Client rpcClient,
+    kj::String addr,
+    kj::Own<IoChannelFactory::SubrequestChannel> channel) {
 
   // Get a channel token for RPC usage, the container runtime can use this
   // token later to redeem a Fetcher whose connect() handler processes the TCP stream.
-  auto token = channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+  auto token = co_await channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
+  { auto drop = kj::mv(channel); }  // no longer needed
 
-  auto req = rpcClient->setEgressTcpRequest();
+  auto req = rpcClient.setEgressTcpRequest();
   req.setHostPort(addr);
   req.setChannelToken(token);
-  return ioctx.awaitIo(js, req.sendIgnoringResult());
+  co_await req.send();
 }
 
 jsg::Promise<void> Container::monitor(jsg::Lock& js) {

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -297,6 +297,20 @@ class Container: public jsg::Object {
 
   class TcpPortWorkerInterface;
   class TcpPortOutgoingFactory;
+
+  // These helpers are static since they will leave the IoContext on the first co_await, so we
+  // don't want them trying to access `rpcClient` via the `IoOwn`.
+  static kj::Promise<void> interceptOutboundHttpImpl(rpc::Container::Client rpcClient,
+      kj::String addr,
+      kj::Own<IoChannelFactory::SubrequestChannel> channel);
+  static kj::Promise<void> interceptAllOutboundHttpImpl(
+      rpc::Container::Client rpcClient, kj::Own<IoChannelFactory::SubrequestChannel> channel);
+  static kj::Promise<void> interceptOutboundHttpsImpl(rpc::Container::Client rpcClient,
+      kj::String addr,
+      kj::Own<IoChannelFactory::SubrequestChannel> channel);
+  static kj::Promise<void> interceptOutboundTcpImpl(rpc::Container::Client rpcClient,
+      kj::String addr,
+      kj::Own<IoChannelFactory::SubrequestChannel> channel);
 };
 
 #define EW_CONTAINER_ISOLATE_TYPES                                                                 \

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2141,7 +2141,8 @@ rpc::JsRpcTarget::Client Fetcher::getClientForOneCall(
 }
 
 void Fetcher::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
-  auto channel = getSubrequestChannel(IoContext::current());
+  auto& ioctx = IoContext::current();
+  auto channel = getSubrequestChannel(ioctx);
   channel->requireAllowsTransfer();
 
   KJ_IF_SOME(handler, serializer.getExternalHandler()) {
@@ -2153,10 +2154,34 @@ void Fetcher::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
       JSG_REQUIRE(FeatureFlags::get(js).getWorkerdExperimental(), DOMDataCloneError,
           "ServiceStub serialization requires the 'experimental' compat flag.");
 
-      auto token = channel->getToken(IoChannelFactory::ChannelTokenUsage::RPC);
-      rpcHandler.write([token = kj::mv(token)](rpc::JsValue::External::Builder builder) {
-        builder.setSubrequestChannelToken(token);
-      });
+      KJ_SWITCH_ONEOF(channel->getTokenMaybeSync(IoChannelFactory::ChannelTokenUsage::RPC)) {
+        KJ_CASE_ONEOF(token, kj::Array<byte>) {
+          rpcHandler.write([token = kj::mv(token)](rpc::JsValue::External::Builder builder) {
+            builder.setSubrequestChannelToken(token);
+          });
+        }
+        KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+          // Token isn't available synchronously, so we have to send a promise.
+          auto paf = kj::newPromiseAndFulfiller<
+              rpc::JsValue::ExternalPusher::DelayedChannelToken::Client>();
+
+          // Arrange to send the token when it's ready.
+          ioctx.addTask(promise
+              .then([pusher = rpcHandler.getExternalPusher(), fulfiller = kj::mv(paf.fulfiller)]
+                    (kj::Array<byte> token) mutable {
+            auto req = pusher.pushDelayedChannelTokenRequest(
+                capnp::MessageSize { 4 + token.size() / sizeof(capnp::word), 0 });
+            req.setToken(token);
+            fulfiller->fulfill(req.send().getCap());
+          }));
+
+          // Write the promise for now.
+          rpcHandler.write([promise = kj::mv(paf.promise)]
+                           (rpc::JsValue::External::Builder builder) mutable{
+            builder.setDelayedSubrequestChannelToken(kj::mv(promise));
+          });
+        }
+      }
       return;
     }
     // TODO(someday): structuredClone() should have special handling that just reproduces the same
@@ -2167,7 +2192,16 @@ void Fetcher::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   // is temporary, anyone using this will lose their data later.
   JSG_REQUIRE(FeatureFlags::get(js).getAllowIrrevocableStubStorage(), DOMDataCloneError,
       "ServiceStub cannot be serialized in this context.");
-  serializer.writeLengthDelimited(channel->getToken(IoChannelFactory::ChannelTokenUsage::STORAGE));
+  KJ_SWITCH_ONEOF(channel->getTokenMaybeSync(IoChannelFactory::ChannelTokenUsage::STORAGE)) {
+    KJ_CASE_ONEOF(token, kj::Array<byte>) {
+      serializer.writeLengthDelimited(token);
+    }
+    KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+      // TODO(stub-storage): Eventually we'll serialize by pointing to an external table.
+      KJ_UNIMPLEMENTED(
+          "tried to store SubrequestChannel whose token is not synchronously available");
+    }
+  }
 }
 
 jsg::Ref<Fetcher> Fetcher::deserialize(jsg::Lock& js,
@@ -2194,11 +2228,22 @@ jsg::Ref<Fetcher> Fetcher::deserialize(jsg::Lock& js,
           "ServiceStub serialization requires the 'experimental' compat flag.");
 
       auto external = rpcHandler.read();
-      KJ_REQUIRE(external.isSubrequestChannelToken());
       auto& ioctx = IoContext::current();
-      auto channel = ioctx.getIoChannelFactory().subrequestChannelFromToken(
-          IoChannelFactory::ChannelTokenUsage::RPC,
-          external.getSubrequestChannelToken());
+      kj::Own<IoChannelFactory::SubrequestChannel> channel;
+
+      if (external.isDelayedSubrequestChannelToken()) {
+        auto promise = ioctx.getExternalPusher()->unwrapDelayedChannelToken(
+            external.getDelayedSubrequestChannelToken());
+        channel = ioctx.getIoChannelFactory().subrequestChannelFromToken(
+            IoChannelFactory::ChannelTokenUsage::RPC, kj::mv(promise));
+      } else if (external.isSubrequestChannelToken()) {
+        channel = ioctx.getIoChannelFactory().subrequestChannelFromToken(
+            IoChannelFactory::ChannelTokenUsage::RPC,
+            external.getSubrequestChannelToken());
+      } else {
+        KJ_FAIL_REQUIRE("wrong external type for Fetcher", external.which());
+      }
+
       return js.alloc<Fetcher>(ioctx.addObject(kj::mv(channel)));
     }
   }

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -854,8 +854,7 @@ jsg::Ref<ReadableStream> ReadableStream::deserialize(
 
   kj::Own<kj::AsyncInputStream> in;
   if (rs.hasStream()) {
-    in =
-        ioctx.getExternalPusher()->unwrapStream(rs.getStream(), externalHandler->getDebugContext());
+    in = ioctx.getExternalPusher()->unwrapStream(rs.getStream());
   } else {
     kj::Maybe<uint64_t> expectedLength;
     auto el = rs.getExpectedLength();

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -630,93 +630,6 @@ jsg::Optional<uint32_t> ByteLengthQueuingStrategy::size(
 
 namespace {
 
-// TODO(cleanup): These classes have been copied to external-pusher.c++. The copies here can be
-//   deleted as soon as we've switched from StreamSink to ExternalPusher and can delete all the
-//   StreamSink-related code. For now I'm not trying to avoid duplication.
-
-// HACK: We need as async pipe, like kj::newOneWayPipe(), except supporting explicit end(). So we
-//   wrap the two ends of the pipe in special adapters that track whether end() was called.
-class ExplicitEndOutputPipeAdapter final: public capnp::ExplicitEndOutputStream {
- public:
-  ExplicitEndOutputPipeAdapter(
-      kj::Own<kj::AsyncOutputStream> inner, kj::Own<kj::RefcountedWrapper<bool>> ended)
-      : inner(kj::mv(inner)),
-        ended(kj::mv(ended)) {}
-
-  kj::Promise<void> write(kj::ArrayPtr<const byte> buffer) override {
-    return KJ_REQUIRE_NONNULL(inner)->write(buffer);
-  }
-  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const byte>> pieces) override {
-    return KJ_REQUIRE_NONNULL(inner)->write(pieces);
-  }
-
-  kj::Maybe<kj::Promise<uint64_t>> tryPumpFrom(
-      kj::AsyncInputStream& input, uint64_t amount) override {
-    return KJ_REQUIRE_NONNULL(inner)->tryPumpFrom(input, amount);
-  }
-
-  kj::Promise<void> whenWriteDisconnected() override {
-    return KJ_REQUIRE_NONNULL(inner)->whenWriteDisconnected();
-  }
-
-  kj::Promise<void> end() override {
-    // Signal to the other side that end() was actually called.
-    ended->getWrapped() = true;
-    inner = kj::none;
-    return kj::READY_NOW;
-  }
-
- private:
-  kj::Maybe<kj::Own<kj::AsyncOutputStream>> inner;
-  kj::Own<kj::RefcountedWrapper<bool>> ended;
-};
-
-class ExplicitEndInputPipeAdapter final: public kj::AsyncInputStream {
- public:
-  ExplicitEndInputPipeAdapter(kj::Own<kj::AsyncInputStream> inner,
-      kj::Own<kj::RefcountedWrapper<bool>> ended,
-      kj::Maybe<uint64_t> expectedLength)
-      : inner(kj::mv(inner)),
-        ended(kj::mv(ended)),
-        expectedLength(expectedLength) {}
-
-  kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    size_t result = co_await inner->tryRead(buffer, minBytes, maxBytes);
-
-    KJ_IF_SOME(l, expectedLength) {
-      KJ_ASSERT(result <= l);
-      l -= result;
-      if (l == 0) {
-        // If we got all the bytes we expected, we treat this as a successful end, because the
-        // underlying KJ pipe is not actually going to wait for the other side to drop. This is
-        // consistent with the behavior of Content-Length in HTTP anyway.
-        ended->getWrapped() = true;
-      }
-    }
-
-    if (result < minBytes) {
-      // Verify that end() was called.
-      if (!ended->getWrapped()) {
-        JSG_FAIL_REQUIRE(Error, "ReadableStream received over RPC disconnected prematurely.");
-      }
-    }
-    co_return result;
-  }
-
-  kj::Maybe<uint64_t> tryGetLength() override {
-    return inner->tryGetLength();
-  }
-
-  kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override {
-    return inner->pumpTo(output, amount);
-  }
-
- private:
-  kj::Own<kj::AsyncInputStream> inner;
-  kj::Own<kj::RefcountedWrapper<bool>> ended;
-  kj::Maybe<uint64_t> expectedLength;
-};
-
 // Wrapper around ReadableStreamSource that prevents deferred proxying. We need this for RPC
 // streams because although they are "system streams", they become disconnected when the IoContext
 // is destroyed, due to the JsRpcCustomEvent being canceled.
@@ -792,32 +705,20 @@ void ReadableStream::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   auto expectedLength = controller.tryGetLength(encoding);
 
   capnp::ByteStream::Client streamCap = [&]() {
-    KJ_IF_SOME(pusher, externalHandler->getExternalPusher()) {
-      auto req = pusher.pushByteStreamRequest(capnp::MessageSize{2, 0});
-      KJ_IF_SOME(el, expectedLength) {
-        req.setLengthPlusOne(el + 1);
-      }
-      auto pipeline = req.sendForPipeline();
-
-      externalHandler->write([encoding, expectedLength, source = pipeline.getSource()](
-                                 rpc::JsValue::External::Builder builder) mutable {
-        auto rs = builder.initReadableStream();
-        rs.setStream(kj::mv(source));
-        rs.setEncoding(encoding);
-      });
-
-      return pipeline.getSink();
-    } else {
-      return externalHandler
-          ->writeStream(
-              [encoding, expectedLength](rpc::JsValue::External::Builder builder) mutable {
-        auto rs = builder.initReadableStream();
-        rs.setEncoding(encoding);
-        KJ_IF_SOME(l, expectedLength) {
-          rs.getExpectedLength().setKnown(l);
-        }
-      }).castAs<capnp::ByteStream>();
+    auto req = externalHandler->getExternalPusher().pushByteStreamRequest(capnp::MessageSize{2, 0});
+    KJ_IF_SOME(el, expectedLength) {
+      req.setLengthPlusOne(el + 1);
     }
+    auto pipeline = req.sendForPipeline();
+
+    externalHandler->write([encoding, expectedLength, source = pipeline.getSource()](
+                               rpc::JsValue::External::Builder builder) mutable {
+      auto rs = builder.initReadableStream();
+      rs.setStream(kj::mv(source));
+      rs.setEncoding(encoding);
+    });
+
+    return pipeline.getSink();
   }();
 
   kj::Own<capnp::ExplicitEndOutputStream> kjStream =
@@ -852,25 +753,7 @@ jsg::Ref<ReadableStream> ReadableStream::deserialize(
 
   auto& ioctx = IoContext::current();
 
-  kj::Own<kj::AsyncInputStream> in;
-  if (rs.hasStream()) {
-    in = ioctx.getExternalPusher()->unwrapStream(rs.getStream());
-  } else {
-    kj::Maybe<uint64_t> expectedLength;
-    auto el = rs.getExpectedLength();
-    if (el.isKnown()) {
-      expectedLength = el.getKnown();
-    }
-
-    auto pipe = kj::newOneWayPipe(expectedLength);
-
-    auto endedFlag = kj::refcounted<kj::RefcountedWrapper<bool>>(false);
-
-    auto out = kj::heap<ExplicitEndOutputPipeAdapter>(kj::mv(pipe.out), kj::addRef(*endedFlag));
-    in = kj::heap<ExplicitEndInputPipeAdapter>(kj::mv(pipe.in), kj::mv(endedFlag), expectedLength);
-
-    externalHandler->setLastStream(ioctx.getByteStreamFactory().kjToCapnp(kj::mv(out)));
-  }
+  kj::Own<kj::AsyncInputStream> in = ioctx.getExternalPusher()->unwrapStream(rs.getStream());
 
   return js.alloc<ReadableStream>(ioctx,
       kj::heap<NoDeferredProxyReadableStream>(newSystemStream(kj::mv(in), encoding, ioctx), ioctx));

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -15,125 +15,6 @@
 
 namespace workerd::api {
 
-namespace {
-
-using StreamSinkFulfiller = kj::Own<kj::PromiseFulfiller<rpc::JsValue::StreamSink::Client>>;
-
-}  // namespace
-
-// Implementation of StreamSink RPC interface. The stream sender calls `startStream()` when
-// serializing each stream, and the recipient calls `setSlot()` when deserializing streams to
-// provide the appropriate destination capability. This class is designed to allow these two
-// calls to happen in either order for each slot.
-class StreamSinkImpl final: public rpc::JsValue::StreamSink::Server, public kj::Refcounted {
- public:
-  ~StreamSinkImpl() noexcept(false) {
-    for (auto& slot: table) {
-      KJ_IF_SOME(f, slot.tryGet<StreamFulfiller>()) {
-        f->reject(KJ_EXCEPTION(FAILED, "expected startStream() was never received"));
-      }
-    }
-  }
-
-  void setSlot(uint i, capnp::Capability::Client stream) {
-    if (table.size() <= i) table.resize(i + 1);
-
-    if (table[i] == nullptr) {
-      table[i] = kj::mv(stream);
-    } else KJ_SWITCH_ONEOF(table[i]) {
-      KJ_CASE_ONEOF(stream, capnp::Capability::Client) {
-        KJ_FAIL_REQUIRE("setSlot() tried to set the same slot twice", i);
-      }
-      KJ_CASE_ONEOF(fulfiller, StreamFulfiller) {
-        fulfiller->fulfill(kj::mv(stream));
-        table[i] = Consumed();
-      }
-      KJ_CASE_ONEOF(_, Consumed) {
-        KJ_FAIL_REQUIRE("setSlot() tried to set the same slot twice", i);
-      }
-    }
-  }
-
-  kj::Promise<void> startStream(StartStreamContext context) override {
-    uint i = context.getParams().getExternalIndex();
-
-    if (table.size() <= i) {
-      // guard against ridiculous table allocation
-      JSG_REQUIRE(i < 1024, Error, "Too many streams in one message.");
-      table.resize(i + 1);
-    }
-
-    if (table[i] == nullptr) {
-      auto paf = kj::newPromiseAndFulfiller<capnp::Capability::Client>();
-      table[i] = kj::mv(paf.fulfiller);
-      context.getResults(capnp::MessageSize{4, 1}).setStream(kj::mv(paf.promise));
-    } else KJ_SWITCH_ONEOF(table[i]) {
-      KJ_CASE_ONEOF(stream, capnp::Capability::Client) {
-        context.getResults(capnp::MessageSize{4, 1}).setStream(kj::mv(stream));
-        table[i] = Consumed();
-      }
-      KJ_CASE_ONEOF(fulfiller, StreamFulfiller) {
-        KJ_FAIL_REQUIRE("startStream() tried to start the same stream twice", i);
-      }
-      KJ_CASE_ONEOF(_, Consumed) {
-        KJ_FAIL_REQUIRE("startStream() tried to start the same stream twice", i);
-      }
-    }
-
-    return kj::READY_NOW;
-  }
-
- private:
-  using StreamFulfiller = kj::Own<kj::PromiseFulfiller<capnp::Capability::Client>>;
-  struct Consumed {};
-
-  // Each slot starts out null (uninitialized). It becomes a Capability::Client if setSlot() is
-  // called first, or a StreamFulfiller if startStream() is called first. It becomes `Consumed`
-  // when the other method is called.
-  // HACK: Slots in the table take advantage of the little-known fact that OneOf has a "null"
-  //   value, which is the value a OneOf has when default-initialized. This is useful because we
-  //   don't want to explicitly initialize skipped slots. Maybe<OneOf> would be another option
-  //   here, but would add 8 bytes to every slot just to store a boolean... feels bloated. There
-  //   are only two methods in this class so I think it's OK.
-  using Slot = kj::OneOf<capnp::Capability::Client, StreamFulfiller, Consumed>;
-
-  kj::Vector<Slot> table;
-};
-
-kj::Maybe<rpc::JsValue::ExternalPusher::Client> RpcSerializerExternalHandler::getExternalPusher() {
-  KJ_IF_SOME(ep, externalPusher) {
-    return ep;
-  } else KJ_IF_SOME(func, getStreamHandlerFunc.tryGet<GetExternalPusherFunc>()) {
-    // First call, set up ExternalPusher.
-    return externalPusher.emplace(func());
-  } else {
-    // Using StreamSink.
-    return kj::none;
-  }
-}
-
-capnp::Capability::Client RpcSerializerExternalHandler::writeStream(BuilderCallback callback) {
-  rpc::JsValue::StreamSink::Client* streamSinkPtr;
-  KJ_IF_SOME(ss, streamSink) {
-    streamSinkPtr = &ss;
-  } else {
-    // First stream written, set up the StreamSink.
-    auto& func = KJ_REQUIRE_NONNULL(getStreamHandlerFunc.tryGet<GetStreamSinkFunc>(),
-        "this serialization is not using StreamSink; use getExternalPusher() instead");
-    streamSinkPtr = &streamSink.emplace(func());
-  }
-
-  auto result = ({
-    auto req = streamSinkPtr->startStreamRequest(capnp::MessageSize{4, 0});
-    req.setExternalIndex(externals.size());
-    req.send().getStream();
-  });
-
-  write(kj::mv(callback));
-
-  return result;
-}
-
 capnp::Orphan<capnp::List<rpc::JsValue::External>> RpcSerializerExternalHandler::build(
     capnp::Orphanage orphanage) {
   auto result = orphanage.newOrphan<capnp::List<rpc::JsValue::External>>(externals.size());
@@ -153,17 +34,6 @@ RpcDeserializerExternalHandler::~RpcDeserializerExternalHandler() noexcept(false
 rpc::JsValue::External::Reader RpcDeserializerExternalHandler::read() {
   KJ_ASSERT(i < externals.size());
   return externals[i++];
-}
-
-void RpcDeserializerExternalHandler::setLastStream(capnp::Capability::Client stream) {
-  KJ_IF_SOME(ss, streamSink) {
-    ss.setSlot(i - 1, kj::mv(stream));
-  } else {
-    auto ss = kj::refcounted<StreamSinkImpl>();
-    ss->setSlot(i - 1, kj::mv(stream));
-    streamSink = *ss;
-    streamSinkCap = rpc::JsValue::StreamSink::Client(kj::mv(ss));
-  }
 }
 
 namespace {
@@ -213,15 +83,13 @@ void serializeJsValue(jsg::Lock& js,
 struct DeserializeResult {
   jsg::JsValue value;
   kj::Own<RpcStubDisposalGroup> disposalGroup;
-  kj::Maybe<rpc::JsValue::StreamSink::Client> streamSink;
 };
 
 // Call to construct a JS value from an `rpc::JsValue`.
-DeserializeResult deserializeJsValue(
-    jsg::Lock& js, rpc::JsValue::Reader reader, kj::Maybe<StreamSinkImpl&> streamSink = kj::none) {
+DeserializeResult deserializeJsValue(jsg::Lock& js, rpc::JsValue::Reader reader) {
   auto disposalGroup = kj::heap<RpcStubDisposalGroup>();
 
-  RpcDeserializerExternalHandler externalHandler(reader.getExternals(), *disposalGroup, streamSink);
+  RpcDeserializerExternalHandler externalHandler(reader.getExternals(), *disposalGroup);
 
   jsg::Deserializer deserializer(js, reader.getV8Serialized(), kj::none, kj::none,
       jsg::Deserializer::Options{
@@ -241,21 +109,14 @@ DeserializeResult deserializeJsValue(
   return {
     .value = deserializer.readValue(js),
     .disposalGroup = kj::mv(disposalGroup),
-    .streamSink = externalHandler.getStreamSink(),
   };
 }
 
 // Does deserializeJsValue() and then adds a `dispose()` method to the returned object (if it is
 // an object) which disposes all stubs therein.
-jsg::JsValue deserializeRpcReturnValue(jsg::Lock& js,
-    rpc::JsRpcTarget::CallResults::Reader callResults,
-    kj::Maybe<StreamSinkImpl&> streamSink) {
-  auto [value, disposalGroup, ss] = deserializeJsValue(js, callResults.getResult(), streamSink);
-
-  if (streamSink == kj::none) {
-    KJ_REQUIRE(ss == kj::none,
-        "RPC returned result using StreamSink even though ExternalPusher was provided");
-  }
+jsg::JsValue deserializeRpcReturnValue(
+    jsg::Lock& js, rpc::JsRpcTarget::CallResults::Reader callResults) {
+  auto [value, disposalGroup] = deserializeJsValue(js, callResults.getResult());
 
   // If the object had a disposer on the callee side, it will run when we discard the callPipeline,
   // so attach that to the disposal group on the caller side. If the returned object did NOT have
@@ -498,11 +359,6 @@ JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
         }
       }
 
-      kj::Maybe<StreamSinkFulfiller> paramsStreamSinkFulfiller;
-
-      bool useExternalPusher =
-          util::Autogate::isEnabled(util::AutogateKey::RPC_USE_EXTERNAL_PUSHER);
-
       KJ_IF_SOME(args, maybeArgs) {
         // If we have arguments, serialize them.
         // Note that we may fail to serialize some element, in which case this will throw back to
@@ -519,22 +375,7 @@ JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
               ? RpcSerializerExternalHandler::DUPLICATE
               : RpcSerializerExternalHandler::TRANSFER;
 
-          RpcSerializerExternalHandler::GetStreamHandlerFunc getStreamHandlerFunc;
-          if (useExternalPusher) {
-            getStreamHandlerFunc.init<RpcSerializerExternalHandler::GetExternalPusherFunc>(
-                [&]() -> rpc::JsValue::ExternalPusher::Client { return client; });
-          } else {
-            getStreamHandlerFunc.init<RpcSerializerExternalHandler::GetStreamSinkFunc>([&]() {
-              // A stream was encountered in the params, so we must expect the response to contain
-              // paramsStreamSink. But we don't have the response yet. So, we need to set up a
-              // temporary promise client, which we hook to the response a little bit later.
-              auto paf = kj::newPromiseAndFulfiller<rpc::JsValue::StreamSink::Client>();
-              paramsStreamSinkFulfiller = kj::mv(paf.fulfiller);
-              return kj::mv(paf.promise);
-            });
-          }
-
-          RpcSerializerExternalHandler externalHandler(stubOwnership, kj::mv(getStreamHandlerFunc));
+          RpcSerializerExternalHandler externalHandler(stubOwnership, client);
           serializeJsValue(js, jsg::JsValue(arr), externalHandler, [&](capnp::MessageSize hint) {
             // TODO(perf): Actually use the size hint.
             return builder.getOperation().initCallWithArgs();
@@ -545,26 +386,13 @@ JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
         builder.getOperation().setGetProperty();
       }
 
-      kj::Maybe<kj::Own<StreamSinkImpl>> resultStreamSink;
-      if (useExternalPusher) {
-        // Unfortunately, we always have to send the ExternalPusher since we don't know whether the
-        // call will return any streams (or other pushed externals). Luckily, it's a
-        // one-per-IoContext object, not a big deal. (It'll take a slot on the capnp export table
-        // though.)
-        builder.getResultsStreamHandler().setExternalPusher(ioContext.getExternalPusher());
-      } else {
-        // Unfortunately, we always have to send a `resultsStreamSink` because we don't know until
-        // after the call completes whether or not it will return any streams. If it's unused,
-        // though, it should only be a couple allocations.
-        builder.getResultsStreamHandler().setStreamSink(
-            kj::addRef(*resultStreamSink.emplace(kj::refcounted<StreamSinkImpl>())));
-      }
+      // Unfortunately, we always have to send the ExternalPusher since we don't know whether the
+      // call will return any streams (or other pushed externals). Luckily, it's a
+      // one-per-IoContext object, not a big deal. (It'll take a slot on the capnp export table
+      // though.)
+      builder.getResultsStreamHandler().setExternalPusher(ioContext.getExternalPusher());
 
       auto callResult = builder.send();
-
-      KJ_IF_SOME(ssf, paramsStreamSinkFulfiller) {
-        ssf->fulfill(callResult.getParamsStreamSink());
-      }
 
       // We need to arrange that our JsRpcPromise will updated in-place with the final settlement
       // of this RPC promise. However, we can't actually construct the JsRpcPromise until we have
@@ -575,10 +403,9 @@ JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
       // RemotePromise lets us consume its pipeline and promise portions independently; we consume
       // the promise here and we consume the pipeline below, both via kj::mv().
       auto jsPromise = ioContext.awaitIo(js, kj::mv(callResult),
-          [weakRef = kj::atomicAddRef(*weakRef), resultStreamSink = kj::mv(resultStreamSink)](
-              jsg::Lock& js,
+          [weakRef = kj::atomicAddRef(*weakRef)](jsg::Lock& js,
               capnp::Response<rpc::JsRpcTarget::CallResults> response) mutable -> jsg::Value {
-        auto jsResult = deserializeRpcReturnValue(js, response, resultStreamSink);
+        auto jsResult = deserializeRpcReturnValue(js, response);
 
         if (weakRef->disposed) {
           // The promise was explicitly disposed before it even resolved. This means we must dispose
@@ -961,7 +788,7 @@ template <typename Func>
 MakeCallPipeline::Result serializeJsValueWithPipeline(jsg::Lock& js,
     jsg::JsValue value,
     Func makeBuilder,
-    RpcSerializerExternalHandler::GetStreamHandlerFunc getStreamSinkFunc);
+    rpc::JsValue::ExternalPusher::Client externalPusher);
 
 // Callee-side implementation of JsRpcTarget.
 //
@@ -1101,45 +928,28 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       // Given a handle for the result, if it's a promise, await the promise, then serialize the
       // final result for return.
 
-      RpcSerializerExternalHandler::GetStreamHandlerFunc getResultsStreamHandlerFunc;
-      auto resultStreamHandler = params.getResultsStreamHandler();
-      switch (resultStreamHandler.which()) {
-        case rpc::JsRpcTarget::CallParams::ResultsStreamHandler::EXTERNAL_PUSHER:
-          getResultsStreamHandlerFunc.init<RpcSerializerExternalHandler::GetExternalPusherFunc>(
-              [cap = resultStreamHandler.getExternalPusher()]() mutable { return kj::mv(cap); });
-          break;
-        case rpc::JsRpcTarget::CallParams::ResultsStreamHandler::STREAM_SINK:
-          getResultsStreamHandlerFunc.init<RpcSerializerExternalHandler::GetStreamSinkFunc>(
-              [cap = resultStreamHandler.getStreamSink()]() mutable { return kj::mv(cap); });
-          break;
-      }
+      auto externalPusher = [&]() -> rpc::JsValue::ExternalPusher::Client {
+        auto resultStreamHandler = params.getResultsStreamHandler();
+        if (resultStreamHandler.hasExternalPusher()) {
+          return resultStreamHandler.getExternalPusher();
+        } else if (resultStreamHandler.hasObsolete4()) {
+          // A StreamSink was provided -- that's the old approach, which should have been
+          // eliminated from prod before this rolled out.
+          return KJ_EXCEPTION(FAILED, "Caller using obsolete StreamSink API?");
+        } else {
+          // The caller simply failed provide an ExternalPusher. This shouldn't happen in prod but
+          // there are some tests that don't set anything. If we return an exception here, it'll
+          // only show up if we actually try to use the ExternalPusher to encode our return value.
+          return KJ_EXCEPTION(
+              FAILED, "Couldn't return stream because caller didn't provide an ExternalPusher.");
+        }
+      }();
 
       kj::Maybe<kj::Own<kj::PromiseFulfiller<rpc::JsRpcTarget::Client>>> callPipelineFulfiller;
 
       // We need another ref to this fulfiller for the error callback. It can rely on being
       // destroyed at the same time as the success callback.
       kj::Maybe<kj::PromiseFulfiller<rpc::JsRpcTarget::Client>&> callPipelineFulfillerRef;
-
-      KJ_IF_SOME(ss, invocationResult.streamSink) {
-        // Since we have a StreamSink, it's important that we hook up the pipeline for that
-        // immediately. Annoyingly, that also means we need to hook up a pipeline for
-        // callPipeline, which we don't actually have yet, so we need to promise-ify it.
-
-        // If the caller requested using ExternalPusher for the results, then it should also use
-        // ExternalPusher for the params. (Theoretically we could support mix-and-match but...
-        // let's keep it simple.)
-        KJ_REQUIRE(resultStreamHandler.isStreamSink(),
-            "RPC params used StreamSink when result is supposed to use ExternalPusher");
-
-        auto paf = kj::newPromiseAndFulfiller<rpc::JsRpcTarget::Client>();
-        callPipelineFulfillerRef = *paf.fulfiller;
-        callPipelineFulfiller = kj::mv(paf.fulfiller);
-
-        capnp::PipelineBuilder<rpc::JsRpcTarget::CallResults> builder(16);
-        builder.setCallPipeline(kj::mv(paf.promise));
-        builder.setParamsStreamSink(ss);
-        callContext.setPipeline(builder.build());
-      }
 
       // HACK: Cap'n Proto call contexts are documented as being pointer-like types where the
       // backing object's lifetime is that of the RPC call, but in reality they are refcounted
@@ -1161,8 +971,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
                       // must take full ownership.
                       [callContext, ownCallContext = kj::mv(ownCallContext),
                           paramDisposalGroup = kj::mv(invocationResult.paramDisposalGroup),
-                          paramsStreamSink = kj::mv(invocationResult.streamSink),
-                          getResultsStreamHandlerFunc = kj::mv(getResultsStreamHandlerFunc),
+                          externalPusher = kj::mv(externalPusher),
                           callPipelineFulfiller = kj::mv(callPipelineFulfiller)](
                           jsg::Lock& js, jsg::Value value) mutable {
         jsg::JsValue resultValue(value.getHandle(js));
@@ -1174,7 +983,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
           hint.capCount += 1;  // for callPipeline
           results = callContext.initResults(hint);
           return results.initResult();
-        }, kj::mv(getResultsStreamHandlerFunc));
+        }, kj::mv(externalPusher));
 
         KJ_SWITCH_ONEOF(maybePipeline) {
           KJ_CASE_ONEOF(obj, MakeCallPipeline::Object) {
@@ -1201,10 +1010,6 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
 
         KJ_IF_SOME(cpf, callPipelineFulfiller) {
           cpf->fulfill(results.getCallPipeline());
-        }
-
-        KJ_IF_SOME(ss, paramsStreamSink) {
-          results.setParamsStreamSink(kj::mv(ss));
         }
 
         // paramDisposalGroup will be destroyed when we return (or when this lambda is destroyed
@@ -1413,7 +1218,6 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
   struct InvocationResult {
     v8::Local<v8::Value> returnValue;
     kj::Maybe<kj::Own<RpcStubDisposalGroup>> paramDisposalGroup;
-    kj::Maybe<rpc::JsValue::StreamSink::Client> streamSink;
   };
 
   // Deserializes the arguments and passes them to the given function.
@@ -1423,7 +1227,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       kj::Maybe<rpc::JsValue::Reader> args) {
     // We received arguments from the client, deserialize them back to JS.
     KJ_IF_SOME(a, args) {
-      auto [value, disposalGroup, streamSink] = deserializeJsValue(js, a);
+      auto [value, disposalGroup] = deserializeJsValue(js, a);
       auto args = KJ_REQUIRE_NONNULL(
           value.tryCast<jsg::JsArray>(), "expected JsArray when deserializing arguments.");
       // Call() expects a `Local<Value> []`... so we populate an array.
@@ -1436,7 +1240,6 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       InvocationResult result{
         .returnValue =
             jsg::check(fn->Call(js.v8Context(), thisArg, arguments.size(), arguments.data())),
-        .streamSink = kj::mv(streamSink),
       };
       if (!disposalGroup->empty()) {
         result.paramDisposalGroup = kj::mv(disposalGroup);
@@ -1475,7 +1278,6 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
     }
 
     kj::Maybe<kj::Own<RpcStubDisposalGroup>> paramDisposalGroup;
-    kj::Maybe<rpc::JsValue::StreamSink::Client> streamSink;
 
     // We're going to pass all the arguments from the client to the function, but we are going to
     // insert `env` and `ctx`. We assume the last two arguments that the function declared are
@@ -1483,8 +1285,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
     kj::Maybe<jsg::JsArray> argsArrayFromClient;
     size_t argCountFromClient = 0;
     KJ_IF_SOME(a, args) {
-      auto [value, disposalGroup, ss] = deserializeJsValue(js, a);
-      streamSink = kj::mv(ss);
+      auto [value, disposalGroup] = deserializeJsValue(js, a);
 
       auto array = KJ_REQUIRE_NONNULL(
           value.tryCast<jsg::JsArray>(), "expected JsArray when deserializing arguments.");
@@ -1537,7 +1338,6 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       .returnValue =
           jsg::check(fn->Call(js.v8Context(), thisArg, arguments.size(), arguments.data())),
       .paramDisposalGroup = kj::mv(paramDisposalGroup),
-      .streamSink = kj::mv(streamSink),
     };
   };
 };
@@ -1656,7 +1456,7 @@ template <typename Func>
 MakeCallPipeline::Result serializeJsValueWithPipeline(jsg::Lock& js,
     jsg::JsValue value,
     Func makeBuilder,
-    RpcSerializerExternalHandler::GetStreamHandlerFunc getStreamHandlerFunc) {
+    rpc::JsValue::ExternalPusher::Client externalPusher) {
   auto maybeDispose = js.withinHandleScope([&]() -> kj::Maybe<jsg::V8Ref<v8::Function>> {
     jsg::JsObject obj = KJ_UNWRAP_OR(value.tryCast<jsg::JsObject>(), { return kj::none; });
 
@@ -1680,7 +1480,7 @@ MakeCallPipeline::Result serializeJsValueWithPipeline(jsg::Lock& js,
 
   // Now that we've extracted our dispose function, we can serialize our value.
   RpcSerializerExternalHandler externalHandler(
-      RpcSerializerExternalHandler::TRANSFER, kj::mv(getStreamHandlerFunc));
+      RpcSerializerExternalHandler::TRANSFER, kj::mv(externalPusher));
   serializeJsValue(js, value, externalHandler, kj::mv(makeBuilder));
 
   auto stubDisposers = externalHandler.releaseStubDisposers();

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -872,6 +872,9 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
   kj::Promise<void> pushAbortSignal(PushAbortSignalContext context) override {
     return externalPusher->pushAbortSignal(context);
   }
+  kj::Promise<void> pushDelayedChannelToken(PushDelayedChannelTokenContext context) override {
+    return externalPusher->pushDelayedChannelToken(context);
+  }
 
   KJ_DISALLOW_COPY_AND_MOVE(JsRpcTargetBase);
 

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -217,14 +217,11 @@ struct DeserializeResult {
 };
 
 // Call to construct a JS value from an `rpc::JsValue`.
-DeserializeResult deserializeJsValue(jsg::Lock& js,
-    rpc::JsValue::Reader reader,
-    kj::LiteralStringConst debugContext,
-    kj::Maybe<StreamSinkImpl&> streamSink = kj::none) {
+DeserializeResult deserializeJsValue(
+    jsg::Lock& js, rpc::JsValue::Reader reader, kj::Maybe<StreamSinkImpl&> streamSink = kj::none) {
   auto disposalGroup = kj::heap<RpcStubDisposalGroup>();
 
-  RpcDeserializerExternalHandler externalHandler(
-      reader.getExternals(), *disposalGroup, streamSink, debugContext);
+  RpcDeserializerExternalHandler externalHandler(reader.getExternals(), *disposalGroup, streamSink);
 
   jsg::Deserializer deserializer(js, reader.getV8Serialized(), kj::none, kj::none,
       jsg::Deserializer::Options{
@@ -253,8 +250,7 @@ DeserializeResult deserializeJsValue(jsg::Lock& js,
 jsg::JsValue deserializeRpcReturnValue(jsg::Lock& js,
     rpc::JsRpcTarget::CallResults::Reader callResults,
     kj::Maybe<StreamSinkImpl&> streamSink) {
-  auto [value, disposalGroup, ss] =
-      deserializeJsValue(js, callResults.getResult(), "return"_kjc, streamSink);
+  auto [value, disposalGroup, ss] = deserializeJsValue(js, callResults.getResult(), streamSink);
 
   if (streamSink == kj::none) {
     KJ_REQUIRE(ss == kj::none,
@@ -1427,7 +1423,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       kj::Maybe<rpc::JsValue::Reader> args) {
     // We received arguments from the client, deserialize them back to JS.
     KJ_IF_SOME(a, args) {
-      auto [value, disposalGroup, streamSink] = deserializeJsValue(js, a, "params"_kjc);
+      auto [value, disposalGroup, streamSink] = deserializeJsValue(js, a);
       auto args = KJ_REQUIRE_NONNULL(
           value.tryCast<jsg::JsArray>(), "expected JsArray when deserializing arguments.");
       // Call() expects a `Local<Value> []`... so we populate an array.
@@ -1487,7 +1483,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
     kj::Maybe<jsg::JsArray> argsArrayFromClient;
     size_t argCountFromClient = 0;
     KJ_IF_SOME(a, args) {
-      auto [value, disposalGroup, ss] = deserializeJsValue(js, a, "paramsNonClass"_kjc);
+      auto [value, disposalGroup, ss] = deserializeJsValue(js, a);
       streamSink = kj::mv(ss);
 
       auto array = KJ_REQUIRE_NONNULL(

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -1897,61 +1897,6 @@ class EntrypointJsRpcTarget final: public JsRpcTargetBase {
   }
 };
 
-// A membrane which wraps the top-level JsRpcTarget of an RPC session on the server side. The
-// purpose of this membrane is to allow only a single top-level call, which then gets a
-// `CompletionMembrane` wrapped around it. Note that we can't just wrap `CompletionMembrane` around
-// the top-level object directly because that capability will not be dropped until the RPC session
-// completes, since it is actually returned as the result of the top-level RPC call, but that
-// call doesn't return until the `CompletionMembrane` says all capabilities were dropped, so this
-// would create a cycle.
-class JsRpcSessionCustomEvent::ServerTopLevelMembrane final: public capnp::MembranePolicy,
-                                                             public kj::Refcounted {
- public:
-  explicit ServerTopLevelMembrane(kj::Own<kj::PromiseFulfiller<void>> doneFulfiller)
-      : completionMembrane(kj::refcounted<CompletionMembrane>(kj::mv(doneFulfiller))) {}
-
-  ~ServerTopLevelMembrane() noexcept(false) {
-    KJ_IF_SOME(cm, completionMembrane) {
-      cm->reject(
-          KJ_EXCEPTION(DISCONNECTED, "JS RPC session canceled without calling an RPC method."));
-    }
-  }
-
-  kj::Maybe<capnp::Capability::Client> inboundCall(
-      uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
-    if (interfaceId == capnp::typeId<rpc::JsRpcTarget>()) {
-      // JsRpcTarget::call()
-      auto cm = kj::mv(JSG_REQUIRE_NONNULL(
-          completionMembrane, Error, "Only one RPC method call is allowed on this object."));
-      completionMembrane = kj::none;
-      return capnp::membrane(kj::mv(target), kj::mv(cm));
-    } else if (interfaceId == capnp::typeId<rpc::JsValue::ExternalPusher>()) {
-      // ExternalPusher methods
-      //
-      // It's important that we use the same membrane that we'll use for call(), so that
-      // capabilities returned by the ExternalPusher will be wrapped in the membrane, hence they
-      // will be unwrapped when passed back through the membrane again to call().
-      auto& cm = *JSG_REQUIRE_NONNULL(
-          completionMembrane, Error, "getExternalPusher() must be called before call()");
-      return capnp::membrane(kj::mv(target), kj::addRef(cm));
-    } else {
-      KJ_FAIL_ASSERT("unkown interface ID for JsRpcTarget");
-    }
-  }
-
-  kj::Maybe<capnp::Capability::Client> outboundCall(
-      uint64_t interfaceId, uint16_t methodId, capnp::Capability::Client target) override {
-    KJ_FAIL_ASSERT("ServerTopLevelMembrane shouldn't have outgoing capabilities");
-  }
-
-  kj::Own<MembranePolicy> addRef() override {
-    return kj::addRef(*this);
-  }
-
- private:
-  kj::Maybe<kj::Own<CompletionMembrane>> completionMembrane;
-};
-
 kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::run(
     kj::Own<IoContext::IncomingRequest> incomingRequest,
     kj::Maybe<kj::StringPtr> entrypointName,
@@ -1976,17 +1921,8 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::run(
   try {
     auto [donePromise, doneFulfiller] = kj::newPromiseAndFulfiller<void>();
 
-    kj::Own<capnp::MembranePolicy> topMembrane;
-    if (util::Autogate::isEnabled(util::AutogateKey::JSRPC_SESSION_HANDLE)) {
-      // When using the session handle approach, we don't need the convoluted
-      // `ServerTopLevelMembrane` because the the top-level `JsRpcTarget` is not unnaturally held
-      // open, so it can be treated the same as any other capability in the session.
-      topMembrane = kj::refcounted<CompletionMembrane>(kj::mv(doneFulfiller));
-    } else {
-      topMembrane = kj::refcounted<ServerTopLevelMembrane>(kj::mv(doneFulfiller));
-    }
-
-    capFulfiller->fulfill(capnp::membrane(revcableTarget.getClient(), kj::mv(topMembrane)));
+    capFulfiller->fulfill(capnp::membrane(
+        revcableTarget.getClient(), kj::refcounted<CompletionMembrane>(kj::mv(doneFulfiller))));
 
     // `donePromise` resolves once there are no longer any capabilities pointing between the client
     // and server as part of this session.
@@ -2083,26 +2019,19 @@ kj::Promise<void> JsRpcSessionCustomEvent::receiveRpc(JsRpcSessionContext contex
 
   auto cap = customEvent->getCap();
 
-  if (util::Autogate::isEnabled(util::AutogateKey::JSRPC_SESSION_HANDLE)) {
-    auto promise = worker.customEvent(kj::mv(customEvent));
+  auto promise = worker.customEvent(kj::mv(customEvent));
 
-    auto results = context.getResults(capnp::MessageSize{4, 2});
-    results.setTopLevel(kj::mv(cap));
+  auto results = context.getResults(capnp::MessageSize{4, 2});
+  results.setTopLevel(kj::mv(cap));
 
-    // Set the returned session capability to resolve to a null capability when the event is
-    // complete. This also neatly arranges that if the session is dropped early, the
-    // `customEvent()` promise is canceled, thus canceling the session.
-    results.setSession(promise.then([ownWorker = kj::mv(ownWorker)](auto outcome) {
-      return rpc::JsRpcSession::Client(nullptr);
-    }));
-  } else {
-    capnp::PipelineBuilder<rpc::EventDispatcher::JsRpcSessionResults> pipelineBuilder;
-    pipelineBuilder.setTopLevel(cap);
-    context.setPipeline(pipelineBuilder.build());
-    context.getResults().setTopLevel(kj::mv(cap));
+  // Set the returned session capability to resolve to a null capability when the event is
+  // complete. This also neatly arranges that if the session is dropped early, the
+  // `customEvent()` promise is canceled, thus canceling the session.
+  results.setSession(promise.then([ownWorker = kj::mv(ownWorker)](auto outcome) {
+    return rpc::JsRpcSession::Client(nullptr);
+  }));
 
-    co_await worker.customEvent(kj::mv(customEvent));
-  }
+  return kj::READY_NOW;
 }
 
 };  // namespace workerd::api

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -36,18 +36,14 @@ constexpr size_t MAX_JS_RPC_MESSAGE_SIZE = 1u << 25;
 // handle RPC specially should use this.
 class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandler {
  public:
-  using GetStreamSinkFunc = kj::Function<rpc::JsValue::StreamSink::Client()>;
-  using GetExternalPusherFunc = kj::Function<rpc::JsValue::ExternalPusher::Client()>;
-  using GetStreamHandlerFunc = kj::OneOf<GetStreamSinkFunc, GetExternalPusherFunc>;
-
   enum StubOwnership { TRANSFER, DUPLICATE };
 
-  // `getStreamSinkFunc` will be called at most once, the first time a stream is encountered in
-  // serialization, to get the StreamSink that should be used.
+  // `getExternalPusherFunc` will be called at most once, the first time a stream is encountered in
+  // serialization, to get the ExternalPusher that should be used.
   RpcSerializerExternalHandler(
-      StubOwnership stubOwnership, GetStreamHandlerFunc getStreamHandlerFunc)
+      StubOwnership stubOwnership, rpc::JsValue::ExternalPusher::Client externalPusher)
       : stubOwnership(stubOwnership),
-        getStreamHandlerFunc(kj::mv(getStreamHandlerFunc)) {}
+        externalPusher(kj::mv(externalPusher)) {}
 
   inline StubOwnership getStubOwnership() {
     return stubOwnership;
@@ -55,9 +51,10 @@ class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandle
 
   using BuilderCallback = kj::Function<void(rpc::JsValue::External::Builder)>;
 
-  // Returns the ExternalPusher for the remote side. Returns kj::none if this serialization is
-  // using the older StreamSink approach, in which case you need to call `writeStream()` instead.
-  kj::Maybe<rpc::JsValue::ExternalPusher::Client> getExternalPusher();
+  // Returns the ExternalPusher for the remote side.
+  rpc::JsValue::ExternalPusher::Client getExternalPusher() {
+    return externalPusher;
+  }
 
   // Add an external. The value is a callback which will be invoked later to fill in the
   // JsValue::External in the Cap'n Proto structure. The external array cannot be allocated until
@@ -66,13 +63,6 @@ class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandle
   void write(BuilderCallback callback) {
     externals.add(kj::mv(callback));
   }
-
-  // Like write(), but use this when there is also a stream associated with the external, i.e.
-  // using StreamSink. This returns a capability which will eventually resolve to the stream.
-  //
-  // StreamSink is being replaced by ExternalPusher. You should only call writeStream() if
-  // getExternalPusher() returns kj::none. If ExternalPusher is available, this method will throw.
-  capnp::Capability::Client writeStream(BuilderCallback callback);
 
   // Build the final list.
   capnp::Orphan<capnp::List<rpc::JsValue::External>> build(capnp::Orphanage orphanage);
@@ -108,50 +98,31 @@ class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandle
 
  private:
   StubOwnership stubOwnership;
-  GetStreamHandlerFunc getStreamHandlerFunc;
+  rpc::JsValue::ExternalPusher::Client externalPusher;
 
   kj::Vector<BuilderCallback> externals;
   kj::Vector<kj::Own<void>> stubDisposers;
-
-  kj::Maybe<rpc::JsValue::StreamSink::Client> streamSink;
-  kj::Maybe<rpc::JsValue::ExternalPusher::Client> externalPusher;
 };
 
 class RpcStubDisposalGroup;
-class StreamSinkImpl;
 
 // ExternalHandler used when deserializing RPC messages. Deserialization functions with which to
 // handle RPC specially should use this.
 class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHandler {
  public:
-  // The `streamSink` parameter should be provided if a StreamSink already exists, e.g. when
-  // deserializing results. If omitted, it will be constructed on-demand.
-  RpcDeserializerExternalHandler(capnp::List<rpc::JsValue::External>::Reader externals,
-      RpcStubDisposalGroup& disposalGroup,
-      kj::Maybe<StreamSinkImpl&> streamSink)
+  RpcDeserializerExternalHandler(
+      capnp::List<rpc::JsValue::External>::Reader externals, RpcStubDisposalGroup& disposalGroup)
       : externals(externals),
-        disposalGroup(disposalGroup),
-        streamSink(streamSink) {}
+        disposalGroup(disposalGroup) {}
   ~RpcDeserializerExternalHandler() noexcept(false);
 
   // Read and return the next external.
   rpc::JsValue::External::Reader read();
 
-  // Call immediately after `read()` when reading an external that is associated with a stream.
-  // `stream` is published back to the sender via StreamSink.
-  void setLastStream(capnp::Capability::Client stream);
-
   // All stubs deserialized as part of a particular parameter or result set are placed in a
   // common disposal group so that they can be disposed together.
   RpcStubDisposalGroup& getDisposalGroup() {
     return disposalGroup;
-  }
-
-  // Call after serialization is complete to get the StreamSink that should handle streams found
-  // while deserializing. Returns none if there were no streams. This should only be called if
-  // a `streamSink` was NOT passed to the constructor.
-  kj::Maybe<rpc::JsValue::StreamSink::Client> getStreamSink() {
-    return kj::mv(streamSinkCap);
   }
 
  private:
@@ -160,9 +131,6 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
 
   kj::UnwindDetector unwindDetector;
   RpcStubDisposalGroup& disposalGroup;
-
-  kj::Maybe<StreamSinkImpl&> streamSink;
-  kj::Maybe<rpc::JsValue::StreamSink::Client> streamSinkCap;
 };
 
 // Base class for objects which can be sent over RPC, but doing so actually sends a stub which

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -128,12 +128,10 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
   // deserializing results. If omitted, it will be constructed on-demand.
   RpcDeserializerExternalHandler(capnp::List<rpc::JsValue::External>::Reader externals,
       RpcStubDisposalGroup& disposalGroup,
-      kj::Maybe<StreamSinkImpl&> streamSink,
-      kj::LiteralStringConst debugContext)
+      kj::Maybe<StreamSinkImpl&> streamSink)
       : externals(externals),
         disposalGroup(disposalGroup),
-        streamSink(streamSink),
-        debugContext(debugContext) {}
+        streamSink(streamSink) {}
   ~RpcDeserializerExternalHandler() noexcept(false);
 
   // Read and return the next external.
@@ -156,12 +154,6 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
     return kj::mv(streamSinkCap);
   }
 
-  // Return a string literal to include in deserialization errors for debugging. (In particular
-  // this specifies if it's params or return.)
-  kj::LiteralStringConst getDebugContext() {
-    return debugContext;
-  }
-
  private:
   capnp::List<rpc::JsValue::External>::Reader externals;
   uint i = 0;
@@ -171,8 +163,6 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
 
   kj::Maybe<StreamSinkImpl&> streamSink;
   kj::Maybe<rpc::JsValue::StreamSink::Client> streamSinkCap;
-
-  kj::LiteralStringConst debugContext;
 };
 
 // Base class for objects which can be sent over RPC, but doing so actually sends a stub which

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -507,8 +507,6 @@ class JsRpcSessionCustomEvent final: public WorkerInterface::CustomEvent {
   uint16_t typeId;
 
   kj::Maybe<kj::String> wrapperModule;
-
-  class ServerTopLevelMembrane;
 };
 
 #define EW_WORKER_RPC_ISOLATE_TYPES                                                                \

--- a/src/workerd/io/external-pusher.c++
+++ b/src/workerd/io/external-pusher.c++
@@ -250,4 +250,30 @@ kj::Promise<void> ExternalPusherImpl::unwrapAbortSignalImpl(
   co_await paf.promise;
 }
 
+// =======================================================================================
+// DelayedChannelToken handling
+
+class ExternalPusherImpl::DelayedChannelTokenImpl final
+    : public ExternalPusher::DelayedChannelToken::Server {
+ public:
+  DelayedChannelTokenImpl(kj::Array<byte> token): token(kj::mv(token)) {}
+
+  kj::Array<byte> token;
+};
+
+kj::Promise<void> ExternalPusherImpl::pushDelayedChannelToken(
+    PushDelayedChannelTokenContext context) {
+  auto token = kj::heapArray(context.getParams().getToken());
+  auto cap = delayedChannelTokenSet.add(kj::heap<DelayedChannelTokenImpl>(kj::mv(token)));
+  context.getResults(capnp::MessageSize{2, 1}).setCap(kj::mv(cap));
+  return kj::READY_NOW;
+}
+
+kj::Promise<kj::Array<byte>> ExternalPusherImpl::unwrapDelayedChannelToken(
+    rpc::JsValue::ExternalPusher::DelayedChannelToken::Client cap) {
+  auto& unwrapped = KJ_REQUIRE_NONNULL(co_await delayedChannelTokenSet.getLocalServer(cap),
+      "pushed external is not a DelayedChannelToken");
+  co_return kj::mv(kj::downcast<DelayedChannelTokenImpl>(unwrapped).token);
+}
+
 }  // namespace workerd

--- a/src/workerd/io/external-pusher.c++
+++ b/src/workerd/io/external-pusher.c++
@@ -131,14 +131,14 @@ kj::Promise<void> ExternalPusherImpl::pushByteStream(PushByteStreamContext conte
 }
 
 kj::Own<kj::AsyncInputStream> ExternalPusherImpl::unwrapStream(
-    ExternalPusher::InputStream::Client cap, kj::LiteralStringConst debugContext) {
-  return kj::newPromisedStream(unwrapStreamImpl(kj::mv(cap), debugContext));
+    ExternalPusher::InputStream::Client cap) {
+  return kj::newPromisedStream(unwrapStreamImpl(kj::mv(cap)));
 }
 
 kj::Promise<kj::Own<kj::AsyncInputStream>> ExternalPusherImpl::unwrapStreamImpl(
-    ExternalPusher::InputStream::Client cap, kj::LiteralStringConst debugContext) {
+    ExternalPusher::InputStream::Client cap) {
   auto& unwrapped = KJ_REQUIRE_NONNULL(co_await inputStreamSet.getLocalServer(cap),
-      "pushed external is not a byte stream", debugContext, cap.debugInfo());
+      "pushed external is not a byte stream", cap.debugInfo());
 
   co_return KJ_REQUIRE_NONNULL(kj::mv(kj::downcast<InputStreamImpl>(unwrapped).stream),
       "pushed byte stream has already been consumed");

--- a/src/workerd/io/external-pusher.c++
+++ b/src/workerd/io/external-pusher.c++
@@ -12,10 +12,6 @@ namespace workerd {
 
 namespace {
 
-// TODO(cleanup): These classes have been copied from streams/readable.c++. The copies there can be
-//   deleted as soon as we've switched from StreamSink to ExternalPusher and can delete all the
-//   StreamSink-related code. For now I'm not trying to avoid duplication.
-
 // HACK: We need as async pipe, like kj::newOneWayPipe(), except supporting explicit end(). So we
 //   wrap the two ends of the pipe in special adapters that track whether end() was called.
 class ExplicitEndOutputPipeAdapter final: public capnp::ExplicitEndOutputStream {
@@ -149,10 +145,6 @@ kj::Promise<kj::Own<kj::AsyncInputStream>> ExternalPusherImpl::unwrapStreamImpl(
 namespace {
 
 // The jsrpc handler that receives aborts from the remote and triggers them locally
-//
-// TODO(cleanup): This class has been copied from basics.c++. The copy there can be
-//   deleted as soon as we've switched from StreamSink to ExternalPusher and can delete all the
-//   StreamSink-related code. For now I'm not trying to avoid duplication.
 class AbortTriggerRpcServer final: public rpc::AbortTrigger::Server {
  public:
   AbortTriggerRpcServer(kj::Own<kj::PromiseFulfiller<void>> fulfiller,

--- a/src/workerd/io/external-pusher.h
+++ b/src/workerd/io/external-pusher.h
@@ -41,14 +41,19 @@ class ExternalPusherImpl: public rpc::JsValue::ExternalPusher::Server, public kj
 
   AbortSignal unwrapAbortSignal(ExternalPusher::AbortSignal::Client cap);
 
+  kj::Promise<kj::Array<byte>> unwrapDelayedChannelToken(
+      rpc::JsValue::ExternalPusher::DelayedChannelToken::Client cap);
+
   kj::Promise<void> pushByteStream(PushByteStreamContext context) override;
   kj::Promise<void> pushAbortSignal(PushAbortSignalContext context) override;
+  kj::Promise<void> pushDelayedChannelToken(PushDelayedChannelTokenContext context) override;
 
  private:
   capnp::ByteStreamFactory& byteStreamFactory;
 
   capnp::CapabilityServerSet<ExternalPusher::InputStream> inputStreamSet;
   capnp::CapabilityServerSet<ExternalPusher::AbortSignal> abortSignalSet;
+  capnp::CapabilityServerSet<ExternalPusher::DelayedChannelToken> delayedChannelTokenSet;
 
   kj::Promise<kj::Own<kj::AsyncInputStream>> unwrapStreamImpl(
       ExternalPusher::InputStream::Client cap);
@@ -58,6 +63,7 @@ class ExternalPusherImpl: public rpc::JsValue::ExternalPusher::Server, public kj
 
   class InputStreamImpl;
   class AbortSignalImpl;
+  class DelayedChannelTokenImpl;
 };
 
 }  // namespace workerd

--- a/src/workerd/io/external-pusher.h
+++ b/src/workerd/io/external-pusher.h
@@ -24,8 +24,7 @@ class ExternalPusherImpl: public rpc::JsValue::ExternalPusher::Server, public kj
 
   using ExternalPusher = rpc::JsValue::ExternalPusher;
 
-  kj::Own<kj::AsyncInputStream> unwrapStream(
-      ExternalPusher::InputStream::Client cap, kj::LiteralStringConst debugContext);
+  kj::Own<kj::AsyncInputStream> unwrapStream(ExternalPusher::InputStream::Client cap);
 
   // Box which holds the reason why an AbortSignal was aborted. May be either:
   // - A serialized V8 value if the signal was aborted from JavaScript.
@@ -52,7 +51,7 @@ class ExternalPusherImpl: public rpc::JsValue::ExternalPusher::Server, public kj
   capnp::CapabilityServerSet<ExternalPusher::AbortSignal> abortSignalSet;
 
   kj::Promise<kj::Own<kj::AsyncInputStream>> unwrapStreamImpl(
-      ExternalPusher::InputStream::Client cap, kj::LiteralStringConst debugContext);
+      ExternalPusher::InputStream::Client cap);
 
   kj::Promise<void> unwrapAbortSignalImpl(
       ExternalPusher::AbortSignal::Client cap, kj::Own<PendingAbortReason> pendingReason);

--- a/src/workerd/io/frankenvalue.h
+++ b/src/workerd/io/frankenvalue.h
@@ -104,6 +104,32 @@ class Frankenvalue {
     }
   }
 
+  // Kind of like `rewriteCaps()`, but the callback returns
+  // kj::OneOf<kj::Own<CapTableEntry>, kj::Promise<kj::Own<CapTableEntry>>>, i.e. it may optionally
+  // decide to be async. If any of the calls return a promise, then `resolveCaps()` returns a
+  // promise created by joining the inner promises -- the Frankenvalue MUST NOT be used until that
+  // promise resolves. (If the promise fails or is canceled, the Frankenvalue must be discarded.)
+  template <typename Func>
+  kj::Maybe<kj::Promise<void>> resolveCaps(Func&& resolve) {
+    kj::Vector<kj::Promise<void>> promises;
+    for (auto& slot: capTable) {
+      KJ_SWITCH_ONEOF(resolve(kj::mv(slot))) {
+        KJ_CASE_ONEOF(replacement, kj::Own<CapTableEntry>) {
+          slot = kj::mv(replacement);
+        }
+        KJ_CASE_ONEOF(promise, kj::Promise<kj::Own<CapTableEntry>>) {
+          promises.add(promise.then(
+              [&slot](kj::Own<CapTableEntry> replacement) { slot = kj::mv(replacement); }));
+        }
+      }
+    }
+    if (promises.empty()) {
+      return kj::none;
+    } else {
+      return kj::joinPromisesFailFast(promises.releaseAsArray());
+    }
+  }
+
   // When deserializing a JS value, the jsg::Deserializer's ExternalHandler will have this type.
   class CapTableReader final: public jsg::Deserializer::ExternalHandler {
    public:

--- a/src/workerd/io/io-channels.c++
+++ b/src/workerd/io/io-channels.c++
@@ -1,6 +1,7 @@
 #include "io-channels.h"
 
 #include <workerd/io/worker-interface.h>
+#include <workerd/io/worker.h>
 
 namespace workerd {
 
@@ -175,7 +176,92 @@ class PromisedActorClassChannel final: public IoChannelFactory::ActorClassChanne
   }
 };
 
+kj::OneOf<kj::Own<Frankenvalue::CapTableEntry>, kj::Promise<kj::Own<Frankenvalue::CapTableEntry>>>
+resolveCap(kj::Own<Frankenvalue::CapTableEntry> cap) {
+  KJ_IF_SOME(typed, kj::tryDowncast<IoChannelFactory::SubrequestChannel>(*cap)) {
+    KJ_SWITCH_ONEOF(typed.getResolved()) {
+      KJ_CASE_ONEOF(channel, kj::Own<IoChannelFactory::SubrequestChannel>) {
+        return kj::implicitCast<kj::Own<Frankenvalue::CapTableEntry>>(kj::mv(channel));
+      }
+      KJ_CASE_ONEOF(promise, kj::Promise<kj::Own<IoChannelFactory::SubrequestChannel>>) {
+        return promise.then([](kj::Own<IoChannelFactory::SubrequestChannel> channel) {
+          return kj::implicitCast<kj::Own<Frankenvalue::CapTableEntry>>(kj::mv(channel));
+        });
+      }
+    }
+    KJ_UNREACHABLE;
+  } else KJ_IF_SOME(typed, kj::tryDowncast<IoChannelFactory::ActorClassChannel>(*cap)) {
+    KJ_SWITCH_ONEOF(typed.getResolved()) {
+      KJ_CASE_ONEOF(channel, kj::Own<IoChannelFactory::ActorClassChannel>) {
+        return kj::implicitCast<kj::Own<Frankenvalue::CapTableEntry>>(kj::mv(channel));
+      }
+      KJ_CASE_ONEOF(promise, kj::Promise<kj::Own<IoChannelFactory::ActorClassChannel>>) {
+        return promise.then([](kj::Own<IoChannelFactory::ActorClassChannel> channel) {
+          return kj::implicitCast<kj::Own<Frankenvalue::CapTableEntry>>(kj::mv(channel));
+        });
+      }
+    }
+    KJ_UNREACHABLE;
+  } else {
+    auto& ref = *cap;
+    KJ_FAIL_ASSERT("unknown type in Frankenvalue", typeid(ref).name());
+  }
+}
+
 }  // namespace
+
+kj::Own<IoChannelFactory::SubrequestChannel> IoChannelFactory::getSubrequestChannel(
+    uint channel, kj::Maybe<Frankenvalue> props, kj::Maybe<VersionRequest> versionRequest) {
+  KJ_IF_SOME(p, props) {
+    KJ_IF_SOME(promise, p.resolveCaps(resolveCap)) {
+      return kj::refcounted<PromisedSubrequestChannel>(
+          promise.then([this, self = addRef(), channel, props = kj::mv(p),
+                           versionRequest = kj::mv(versionRequest)]() mutable {
+        return getSubrequestChannelResolved(channel, kj::mv(props), kj::mv(versionRequest));
+      }));
+    }
+  }
+  return getSubrequestChannelResolved(channel, kj::mv(props), kj::mv(versionRequest));
+}
+
+kj::Own<IoChannelFactory::ActorClassChannel> IoChannelFactory::getActorClass(
+    uint channel, kj::Maybe<Frankenvalue> props) {
+  KJ_IF_SOME(p, props) {
+    KJ_IF_SOME(promise, p.resolveCaps(resolveCap)) {
+      return kj::refcounted<PromisedActorClassChannel>(
+          promise.then([this, self = addRef(), channel, props = kj::mv(p)]() mutable {
+        return getActorClassResolved(channel, kj::mv(props));
+      }));
+    }
+  }
+  return getActorClassResolved(channel, kj::mv(props));
+}
+
+kj::Own<IoChannelFactory::SubrequestChannel> WorkerStubChannel::getEntrypoint(
+    kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits) {
+  KJ_IF_SOME(promise, props.resolveCaps(resolveCap)) {
+    return kj::refcounted<PromisedSubrequestChannel>(
+        promise.then([self = addRefToThis(), name = kj::mv(name), props = kj::mv(props),
+                         limits = kj::mv(limits)]() mutable {
+      return self->getEntrypointResolved(kj::mv(name), kj::mv(props), kj::mv(limits));
+    }));
+  } else {
+    return getEntrypointResolved(kj::mv(name), kj::mv(props), kj::mv(limits));
+  }
+}
+
+kj::Own<IoChannelFactory::ActorClassChannel> WorkerStubChannel::getActorClass(
+    kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits) {
+  KJ_IF_SOME(promise, props.resolveCaps(resolveCap)) {
+    return kj::refcounted<PromisedActorClassChannel>(
+        promise.then([self = addRefToThis(), name = kj::mv(name), props = kj::mv(props),
+                         limits = kj::mv(limits)]() mutable {
+      return self->getActorClassResolved(kj::mv(name), kj::mv(props), kj::mv(limits));
+    }));
+  } else {
+    return getActorClassResolved(kj::mv(name), kj::mv(props), kj::mv(limits));
+  }
+}
 
 kj::Own<IoChannelFactory::SubrequestChannel> IoChannelFactory::subrequestChannelFromToken(
     ChannelTokenUsage usage, kj::Promise<kj::Array<byte>> token) {
@@ -201,6 +287,53 @@ kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> IoChannelFactory::Actor
   JSG_FAIL_REQUIRE(DOMDataCloneError,
       "Durable Object stubs cannot (yet) be transferred between Workers. This will change in "
       "a future version.");
+}
+
+kj::Promise<void> DynamicWorkerSource::ensureAllResolved() {
+  kj::Vector<kj::Promise<void>> promises;
+
+  KJ_IF_SOME(promise, env.resolveCaps(resolveCap)) {
+    promises.add(kj::mv(promise));
+  }
+
+  auto resolveChannelSlot = [&](kj::Own<IoChannelFactory::SubrequestChannel>& slot) {
+    KJ_SWITCH_ONEOF(slot->getResolved()) {
+      KJ_CASE_ONEOF(channel, kj::Own<IoChannelFactory::SubrequestChannel>) {
+        slot = kj::mv(channel);
+      }
+      KJ_CASE_ONEOF(promise, kj::Promise<kj::Own<IoChannelFactory::SubrequestChannel>>) {
+        promises.add(promise.then([&slot](kj::Own<IoChannelFactory::SubrequestChannel> channel) {
+          slot = kj::mv(channel);
+        }));
+      }
+    }
+  };
+
+  KJ_IF_SOME(slot, globalOutbound) {
+    resolveChannelSlot(slot);
+  }
+
+  for (auto& slot: tails) {
+    resolveChannelSlot(slot);
+  }
+  for (auto& slot: streamingTails) {
+    resolveChannelSlot(slot);
+  }
+
+  if (!promises.empty()) {
+    co_await kj::joinPromisesFailFast(promises.releaseAsArray());
+  }
+}
+
+kj::Promise<void> Worker::Actor::FacetManager::StartInfo::ensureAllResolved() {
+  KJ_SWITCH_ONEOF(actorClass->getResolved()) {
+    KJ_CASE_ONEOF(channel, kj::Own<IoChannelFactory::ActorClassChannel>) {
+      actorClass = kj::mv(channel);
+    }
+    KJ_CASE_ONEOF(promise, kj::Promise<kj::Own<IoChannelFactory::ActorClassChannel>>) {
+      actorClass = co_await promise;
+    }
+  }
 }
 
 uint IoChannelCapTableEntry::getChannelNumber(Type expectedType) {

--- a/src/workerd/io/io-channels.c++
+++ b/src/workerd/io/io-channels.c++
@@ -1,13 +1,33 @@
 #include "io-channels.h"
 
+#include <workerd/io/worker-interface.h>
+
 namespace workerd {
 
-kj::Array<byte> IoChannelFactory::SubrequestChannel::getToken(ChannelTokenUsage usage) {
-  JSG_FAIL_REQUIRE(DOMDataCloneError, "This ServiceStub cannot be serialized.");
+kj::Promise<kj::Array<byte>> IoChannelFactory::SubrequestChannel::getToken(
+    ChannelTokenUsage usage) {
+  KJ_SWITCH_ONEOF(getTokenMaybeSync(usage)) {
+    KJ_CASE_ONEOF(token, kj::Array<byte>) {
+      return kj::mv(token);
+    }
+    KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+      return kj::mv(promise);
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
-kj::Array<byte> IoChannelFactory::ActorClassChannel::getToken(ChannelTokenUsage usage) {
-  JSG_FAIL_REQUIRE(DOMDataCloneError, "This Durable Object class cannot be serialized.");
+kj::Promise<kj::Array<byte>> IoChannelFactory::ActorClassChannel::getToken(
+    ChannelTokenUsage usage) {
+  KJ_SWITCH_ONEOF(getTokenMaybeSync(usage)) {
+    KJ_CASE_ONEOF(token, kj::Array<byte>) {
+      return kj::mv(token);
+    }
+    KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+      return kj::mv(promise);
+    }
+  }
+  KJ_UNREACHABLE;
 }
 
 kj::Own<IoChannelFactory::SubrequestChannel> IoChannelFactory::subrequestChannelFromToken(
@@ -21,7 +41,163 @@ kj::Own<IoChannelFactory::ActorClassChannel> IoChannelFactory::actorClassFromTok
       DOMDataCloneError, "This Worker is not able to deserialize Durable Object class stubs.");
 }
 
+namespace {
+
+class PromisedSubrequestChannel final: public IoChannelFactory::SubrequestChannel {
+ public:
+  PromisedSubrequestChannel(kj::Promise<kj::Own<SubrequestChannel>> promise)
+      : readyPromise(waitForResolution(kj::mv(promise)).fork()) {}
+
+  kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
+    KJ_IF_SOME(channel, inner) {
+      return channel->startRequest(kj::mv(metadata));
+    } else {
+      return newPromisedWorkerInterface(
+          readyPromise.addBranch().then([this, metadata = kj::mv(metadata)]() mutable {
+        return KJ_ASSERT_NONNULL(inner)->startRequest(kj::mv(metadata));
+      }));
+    }
+  }
+
+  void requireAllowsTransfer() override {
+    // PromisedSubrequestChannel is used for channels initialized from a promised channel token.
+    // A SubrequestChannel created from a channel token should always support transfer, via channel
+    // tokens.
+  }
+
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    KJ_IF_SOME(channel, inner) {
+      return channel->getTokenMaybeSync(usage);
+    } else {
+      return readyPromise.addBranch().then([this, usage]() -> kj::Promise<kj::Array<byte>> {
+        KJ_SWITCH_ONEOF(KJ_ASSERT_NONNULL(inner)->getTokenMaybeSync(usage)) {
+          KJ_CASE_ONEOF(token, kj::Array<byte>) {
+            return kj::mv(token);
+          }
+          KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+            return kj::mv(promise);
+          }
+        }
+        KJ_UNREACHABLE;
+      });
+    }
+  }
+
+  kj::OneOf<kj::Own<SubrequestChannel>, kj::Promise<kj::Own<SubrequestChannel>>> getResolved()
+      override {
+    KJ_IF_SOME(channel, inner) {
+      return kj::addRef(*channel);
+    } else {
+      return readyPromise.addBranch().then(
+          [this]() mutable { return kj::addRef(*KJ_ASSERT_NONNULL(inner)); });
+    }
+  }
+
+ private:
+  kj::ForkedPromise<void> readyPromise;
+  kj::Maybe<kj::Own<SubrequestChannel>> inner;
+
+  kj::Promise<void> waitForResolution(kj::Promise<kj::Own<SubrequestChannel>> promise) {
+    for (;;) {
+      auto resolution = co_await promise;
+      KJ_SWITCH_ONEOF(resolution->getResolved()) {
+        KJ_CASE_ONEOF(channel, kj::Own<SubrequestChannel>) {
+          inner = kj::mv(channel);
+          co_return;
+        }
+        KJ_CASE_ONEOF(deeperPromise, kj::Promise<kj::Own<SubrequestChannel>>) {
+          // Promise resolved to another promise, wait for it too.
+          promise = kj::mv(deeperPromise);
+        }
+      }
+    }
+  }
+};
+
+class PromisedActorClassChannel final: public IoChannelFactory::ActorClassChannel {
+ public:
+  PromisedActorClassChannel(kj::Promise<kj::Own<ActorClassChannel>> promise)
+      : readyPromise(waitForResolution(kj::mv(promise)).fork()) {}
+
+  void requireAllowsTransfer() override {
+    // PromisedActorClassChannel is used for channels initialized from a promised channel token.
+    // A ActorClassChannel created from a channel token should always support transfer, via channel
+    // tokens.
+  }
+
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    KJ_IF_SOME(channel, inner) {
+      return channel->getTokenMaybeSync(usage);
+    } else {
+      return readyPromise.addBranch().then([this, usage]() -> kj::Promise<kj::Array<byte>> {
+        KJ_SWITCH_ONEOF(KJ_ASSERT_NONNULL(inner)->getTokenMaybeSync(usage)) {
+          KJ_CASE_ONEOF(token, kj::Array<byte>) {
+            return kj::mv(token);
+          }
+          KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+            return kj::mv(promise);
+          }
+        }
+        KJ_UNREACHABLE;
+      });
+    }
+  }
+
+  kj::OneOf<kj::Own<ActorClassChannel>, kj::Promise<kj::Own<ActorClassChannel>>> getResolved()
+      override {
+    KJ_IF_SOME(channel, inner) {
+      return kj::addRef(*channel);
+    } else {
+      return readyPromise.addBranch().then(
+          [this]() mutable { return kj::addRef(*KJ_ASSERT_NONNULL(inner)); });
+    }
+  }
+
+ private:
+  kj::ForkedPromise<void> readyPromise;
+  kj::Maybe<kj::Own<ActorClassChannel>> inner;
+
+  kj::Promise<void> waitForResolution(kj::Promise<kj::Own<ActorClassChannel>> promise) {
+    for (;;) {
+      auto resolution = co_await promise;
+      KJ_SWITCH_ONEOF(resolution->getResolved()) {
+        KJ_CASE_ONEOF(channel, kj::Own<ActorClassChannel>) {
+          inner = kj::mv(channel);
+          co_return;
+        }
+        KJ_CASE_ONEOF(deeperPromise, kj::Promise<kj::Own<ActorClassChannel>>) {
+          promise = kj::mv(deeperPromise);
+        }
+      }
+    }
+  }
+};
+
+}  // namespace
+
+kj::Own<IoChannelFactory::SubrequestChannel> IoChannelFactory::subrequestChannelFromToken(
+    ChannelTokenUsage usage, kj::Promise<kj::Array<byte>> token) {
+  return kj::refcounted<PromisedSubrequestChannel>(token.then([this, usage](kj::Array<byte> token) {
+    return subrequestChannelFromToken(usage, token.asPtr());
+  }));
+}
+
+kj::Own<IoChannelFactory::ActorClassChannel> IoChannelFactory::actorClassFromToken(
+    ChannelTokenUsage usage, kj::Promise<kj::Array<byte>> token) {
+  return kj::refcounted<PromisedActorClassChannel>(token.then(
+      [this, usage](kj::Array<byte> token) { return actorClassFromToken(usage, token.asPtr()); }));
+}
+
 void IoChannelFactory::ActorChannel::requireAllowsTransfer() {
+  JSG_FAIL_REQUIRE(DOMDataCloneError,
+      "Durable Object stubs cannot (yet) be transferred between Workers. This will change in "
+      "a future version.");
+}
+
+kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> IoChannelFactory::ActorChannel::
+    getTokenMaybeSync(ChannelTokenUsage usage) {
   JSG_FAIL_REQUIRE(DOMDataCloneError,
       "Durable Object stubs cannot (yet) be transferred between Workers. This will change in "
       "a future version.");

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -213,6 +213,12 @@ class IoChannelFactory {
     // SubrequestChannel, return the inner channel -- synchronously if the promise has resolved
     // already, otherwise asynchronously.
     //
+    // Note that the various `IoChannelFactory` methods that take `props` or `env` objects all
+    // automatically resolve all channel objects *before* passing off to the underlying
+    // implementation. In the internal codebase, implementations end up needing to downcast these
+    // objects to implementation-specific types, and handling the need to call getResolved()
+    // in every use case would be painful, so it is taken care of in this layer.
+    //
     // Default implementation returns self.
     virtual kj::OneOf<kj::Own<SubrequestChannel>, kj::Promise<kj::Own<SubrequestChannel>>>
     getResolved() {
@@ -229,10 +235,19 @@ class IoChannelFactory {
   // `props` and `versionRequest` can only be specified if this is a loopback channel (i.e. from
   // ctx.exports). For any other channel, they will throw.
   //
+  // The non-virtual method dispatches to getSubrequestChannelResolved(), but only after resolving
+  // all channels embedded in `props` (that is, calling `getResolved()` on all of them, waiting
+  // for the resolutions if necessary, and replacing the caps with the resolutions).
+  //
   // TODO(cleanup): Consider getting rid of `startSubrequest()` in favor of this.
-  virtual kj::Own<SubrequestChannel> getSubrequestChannel(uint channel,
+  kj::Own<SubrequestChannel> getSubrequestChannel(uint channel,
       kj::Maybe<Frankenvalue> props = kj::none,
-      kj::Maybe<VersionRequest> versionRequest = kj::none) = 0;
+      kj::Maybe<VersionRequest> versionRequest = kj::none);
+
+  // Underlying implementation of getSubrequestChannel(). The implementation can assume that `props`
+  // contains strictly resolved channels.
+  virtual kj::Own<SubrequestChannel> getSubrequestChannelResolved(
+      uint channel, kj::Maybe<Frankenvalue> props, kj::Maybe<VersionRequest> versionRequest) = 0;
 
   // Stub for a remote actor. Allows sending requests to the actor.
   class ActorChannel: public SubrequestChannel {
@@ -293,11 +308,16 @@ class IoChannelFactory {
   //
   // `props` can only be specified if this is a loopback channel (i.e. from ctx.exports). For any
   // other channel, it will throw.
-  virtual kj::Own<ActorClassChannel> getActorClass(
-      uint channel, kj::Maybe<Frankenvalue> props = kj::none) {
-    // TODO(cleanup): Remove this once the production runtime has implemented this.
-    KJ_UNIMPLEMENTED("This runtime doesn't support actor class channels.");
-  }
+  //
+  // The non-virtual method dispatches to getActorClassResolved(), but only after resolving
+  // all channels embedded in `props` (that is, calling `getResolved()` on all of them, waiting
+  // for the resolutions if necessary, and replacing the caps with the resolutions).
+  kj::Own<ActorClassChannel> getActorClass(uint channel, kj::Maybe<Frankenvalue> props = kj::none);
+
+  // Underlying implementation of getActorClass(). The implementation can assume that `props`
+  // contains strictly resolved channels.
+  virtual kj::Own<ActorClassChannel> getActorClassResolved(
+      uint channel, kj::Maybe<Frankenvalue> props) = 0;
 
   // Aborts all actors except those in namespaces marked with `preventEviction`.
   virtual void abortAllActors(kj::Maybe<kj::Exception&> reason) {
@@ -341,6 +361,15 @@ class IoChannelFactory {
       ChannelTokenUsage usage, kj::Promise<kj::Array<byte>> token);
   kj::Own<ActorClassChannel> actorClassFromToken(
       ChannelTokenUsage usage, kj::Promise<kj::Array<byte>> token);
+
+  // Return a strong reference to this same factory. Used in the implementations of
+  // getSubrequestChannel() and getActorClass() when delayed resolution is needed.
+  //
+  // TODO(cleanup): This is hacky. IoChannelFactory isn't declared to simply extend kj::Refcounted
+  //   because the workerd implementation is privately implemented by Server::WorkerService, which
+  //   inherits kj::Refcounted a different way. But maybe it's time for Server::WorkerService to
+  //   stop working that way?
+  virtual kj::Own<void> addRef() = 0;
 };
 
 // ResourceLimits provides a means to control the resource allocation for a worker stage via a
@@ -360,12 +389,20 @@ struct ResourceLimits {
 //
 // This object is returned before the Worker actually loads, so if any errors occur while loading,
 // any requests sent to the Worker will fail, propagating the exception.
-class WorkerStubChannel {
+class WorkerStubChannel: public kj::Refcounted {
  public:
-  virtual kj::Own<IoChannelFactory::SubrequestChannel> getEntrypoint(
+  // As with IoChannelFactory::getSubrequestChannel(), the non-virtual method waits for `props` to
+  // resolve first, then calls the virtual method.
+  kj::Own<IoChannelFactory::SubrequestChannel> getEntrypoint(
+      kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits);
+  virtual kj::Own<IoChannelFactory::SubrequestChannel> getEntrypointResolved(
       kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits) = 0;
 
-  virtual kj::Own<IoChannelFactory::ActorClassChannel> getActorClass(
+  // As with IoChannelFactory::getActorClass(), the non-virtual method waits for `props` to
+  // resolve first, then calls the virtual method.
+  kj::Own<IoChannelFactory::ActorClassChannel> getActorClass(
+      kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits);
+  virtual kj::Own<IoChannelFactory::ActorClassChannel> getActorClassResolved(
       kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits) = 0;
 
   // TODO(someday): Allow caller to enumerate entrypoints?
@@ -417,6 +454,10 @@ struct DynamicWorkerSource {
       .ownContentIsRpcResponse = ownContentIsRpcResponse,
     };
   }
+
+  // Walks through all channels in `env` and other properties and ensures that they point at
+  // resolved objects by calling their `getResolved()` methods.
+  kj::Promise<void> ensureAllResolved();
 };
 
 // A Frankenvalue::CapTableEntry which directly references a numbered I/O channel. This is ONLY

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -198,9 +198,26 @@ class IoChannelFactory {
     virtual void requireAllowsTransfer() = 0;
 
     // Get a token representing this SubrequestChannel which can be converted back into a
-    // SubrequestChannel using subrequestChannelFromToken(). Default implementation throws a
-    // TypeError.
-    virtual kj::Array<byte> getToken(ChannelTokenUsage usage);
+    // SubrequestChannel using subrequestChannelFromToken(). This is a convenience wrapper around
+    // getTokenMaybeSync() for callers that don't care about the synchronous optimization.
+    kj::Promise<kj::Array<byte>> getToken(ChannelTokenUsage usage);
+
+    // Like getToken() but may return the token synchronously. This is what subclasses must
+    // implement. The synchronous optimization is important because there is significant additional
+    // overhead in the RPC system when the token cannot be created synchronously (need to use
+    // ExternalPusher to send a DelayedChannelToken).
+    virtual kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+        ChannelTokenUsage usage) = 0;
+
+    // If this SubrequestChannel is just a wrapper around a promise for some later
+    // SubrequestChannel, return the inner channel -- synchronously if the promise has resolved
+    // already, otherwise asynchronously.
+    //
+    // Default implementation returns self.
+    virtual kj::OneOf<kj::Own<SubrequestChannel>, kj::Promise<kj::Own<SubrequestChannel>>>
+    getResolved() {
+      return kj::addRef(*this);
+    }
   };
 
   // Obtain an object representing a particular subrequest channel.
@@ -226,6 +243,8 @@ class IoChannelFactory {
 
     // For now, actor stubs are not transferrable -- but we do intend to change that at some point.
     void requireAllowsTransfer() override final;
+    kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+        ChannelTokenUsage usage) override final;
   };
 
   // Get an actor stub from the given namespace for the actor with the given ID.
@@ -258,7 +277,13 @@ class IoChannelFactory {
 
     // Same as the corresponding methods on SubrequestChannel.
     virtual void requireAllowsTransfer() = 0;
-    virtual kj::Array<byte> getToken(ChannelTokenUsage usage);
+    kj::Promise<kj::Array<byte>> getToken(ChannelTokenUsage usage);
+    virtual kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+        ChannelTokenUsage usage) = 0;
+    virtual kj::OneOf<kj::Own<ActorClassChannel>, kj::Promise<kj::Own<ActorClassChannel>>>
+    getResolved() {
+      return kj::addRef(*this);
+    }
 
     // This class has no functional methods, since it serves as a token to be passed to other
     // interfaces (namely the facets API).
@@ -309,6 +334,13 @@ class IoChannelFactory {
       ChannelTokenUsage usage, kj::ArrayPtr<const byte> token);
   virtual kj::Own<ActorClassChannel> actorClassFromToken(
       ChannelTokenUsage usage, kj::ArrayPtr<const byte> token);
+
+  // Overloads which accept a promise. Any attempts to use the channel will have to wait for the
+  // token to arrive first, but this should be transparent.
+  kj::Own<SubrequestChannel> subrequestChannelFromToken(
+      ChannelTokenUsage usage, kj::Promise<kj::Array<byte>> token);
+  kj::Own<ActorClassChannel> actorClassFromToken(
+      ChannelTokenUsage usage, kj::Promise<kj::Array<byte>> token);
 };
 
 // ResourceLimits provides a means to control the resource allocation for a worker stage via a

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -515,14 +515,10 @@ struct JsValue {
       }
 
       readableStream :group {
-        # A ReadableStream. The sender of the JsValue will use the associated StreamSink to open a
-        # stream of type `ByteStream`.
+        # A ReadableStream.
 
         stream @10 :ExternalPusher.InputStream;
-        # If present, a stream pushed using the destination isolate's ExternalPusher.
-        #
-        # If null (deprecated), then the sender will use the associated StreamSink to open a stream
-        # of type `ByteStream`. StreamSink is in the process of being replaced by ExternalPusher.
+        # A stream pushed using the destination isolate's ExternalPusher.
 
         encoding @4 :StreamEncoding;
         # Bytes read from the stream have this encoding.
@@ -536,14 +532,7 @@ struct JsValue {
         }
       }
 
-      abortTrigger @7 :Void;
-      # Indicates that an `AbortTrigger` is being passed, see the `AbortTrigger` interface for the
-      # mechanism used to trigger the abort later. This is modeled as a stream, since the sender is
-      # the one that will later on send the abort signal. This external will have an associated
-      # stream in the corresponding `StreamSink` with type `AbortTrigger`.
-      #
-      # TODO(soon): This will be obsolete when we stop using `StreamSink`; `abortSignal` will
-      #   replace it. (The name is wrong anyway -- this is the signal end, not the trigger end.)
+      obsolete7 @7 :Void;
 
       abortSignal @11 :ExternalPusher.AbortSignal;
       # Indicates that an `AbortSignal` is being passed.
@@ -554,29 +543,6 @@ struct JsValue {
 
       # TODO(soon): WebSocket, Request, Response
     }
-  }
-
-  interface StreamSink {
-    # A JsValue may contain streams that flow from the sender to the receiver. We don't want such
-    # streams to require a network round trip before the stream can begin pumping. So, we need a
-    # place to start sending bytes right away.
-    #
-    # To that end, JsRpcTarget::call() returns a `paramsStreamSink`. Immediately upon sending the
-    # request, the client can use promise pipelining to begin pushing bytes to this object.
-    #
-    # Similarly, the caller passes a `resultsStreamSink` to the callee. If the response contains
-    # any streams, it can start pushing to this immediately after responding.
-    #
-    # TODO(soon): This design is overcomplicated since it requires allocating StreamSinks for every
-    #   request, even when not used, and requires a lot of weird promise magic. The newer
-    #   ExternalPusher design is simpler, and only incurs overhead when used. Once all of
-    #   production has been updated to understand ExternalPusher, then we can flip an autogate to
-    #   use it by default. Once that has rolled out globally, we can remove StreamSink.
-
-    startStream @0 (externalIndex :UInt32) -> (stream :Capability);
-    # Opens a stream corresponding to the given index in the JsValue's `externals` array. The type
-    # of capability returned depends on the type of external. E.g. for `readableStream`, it is a
-    # `ByteStream`.
   }
 
   interface ExternalPusher {
@@ -699,13 +665,10 @@ interface JsRpcTarget extends(JsValue.ExternalPusher) $Cxx.allowCancellation {
     }
 
     resultsStreamHandler :union {
-      # We're in the process of switching from `StreamSink` to `ExternalPusher`. A caller will only
-      # offer one or the other, and expect the callee to use that. (Initially, callers will still
-      # send StreamSink for backwards-compatibility, but once all recipients are able to understand
-      # ExternalPusher, we'll flip an autogate to make callers send it.)
+      # This union is now always of type `externalPusher`.
 
-      streamSink @4 :JsValue.StreamSink;
-      # StreamSink used for ReadableStreams found in the results.
+      obsolete4 @4 :Capability;
+      # From old StreamSink approach, replaced by ExternalPusher.
 
       externalPusher @5 :JsValue.ExternalPusher;
       # ExternalPusher object which will push into the caller's isolate. Use this to push externals
@@ -734,9 +697,8 @@ interface JsRpcTarget extends(JsValue.ExternalPusher) $Cxx.allowCancellation {
     # `callPipeline` until the disposer is invoked. If `hasDisposer` is false, `callPipeline` can
     # safely be dropped immediately.
 
-    paramsStreamSink @3 :JsValue.StreamSink;
-    # StreamSink used for ReadableStreams found in the params. The caller begins sending bytes for
-    # these streams immediately using promise pipelining.
+    obsolete3 @3 :Capability;
+    # From old StreamSink approach, replaced by ExternalPusher.
   }
 
   call @0 CallParams -> CallResults;

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -541,6 +541,14 @@ struct JsValue {
       actorClassChannelToken @9 :Data;
       # Encoded ChannelTokens. See channel-token.capnp.
 
+      delayedSubrequestChannelToken @12 :ExternalPusher.DelayedChannelToken;
+      delayedActorClassChannelToken @13 :ExternalPusher.DelayedChannelToken;
+      # Channel tokens which will be delivered asynchronously. This is sometimes needed in cases
+      # where the calling worker needs to invoke an asynchronous task to construct the channel
+      # token. We do not want to delay sending the RPC (especially as this could violate ordering
+      # guarantees), so instead we send it with a placeholder representing the token to be provided
+      # later.
+
       # TODO(soon): WebSocket, Request, Response
     }
   }
@@ -586,6 +594,19 @@ struct JsValue {
     interface AbortSignal {
       # No methods. This can be unwrapped by the recipient to obtain a Promise<void> which
       # rejects when the signal is aborted.
+    }
+
+    pushDelayedChannelToken @2 (token :Data) -> (cap :DelayedChannelToken);
+    # Use with `delayed*ChannelToken` members of `External`.
+    #
+    # Generally, this `push` method is actually called some time *after* the initial RPC is sent.
+    # In the initial RPC, the caller fills in the `DelayedChannelToken` with a promise capability.
+    # Later, when it has the final channel token, it calls `pushDelayedChannelToken()`, then
+    # resolves the earlier promise to the result.
+
+    interface DelayedChannelToken {
+      # No methods. This can be unwrapped by the recipient to obtain the channel token passed to
+      # `pushDelayedChannelToken()`.
     }
 
     # TODO(soon):

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -772,24 +772,12 @@ interface EventDispatcher @0xf20697475ec1752d {
   # Opens a JS rpc "session". The call does not return until the session is complete.
   #
   # `topLevel` is the top-level RPC target, on which exactly one method call can be made. This
-  # call should be made using pipelining to avoid a round trip at startup, and to properly handle
-  # the old semantics while they still exist in production (see below).
+  # call should be made using pipelining to avoid a round trip at startup.
   #
-  # The exact return semantics of this method are currently in flux. Both an old approach and a
-  # new approach may be live in production:
-  # * Old approach: `jsRpcSession()` does not return until (1) exactly one call has been made on
-  #   `topLevel`, and (2) any stubs passed over that call (in either direction) have been dropped.
-  #   The session can be canceled by cancelling the call. When the call returns, `session` is null,
-  #   which is consistent with the session being complete.
-  # * New approach: `jsRpcSession()` returns immediately. The returned `session` capability keeps
-  #   the session alive. Dropping `session` cancels the session. `session` resolves itself to a
-  #   null capability when `topLevel` and all stubs introduced through it have been dropped; the
-  #   caller may await `whenResolved()` to find out when this happens.
-  #
-  # The transition will take place in three phases:
-  # 1. Caller is adjusted to support both approaches.
-  # 2. Automate is rolled out to switch the callee to the new approach.
-  # 3. Remove code to support old approach.
+  # `jsRpcSession()` returns immediately. The returned `session` capability keeps the session
+  # alive. Dropping `session` cancels the session. `session` resolves itself to a null capability
+  # when `topLevel` and all stubs introduced through it have been dropped; the caller may await
+  # `whenResolved()` to find out when this happens.
   #
   # In C++, we use `WorkerInterface::customEvent()` to dispatch this event.
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -911,6 +911,12 @@ class Worker::Actor final: public kj::Refcounted {
 
       // ctx.id for the child object.
       Worker::Actor::Id id;
+
+      // Ensures `actorClass` is a fully-resolved channel.
+      //
+      // This is implemented in io-channels.c++ next to DynamicWorkerSource::ensureAllResolved()
+      // since they are very similar.
+      kj::Promise<void> ensureAllResolved();
     };
 
     // Returns the nesting depth of this facet. Root = 0, direct child of root = 1, etc.

--- a/src/workerd/server/channel-token-test.c++
+++ b/src/workerd/server/channel-token-test.c++
@@ -5,6 +5,7 @@
 #include "channel-token.h"
 
 #include <capnp/message.h>
+#include <kj/async.h>
 #include <kj/test.h>
 
 namespace workerd::server {
@@ -38,10 +39,30 @@ struct ServiceTriplet {
   }
 };
 
+kj::Array<byte> expectSync(kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> variant) {
+  return KJ_ASSERT_NONNULL(
+      kj::mv(variant).tryGet<kj::Array<byte>>(), "expected token to be rendered synchronously");
+}
+
 class MockSubrequestChannel: public IoChannelFactory::SubrequestChannel {
  public:
+  // Simple mock used by the resolver when decoding tokens. Its getTokenMaybeSync() is never
+  // called in that context.
   MockSubrequestChannel(ServiceTriplet triplet): triplet(kj::mv(triplet)) {}
+
+  // Mock used as a nested cap inside a parent channel's props. It generates its own token by
+  // calling back into the ChannelTokenHandler. If `readyPromise` is provided, the token is only
+  // produced asynchronously after `readyPromise` resolves.
+  MockSubrequestChannel(ChannelTokenHandler& handler,
+      ServiceTriplet triplet,
+      kj::Maybe<kj::Promise<void>> readyPromise = kj::none)
+      : handler(handler),
+        triplet(kj::mv(triplet)),
+        readyPromise(kj::mv(readyPromise)) {}
+
+  kj::Maybe<ChannelTokenHandler&> handler;
   ServiceTriplet triplet;
+  kj::Maybe<kj::Promise<void>> readyPromise;
 
   kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
     KJ_UNREACHABLE;
@@ -49,15 +70,57 @@ class MockSubrequestChannel: public IoChannelFactory::SubrequestChannel {
   void requireAllowsTransfer() override {
     KJ_UNREACHABLE;
   }
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    auto& h = KJ_ASSERT_NONNULL(handler, "this mock was not constructed with a handler ref");
+    KJ_IF_SOME(p, readyPromise) {
+      auto promise = kj::mv(p);
+      readyPromise = kj::none;
+      return promise.then([&h, usage, this]() mutable -> kj::Array<byte> {
+        return expectSync(h.encodeSubrequestChannelToken(usage, triplet.serviceName,
+            triplet.entrypoint.map([](kj::String& s) -> kj::StringPtr { return s; }),
+            triplet.props));
+      });
+    } else {
+      return expectSync(h.encodeSubrequestChannelToken(usage, triplet.serviceName,
+          triplet.entrypoint.map([](kj::String& s) -> kj::StringPtr { return s; }), triplet.props));
+    }
+  }
 };
 
 class MockActorClassChannel: public IoChannelFactory::ActorClassChannel {
  public:
   MockActorClassChannel(ServiceTriplet triplet): triplet(kj::mv(triplet)) {}
+
+  MockActorClassChannel(ChannelTokenHandler& handler,
+      ServiceTriplet triplet,
+      kj::Maybe<kj::Promise<void>> readyPromise = kj::none)
+      : handler(handler),
+        triplet(kj::mv(triplet)),
+        readyPromise(kj::mv(readyPromise)) {}
+
+  kj::Maybe<ChannelTokenHandler&> handler;
   ServiceTriplet triplet;
+  kj::Maybe<kj::Promise<void>> readyPromise;
 
   void requireAllowsTransfer() override {
     KJ_UNREACHABLE;
+  }
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    auto& h = KJ_ASSERT_NONNULL(handler, "this mock was not constructed with a handler ref");
+    KJ_IF_SOME(p, readyPromise) {
+      auto promise = kj::mv(p);
+      readyPromise = kj::none;
+      return promise.then([&h, usage, this]() mutable -> kj::Array<byte> {
+        return expectSync(h.encodeActorClassChannelToken(usage, triplet.serviceName,
+            triplet.entrypoint.map([](kj::String& s) -> kj::StringPtr { return s; }),
+            triplet.props));
+      });
+    } else {
+      return expectSync(h.encodeActorClassChannelToken(usage, triplet.serviceName,
+          triplet.entrypoint.map([](kj::String& s) -> kj::StringPtr { return s; }), triplet.props));
+    }
   }
 };
 
@@ -78,12 +141,24 @@ class MockResolver: public ChannelTokenHandler::Resolver {
 
 using Usage = IoChannelFactory::ChannelTokenUsage;
 
+// Build a Frankenvalue whose capTable contains the given entries. The base value is an empty
+// object. This goes through the capnp serialization path since Frankenvalue doesn't otherwise
+// expose a way to construct a cap table directly.
+Frankenvalue propsWithCaps(kj::Vector<kj::Own<Frankenvalue::CapTableEntry>> caps) {
+  capnp::MallocMessageBuilder message;
+  auto builder = message.getRoot<rpc::Frankenvalue>();
+  builder.setEmptyObject();
+  builder.setCapTableSize(caps.size());
+  return Frankenvalue::fromCapnp(builder.asReader(), kj::mv(caps));
+}
+
 KJ_TEST("channel token basics") {
   MockResolver resolver;
   ChannelTokenHandler handler(resolver);
 
   auto props = Frankenvalue::fromJson(kj::str("{\"foo\": 123}"));
-  auto token = handler.encodeSubrequestChannelToken(Usage::RPC, "foo", "MyEntry"_kj, props);
+  auto token =
+      expectSync(handler.encodeSubrequestChannelToken(Usage::RPC, "foo", "MyEntry"_kj, props));
 
   // Decoding works.
   {
@@ -135,7 +210,8 @@ KJ_TEST("channel tokens for storage") {
   ChannelTokenHandler handler(resolver);
 
   auto props = Frankenvalue::fromJson(kj::str("{\"foo\": 123}"));
-  auto token = handler.encodeSubrequestChannelToken(Usage::STORAGE, "foo", "MyEntry"_kj, props);
+  auto token =
+      expectSync(handler.encodeSubrequestChannelToken(Usage::STORAGE, "foo", "MyEntry"_kj, props));
 
   // Decoding works.
   {
@@ -168,7 +244,8 @@ KJ_TEST("actor class channel tokens") {
   ChannelTokenHandler handler(resolver);
 
   auto props = Frankenvalue::fromJson(kj::str("{\"foo\": 123}"));
-  auto token = handler.encodeActorClassChannelToken(Usage::RPC, "foo", "MyEntry"_kj, props);
+  auto token =
+      expectSync(handler.encodeActorClassChannelToken(Usage::RPC, "foo", "MyEntry"_kj, props));
 
   // Decoding works.
   {
@@ -180,6 +257,124 @@ KJ_TEST("actor class channel tokens") {
   // Decoding as the wrong type fails.
   KJ_EXPECT_THROW_MESSAGE(
       "channel token type mismatch", handler.decodeSubrequestChannelToken(Usage::RPC, token));
+}
+
+KJ_TEST("channel token with nested channels (all synchronous)") {
+  MockResolver resolver;
+  ChannelTokenHandler handler(resolver);
+
+  // Build a props cap table containing a SubrequestChannel and an ActorClassChannel, both of
+  // which produce their tokens synchronously.
+  kj::Vector<kj::Own<Frankenvalue::CapTableEntry>> caps;
+  caps.add(kj::refcounted<MockSubrequestChannel>(handler,
+      ServiceTriplet(
+          "nested-subreq", "NestedEntry"_kj, Frankenvalue::fromJson(kj::str("{\"inner\": 1}")))));
+  caps.add(kj::refcounted<MockActorClassChannel>(handler,
+      ServiceTriplet("nested-actor", kj::Maybe<kj::StringPtr>(kj::none),
+          Frankenvalue::fromJson(kj::str("{\"inner\": 2}")))));
+  auto props = propsWithCaps(kj::mv(caps));
+
+  // Encoding is synchronous.
+  auto token =
+      expectSync(handler.encodeSubrequestChannelToken(Usage::RPC, "outer", "OuterEntry"_kj, props));
+
+  // Decoding works and restores the nested channels.
+  {
+    auto channel =
+        handler.decodeSubrequestChannelToken(Usage::RPC, token).downcast<MockSubrequestChannel>();
+    KJ_EXPECT(channel->triplet.serviceName == "outer");
+    KJ_EXPECT(channel->triplet.entrypoint.map([](kj::String& s) -> kj::StringPtr { return s; }) ==
+        "OuterEntry"_kj);
+
+    auto capTable = channel->triplet.props.getCapTable();
+    KJ_ASSERT(capTable.size() == 2);
+
+    auto& nestedSub = KJ_ASSERT_NONNULL(kj::tryDowncast<MockSubrequestChannel>(*capTable[0]),
+        "expected nested cap 0 to be a SubrequestChannel");
+    KJ_EXPECT(nestedSub.triplet ==
+        ServiceTriplet(
+            "nested-subreq", "NestedEntry"_kj, Frankenvalue::fromJson(kj::str("{\"inner\": 1}"))));
+
+    auto& nestedActor = KJ_ASSERT_NONNULL(kj::tryDowncast<MockActorClassChannel>(*capTable[1]),
+        "expected nested cap 1 to be an ActorClassChannel");
+    KJ_EXPECT(nestedActor.triplet ==
+        ServiceTriplet("nested-actor", kj::Maybe<kj::StringPtr>(kj::none),
+            Frankenvalue::fromJson(kj::str("{\"inner\": 2}"))));
+  }
+
+  // Also works with STORAGE usage.
+  auto storageToken = expectSync(
+      handler.encodeSubrequestChannelToken(Usage::STORAGE, "outer", "OuterEntry"_kj, props));
+  {
+    auto channel = handler.decodeSubrequestChannelToken(Usage::STORAGE, storageToken)
+                       .downcast<MockSubrequestChannel>();
+    KJ_EXPECT(channel->triplet.props.getCapTable().size() == 2);
+  }
+
+  // And the outer channel can itself be an ActorClassChannel.
+  auto actorToken =
+      expectSync(handler.encodeActorClassChannelToken(Usage::RPC, "outer", "OuterEntry"_kj, props));
+  {
+    auto channel = handler.decodeActorClassChannelToken(Usage::RPC, actorToken)
+                       .downcast<MockActorClassChannel>();
+    KJ_EXPECT(channel->triplet.props.getCapTable().size() == 2);
+  }
+}
+
+KJ_TEST("channel token with nested channel that generates token asynchronously") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  MockResolver resolver;
+  ChannelTokenHandler handler(resolver);
+
+  // One nested channel is ready synchronously, the other only becomes ready when we fulfill a
+  // paf. The whole encoding therefore cannot complete until we fulfill the paf.
+  auto paf = kj::newPromiseAndFulfiller<void>();
+
+  kj::Vector<kj::Own<Frankenvalue::CapTableEntry>> caps;
+  caps.add(kj::refcounted<MockSubrequestChannel>(handler,
+      ServiceTriplet("sync-subreq", "SyncEntry"_kj,
+          Frankenvalue::fromJson(kj::str("{\"inner\": \"sync\"}")))));
+  caps.add(kj::refcounted<MockActorClassChannel>(handler,
+      ServiceTriplet("async-actor", "AsyncEntry"_kj,
+          Frankenvalue::fromJson(kj::str("{\"inner\": \"async\"}"))),
+      kj::mv(paf.promise)));
+  auto props = propsWithCaps(kj::mv(caps));
+
+  // Encoding returns a promise rather than a synchronous result, because one of the nested
+  // channels needs to wait before generating its token.
+  auto tokenOneOf =
+      handler.encodeSubrequestChannelToken(Usage::RPC, "outer", "OuterEntry"_kj, props);
+  auto tokenPromise = KJ_ASSERT_NONNULL(kj::mv(tokenOneOf).tryGet<kj::Promise<kj::Array<byte>>>(),
+      "expected token to be rendered asynchronously when a nested channel is pending");
+
+  // The promise should not be ready yet.
+  KJ_EXPECT(!tokenPromise.poll(waitScope));
+
+  // Once we fulfill the pending promise, the token is produced.
+  paf.fulfiller->fulfill();
+  auto token = tokenPromise.wait(waitScope);
+
+  // Decoding works and restores the nested channels.
+  auto channel =
+      handler.decodeSubrequestChannelToken(Usage::RPC, token).downcast<MockSubrequestChannel>();
+  KJ_EXPECT(channel->triplet.serviceName == "outer");
+
+  auto capTable = channel->triplet.props.getCapTable();
+  KJ_ASSERT(capTable.size() == 2);
+
+  auto& nestedSub = KJ_ASSERT_NONNULL(kj::tryDowncast<MockSubrequestChannel>(*capTable[0]),
+      "expected nested cap 0 to be a SubrequestChannel");
+  KJ_EXPECT(nestedSub.triplet ==
+      ServiceTriplet(
+          "sync-subreq", "SyncEntry"_kj, Frankenvalue::fromJson(kj::str("{\"inner\": \"sync\"}"))));
+
+  auto& nestedActor = KJ_ASSERT_NONNULL(kj::tryDowncast<MockActorClassChannel>(*capTable[1]),
+      "expected nested cap 1 to be an ActorClassChannel");
+  KJ_EXPECT(nestedActor.triplet ==
+      ServiceTriplet("async-actor", "AsyncEntry"_kj,
+          Frankenvalue::fromJson(kj::str("{\"inner\": \"async\"}"))));
 }
 
 }  // namespace

--- a/src/workerd/server/channel-token.c++
+++ b/src/workerd/server/channel-token.c++
@@ -35,14 +35,15 @@ ChannelTokenHandler::ChannelTokenHandler(Resolver& resolver): resolver(resolver)
   kj::arrayPtr(keyId).copyFrom(kj::arrayPtr(hash).first(KEY_ID_SIZE));
 }
 
-kj::Array<byte> ChannelTokenHandler::encodeChannelTokenImpl(ChannelToken::Type type,
-    IoChannelFactory::ChannelTokenUsage usage,
-    kj::StringPtr serviceName,
-    kj::Maybe<kj::StringPtr> entrypoint,
-    Frankenvalue& props) {
-  capnp::word scratch[128]{};
-  capnp::MallocMessageBuilder message(scratch);
-  auto builder = message.getRoot<ChannelToken>();
+kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> ChannelTokenHandler::
+    encodeChannelTokenImpl(ChannelToken::Type type,
+        IoChannelFactory::ChannelTokenUsage usage,
+        kj::StringPtr serviceName,
+        kj::Maybe<kj::StringPtr> entrypoint,
+        Frankenvalue& props) {
+  auto message = kj::heap<capnp::MallocMessageBuilder>(128);
+  auto builder = message->getRoot<ChannelToken>();
+  kj::Vector<kj::Promise<void>> promises;
 
   builder.setType(type);
 
@@ -64,10 +65,28 @@ kj::Array<byte> ChannelTokenHandler::encodeChannelTokenImpl(ChannelToken::Type t
 
       for (auto i: kj::indices(capTable)) {
         KJ_IF_SOME(subreq, kj::tryDowncast<IoChannelFactory::SubrequestChannel>(*capTable[i])) {
-          caps[i].setSubrequestChannel(subreq.getToken(usage));
+          KJ_SWITCH_ONEOF(subreq.getTokenMaybeSync(usage)) {
+            KJ_CASE_ONEOF(token, kj::Array<byte>) {
+              caps[i].setSubrequestChannel(token);
+            }
+            KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+              promises.add(promise.then([slot = caps[i]](kj::Array<byte> token) mutable {
+                slot.setSubrequestChannel(token);
+              }));
+            }
+          }
         } else KJ_IF_SOME(actorClass,
             kj::tryDowncast<IoChannelFactory::ActorClassChannel>(*capTable[i])) {
-          caps[i].setActorClassChannel(actorClass.getToken(usage));
+          KJ_SWITCH_ONEOF(actorClass.getTokenMaybeSync(usage)) {
+            KJ_CASE_ONEOF(token, kj::Array<byte>) {
+              caps[i].setActorClassChannel(token);
+            }
+            KJ_CASE_ONEOF(promise, kj::Promise<kj::Array<byte>>) {
+              promises.add(promise.then([slot = caps[i]](kj::Array<byte> token) mutable {
+                slot.setActorClassChannel(token);
+              }));
+            }
+          }
         } else {
           KJ_FAIL_REQUIRE("unknown type in props");
         }
@@ -75,6 +94,18 @@ kj::Array<byte> ChannelTokenHandler::encodeChannelTokenImpl(ChannelToken::Type t
     }
   }
 
+  if (promises.empty()) {
+    return serializeTokenImpl(usage, *message);
+  } else {
+    return kj::joinPromisesFailFast(promises.releaseAsArray())
+        .then([this, usage, message = kj::mv(message)]() mutable {
+      return serializeTokenImpl(usage, *message);
+    });
+  }
+}
+
+kj::Array<byte> ChannelTokenHandler::serializeTokenImpl(
+    IoChannelFactory::ChannelTokenUsage usage, capnp::MessageBuilder& message) {
   kj::VectorOutputStream out;
   capnp::writePackedMessage(out, message);
 
@@ -135,20 +166,20 @@ kj::Array<byte> ChannelTokenHandler::encodeChannelTokenImpl(ChannelToken::Type t
   KJ_UNREACHABLE;
 }
 
-kj::Array<byte> ChannelTokenHandler::encodeSubrequestChannelToken(
-    IoChannelFactory::ChannelTokenUsage usage,
-    kj::StringPtr serviceName,
-    kj::Maybe<kj::StringPtr> entrypoint,
-    Frankenvalue& props) {
+kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> ChannelTokenHandler::
+    encodeSubrequestChannelToken(IoChannelFactory::ChannelTokenUsage usage,
+        kj::StringPtr serviceName,
+        kj::Maybe<kj::StringPtr> entrypoint,
+        Frankenvalue& props) {
   return encodeChannelTokenImpl(
       ChannelToken::Type::SUBREQUEST, usage, serviceName, entrypoint, props);
 }
 
-kj::Array<byte> ChannelTokenHandler::encodeActorClassChannelToken(
-    IoChannelFactory::ChannelTokenUsage usage,
-    kj::StringPtr serviceName,
-    kj::Maybe<kj::StringPtr> entrypoint,
-    Frankenvalue& props) {
+kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> ChannelTokenHandler::
+    encodeActorClassChannelToken(IoChannelFactory::ChannelTokenUsage usage,
+        kj::StringPtr serviceName,
+        kj::Maybe<kj::StringPtr> entrypoint,
+        Frankenvalue& props) {
   return encodeChannelTokenImpl(
       ChannelToken::Type::ACTOR_CLASS, usage, serviceName, entrypoint, props);
 }

--- a/src/workerd/server/channel-token.h
+++ b/src/workerd/server/channel-token.h
@@ -37,11 +37,13 @@ class ChannelTokenHandler {
   explicit ChannelTokenHandler(Resolver& resolver);
 
   // Helpers to implement `IoChannelFactory::{SubrequestChannel,ActorClassChannel}::getToken()`.
-  kj::Array<byte> encodeSubrequestChannelToken(IoChannelFactory::ChannelTokenUsage usage,
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> encodeSubrequestChannelToken(
+      IoChannelFactory::ChannelTokenUsage usage,
       kj::StringPtr serviceName,
       kj::Maybe<kj::StringPtr> entrypoint,
       Frankenvalue& props);
-  kj::Array<byte> encodeActorClassChannelToken(IoChannelFactory::ChannelTokenUsage usage,
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> encodeActorClassChannelToken(
+      IoChannelFactory::ChannelTokenUsage usage,
       kj::StringPtr serviceName,
       kj::Maybe<kj::StringPtr> entrypoint,
       Frankenvalue& props);
@@ -73,11 +75,14 @@ class ChannelTokenHandler {
   static_assert(sizeof(TokenHeader) == 32);
 
   // Implementation for both `encode` methods.
-  kj::Array<byte> encodeChannelTokenImpl(ChannelToken::Type type,
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> encodeChannelTokenImpl(
+      ChannelToken::Type type,
       IoChannelFactory::ChannelTokenUsage usage,
       kj::StringPtr serviceName,
       kj::Maybe<kj::StringPtr> entrypoint,
       Frankenvalue& props);
+  kj::Array<byte> serializeTokenImpl(
+      IoChannelFactory::ChannelTokenUsage usage, capnp::MessageBuilder& message);
 
   // Implementation that dynamically returns either SubrequestChannel or ActorClassChannel, which
   // both happen to inherit CapTableEntry. The caller will immediately downcast to the right type.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -164,7 +164,7 @@ static inline kj::Own<T> fakeOwn(T& ref) {
   return kj::Own<T>(&ref, kj::NullDisposer::instance);
 }
 
-void throwDynamicEntrypointTransferError() {
+[[noreturn]] void throwDynamicEntrypointTransferError() {
   JSG_FAIL_REQUIRE(DOMDataCloneError,
       "Entrypoints to dynamically-loaded workers cannot be transferred to other Workers, "
       "because the system does not know how to reload this Worker from scratch. Instead, "
@@ -552,11 +552,22 @@ class Server::InvalidConfigService final: public Service {
   bool hasHandler(kj::StringPtr handlerName) override {
     return false;
   }
+
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    // Can't get here because workerd would have failed to start.
+    KJ_UNREACHABLE;
+  }
 };
 
 class Server::InvalidConfigActorClass final: public ActorClass {
  public:
   void requireAllowsTransfer() override {
+    // Can't get here because workerd would have failed to start.
+    KJ_UNREACHABLE;
+  }
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
     // Can't get here because workerd would have failed to start.
     KJ_UNREACHABLE;
   }
@@ -644,6 +655,11 @@ class Server::ExternalTcpService final: public Service, private WorkerInterface 
     return handlerName == "fetch"_kj || handlerName == "connect"_kj;
   }
 
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    JSG_FAIL_REQUIRE(DOMDataCloneError, "ExternalService can't be passed over RPC.");
+  }
+
  private:
   kj::Own<kj::NetworkAddress> addr;
 
@@ -726,6 +742,11 @@ class Server::ExternalHttpService final: public Service {
 
   bool hasHandler(kj::StringPtr handlerName) override {
     return handlerName == "fetch"_kj || handlerName == "connect"_kj;
+  }
+
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    JSG_FAIL_REQUIRE(DOMDataCloneError, "ExternalService can't be passed over RPC.");
   }
 
  private:
@@ -964,6 +985,11 @@ class Server::NetworkService final: public Service, private WorkerInterface {
     return handlerName == "fetch"_kj || handlerName == "connect"_kj;
   }
 
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    JSG_FAIL_REQUIRE(DOMDataCloneError, "NetworkService can't be passed over RPC.");
+  }
+
  private:
   kj::Own<kj::Network> network;
   kj::Maybe<kj::Own<kj::Network>> tlsNetwork;
@@ -1058,6 +1084,11 @@ class Server::DiskDirectoryService final: public Service, private WorkerInterfac
 
   bool hasHandler(kj::StringPtr handlerName) override {
     return handlerName == "fetch"_kj;
+  }
+
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    JSG_FAIL_REQUIRE(DOMDataCloneError, "DiskDirectoryService can't be passed over RPC.");
   }
 
  private:
@@ -1978,6 +2009,20 @@ class Server::WorkerService final: public Service,
 
   void requireAllowsTransfer() override {
     if (isDynamic) throwDynamicEntrypointTransferError();
+  }
+
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    requireAllowsTransfer();
+
+    // encodeSubrequestChannelToken wants a reference to the props. It needs this reference to
+    // be non-const because it might refcount things. But if it's an empty object then there's
+    // nothing to refcount. So we can just declare this statically...
+    static Frankenvalue EMPTY_PROPS;
+
+    // If requireAllowsTransfer() passed, then we are not dynamic so should have a service name.
+    return channelTokenHandler.encodeSubrequestChannelToken(
+        usage, KJ_ASSERT_NONNULL(serviceName), kj::none, EMPTY_PROPS);
   }
 
   kj::Maybe<kj::Own<Service>> getEntrypoint(kj::Maybe<kj::StringPtr> name, Frankenvalue props) {
@@ -2910,6 +2955,18 @@ class Server::WorkerService final: public Service,
       static kj::Promise<ClassAndId> callFacetStartCallback(
           kj::Function<kj::Promise<StartInfo>()> getStartInfo) {
         auto info = co_await getStartInfo();
+
+        // Wait for the provided ActorClassChannel to be fully resolved, so that we will be able to
+        // downcast it to our `ActorClass` type.
+        KJ_SWITCH_ONEOF(info.actorClass->getResolved()) {
+          KJ_CASE_ONEOF(resolved, kj::Own<IoChannelFactory::ActorClassChannel>) {
+            info.actorClass = kj::mv(resolved);
+          }
+          KJ_CASE_ONEOF(promise, kj::Promise<kj::Own<IoChannelFactory::ActorClassChannel>>) {
+            info.actorClass = co_await promise;
+          }
+        }
+
         co_return ClassAndId(info.actorClass.downcast<ActorClass>(), kj::mv(info.id));
       }
     };
@@ -3216,7 +3273,8 @@ class Server::WorkerService final: public Service,
       worker->requireAllowsTransfer();
     }
 
-    kj::Array<byte> getToken(ChannelTokenUsage usage) override {
+    kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+        ChannelTokenUsage usage) override {
       worker->requireAllowsTransfer();
 
       // If requireAllowsTransfer() passed, then we are not dynamic so should have a service name.
@@ -3288,7 +3346,8 @@ class Server::WorkerService final: public Service,
       return kj::refcounted<ActorClassImpl>(*service, className, kj::mv(props));
     }
 
-    kj::Array<byte> getToken(ChannelTokenUsage usage) override {
+    kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+        ChannelTokenUsage usage) override {
       service->requireAllowsTransfer();
 
       // If requireAllowsTransfer() passed, then we are not dynamic so should have a service name.
@@ -4219,7 +4278,7 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
   class WorkerStubImpl;
   kj::HashMap<kj::String, kj::Rc<WorkerStubImpl>> isolates;
 
-  class NullGlobalOutboundChannel: public IoChannelFactory::SubrequestChannel {
+  class NullGlobalOutboundChannel final: public IoChannelFactory::SubrequestChannel {
    public:
     kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
       JSG_FAIL_REQUIRE(Error,
@@ -4237,6 +4296,11 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
       // is needed for some reason, it wouldn't be hard to support. But we might want to change
       // the error message it throws from startRequest(), since the error would be somewhat
       // misleading after the channel has been transferred.
+      JSG_FAIL_REQUIRE(DOMDataCloneError, "The null global outbound is not transferrable.");
+    }
+
+    kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+        IoChannelFactory::ChannelTokenUsage usage) override {
       JSG_FAIL_REQUIRE(DOMDataCloneError, "The null global outbound is not transferrable.");
     }
   };
@@ -4407,6 +4471,11 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
         throwDynamicEntrypointTransferError();
       }
 
+      kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+          IoChannelFactory::ChannelTokenUsage usage) override {
+        throwDynamicEntrypointTransferError();
+      }
+
      private:
       kj::Rc<WorkerStubImpl> isolate;
       kj::Maybe<kj::String> entrypointName;
@@ -4450,6 +4519,11 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
             props(kj::mv(props)) {}
 
       void requireAllowsTransfer() override {
+        throwDynamicEntrypointTransferError();
+      }
+
+      kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+          IoChannelFactory::ChannelTokenUsage usage) override {
         throwDynamicEntrypointTransferError();
       }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -2955,6 +2955,7 @@ class Server::WorkerService final: public Service,
       static kj::Promise<ClassAndId> callFacetStartCallback(
           kj::Function<kj::Promise<StartInfo>()> getStartInfo) {
         auto info = co_await getStartInfo();
+        co_await info.ensureAllResolved();
 
         // Wait for the provided ActorClassChannel to be fully resolved, so that we will be able to
         // downcast it to our `ActorClass` type.
@@ -3526,7 +3527,7 @@ class Server::WorkerService final: public Service,
     co_return;
   }
 
-  kj::Own<SubrequestChannel> getSubrequestChannel(uint channel,
+  kj::Own<SubrequestChannel> getSubrequestChannelResolved(uint channel,
       kj::Maybe<Frankenvalue> props,
       kj::Maybe<VersionRequest> versionRequest) override {
     auto& channels =
@@ -3590,7 +3591,8 @@ class Server::WorkerService final: public Service,
     return ns.getActorChannel(kj::str(id));
   }
 
-  kj::Own<ActorClassChannel> getActorClass(uint channel, kj::Maybe<Frankenvalue> props) override {
+  kj::Own<ActorClassChannel> getActorClassResolved(
+      uint channel, kj::Maybe<Frankenvalue> props) override {
     auto& channels =
         KJ_REQUIRE_NONNULL(ioChannels.tryGet<LinkedIoChannels>(), "link() has not been called");
 
@@ -3651,6 +3653,10 @@ class Server::WorkerService final: public Service,
   kj::Own<ActorClassChannel> actorClassFromToken(
       ChannelTokenUsage usage, kj::ArrayPtr<const byte> token) override {
     return channelTokenHandler.decodeActorClassChannelToken(usage, token);
+  }
+
+  kj::Own<void> addRef() override {
+    return kj::addRef(*this);
   }
 
   // ---------------------------------------------------------------------------
@@ -4305,7 +4311,7 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
     }
   };
 
-  class WorkerStubImpl final: public WorkerStubChannel, public kj::Refcounted {
+  class WorkerStubImpl final: public WorkerStubChannel {
    public:
     WorkerStubImpl(Server& server,
         kj::String isolateName,
@@ -4324,12 +4330,12 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
       }
     }
 
-    kj::Own<IoChannelFactory::SubrequestChannel> getEntrypoint(
+    kj::Own<IoChannelFactory::SubrequestChannel> getEntrypointResolved(
         kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits) override {
       return kj::refcounted<SubrequestChannelImpl>(addRefToThis(), kj::mv(name), kj::mv(props));
     }
 
-    kj::Own<IoChannelFactory::ActorClassChannel> getActorClass(
+    kj::Own<IoChannelFactory::ActorClassChannel> getActorClassResolved(
         kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits) override {
       return kj::refcounted<ActorClassImpl>(addRefToThis(), kj::mv(name), kj::mv(props));
     }
@@ -4354,6 +4360,7 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted {
         kj::String isolateName,
         kj::Function<kj::Promise<DynamicWorkerSource>()> fetchSource) {
       auto source = co_await fetchSource();
+      co_await source.ensureAllResolved();
       static const kj::HashMap<kj::String, ActorConfig> EMPTY_ACTOR_CONFIGS;
 
       // Rewrite the capabilities in `env` in order to build the I/O channel table.

--- a/src/workerd/server/workerd-debug-port-client.c++
+++ b/src/workerd/server/workerd-debug-port-client.c++
@@ -48,6 +48,11 @@ class WorkerdBootstrapSubrequestChannel final: public IoChannelFactory::Subreque
     JSG_FAIL_REQUIRE(Error, "WorkerdDebugPort bindings cannot be transferred to other workers");
   }
 
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage usage) override {
+    JSG_FAIL_REQUIRE(Error, "WorkerdDebugPort bindings cannot be transferred to other workers");
+  }
+
  private:
   rpc::WorkerdBootstrap::Client bootstrap;
   capnp::HttpOverCapnpFactory& httpOverCapnpFactory;

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -137,10 +137,14 @@ struct TestFixture {
     kj::Own<WorkerInterface> startSubrequest(uint channel, SubrequestMetadata metadata) override {
       KJ_FAIL_ASSERT("no subrequests");
     }
-    kj::Own<SubrequestChannel> getSubrequestChannel(uint channel,
+    kj::Own<SubrequestChannel> getSubrequestChannelResolved(uint channel,
         kj::Maybe<Frankenvalue> props,
         kj::Maybe<VersionRequest> versionRequest) override {
       KJ_FAIL_ASSERT("no subrequests");
+    }
+    kj::Own<ActorClassChannel> getActorClassResolved(
+        uint channel, kj::Maybe<Frankenvalue> props) override {
+      KJ_FAIL_ASSERT("no actor classes");
     }
     capnp::Capability::Client getCapability(uint channel) override {
       KJ_FAIL_ASSERT("no capabilities");
@@ -167,6 +171,10 @@ struct TestFixture {
     kj::Own<ActorChannel> getColoLocalActor(
         uint channel, kj::StringPtr id, SpanParent parentSpan) override {
       KJ_FAIL_REQUIRE("no actor channels");
+    }
+
+    kj::Own<void> addRef() override {
+      KJ_FAIL_REQUIRE("not used");
     }
 
     TimerChannel& timer;

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -29,8 +29,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "tail-stream-refactor"_kj;
     case AutogateKey::RUST_BACKED_NODE_DNS:
       return "rust-backed-node-dns"_kj;
-    case AutogateKey::RPC_USE_EXTERNAL_PUSHER:
-      return "rpc-use-external-pusher"_kj;
     case AutogateKey::WASM_SHUTDOWN_SIGNAL_SHIM:
       return "wasm-shutdown-signal-shim"_kj;
     case AutogateKey::ENABLE_FAST_TEXTENCODER:

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -45,8 +45,6 @@ kj::StringPtr KJ_STRINGIFY(AutogateKey key) {
       return "updated-auto-allocate-chunk-size"_kj;
     case AutogateKey::PYTHON_ABORT_ISOLATE_ON_FATAL_ERROR:
       return "python-abort-isolate-on-fatal-error"_kj;
-    case AutogateKey::JSRPC_SESSION_HANDLE:
-      return "jsrpc-session-handle"_kj;
     case AutogateKey::NumOfKeys:
       KJ_FAIL_ASSERT("NumOfKeys should not be used in getName");
   }

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -33,8 +33,6 @@ enum class AutogateKey {
   TAIL_STREAM_REFACTOR,
   // Enable Rust-backed Node.js DNS implementation
   RUST_BACKED_NODE_DNS,
-  // Use ExternalPusher instead of StreamSink to handle streams in RPC.
-  RPC_USE_EXTERNAL_PUSHER,
   // Enable the WebAssembly.instantiate shim that detects modules exporting __instance_signal /
   // __instance_terminated and registers them for receiving the CPU-limit shutdown signal.
   WASM_SHUTDOWN_SIGNAL_SHIM,

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -50,9 +50,6 @@ enum class AutogateKey {
   UPDATED_AUTO_ALLOCATE_CHUNK_SIZE,
   // Call abortIsolate() when a Python worker encounters a fatal error.
   PYTHON_ABORT_ISOLATE_ON_FATAL_ERROR,
-  // `jsRpcSession()` returns a session handle instead of having the call itself hang until the
-  // session is complete.
-  JSRPC_SESSION_HANDLE,
   NumOfKeys  // Reserved for iteration.
 };
 


### PR DESCRIPTION
There are cases where it is difficult to acquire the channel token for a SubrequestChannel or ActorClassChannel synchronously, but until now we have needed to do so in order to serialize `Fetcher`s and `DurableObjectClass`es.

We can't make serialization itself be async, because this would mess up e-order: A call that needs to wait for something while serializing params might end up being delayed until after some subsequent call which didn't wait, and so would be delivered out-of-order.

To avoid this, we make it possible for a call to be sent with an IOU for the channel tokens. This uses `ExternalPusher`. The call embeds an external which is a promise capability. Later, the caller invokes the callee's `ExternalPusher` to push the channel token to it, and resolves the IOU promise to the resulting object. The callee can then unwrap the promise to get their token.

---------------------

This PR also, in preparation for landing the above, does some cleanup:
* Remove StreamSink in favor of ExternalPusher, since this new functionality requires ExternalPusher.
* Remove ServerTopLevelMembrane, since it otherwise prevented ExternalPusher from receiving calls after the RPC call(), and this new functionality needs that.

These two cleanups require that the respective autogates have rolled out, namely `rpc-use-external-pusher` and `jsrpc-session-handle`. DO NOT MERGE this PR until those have rolled out! I am leaving this marked as "draft" until that time.