### PR TITLE
Fix `JSG_TS_OVERRIDE` macro corruption from `<stdio.h>` macros

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -592,9 +592,14 @@ using HasGetTemplateOverload = decltype(kj::instance<T&>().getTemplate(
 // This macro accepts a single override parameter containing a partial TypeScript statement definition.
 // Varargs are accepted so that overrides can contain `,` outside of balanced brackets. See the
 // `## TypeScript` section of the JSG README.md for many more details and examples.
+//
+// The varargs are stringified directly with `#__VA_ARGS__` to capture the user's source verbatim;
+// see the comment on `JSG_STRING_LITERAL` in macro-meta.h for why a forwarding helper would be
+// wrong here. The other `JSG_*_TS_OVERRIDE` and `JSG_*_TS_DEFINE` macros below follow the same
+// pattern for the same reason.
 #define JSG_TS_OVERRIDE(...)                                                                       \
   do {                                                                                             \
-    static const char OVERRIDE[] = JSG_STRING_LITERAL(__VA_ARGS__);                                \
+    static const char OVERRIDE[] = #__VA_ARGS__;                                                   \
     registry.template registerTypeScriptOverride<OVERRIDE>();                                      \
   } while (false)
 
@@ -605,7 +610,7 @@ using HasGetTemplateOverload = decltype(kj::instance<T&>().getTemplate(
 // README.md for more details.
 #define JSG_TS_DEFINE(...)                                                                         \
   do {                                                                                             \
-    static const char DEFINE[] = JSG_STRING_LITERAL(__VA_ARGS__);                                  \
+    static const char DEFINE[] = #__VA_ARGS__;                                                     \
     registry.template registerTypeScriptDefine<DEFINE>();                                          \
   } while (false)
 
@@ -627,8 +632,7 @@ using HasGetTemplateOverload = decltype(kj::instance<T&>().getTemplate(
 // declaration, inside the same `struct` definition. See the `## TypeScript` section of the JSG README.md
 // for many more details and examples.
 #define JSG_STRUCT_TS_OVERRIDE(...)                                                                \
-  static constexpr char _JSG_STRUCT_TS_OVERRIDE_DO_NOT_USE_DIRECTLY[] =                            \
-      JSG_STRING_LITERAL(__VA_ARGS__)
+  static constexpr char _JSG_STRUCT_TS_OVERRIDE_DO_NOT_USE_DIRECTLY[] = #__VA_ARGS__
 
 // Like JSG_STRUCT_TS_OVERRIDE, however it enables dynamic selection of TS_OVERRIDE.
 // Should be placed adjacent to the JSG_STRUCT declaration, inside the same struct definition.
@@ -641,8 +645,7 @@ using HasGetTemplateOverload = decltype(kj::instance<T&>().getTemplate(
 // declaration, inside the same `struct` definition. See the `## TypeScript`section of the JSG README.md
 // for more details.
 #define JSG_STRUCT_TS_DEFINE(...)                                                                  \
-  static constexpr char _JSG_STRUCT_TS_DEFINE_DO_NOT_USE_DIRECTLY[] =                              \
-      JSG_STRING_LITERAL(__VA_ARGS__)
+  static constexpr char _JSG_STRUCT_TS_DEFINE_DO_NOT_USE_DIRECTLY[] = #__VA_ARGS__
 
 // Adds a group of javascript modules to the module registry when context is instantiated.
 // bundle is of a Bundle type from workerd/jsg/modules.capnp.

--- a/src/workerd/jsg/macro-meta.h
+++ b/src/workerd/jsg/macro-meta.h
@@ -12,7 +12,19 @@
 
 #define JSG_STRING_LITERAL_(...) #__VA_ARGS__
 #define JSG_STRING_LITERAL(...) JSG_STRING_LITERAL_(__VA_ARGS__)
-// JSG_STRING_LITERAL(foo, bar) expands to the string literal: "foo, bar"
+// JSG_STRING_LITERAL(foo, bar) expands to the string literal: "foo, bar".
+//
+// This is the standard two-step "stringify after macro expansion" idiom: arguments are
+// macro-expanded first, then stringified. Useful when callers pass identifiers that are themselves
+// macros and you want to capture the expanded value (e.g. `JSG_STRING_LITERAL(__LINE__)` ->
+// `"123"`).
+//
+// Do NOT use this to stringify user-supplied source-code blocks -- the implicit expansion will
+// silently corrupt identifiers that happen to collide with platform header macros. On Darwin, for
+// example, `<stdio.h>` defines `stdin`/`stdout`/`stderr` as `__stdinp`/`__stdoutp`/`__stderrp`, so
+// `JSG_STRING_LITERAL({ stdin: 1 })` produces `"{ __stdinp: 1 }"` rather than the literal text.
+// For source-code blocks, stringify directly with `#__VA_ARGS__` at the outermost macro that
+// captures the user's tokens (see `JSG_TS_OVERRIDE` in jsg.h for an example).
 
 #define JSG_EXPAND(...) __VA_ARGS__
 // Identity macro. Often useful in macro hacking.

--- a/src/workerd/jsg/rtti-test.c++
+++ b/src/workerd/jsg/rtti-test.c++
@@ -367,6 +367,29 @@ struct TestTypeScriptStruct {
   JSG_STRUCT_TS_OVERRIDE(RenamedStructThing { structThing: 42 });
 };
 
+struct TestTypeScriptStdioResourceType: public jsg::Object {
+  int getThing() {
+    return 42;
+  }
+
+  JSG_RESOURCE_TYPE(TestTypeScriptStdioResourceType) {
+    JSG_READONLY_INSTANCE_PROPERTY(thing, getThing);
+
+    JSG_TS_ROOT();
+    JSG_TS_DEFINE(interface Define { stdin: 0; stdout: 1; stderr: 2 });
+    JSG_TS_OVERRIDE({ stdin: 0; stdout: 1; stderr: 2 });
+  };
+};
+
+struct TestTypeScriptStdioStruct {
+  int structThing;
+  JSG_STRUCT(structThing);
+
+  JSG_STRUCT_TS_ROOT();
+  JSG_STRUCT_TS_DEFINE(interface StructDefine { stdin: 0; stdout: 1; stderr: 2 });
+  JSG_STRUCT_TS_OVERRIDE(Renamed { stdin: 0; stdout: 1; stderr: 2 });
+};
+
 KJ_TEST("typescript macros") {
   KJ_EXPECT(tStructure<TestTypeScriptResourceType>() ==
       "(name = \"TestTypeScriptResourceType\", members = ["
@@ -385,6 +408,29 @@ KJ_TEST("typescript macros") {
       "tsRoot = true, "
       "tsOverride = \"RenamedStructThing { structThing: 42 }\", "
       "tsDefine = \"interface StructDefine {}\", "
+      "disposable = false, asyncDisposable = false)");
+}
+
+KJ_TEST("typescript macros with stdio identifiers") {
+  // `<stdio.h>` on Darwin defines `stdin`/`stdout`/`stderr` as macros. The TS override and define
+  // macros must capture the user's source verbatim so these tokens are not expanded.
+  KJ_EXPECT(tStructure<TestTypeScriptStdioResourceType>() ==
+      "(name = \"TestTypeScriptStdioResourceType\", members = ["
+      "(property = (name = \"thing\", type = (number = (name = \"int\")), readonly = true, lazy = false, prototype = false, getterFastApiCompatible = true, setterFastApiCompatible = false))], "
+      "iterable = false, asyncIterable = false, "
+      "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestTypeScriptStdioResourceType\", "
+      "tsRoot = true, "
+      "tsOverride = \"{ stdin: 0; stdout: 1; stderr: 2 }\", "
+      "tsDefine = \"interface Define { stdin: 0; stdout: 1; stderr: 2 }\", "
+      "disposable = false, asyncDisposable = false)");
+  KJ_EXPECT(tStructure<TestTypeScriptStdioStruct>() ==
+      "(name = \"TestTypeScriptStdioStruct\", members = ["
+      "(property = (name = \"structThing\", type = (number = (name = \"int\")), readonly = false, lazy = false, prototype = false, getterFastApiCompatible = false, setterFastApiCompatible = false))], "
+      "iterable = false, asyncIterable = false, "
+      "fullyQualifiedName = \"workerd::jsg::rtti::(anonymous namespace)::TestTypeScriptStdioStruct\", "
+      "tsRoot = true, "
+      "tsOverride = \"Renamed { stdin: 0; stdout: 1; stderr: 2 }\", "
+      "tsDefine = \"interface StructDefine { stdin: 0; stdout: 1; stderr: 2 }\", "
       "disposable = false, asyncDisposable = false)");
 }
 


### PR DESCRIPTION
## Problem

The `JSG_TS_OVERRIDE`, `JSG_TS_DEFINE`, `JSG_STRUCT_TS_OVERRIDE`, and `JSG_STRUCT_TS_DEFINE` macros stringify their varargs via `JSG_STRING_LITERAL`, a two-step helper that expands macro identifiers in the argument before stringification.

On Darwin, `<stdio.h>` defines `stdin`, `stdout`, and `stderr` as preprocessor macros (`__stdinp`, `__stdoutp`, `__stderrp`). Override blocks containing those identifiers are silently corrupted in the stringified TypeScript:

```cpp
JSG_TS_OVERRIDE({ readonly stdin: WritableStream | null });
// macOS: "{ readonly __stdinp: WritableStream | null }"
// Linux: "{ readonly stdin: WritableStream | null }"
```

This is observable in `src/workerd/api/container.h`, where the `ExecOptions` and `ExecProcess` overrides reference these names. The platform divergence breaks `bazel run //types` for downstream consumers building on macOS — the generated `worker-configuration.d.ts` differs from the Linux-built committed snapshot.

## Fix

Stringify directly with `#__VA_ARGS__` at the outermost macro that captures the user's tokens, rather than forwarding through `JSG_STRING_LITERAL`. Single-step stringification doesn't trigger preprocessor expansion of the argument tokens.

`JSG_STRING_LITERAL` is preserved in `macro-meta.h` (it is still used by `edgeworker/server/async-signal-debug.h` for variable-name logging where two-step semantics are harmless). Its doc comment now warns against using it for user-supplied source-code blocks and points readers at the correct pattern.

## Testing

Added a regression test (`KJ_TEST("typescript macros with stdio identifiers")` in `rtti-test.c++`) that asserts override and define blocks containing `stdin`/`stdout`/`stderr` survive stringification verbatim. Verified on macOS that:

- The new test fails with the bug present, passes with the fix applied.
- `bazel test //src/workerd/jsg:all` — 46/46 pass.
- `bazel build //types` — generated experimental and latest types match the committed Linux snapshot exactly (`diff -r types/generated-snapshot/ bazel-bin/types/definitions/` is empty).