### PR TITLE
Sketch of new Request(Proxy(Request))

### DIFF
--- a/samples/helloworld_esm/worker.js
+++ b/samples/helloworld_esm/worker.js
@@ -4,6 +4,22 @@
 
 export default {
   async fetch(req, env) {
+
+    const r = new Request('https://example.com/', {
+      headers: {
+        'x-hello': 'world',
+      }
+    });
+
+    const r2 = new Request(new Proxy(r, {
+      get(...args) {
+        return Reflect.get(...args);
+      }
+    }));
+
+    console.log(r2.url);
+    console.log(r2.headers);
+
     return new Response("Hello World\n");
   }
 };

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -388,7 +388,6 @@ jsg::Ref<Request> Request::constructor(
   Redirect redirect = Redirect::FOLLOW;
   CacheMode cacheMode = CacheMode::NONE;
   Response_BodyEncoding responseBodyEncoding = Response_BodyEncoding::AUTO;
-
   KJ_SWITCH_ONEOF(input) {
     KJ_CASE_ONEOF(u, kj::String) {
       url = kj::mv(u);
@@ -457,6 +456,57 @@ jsg::Ref<Request> Request::constructor(
       redirect = oldRequest->getRedirectEnum();
       fetcher = oldRequest->getFetcher();
       signal = oldRequest->getSignal();
+    }
+    KJ_CASE_ONEOF(p, jsg::Proxy<RequestProxy>) {
+      auto value = kj::mv(p.value);
+      url = kj::mv(value.url);
+      if (FeatureFlags::get(js).getFetchStandardUrl()) {
+        auto parsed = JSG_REQUIRE_NONNULL(
+            jsg::Url::tryParse(url.asPtr()), TypeError, kj::str("Invalid URL: ", url));
+        url = kj::str(parsed.getHref());
+      }
+      KJ_IF_SOME(m, value.method) {
+        // Same parsing as initDict (lines 478-503)
+        KJ_IF_SOME(code, tryParseHttpMethod(m)) {
+          method = code;
+        } else KJ_IF_SOME(code, kj::tryParseHttpMethod(toUpper(m))) {
+          method = code;
+          if (!FeatureFlags::get(js).getUpperCaseAllHttpMethods()) {
+            switch (method) {
+              case kj::HttpMethod::GET:
+              case kj::HttpMethod::POST:
+              case kj::HttpMethod::PUT:
+              case kj::HttpMethod::DELETE:
+              case kj::HttpMethod::HEAD:
+              case kj::HttpMethod::OPTIONS:
+                break;
+              default:
+                JSG_FAIL_REQUIRE(TypeError, kj::str("Invalid HTTP method string: ", m));
+            }
+          }
+        } else {
+          JSG_FAIL_REQUIRE(TypeError, kj::str("Invalid HTTP method string: ", m));
+        }
+      }
+      KJ_IF_SOME(h, value.headers) {
+        headers = Headers::constructor(js, kj::mv(h));
+      }
+      KJ_IF_SOME(r, value.redirect) {
+        redirect = JSG_REQUIRE_NONNULL(Request::tryParseRedirect(r), TypeError,
+            "Invalid redirect value, must be one of \"follow\" or \"manual\" ...");
+      }
+      KJ_IF_SOME(s, value.signal) {
+        signal = kj::mv(s);
+      }
+      KJ_IF_SOME(c, value.cf) {
+        auto cloned = c.deepClone(js);
+        cf = CfProperty(js, jsg::JsObject(cloned.getHandle(js)));
+      }
+      KJ_IF_SOME(b, kj::mv(value.body).orDefault(kj::none)) {
+        body = Body::extractBody(js, kj::mv(b));
+        JSG_REQUIRE(method != kj::HttpMethod::GET && method != kj::HttpMethod::HEAD, TypeError,
+            "Request with a GET or HEAD method cannot have a body.");
+      }
     }
   }
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -656,6 +656,18 @@ struct RequestInitializerDict {
   void validate(jsg::Lock&);
 };
 
+struct RequestProxy {
+  kj::String url;
+  jsg::Optional<kj::String> method;
+  jsg::Optional<Headers::Initializer> headers;
+  jsg::Optional<kj::Maybe<Body::Initializer>> body;
+  jsg::Optional<kj::String> redirect;
+  jsg::Optional<kj::Maybe<jsg::Ref<AbortSignal>>> signal;
+  jsg::Optional<jsg::V8Ref<v8::Object>> cf;
+
+  JSG_STRUCT(url, method, headers, body, redirect, signal, cf);
+};
+
 class Request final: public Body {
  public:
   enum class Redirect {
@@ -731,7 +743,7 @@ class Request final: public Body {
 
   using InitializerDict = RequestInitializerDict;
 
-  using Info = kj::OneOf<jsg::Ref<Request>, kj::String>;
+  using Info = kj::OneOf<jsg::Ref<Request>, jsg::Proxy<RequestProxy>, kj::String>;
   using Initializer = kj::OneOf<InitializerDict, jsg::Ref<Request>>;
 
   // Wrapper around Request::constructor that calls it only if necessary, and returns a
@@ -1225,7 +1237,7 @@ jsg::Ref<Response> makeHttpResponse(jsg::Lock& js,
       api::Headers::ValueIterator::Next, api::Body, api::Response, api::Response::InitializerDict, \
       api::Request, api::Request::InitializerDict, api::Fetcher, api::Fetcher::PutOptions,         \
       api::Fetcher::ScheduledOptions, api::Fetcher::ScheduledResult, api::Fetcher::QueueResult,    \
-      api::Fetcher::ServiceBindingQueueMessage
+      api::Fetcher::ServiceBindingQueueMessage, api::RequestProxy
 
 // The list of http.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -2010,6 +2010,13 @@ struct NonCoercible {
   T value;
 };
 
+// A type that unwraps only when the value is a v8::Proxy. The value is a JSG_STRUCT
+// instance that is extracted from the proxy.
+template <typename T>
+struct Proxy {
+  T value;
+};
+
 // -----------------------------------------------------------------------------
 
 // A Sequence<T> in C++ corresponds to a Sequence IDL type. A sequence is a list of values

--- a/src/workerd/jsg/rtti.h
+++ b/src/workerd/jsg/rtti.h
@@ -410,6 +410,13 @@ struct BuildRtti<Configuration, jsg::Dict<V, K>> {
   }
 };
 
+template <typename Configuration, typename T>
+struct BuildRtti<Configuration, jsg::Proxy<T>> {
+  static void build(Type::Builder builder, Builder<Configuration>& rtti) {
+    // TODO(now)
+  }
+};
+
 template <typename Configuration, typename... Variants>
 struct BuildRtti<Configuration, kj::OneOf<Variants...>> {
   using Seq = std::index_sequence_for<Variants...>;

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -442,7 +442,8 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
                    public ObjectWrapper<Self>,
                    public V8HandleWrapper,
                    public UnimplementedWrapper,
-                   public JsValueWrapper {
+                   public JsValueWrapper,
+                   public ProxyWrapper<Self> {
   // TODO(soon): Should the TypeWrapper object be stored on the isolate rather than the context?
  public:
   template <typename MetaConfiguration>
@@ -506,6 +507,7 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
   USING_WRAPPER(V8HandleWrapper);
   USING_WRAPPER(UnimplementedWrapper);
   USING_WRAPPER(JsValueWrapper);
+  USING_WRAPPER(ProxyWrapper<Self>);
 #undef USING_WRAPPER
 
   template <typename U>

--- a/src/workerd/jsg/value.h
+++ b/src/workerd/jsg/value.h
@@ -1487,4 +1487,34 @@ class ExceptionWrapper {
   }
 };
 
+// =======================================================================================
+
+template <typename TypeWrapper>
+class ProxyWrapper {
+ public:
+  template <typename T>
+  static const std::type_info& getName(Proxy<T>*) {
+    return TypeWrapper::getName(static_cast<T*>(nullptr));
+  }
+
+  template <typename T>
+  v8::Local<v8::Value> wrap(Lock& js,
+      v8::Local<v8::Context> context,
+      kj::Maybe<v8::Local<v8::Object>> creator,
+      Proxy<T> instance) = delete;
+
+  template <typename T>
+  kj::Maybe<Proxy<T>> tryUnwrap(Lock& js,
+      v8::Local<v8::Context> context,
+      v8::Local<v8::Value> handle,
+      Proxy<T>*,
+      kj::Maybe<v8::Local<v8::Object>> parentObject) {
+    if (handle->IsProxy()) {
+      auto& typeWrapper = static_cast<TypeWrapper&>(*this);
+      return typeWrapper.tryUnwrap(js, context, handle, static_cast<T*>(nullptr), parentObject);
+    }
+    return kj::none;
+  }
+};
+
 }  // namespace workerd::jsg


### PR DESCRIPTION
A skech of an approach to addressing https://github.com/cloudflare/workerd/issues/6700

This is not quite functional yet due to a limitation with handling jsg::Objects through the lens of JSG_STRUCT... well, more limitation of handling jsg::Objects through Proxy:

```
  const rp = new Proxy(r, {
    get(...args) {
      return Reflect.get(...args);
    }
  });

  console.log(rp.url);  // throws
```

This is a different problem tho. The sketch shows how we can make `new Request(Proxy(Request))` work in general.