### PR TITLE
Add served_by_colo to D1 tracing spans

### DIFF
--- a/src/cloudflare/internal/d1-api.ts
+++ b/src/cloudflare/internal/d1-api.ts
@@ -20,7 +20,7 @@ interface D1Meta {
   served_by_region?: string;
 
   /**
-   * The three letters airport code of the colo that executed the query.
+   * The three-letter airport code of the colo that executed the query.
    */
   served_by_colo?: string;
 

--- a/src/cloudflare/internal/d1-api.ts
+++ b/src/cloudflare/internal/d1-api.ts
@@ -20,6 +20,11 @@ interface D1Meta {
   served_by_region?: string;
 
   /**
+   * The three letters airport code of the colo that executed the query.
+   */
+  served_by_colo?: string;
+
+  /**
    * True if-and-only-if the database instance that executed the query was the primary.
    */
   served_by_primary?: boolean;
@@ -754,6 +759,10 @@ function addD1MetaToSpan(span: Span, meta: D1Meta): void {
     meta.served_by_region
   );
   span.setAttribute(
+    'cloudflare.d1.response.served_by_colo',
+    meta.served_by_colo
+  );
+  span.setAttribute(
     'cloudflare.d1.response.served_by_primary',
     meta.served_by_primary
   );
@@ -794,6 +803,9 @@ function aggregateD1Meta(metas: PartialD1Meta[]): D1Meta {
     aggregatedMeta.last_row_id = meta.last_row_id ?? 0;
     if (meta.served_by_region) {
       aggregatedMeta.served_by_region = meta.served_by_region;
+    }
+    if (meta.served_by_colo) {
+      aggregatedMeta.served_by_colo = meta.served_by_colo;
     }
     if (meta.served_by_primary) {
       aggregatedMeta.served_by_primary = meta.served_by_primary;

--- a/src/cloudflare/internal/test/d1/d1-api-instrumentation-test.js
+++ b/src/cloudflare/internal/test/d1/d1-api-instrumentation-test.js
@@ -44,6 +44,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 0,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -99,6 +100,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 0,
     'cloudflare.d1.response.changed_db': true,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -125,6 +127,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 0,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -151,6 +154,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 0,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -177,6 +181,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 0,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -209,6 +214,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': true,
     'cloudflare.d1.response.changes': 2,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -235,6 +241,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': true,
     'cloudflare.d1.response.changes': 2,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -267,6 +274,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': true,
     'cloudflare.d1.response.changes': 2,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -293,6 +301,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -319,6 +328,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -345,6 +355,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -371,6 +382,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -397,6 +409,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -423,6 +436,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -449,6 +463,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -475,6 +490,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -501,6 +517,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -527,6 +544,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -553,6 +571,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -579,6 +598,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -605,6 +625,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -631,6 +652,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -657,6 +679,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -683,6 +706,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -712,6 +736,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -738,6 +763,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -764,6 +790,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -790,6 +817,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -816,6 +844,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -842,6 +871,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 2,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -873,6 +903,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 3,
     'cloudflare.d1.response.changed_db': true,
     'cloudflare.d1.response.changes': 5,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -899,6 +930,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 3,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -925,6 +957,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 3,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -951,6 +984,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 3,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -977,6 +1011,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 3,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -1003,6 +1038,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 3,
     'cloudflare.d1.response.changed_db': false,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {
@@ -1030,6 +1066,7 @@ const expectedSpans = [
     'cloudflare.d1.response.last_row_id': 3,
     'cloudflare.d1.response.changed_db': true,
     'cloudflare.d1.response.changes': 0,
+    'cloudflare.d1.response.served_by_colo': 'DFW',
     closed: true,
   },
   {

--- a/src/cloudflare/internal/test/d1/d1-mock.js
+++ b/src/cloudflare/internal/test/d1/d1-mock.js
@@ -90,6 +90,7 @@ export class D1MockDO {
       meta: {
         duration: Math.random() * 0.01,
         served_by: 'd1-mock',
+        served_by_colo: 'DFW',
         changes: num_changes,
         last_row_id: last_row_id_after,
         changed_db,


### PR DESCRIPTION
Our `meta` object in the response contains `served_by_colo` since couple of months ago: https://developers.cloudflare.com/api/resources/d1/subresources/database/methods/query#(resource)%20d1.database%20%3E%20(model)%20query_result%20%3E%20(schema)%20%3E%20(property)%20meta%20%3E%20(property)%20served_by_colo

<img width="857" height="889" alt="image" src="https://github.com/user-attachments/assets/352946f6-1bfa-435e-9e2f-8c5e3a5a5c3f" />
