### PR TITLE
EW-6888 Report killSwitch exceptions as failed

### DIFF
--- a/src/rust/worker/kill_switch.rs
+++ b/src/rust/worker/kill_switch.rs
@@ -43,7 +43,7 @@ pub struct Worker {}
 impl Worker {
     fn error(file: &str, line: u32) -> Result<()> {
         Err(KjError::new(
-            cxx::KjExceptionType::Overloaded,
+            cxx::KjExceptionType::Failed,
             "jsg.Error: This script has been killed.".to_owned(),
         )
         .with_details(vec![(SCRIPT_KILLED_DETAIL_ID, vec![])])

--- a/src/rust/worker/test.c++
+++ b/src/rust/worker/test.c++
@@ -78,7 +78,7 @@ KJ_TEST("kill_switch worker") {
   }
 
   auto& e = KJ_ASSERT_NONNULL(exception);
-  KJ_ASSERT(e.getType() == kj::Exception::Type::OVERLOADED);
+  KJ_ASSERT(e.getType() == kj::Exception::Type::FAILED);
   KJ_ASSERT(e.getDescription() == "jsg.Error: This script has been killed.");
   KJ_ASSERT(e.getDetail(SCRIPT_KILLED_DETAIL_ID) != kj::none);
 }
@@ -111,7 +111,7 @@ KJ_TEST("kill_switch worker connect") {
   }
 
   auto& e = KJ_ASSERT_NONNULL(exception);
-  KJ_ASSERT(e.getType() == kj::Exception::Type::OVERLOADED);
+  KJ_ASSERT(e.getType() == kj::Exception::Type::FAILED);
   KJ_ASSERT(e.getDescription() == "jsg.Error: This script has been killed.");
   KJ_ASSERT(e.getDetail(SCRIPT_KILLED_DETAIL_ID) != kj::none);
 }


### PR DESCRIPTION
These errors don't actually indicate that the runtime is overloaded, assign the default exception type to them.

See the downstream PR for context.