### PR TITLE
EW-10817 Add WebSocketDataMessage helper for text-or-binary payloads

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -274,6 +274,16 @@ wd_cc_library(
 )
 
 wd_cc_library(
+    name = "web-socket-data-message",
+    hdrs = ["web-socket-data-message.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj",
+        "@capnp-cpp//src/kj/compat:kj-http",
+    ],
+)
+
+wd_cc_library(
     name = "r2",
     srcs = glob(["r2*.c++"]),
     hdrs = glob(["r2*.h"]),
@@ -647,6 +657,13 @@ kj_test(
 kj_test(
     src = "cf-property-test.c++",
     deps = ["//src/workerd/tests:test-fixture"],
+)
+
+kj_test(
+    src = "web-socket-data-message-test.c++",
+    deps = [
+        ":web-socket-data-message",
+    ],
 )
 
 kj_test(

--- a/src/workerd/api/web-socket-data-message-test.c++
+++ b/src/workerd/api/web-socket-data-message-test.c++
@@ -1,0 +1,354 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "web-socket-data-message.h"
+
+#include <kj/test.h>
+
+namespace workerd::api {
+namespace {
+
+// =============================================================================
+// Construction + basic accessors.
+// =============================================================================
+
+KJ_TEST("WebSocketDataMessage: text construction, isText/isBinary, size()") {
+  WebSocketDataMessage msg(kj::str("hello"));
+  KJ_EXPECT(msg.isText());
+  KJ_EXPECT(!msg.isBinary());
+  KJ_EXPECT(msg.size() == 5);
+}
+
+KJ_TEST("WebSocketDataMessage: binary construction, isText/isBinary, size()") {
+  WebSocketDataMessage msg(kj::heapArray<kj::byte>({0x01, 0x02, 0x03}));
+  KJ_EXPECT(msg.isBinary());
+  KJ_EXPECT(!msg.isText());
+  KJ_EXPECT(msg.size() == 3);
+}
+
+KJ_TEST("WebSocketDataMessage: JSG-shape ctor lifts text from string-first OneOf") {
+  // String-first matches our internal storage; the OneOf move ctor handles this directly.
+  kj::OneOf<kj::String, kj::Array<kj::byte>> jsgInput = kj::str("from-jsg");
+  WebSocketDataMessage msg(kj::mv(jsgInput));
+  KJ_EXPECT(msg.isText());
+  KJ_EXPECT(msg.size() == 8);
+  KJ_IF_SOME(text, msg.tryGetText()) {
+    KJ_EXPECT(text == "from-jsg"_kj);
+  } else {
+    KJ_FAIL_EXPECT("expected text variant after JSG-shape lift");
+  }
+}
+
+KJ_TEST("WebSocketDataMessage: JSG-shape ctor lifts binary from string-first OneOf") {
+  kj::OneOf<kj::String, kj::Array<kj::byte>> jsgInput = kj::heapArray<kj::byte>({0xab, 0xcd});
+  WebSocketDataMessage msg(kj::mv(jsgInput));
+  KJ_EXPECT(msg.isBinary());
+  KJ_EXPECT(msg.size() == 2);
+}
+
+KJ_TEST("WebSocketDataMessage: JSG-shape ctor accepts binary-first OneOf via subset ctor") {
+  // Binary-first matches `WebSocket::send`'s JSG parameter shape. `kj::OneOf`'s SFINAE-
+  // enabled subset ctor reorders the variants during construction — no per-variant switch
+  // required at the caller.
+  kj::OneOf<kj::Array<kj::byte>, kj::String> jsgInput = kj::str("binary-first");
+  WebSocketDataMessage msg(kj::mv(jsgInput));
+  KJ_EXPECT(msg.isText());
+  KJ_EXPECT(msg.size() == 12);
+  KJ_IF_SOME(text, msg.tryGetText()) {
+    KJ_EXPECT(text == "binary-first"_kj);
+  } else {
+    KJ_FAIL_EXPECT("expected text variant after binary-first lift");
+  }
+
+  kj::OneOf<kj::Array<kj::byte>, kj::String> jsgBin = kj::heapArray<kj::byte>({0x42, 0x43});
+  WebSocketDataMessage binMsg(kj::mv(jsgBin));
+  KJ_EXPECT(binMsg.isBinary());
+  KJ_EXPECT(binMsg.size() == 2);
+  KJ_IF_SOME(bytes, binMsg.tryGetBinary()) {
+    KJ_EXPECT(bytes[0] == 0x42 && bytes[1] == 0x43);
+  } else {
+    KJ_FAIL_EXPECT("expected binary variant");
+  }
+}
+
+KJ_TEST("WebSocketDataMessage: move construction preserves variant and contents") {
+  WebSocketDataMessage src(kj::heapArray<kj::byte>({0xab, 0xcd}));
+  WebSocketDataMessage dst(kj::mv(src));
+  KJ_EXPECT(dst.isBinary());
+  KJ_EXPECT(dst.size() == 2);
+  KJ_IF_SOME(bytes, dst.tryGetBinary()) {
+    KJ_EXPECT(bytes[0] == 0xab && bytes[1] == 0xcd);
+  } else {
+    KJ_FAIL_EXPECT("expected binary variant after move");
+  }
+}
+
+// =============================================================================
+// `asOneOf()` + `KJ_SWITCH_ONEOF` dispatch — verifies the borrowed-view OneOf works for
+// switch dispatch on both Message and Ptr, with cases bound to `kj::StringPtr` /
+// `kj::ArrayPtr<const byte>`.
+// =============================================================================
+
+KJ_TEST("WebSocketDataMessage::asOneOf: text variant dispatches via KJ_SWITCH_ONEOF") {
+  WebSocketDataMessage msg(kj::str("hello"));
+
+  bool sawText = false;
+  KJ_SWITCH_ONEOF(msg.asOneOf()) {
+    KJ_CASE_ONEOF(text, kj::StringPtr) {
+      KJ_EXPECT(text == "hello"_kj);
+      sawText = true;
+    }
+    KJ_CASE_ONEOF(bytes, kj::ArrayPtr<const kj::byte>) {
+      KJ_FAIL_EXPECT("expected text variant");
+    }
+  }
+  KJ_EXPECT(sawText);
+}
+
+KJ_TEST("WebSocketDataMessage::asOneOf: binary variant dispatches via KJ_SWITCH_ONEOF") {
+  WebSocketDataMessage msg(kj::heapArray<kj::byte>({0x01, 0x02, 0x03}));
+
+  bool sawBytes = false;
+  KJ_SWITCH_ONEOF(msg.asOneOf()) {
+    KJ_CASE_ONEOF(text, kj::StringPtr) {
+      KJ_FAIL_EXPECT("expected binary variant");
+    }
+    KJ_CASE_ONEOF(bytes, kj::ArrayPtr<const kj::byte>) {
+      KJ_EXPECT(bytes.size() == 3);
+      KJ_EXPECT(bytes[0] == 0x01 && bytes[1] == 0x02 && bytes[2] == 0x03);
+      sawBytes = true;
+    }
+  }
+  KJ_EXPECT(sawBytes);
+}
+
+KJ_TEST("WebSocketDataMessagePtr::asOneOf: KJ_SWITCH_ONEOF dispatch on Ptr") {
+  kj::byte buf[] = {0xde, 0xad};
+  WebSocketDataMessagePtr ptr{kj::ArrayPtr<const kj::byte>(buf)};
+
+  bool sawBytes = false;
+  KJ_SWITCH_ONEOF(ptr.asOneOf()) {
+    KJ_CASE_ONEOF(text, kj::StringPtr) {
+      KJ_FAIL_EXPECT("expected binary variant");
+    }
+    KJ_CASE_ONEOF(bytes, kj::ArrayPtr<const kj::byte>) {
+      KJ_EXPECT(bytes.size() == 2);
+      sawBytes = true;
+    }
+  }
+  KJ_EXPECT(sawBytes);
+}
+
+// =============================================================================
+// Borrowed-view inspection.
+// =============================================================================
+
+KJ_TEST("WebSocketDataMessage: tryGetText/tryGetBinary for present and absent variants") {
+  WebSocketDataMessage textMsg(kj::str("ping"));
+  KJ_IF_SOME(text, textMsg.tryGetText()) {
+    KJ_EXPECT(text == "ping"_kj);
+  } else {
+    KJ_FAIL_EXPECT("expected to unwrap text variant");
+  }
+  KJ_EXPECT(textMsg.tryGetBinary() == kj::none);
+
+  WebSocketDataMessage binMsg(kj::heapArray<kj::byte>({0x10, 0x20}));
+  KJ_IF_SOME(bytes, binMsg.tryGetBinary()) {
+    KJ_EXPECT(bytes.size() == 2);
+    KJ_EXPECT(bytes[0] == 0x10 && bytes[1] == 0x20);
+  } else {
+    KJ_FAIL_EXPECT("expected to unwrap binary variant");
+  }
+  KJ_EXPECT(binMsg.tryGetText() == kj::none);
+}
+
+KJ_TEST("WebSocketDataMessage::asPtr: text round-trip preserves variant and contents") {
+  WebSocketDataMessage msg(kj::str("round"));
+  auto ptr = msg.asPtr();
+  KJ_EXPECT(ptr.isText());
+  KJ_EXPECT(ptr.size() == 5);
+  KJ_IF_SOME(text, ptr.tryGetText()) {
+    KJ_EXPECT(text == "round"_kj);
+  } else {
+    KJ_FAIL_EXPECT("expected text variant");
+  }
+}
+
+KJ_TEST("WebSocketDataMessage::asPtr: binary round-trip preserves variant and contents") {
+  WebSocketDataMessage msg(kj::heapArray<kj::byte>({0xab, 0xcd}));
+  auto ptr = msg.asPtr();
+  KJ_EXPECT(ptr.isBinary());
+  KJ_EXPECT(ptr.size() == 2);
+  KJ_IF_SOME(bytes, ptr.tryGetBinary()) {
+    KJ_EXPECT(bytes[0] == 0xab && bytes[1] == 0xcd);
+  } else {
+    KJ_FAIL_EXPECT("expected binary variant");
+  }
+}
+
+// =============================================================================
+// `WebSocketDataMessagePtr` direct construction + inspection.
+// =============================================================================
+
+KJ_TEST("WebSocketDataMessagePtr: text construction, isText/isBinary, size()") {
+  kj::StringPtr s = "hello"_kj;
+  WebSocketDataMessagePtr ptr(s);
+  KJ_EXPECT(ptr.isText());
+  KJ_EXPECT(!ptr.isBinary());
+  KJ_EXPECT(ptr.size() == 5);
+}
+
+KJ_TEST("WebSocketDataMessagePtr: binary construction, isText/isBinary, size()") {
+  kj::byte buf[] = {0x01, 0x02, 0x03, 0x04};
+  WebSocketDataMessagePtr ptr{kj::ArrayPtr<const kj::byte>(buf)};
+  KJ_EXPECT(ptr.isBinary());
+  KJ_EXPECT(!ptr.isText());
+  KJ_EXPECT(ptr.size() == 4);
+}
+
+KJ_TEST("WebSocketDataMessagePtr::toOwned: text round-trip allocates owned copy") {
+  kj::StringPtr borrowed = "owned"_kj;
+  WebSocketDataMessagePtr ptr(borrowed);
+  WebSocketDataMessage owned = ptr.toOwned();
+  KJ_EXPECT(owned.isText());
+  KJ_EXPECT(owned.size() == 5);
+  KJ_IF_SOME(text, owned.tryGetText()) {
+    KJ_EXPECT(text == "owned"_kj);
+  } else {
+    KJ_FAIL_EXPECT("expected text variant");
+  }
+}
+
+KJ_TEST("WebSocketDataMessagePtr::toOwned: binary round-trip allocates owned copy") {
+  kj::byte buf[] = {0xab, 0xcd};
+  WebSocketDataMessagePtr ptr{kj::ArrayPtr<const kj::byte>(buf)};
+  WebSocketDataMessage owned = ptr.toOwned();
+  KJ_EXPECT(owned.isBinary());
+  KJ_EXPECT(owned.size() == 2);
+  KJ_IF_SOME(bytes, owned.tryGetBinary()) {
+    KJ_EXPECT(bytes[0] == 0xab && bytes[1] == 0xcd);
+    // Mutating the original buffer must not affect the owned copy.
+    buf[0] = 0xff;
+    KJ_EXPECT(bytes[0] == 0xab);
+  } else {
+    KJ_FAIL_EXPECT("expected binary variant");
+  }
+}
+
+// =============================================================================
+// Content-equality (`operator==`) on Message and Ptr.
+// =============================================================================
+
+KJ_TEST("operator==: text Message matches StringPtr with same content") {
+  WebSocketDataMessage msg(kj::str("ping"));
+  KJ_EXPECT(msg == "ping"_kj);
+  // C++23 rewrite gives symmetric form for free.
+  KJ_EXPECT("ping"_kj == msg);
+}
+
+KJ_TEST("operator==: text Message rejects different StringPtr content") {
+  WebSocketDataMessage msg(kj::str("ping"));
+  KJ_EXPECT(!(msg == "pong"_kj));
+}
+
+KJ_TEST("operator==: text Message rejects ArrayPtr (variant mismatch)") {
+  WebSocketDataMessage msg(kj::str("ping"));
+  // Bytes that would equal "ping" in ASCII; must still return false because the variants
+  // don't match.
+  kj::byte pingBytes[] = {0x70, 0x69, 0x6e, 0x67};
+  KJ_EXPECT(!(msg == kj::ArrayPtr<const kj::byte>(pingBytes)));
+}
+
+KJ_TEST("operator==: binary Message matches ArrayPtr with same content") {
+  WebSocketDataMessage msg(kj::heapArray<kj::byte>({0x01, 0x02, 0x03}));
+  kj::byte expected[] = {0x01, 0x02, 0x03};
+  KJ_EXPECT(msg == kj::ArrayPtr<const kj::byte>(expected));
+  KJ_EXPECT(kj::ArrayPtr<const kj::byte>(expected) == msg);
+}
+
+KJ_TEST("operator==: binary Message rejects different ArrayPtr content") {
+  WebSocketDataMessage msg(kj::heapArray<kj::byte>({0x01, 0x02, 0x03}));
+  kj::byte different[] = {0x01, 0x02, 0x04};
+  KJ_EXPECT(!(msg == kj::ArrayPtr<const kj::byte>(different)));
+}
+
+KJ_TEST("operator==: binary Message rejects ArrayPtr of different length") {
+  WebSocketDataMessage msg(kj::heapArray<kj::byte>({0x01, 0x02, 0x03}));
+  kj::byte shorter[] = {0x01, 0x02};
+  KJ_EXPECT(!(msg == kj::ArrayPtr<const kj::byte>(shorter)));
+}
+
+KJ_TEST("operator==: binary Message rejects StringPtr (variant mismatch)") {
+  WebSocketDataMessage msg(kj::heapArray<kj::byte>({0x70, 0x69, 0x6e, 0x67}));
+  KJ_EXPECT(!(msg == "ping"_kj));
+}
+
+KJ_TEST("operator==: Ptr matches its borrowed StringPtr/ArrayPtr") {
+  kj::StringPtr text = "ping"_kj;
+  WebSocketDataMessagePtr textPtr(text);
+  KJ_EXPECT(textPtr == "ping"_kj);
+  KJ_EXPECT(!(textPtr == "pong"_kj));
+
+  kj::byte buf[] = {0xab, 0xcd};
+  WebSocketDataMessagePtr binPtr{kj::ArrayPtr<const kj::byte>(buf)};
+  kj::byte expected[] = {0xab, 0xcd};
+  KJ_EXPECT(binPtr == kj::ArrayPtr<const kj::byte>(expected));
+  kj::byte different[] = {0xab, 0xce};
+  KJ_EXPECT(!(binPtr == kj::ArrayPtr<const kj::byte>(different)));
+}
+
+// =============================================================================
+// `sendVia` over a real `kj::WebSocket` pipe.
+// =============================================================================
+
+KJ_TEST("WebSocketDataMessagePtr::sendVia dispatches text frame to kj::WebSocket") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  auto pipe = kj::newWebSocketPipe();
+  WebSocketDataMessagePtr ptr(kj::StringPtr("hello"_kj));
+
+  auto sendPromise = ptr.sendVia(*pipe.ends[0]);
+  auto received = pipe.ends[1]->receive().wait(waitScope);
+  sendPromise.wait(waitScope);
+
+  KJ_ASSERT(received.is<kj::String>());
+  KJ_EXPECT(received.get<kj::String>() == "hello"_kj);
+}
+
+KJ_TEST("WebSocketDataMessagePtr::sendVia dispatches binary frame to kj::WebSocket") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  auto pipe = kj::newWebSocketPipe();
+  kj::byte buf[] = {0x01, 0x02, 0x03};
+  WebSocketDataMessagePtr ptr{kj::ArrayPtr<const kj::byte>(buf)};
+
+  auto sendPromise = ptr.sendVia(*pipe.ends[0]);
+  auto received = pipe.ends[1]->receive().wait(waitScope);
+  sendPromise.wait(waitScope);
+
+  KJ_ASSERT(received.is<kj::Array<kj::byte>>());
+  auto& bytes = received.get<kj::Array<kj::byte>>();
+  KJ_EXPECT(bytes.size() == 3);
+  KJ_EXPECT(bytes[0] == 0x01 && bytes[1] == 0x02 && bytes[2] == 0x03);
+}
+
+KJ_TEST("WebSocketDataMessage::sendVia delegates to kj::WebSocket via asPtr") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  auto pipe = kj::newWebSocketPipe();
+  WebSocketDataMessage msg(kj::str("delegated"));
+
+  auto sendPromise = msg.sendVia(*pipe.ends[0]);
+  auto received = pipe.ends[1]->receive().wait(waitScope);
+  sendPromise.wait(waitScope);
+
+  KJ_ASSERT(received.is<kj::String>());
+  KJ_EXPECT(received.get<kj::String>() == "delegated"_kj);
+}
+
+}  // namespace
+}  // namespace workerd::api

--- a/src/workerd/api/web-socket-data-message.h
+++ b/src/workerd/api/web-socket-data-message.h
@@ -1,0 +1,255 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <kj/array.h>
+#include <kj/async.h>
+#include <kj/compat/http.h>
+#include <kj/one-of.h>
+#include <kj/string.h>
+
+namespace workerd::api {
+
+class WebSocketDataMessagePtr;
+
+// Owned text-or-binary WebSocket data payload, with a domain-named, read-only inspection
+// surface — `isText()` / `isBinary()` / `tryGetText()` / `tryGetBinary()` — plus
+// uniform `size()`, `sendVia(kj::WebSocket&)`, `asPtr()`, and `asOneOf()` for
+// `KJ_SWITCH_ONEOF` dispatch. Designed for queues and pump state in WebSocket auto-response
+// and outgoing-message paths where a message is text-or-binary and flows from
+// enqueue → eventually-send → drop.
+//
+// The wrapper is move-only (the contained `kj::String` / `kj::Array<byte>` are owned).
+//
+// Inspection delegates through a temporarily-constructed `WebSocketDataMessagePtr`. That has
+// two consequences worth understanding:
+//
+//   * Callers cannot mutate the contained data through inspection — `tryGetText()` returns
+//     a `kj::Maybe<kj::StringPtr>` (not `kj::String&`), and `KJ_SWITCH_ONEOF(msg.asOneOf())`
+//     cases bind to `kj::StringPtr` / `kj::ArrayPtr<const byte>`. The owned-vs-borrowed
+//     distinction is purely about lifetime; reads are always borrows.
+//
+//   * The storage type is hidden from the inspection surface. If we later change owned
+//     storage (e.g. to `kj::ConstString`), no caller needs to update — they speak
+//     `StringPtr` / `ArrayPtr<const byte>` regardless.
+//
+// `KJ_SWITCH_ONEOF` support is provided through `asOneOf()`, which returns a fresh
+// `kj::OneOf<kj::StringPtr, kj::ArrayPtr<const byte>>` by value. Callers write
+// `KJ_SWITCH_ONEOF(msg.asOneOf())` rather than `KJ_SWITCH_ONEOF(msg)` directly.
+class WebSocketDataMessage {
+ public:
+  // Owned construction.
+  explicit WebSocketDataMessage(kj::String text): data(kj::mv(text)) {}
+  explicit WebSocketDataMessage(kj::Array<kj::byte> bytes): data(kj::mv(bytes)) {}
+
+  // Lifts a `kj::OneOf` directly into a `WebSocketDataMessage`. Accepts either variant ordering —
+  // `kj::OneOf`'s subset ctor handles the reordering, so callers can pass `kj::OneOf<kj::String,
+  // kj::Array<byte>>` (matching our storage) or `kj::OneOf<kj::Array<byte>, kj::String>` (matching
+  // `WebSocket::send`'s JSG parameter) without writing a per-variant switch.
+  explicit WebSocketDataMessage(kj::OneOf<kj::String, kj::Array<kj::byte>> jsgInput)
+      : data(kj::mv(jsgInput)) {}
+
+  KJ_DISALLOW_COPY(WebSocketDataMessage);
+  WebSocketDataMessage(WebSocketDataMessage&&) = default;
+  WebSocketDataMessage& operator=(WebSocketDataMessage&&) = default;
+
+  // Returns a non-owning view of this message. The returned `WebSocketDataMessagePtr`
+  // borrows from `*this`; callers must keep `*this` alive for the duration of any use.
+  // Defined inline at the bottom of this file, after `WebSocketDataMessagePtr`.
+  inline WebSocketDataMessagePtr asPtr() const KJ_LIFETIMEBOUND;
+
+  // Returns a `kj::OneOf` of borrowed views suitable for `KJ_SWITCH_ONEOF`. The borrowed views
+  // inside reference `*this`'s storage. `*this` must outlive any use of borrows captured by
+  // `KJ_CASE_ONEOF` bindings.
+  inline kj::OneOf<kj::StringPtr, kj::ArrayPtr<const kj::byte>> asOneOf() const KJ_LIFETIMEBOUND;
+
+  // Sends this message over `ws`, dispatching to the appropriate `kj::WebSocket::send`
+  // overload based on which variant is held. Equivalent to `asPtr().sendVia(ws)`. The
+  // message data (i.e. `*this`) must outlive the returned promise.
+  inline kj::Promise<void> sendVia(kj::WebSocket& ws) const;
+
+  // Number of bytes in the text or binary payload.
+  inline size_t size() const;
+
+  inline bool isText() const;
+  inline bool isBinary() const;
+
+  // Returns a non-owning view of the underlying text. Borrows from `*this`; the returned
+  // pointer is valid for the lifetime of `*this`.
+  inline kj::Maybe<kj::StringPtr> tryGetText() const KJ_LIFETIMEBOUND;
+
+  // Returns a non-owning view of the underlying bytes. Borrows from `*this`; the returned
+  // pointer is valid for the lifetime of `*this`.
+  inline kj::Maybe<kj::ArrayPtr<const kj::byte>> tryGetBinary() const KJ_LIFETIMEBOUND;
+
+  // Content-equality against a borrowed text/binary view. Returns false if the message is
+  // holding the other variant. C++23 rewrite rules give symmetric `text == msg` /
+  // `bytes == msg` for free.
+  inline bool operator==(kj::StringPtr text) const;
+  inline bool operator==(kj::ArrayPtr<const kj::byte> bytes) const;
+
+ private:
+  kj::OneOf<kj::String, kj::Array<kj::byte>> data;
+};
+
+// Non-owning counterpart to `WebSocketDataMessage`. Useful at API boundaries that accept a
+// borrowed text-or-binary message (e.g. size checks against an inbound payload), and for
+// dispatching a queued message onto the wire via `sendVia()`.
+//
+// Implicit construction from `kj::StringPtr` and `kj::ArrayPtr<const kj::byte>` is allowed —
+// short-lived non-owning pointers across argument lists benefit from the convenience and
+// there's no ownership to confuse.
+class WebSocketDataMessagePtr {
+ public:
+  WebSocketDataMessagePtr(kj::StringPtr text): data(text) {}
+  WebSocketDataMessagePtr(kj::ArrayPtr<const kj::byte> bytes): data(bytes) {}
+
+  // Trivially copyable; no need to spell out copy/move ctors.
+
+  // Returns a copy of the underlying `kj::OneOf<kj::StringPtr, kj::ArrayPtr<const byte>>` for use
+  // with `KJ_SWITCH_ONEOF`. The borrowed pointers inside still reference whatever this Ptr was
+  // constructed against; valid for that lifetime.
+  kj::OneOf<kj::StringPtr, kj::ArrayPtr<const kj::byte>> asOneOf() const {
+    return data;
+  }
+
+  // Dispatches to `kj::WebSocket::send(kj::StringPtr)` or
+  // `kj::WebSocket::send(kj::ArrayPtr<const byte>)` depending on which variant is held. The
+  // referenced bytes/string must outlive the returned promise.
+  kj::Promise<void> sendVia(kj::WebSocket& ws) const {
+    KJ_SWITCH_ONEOF(data) {
+      KJ_CASE_ONEOF(text, kj::StringPtr) {
+        return ws.send(text);
+      }
+      KJ_CASE_ONEOF(bytes, kj::ArrayPtr<const kj::byte>) {
+        return ws.send(bytes);
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  // Number of bytes in the text or binary payload.
+  size_t size() const {
+    KJ_SWITCH_ONEOF(data) {
+      KJ_CASE_ONEOF(text, kj::StringPtr) {
+        return text.size();
+      }
+      KJ_CASE_ONEOF(bytes, kj::ArrayPtr<const kj::byte>) {
+        return bytes.size();
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  // Returns a freshly-allocated owning copy of the referenced data. Useful at API boundaries
+  // that accept a borrowed message and need to retain it (e.g. enqueueing for later send).
+  WebSocketDataMessage toOwned() const {
+    KJ_SWITCH_ONEOF(data) {
+      KJ_CASE_ONEOF(text, kj::StringPtr) {
+        return WebSocketDataMessage(kj::str(text));
+      }
+      KJ_CASE_ONEOF(bytes, kj::ArrayPtr<const kj::byte>) {
+        return WebSocketDataMessage(kj::heapArray(bytes));
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+
+  bool isText() const {
+    return data.is<kj::StringPtr>();
+  }
+  bool isBinary() const {
+    return data.is<kj::ArrayPtr<const kj::byte>>();
+  }
+
+  // Returns the underlying `kj::StringPtr` by value. Borrows from whatever this Ptr was constructed
+  // against; valid for that lifetime.
+  kj::Maybe<kj::StringPtr> tryGetText() const {
+    KJ_IF_SOME(text, data.tryGet<kj::StringPtr>()) {
+      return text;
+    }
+    return kj::none;
+  }
+  kj::Maybe<kj::ArrayPtr<const kj::byte>> tryGetBinary() const {
+    KJ_IF_SOME(bytes, data.tryGet<kj::ArrayPtr<const kj::byte>>()) {
+      return bytes;
+    }
+    return kj::none;
+  }
+
+  // Content-equality against a borrowed text/binary view. Returns false if this Ptr is
+  // holding the other variant.
+  bool operator==(kj::StringPtr text) const {
+    KJ_IF_SOME(t, tryGetText()) {
+      return t == text;
+    }
+    return false;
+  }
+  bool operator==(kj::ArrayPtr<const kj::byte> bytes) const {
+    KJ_IF_SOME(b, tryGetBinary()) {
+      return b == bytes;
+    }
+    return false;
+  }
+
+ private:
+  kj::OneOf<kj::StringPtr, kj::ArrayPtr<const kj::byte>> data;
+};
+
+// ============================================================================
+// `WebSocketDataMessage` inline definitions — placed after `WebSocketDataMessagePtr` is
+// fully declared so its constructors are visible.
+// ============================================================================
+
+inline WebSocketDataMessagePtr WebSocketDataMessage::asPtr() const {
+  KJ_SWITCH_ONEOF(data) {
+    KJ_CASE_ONEOF(text, kj::String) {
+      return WebSocketDataMessagePtr(text.asPtr());
+    }
+    KJ_CASE_ONEOF(bytes, kj::Array<kj::byte>) {
+      return WebSocketDataMessagePtr(bytes.asPtr());
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+inline kj::OneOf<kj::StringPtr, kj::ArrayPtr<const kj::byte>> WebSocketDataMessage::asOneOf()
+    const {
+  return asPtr().asOneOf();
+}
+
+inline kj::Promise<void> WebSocketDataMessage::sendVia(kj::WebSocket& ws) const {
+  return asPtr().sendVia(ws);
+}
+
+inline size_t WebSocketDataMessage::size() const {
+  return asPtr().size();
+}
+
+inline bool WebSocketDataMessage::isText() const {
+  return asPtr().isText();
+}
+
+inline bool WebSocketDataMessage::isBinary() const {
+  return asPtr().isBinary();
+}
+
+inline kj::Maybe<kj::StringPtr> WebSocketDataMessage::tryGetText() const {
+  return asPtr().tryGetText();
+}
+
+inline kj::Maybe<kj::ArrayPtr<const kj::byte>> WebSocketDataMessage::tryGetBinary() const {
+  return asPtr().tryGetBinary();
+}
+
+inline bool WebSocketDataMessage::operator==(kj::StringPtr text) const {
+  return asPtr() == text;
+}
+
+inline bool WebSocketDataMessage::operator==(kj::ArrayPtr<const kj::byte> bytes) const {
+  return asPtr() == bytes;
+}
+
+}  // namespace workerd::api

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -536,3 +536,11 @@ kj_test(
         "//src/workerd/tests:test-fixture",
     ],
 )
+
+kj_test(
+    src = "hibernation-manager-test.c++",
+    deps = [
+        ":io",
+        "//src/workerd/tests:test-fixture",
+    ],
+)

--- a/src/workerd/io/hibernation-manager-test.c++
+++ b/src/workerd/io/hibernation-manager-test.c++
@@ -1,0 +1,947 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Tests for HibernationManager behavior. The tests interact with the abstract
+// HibernationManager interface so that the same suite can run against any
+// concrete implementation that may exist over time (autogated in production).
+//
+// A note on the code comments throughout this file: they mix descriptions of
+// the implementation as it stands today with motivations and references to
+// in-progress refactor work. They may go stale relative to the current
+// implementation as that work lands. The tests themselves are the source of
+// truth for the contract; comments are best-effort context.
+//
+// A few tests use KJ_EXPECT_LOG to capture the production "another message
+// send is already in progress" assertion as an expected ERROR log. They pass
+// while the bug is present and fail loudly when the fix lands. Search the
+// file for "regression test for EW-10817" to find them.
+
+#include <workerd/api/web-socket.h>
+#include <workerd/io/hibernation-manager.h>
+#include <workerd/io/worker-interface.h>
+#include <workerd/io/worker.h>
+#include <workerd/tests/test-fixture.h>
+
+#include <kj/compat/http.h>
+#include <kj/test.h>
+
+#if KJ_HAS_COMPILER_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#include <sanitizer/lsan_interface.h>
+#endif
+
+namespace workerd {
+
+namespace {
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+// Counts callbacks observed by StubLoopback / StubWorkerInterface so tests can
+// assert dispatch behavior (e.g., auto-response should NOT dispatch).
+struct DispatchStats {
+  uint getWorkerCalls = 0;
+  uint customEventCalls = 0;
+};
+
+// Minimal WorkerInterface for tests. Returns success on customEvent (so the HM's
+// readLoop continues normally) and counts calls. All other methods are
+// unimplemented — this is only suitable for tests that exercise the
+// hibernation event dispatch path, which goes through customEvent().
+class StubWorkerInterface final: public WorkerInterface {
+ public:
+  explicit StubWorkerInterface(DispatchStats& stats): stats(stats) {}
+
+  kj::Promise<WorkerInterface::CustomEvent::Result> customEvent(
+      kj::Own<WorkerInterface::CustomEvent> event) override {
+    ++stats.customEventCalls;
+    return WorkerInterface::CustomEvent::Result{.outcome = EventOutcome::OK};
+  }
+
+  kj::Promise<void> request(kj::HttpMethod,
+      kj::StringPtr,
+      const kj::HttpHeaders&,
+      kj::AsyncInputStream&,
+      kj::HttpService::Response&) override {
+    KJ_UNIMPLEMENTED("StubWorkerInterface::request not used");
+  }
+  kj::Promise<void> connect(kj::StringPtr,
+      const kj::HttpHeaders&,
+      kj::AsyncIoStream&,
+      ConnectResponse&,
+      kj::HttpConnectSettings) override {
+    KJ_UNIMPLEMENTED("StubWorkerInterface::connect not used");
+  }
+  kj::Promise<void> prewarm(kj::StringPtr) override {
+    KJ_UNIMPLEMENTED("StubWorkerInterface::prewarm not used");
+  }
+  kj::Promise<ScheduledResult> runScheduled(kj::Date, kj::StringPtr) override {
+    KJ_UNIMPLEMENTED("StubWorkerInterface::runScheduled not used");
+  }
+  kj::Promise<AlarmResult> runAlarm(kj::Date, uint32_t) override {
+    KJ_UNIMPLEMENTED("StubWorkerInterface::runAlarm not used");
+  }
+
+ private:
+  DispatchStats& stats;
+};
+
+// Test loopback that hands out StubWorkerInterfaces and counts getWorker calls.
+class StubLoopback final: public Worker::Actor::Loopback, public kj::Refcounted {
+ public:
+  explicit StubLoopback(DispatchStats& stats): stats(stats) {}
+
+  kj::Own<WorkerInterface> getWorker(IoChannelFactory::SubrequestMetadata) override {
+    ++stats.getWorkerCalls;
+    return kj::heap<StubWorkerInterface>(stats);
+  }
+
+  kj::Own<Worker::Actor::Loopback> addRef() override {
+    return kj::addRef(*this);
+  }
+
+ private:
+  DispatchStats& stats;
+};
+
+// Helpers below are intentionally split so the HibernationManager can outlive any single
+// IncomingRequest, which matters for tests that span multiple IRs. makeTestHm() needs no
+// IoContext; acceptNewWebSocket() and sendFromDo() do (the api::WebSocket constructor stores
+// IoOwn members, and ws.send() is delivered through the IoContext's pump).
+
+// SetupParams builder that installs a StubLoopback on the actor referencing `stats`. The
+// caller MUST keep `stats` alive for the lifetime of the resulting TestFixture (declare it
+// before the fixture). The same StubLoopback is later retrieved via actor.getLoopback() and
+// handed to the HM, so actor and HM share a single Loopback (mirroring production).
+TestFixture::SetupParams stubLoopbackParams(DispatchStats& stats, kj::String actorId) {
+  return {
+    .actorId = Worker::Actor::Id(kj::mv(actorId)),
+    .useRealTimers = true,
+    .actorLoopback = kj::refcounted<StubLoopback>(stats),
+  };
+}
+
+// Create a HibernationManager. The constructor (and setTimerChannel) don't need an IoContext;
+// production typically constructs the HM inside one only because the trigger — a JS call to
+// state.acceptWebSocket — runs in one. The HM itself is IoContext-independent and this test
+// pattern keeps that explicit so any inadvertent dependency growth shows up.
+kj::Own<Worker::Actor::HibernationManager> makeTestHm(TestFixture& fixture) {
+  auto hm = kj::refcounted<HibernationManagerImpl>(fixture.getActor().getLoopback(), 0);
+  hm->setTimerChannel(fixture.getTimerChannel());
+  return hm;
+}
+
+// Same, but configure auto-response. Both `autoRequest` and `autoResponse` are required.
+kj::Own<Worker::Actor::HibernationManager> makeTestHm(
+    TestFixture& fixture, kj::StringPtr autoRequest, kj::StringPtr autoResponse) {
+  auto hm = makeTestHm(fixture);
+  hm->setWebSocketAutoResponse(autoRequest, autoResponse);
+  return hm;
+}
+
+// Create an api::WebSocket, accept it into the HM under `tag` (or untagged if `tag` is empty),
+// and return the eyeball end of the new pipe. Tests can call this multiple times to attach
+// multiple concurrent WebSockets; pass distinct tags to identify them later via getWebSockets.
+//
+// Needs an IoContext (the api::WebSocket constructor stores IoOwn members), supplied by the
+// IR. Test code should pick an IR whose IoContext should "own" this api::WebSocket.
+kj::Own<kj::WebSocket> acceptNewWebSocket(TestFixture& fixture,
+    IoContext::IncomingRequest& request,
+    Worker::Actor::HibernationManager& hm,
+    kj::StringPtr tag = ""_kj) {
+  kj::Own<kj::WebSocket> eyeball;
+  fixture.enterContext(request, [&](const TestFixture::Environment& env) {
+    auto pipe = kj::newWebSocketPipe();
+    eyeball = kj::mv(pipe.ends[0]);
+    // TODO(bug) EW-10817: leak a ref so the api::WebSocket survives the AsyncObject destructor
+    // issue (resolving EW-10817 will naturally remove the need for this). Tell LSan the leak
+    // is intentional so it doesn't fail tests under sanitizer builds.
+    auto apiWs = env.js.alloc<api::WebSocket>(env.js, kj::mv(pipe.ends[1]));
+    auto* leaked = new jsg::Ref<api::WebSocket>(apiWs.addRef());
+#if KJ_HAS_COMPILER_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+    __lsan_ignore_object(leaked);
+#else
+    (void)leaked;
+#endif
+    auto tags = kj::heapArray<kj::String>(tag.size() == 0 ? 0 : 1);
+    if (tag.size() != 0) tags[0] = kj::str(tag);
+    hm.acceptWebSocket(kj::mv(apiWs), tags);
+  });
+  return eyeball;
+}
+
+// Send a string message from the DO side, on the WebSocket identified by `tag` (or the only
+// untagged one if `tag` is empty). Enters the supplied IR's IoContext for the duration of
+// the send setup; the actual ws.send happens asynchronously after the lock is released.
+void sendFromDo(TestFixture& fixture,
+    IoContext::IncomingRequest& request,
+    Worker::Actor::HibernationManager& hm,
+    kj::StringPtr msg,
+    kj::StringPtr tag = ""_kj) {
+  fixture.enterContext(request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets =
+        hm.getWebSockets(js, tag.size() == 0 ? kj::Maybe<kj::StringPtr>(kj::none) : tag);
+    KJ_ASSERT(
+        websockets.size() == 1, "expected exactly one WebSocket for tag", tag, websockets.size());
+    websockets[0]->send(js, kj::OneOf<kj::Array<kj::byte>, kj::String>(kj::str(msg)));
+  });
+}
+
+KJ_TEST("HibernationManager: smoke (create, accept, query)") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("smoke")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto websockets = hm->getWebSockets(env.js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+  });
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: DO sends string message to eyeball") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("do-send-string")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  sendFromDo(fixture, *request, *hm, "hello"_kj);
+
+  // Drive the pump; the message should arrive at the eyeball end.
+  auto msg = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::String>());
+  KJ_ASSERT(msg.get<kj::String>() == "hello"_kj);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: eyeball sends non-auto-response message → dispatched to worker") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("eyeball-send")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Eyeball sends a message that does NOT match any auto-response config.
+  end1->send("hello from eyeball"_kj).wait(fixture.getWaitScope());
+
+  // Give the HM's readLoop time to receive and dispatch.
+  fixture.pollEventLoop();
+
+  KJ_ASSERT(stats.customEventCalls >= 1, "expected at least one customEvent dispatch",
+      stats.customEventCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: DO close sends close frame to eyeball") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("do-close")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("bye")));
+  });
+
+  // The eyeball should receive a Close message.
+  auto msg = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::WebSocket::Close>());
+  auto& close = msg.get<kj::WebSocket::Close>();
+  KJ_ASSERT(close.code == 1001, close.code);
+  KJ_ASSERT(close.reason == "bye"_kj, close.reason);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: eyeball close dispatches webSocketClose to worker") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("eyeball-close")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Eyeball closes the WS. The HM's readLoop should observe the close and dispatch a
+  // webSocketClose event to the worker via customEvent.
+  end1->close(1001, "eyeball bye"_kj).wait(fixture.getWaitScope());
+
+  fixture.pollEventLoop();
+
+  KJ_ASSERT(stats.customEventCalls >= 1, "expected at least one customEvent dispatch",
+      stats.customEventCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: DO sends binary message to eyeball") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("do-send-bin")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    auto bytes = kj::heapArray<kj::byte>({0xde, 0xad, 0xbe, 0xef});
+    websockets[0]->send(js, kj::OneOf<kj::Array<kj::byte>, kj::String>(kj::mv(bytes)));
+  });
+
+  auto msg = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::Array<kj::byte>>());
+  auto& bytes = msg.get<kj::Array<kj::byte>>();
+  KJ_ASSERT(bytes.size() == 4);
+  KJ_ASSERT(bytes[0] == 0xde && bytes[1] == 0xad && bytes[2] == 0xbe && bytes[3] == 0xef);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: eyeball sends binary message → dispatched to worker") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("eyeball-send-bin")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  auto bytes = kj::heapArray<kj::byte>({0xca, 0xfe, 0xba, 0xbe});
+  end1->send(bytes.asPtr()).wait(fixture.getWaitScope());
+
+  fixture.pollEventLoop();
+  KJ_ASSERT(stats.customEventCalls >= 1, "expected at least one customEvent dispatch",
+      stats.customEventCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: multiple tagged WebSockets are addressable independently") {
+  // Accept two WebSockets under distinct tags. getWebSockets(js, tag) should return only the
+  // matching one; getWebSockets(js, kj::none) returns both. DO-side sends, scoped via tag,
+  // reach only the addressed eyeball.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("multi-ws")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto aliceEnd1 = acceptNewWebSocket(fixture, *request, *hm, "alice"_kj);
+  auto bobEnd1 = acceptNewWebSocket(fixture, *request, *hm, "bob"_kj);
+
+  // The HM tracks both; getWebSockets without a tag returns the union.
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    KJ_ASSERT(hm->getWebSockets(js, kj::none).size() == 2);
+    KJ_ASSERT(hm->getWebSockets(js, "alice"_kj).size() == 1);
+    KJ_ASSERT(hm->getWebSockets(js, "bob"_kj).size() == 1);
+  });
+
+  // DO sends a message addressed to alice; only alice's eyeball gets it.
+  sendFromDo(fixture, *request, *hm, "for-alice"_kj, "alice"_kj);
+  auto msgA = aliceEnd1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msgA.is<kj::String>() && msgA.get<kj::String>() == "for-alice"_kj);
+
+  // Bob should have received nothing yet.
+  auto bobReceive = bobEnd1->receive();
+  fixture.pollEventLoop();
+  KJ_ASSERT(!bobReceive.poll(fixture.getWaitScope()), "bob should not have received anything yet");
+
+  // Now send to bob; the previous receive promise resolves.
+  sendFromDo(fixture, *request, *hm, "for-bob"_kj, "bob"_kj);
+  auto msgB = bobReceive.wait(fixture.getWaitScope());
+  KJ_ASSERT(msgB.is<kj::String>() && msgB.get<kj::String>() == "for-bob"_kj);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: auto-response request not dispatched to worker (active)") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("autoresp-active")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Eyeball sends a message that matches the auto-response request.
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+
+  // The HM should reply with the configured response and NOT dispatch to the worker.
+  auto msg = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::String>());
+  KJ_ASSERT(msg.get<kj::String>() == "pong"_kj);
+
+  // Wait for any potential dispatch (there shouldn't be one).
+  fixture.pollEventLoop();
+  KJ_ASSERT(stats.customEventCalls == 0, "auto-response should not dispatch to worker",
+      stats.customEventCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: auto-response not dispatched to worker (hibernated)") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("autoresp-hibernated")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Hibernate before any messages flow.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  // Eyeball sends a ping. The HM's hibernated-mode readLoop should send pong directly
+  // (bypassing the pump, which has no IoContext during hibernation) and NOT dispatch.
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+  auto msg = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::String>() && msg.get<kj::String>() == "pong"_kj);
+
+  fixture.pollEventLoop();
+  KJ_ASSERT(
+      stats.customEventCalls == 0, "auto-response should not dispatch", stats.customEventCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: auto-response interleaved with DO sends (active)") {
+  // Verifies that, in active mode, auto-response pongs interleaved with DO-side sends all
+  // arrive at the eyeball without tripping the "another message send is already in progress"
+  // assertion. The pump and sendAutoResponse synchronize on ongoingAutoResponse in active
+  // mode; if that synchronization breaks this test will trip the bug class targeted by
+  // EW-10817 — but in active mode it should hold.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("autoresp-interleaved")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  sendFromDo(fixture, *request, *hm, "before"_kj);
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+  sendFromDo(fixture, *request, *hm, "after"_kj);
+
+  // Drain three messages from the eyeball. The order isn't guaranteed; verify the set.
+  bool sawBefore = false, sawPong = false, sawAfter = false;
+  for (int i = 0; i < 3; ++i) {
+    auto msg = end1->receive().wait(fixture.getWaitScope());
+    KJ_ASSERT(msg.is<kj::String>(), "expected string message", i);
+    auto& s = msg.get<kj::String>();
+    if (s == "before"_kj)
+      sawBefore = true;
+    else if (s == "pong"_kj)
+      sawPong = true;
+    else if (s == "after"_kj)
+      sawAfter = true;
+    else
+      KJ_FAIL_ASSERT("unexpected message", s);
+  }
+  KJ_ASSERT(sawBefore && sawPong && sawAfter);
+
+  KJ_ASSERT(stats.customEventCalls == 0, "auto-response should not dispatch to worker",
+      stats.customEventCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: comm across multiple IncomingRequests sharing an IoContext") {
+  // The actor pattern: a single IoContext outlives any one IncomingRequest. The api::WebSocket
+  // is bound to the IoContext (via IoOwn members), not to any specific IR, so it must remain
+  // usable as IRs come and go.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("multi-ir-serial")));
+  auto hm = makeTestHm(fixture);
+  auto context = fixture.newIoContext();
+
+  // Request 1: accept a WS, send a message from the DO side, receive it on the eyeball.
+  // (We must read the message before draining; the pump's send blocks on a reader.)
+  auto request1 = fixture.newIncomingRequest(*context);
+  auto end1 = acceptNewWebSocket(fixture, *request1, *hm);
+  sendFromDo(fixture, *request1, *hm, "from-r1"_kj);
+  auto msg1 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg1.is<kj::String>());
+  KJ_ASSERT(msg1.get<kj::String>() == "from-r1"_kj);
+  fixture.drainAndDestroy(kj::mv(request1));
+
+  // Request 2: same IoContext, same WS; send another message and receive it.
+  auto request2 = fixture.newIncomingRequest(*context);
+  sendFromDo(fixture, *request2, *hm, "from-r2"_kj);
+  auto msg2 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg2.is<kj::String>());
+  KJ_ASSERT(msg2.get<kj::String>() == "from-r2"_kj);
+  fixture.drainAndDestroy(kj::mv(request2));
+}
+
+KJ_TEST("HibernationManager: two concurrent IncomingRequests sharing an IoContext") {
+  // Two IncomingRequests delivered against the same IoContext, with overlapping lifetimes.
+  // This is a real production pattern: e.g. a chat-room DO might be handling a message from
+  // one user (one IR) and concurrently fan it out to another user, where the fan-out is
+  // structured as a second IR against the same actor. The IoContext model accommodates this
+  // — the second's delivered() just makes the first non-current — and work routed via either
+  // IR's enterContext lands on the single shared IoContext correctly.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("multi-ir-parallel")));
+  auto hm = makeTestHm(fixture);
+  auto context = fixture.newIoContext();
+
+  auto request1 = fixture.newIncomingRequest(*context);
+  auto end1 = acceptNewWebSocket(fixture, *request1, *hm);
+  auto request2 = fixture.newIncomingRequest(*context);  // IR1 still alive at this point.
+
+  // Send via IR1; the IoContext is shared, so this works even though IR2 is "current".
+  sendFromDo(fixture, *request1, *hm, "from-r1"_kj);
+  auto msg1 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg1.is<kj::String>() && msg1.get<kj::String>() == "from-r1"_kj);
+
+  // Send via IR2.
+  sendFromDo(fixture, *request2, *hm, "from-r2"_kj);
+  auto msg2 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg2.is<kj::String>() && msg2.get<kj::String>() == "from-r2"_kj);
+
+  // Destroy the older IR first; IR2 keeps working.
+  fixture.drainAndDestroy(kj::mv(request1));
+  sendFromDo(fixture, *request2, *hm, "from-r2-again"_kj);
+  auto msg3 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg3.is<kj::String>() && msg3.get<kj::String>() == "from-r2-again"_kj);
+
+  fixture.drainAndDestroy(kj::mv(request2));
+}
+
+// ---------- Same-IoContext hibernation flows ----------
+
+KJ_TEST("HibernationManager: comm survives hibernation/revival within one IoContext") {
+  // The classic hibernation flow: the HM's activeOrPackage transitions from
+  // jsg::Ref<api::WebSocket> to HibernationPackage, then a fresh api::WebSocket is
+  // materialized on demand by getWebSockets(). This works as long as no message is
+  // in-flight on the pipe at the moment hibernation runs (the in-flight cases are tested
+  // separately below).
+  //
+  // This test stays within a single IoContext. See the cross-IoContext variant further down
+  // for the production-style flow where the actor is also evicted and recreated.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("hibernate-survive")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Round-trip a message, fully drained, before hibernation.
+  sendFromDo(fixture, *request, *hm, "before-hib"_kj);
+  auto msg1 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg1.is<kj::String>() && msg1.get<kj::String>() == "before-hib"_kj);
+
+  // Hibernate. Replaces the active api::WebSocket on the HM with a HibernationPackage.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  // After hibernation, getWebSockets should rebuild a fresh api::WebSocket from the package.
+  sendFromDo(fixture, *request, *hm, "after-hib"_kj);
+  auto msg2 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg2.is<kj::String>() && msg2.get<kj::String>() == "after-hib"_kj);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: in-flight DO close survives hibernation within one IoContext") {
+  // The DO calls close() while the eyeball isn't reading; the pump queues the Close into
+  // outgoingMessages and blocks on a BlockedSend on the pipe. Hibernation runs. Verify that
+  // when the eyeball reads, it gets the Close.
+  //
+  // Mechanism: the OLD api::WebSocket is dropped from activeOrPackage during hibernation, but
+  // its pump task lives on (held alive via JSG_THIS in the pump's continuation, which is in
+  // the IoContext's tasks/waitUntilTasks list). The old pump's blocked ws.close(...) is still
+  // waiting on the pipe; once the eyeball reads, it delivers the Close. The Close is NOT
+  // dropped within a single IoContext — IoContext destruction is what loses it.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("close-race-same-ioc")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("queued-close")));
+  });
+  fixture.pollEventLoop();  // pump blocks on the close BlockedSend
+
+  // Hibernate while the close is mid-send. activeOrPackage transitions; but we leave the
+  // IoContext alive (don't drainAndDestroy yet), so the OLD pump task keeps running.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  // Eyeball reads — should receive the Close that was queued before hibernation.
+  auto msg = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::WebSocket::Close>(), "expected Close");
+  auto& close = msg.get<kj::WebSocket::Close>();
+  KJ_ASSERT(close.code == 1001, close.code);
+  KJ_ASSERT(close.reason == "queued-close"_kj, close.reason);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: in-flight auto-response orphans BlockedSend during hibernation") {
+  // Regression test for EW-10817. sendAutoResponse creates a BlockedSend on the pipe (held in
+  // a plain kj::Own outside any IoOwn — see web-socket.c++:874), then hibernation replaces
+  // activeOrPackage without carrying that state. The new api::WebSocket's pump skips the wait
+  // and trips on the orphaned BlockedSend.
+  //
+  // The KJ_EXPECT_LOG below captures the bug's symptom (the assertion's ERROR log) so the
+  // test passes while EW-10817 is open. When the bug is fixed, the log won't fire and the
+  // KJ_EXPECT_LOG will fail — that's the signal to update this test (delete the EXPECT_LOG,
+  // delete the workaround end1->receive() drain at the end, and add positive assertions about
+  // what should happen instead).
+  KJ_EXPECT_LOG(ERROR, "another message send is already in progress");
+
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("ew-10817-autoresp")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Send ping → readLoop → sendAutoResponse → BlockedSend.
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+
+  // Hibernate.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  // Unhibernate + close → hits orphaned BlockedSend.
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("stale")));
+  });
+
+  fixture.pollEventLoop();
+
+  // Drain end1 to consume the orphaned pong (held outside any IoOwn — the very thing this
+  // test is documenting). Without this, the kj event loop fails its "no events left"
+  // assertion at teardown. Once EW-10817 is fixed, the orphan won't exist; this drain becomes
+  // unnecessary and the test will need updating.
+  end1->receive().wait(fixture.getWaitScope());
+}
+
+KJ_TEST("HibernationManager: in-flight DO send orphans BlockedSend during hibernation") {
+  // Regression test for EW-10817. Same shape as the auto-response variant above but driven by
+  // a DO-side ws.send() — the pump creates a BlockedSend on the pipe (no BPT yet), hibernation
+  // orphans it, the next operation on the new api::WebSocket trips the assertion. See the
+  // auto-response variant above for the EXPECT_LOG / lifecycle details.
+  //
+  // The pump task is in waitUntilTasks (actors route addTask there) and it's stuck on the
+  // BlockedSend; the IR's destructor at the end of the test logs a "failed to invoke drain()"
+  // warning that we capture here so the test output stays clean.
+  KJ_EXPECT_LOG(ERROR, "another message send is already in progress");
+  KJ_EXPECT_LOG(WARNING, "failed to invoke drain() on IncomingRequest before destroying it");
+
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("ew-10817-dosend")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+
+  sendFromDo(fixture, *request, *hm, "hello from DO"_kj);
+
+  fixture.pollEventLoop();
+
+  // Hibernate.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  // Unhibernate + close → hits orphaned BlockedSend.
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("stale")));
+  });
+
+  fixture.pollEventLoop();
+}
+
+// ---------- Cross-IoContext hibernation flows (with actor eviction) ----------
+
+KJ_TEST("HibernationManager: comm survives hibernation + actor eviction (cross-IoContext)") {
+  // Production-style hibernation: the actor is fully evicted and a new one is created on
+  // revival. The HM outlives any actor instance (in production, the namespace pulls the HM
+  // off the dying actor; in this test, the test holds it directly). After eviction, a brand
+  // new IoContext is built against the new actor, and the HM revives the WebSocket into it.
+  //
+  // This test exercises the no-in-flight-state cross-IoContext path: it round-trips a message
+  // before hibernating, so there's no pending BlockedSend on the pipe to orphan. It passes
+  // both before and after EW-10817 is fixed; its job is to ensure the unified-queue refactor
+  // doesn't break the basic eviction-and-revive flow. The actual bug-firing cross-IoContext
+  // case is the auto-response variant below.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("hibernate-evict")));
+  auto hm = makeTestHm(fixture);
+
+  // Phase 1: accept WS under the original actor's IoContext, round-trip a message.
+  auto request1 = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request1, *hm);
+  sendFromDo(fixture, *request1, *hm, "pre-evict"_kj);
+  auto msg1 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg1.is<kj::String>() && msg1.get<kj::String>() == "pre-evict"_kj);
+
+  // Hibernate, drain the IR, evict the actor.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+  fixture.drainAndDestroy(kj::mv(request1));
+  fixture.resetActor();
+
+  // Phase 2: a brand new actor + IoContext. The HM (held by the test) is unchanged.
+  auto request2 = fixture.newIncomingRequest();
+  sendFromDo(fixture, *request2, *hm, "post-evict"_kj);
+  auto msg2 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg2.is<kj::String>() && msg2.get<kj::String>() == "post-evict"_kj);
+
+  fixture.drainAndDestroy(kj::mv(request2));
+}
+
+KJ_TEST("HibernationManager: in-flight DO close lost across IoContext destruction") {
+  // Cross-IoContext variant of the in-flight-close test above: same setup, but we drop the
+  // IR (destroying the IoContext) before the eyeball reads. The IoContext destruction
+  // cancels the pump task, which cancels the in-flight ws.close(), cleaning up the
+  // BlockedSend. The Close is silently lost — the eyeball never sees a clean WebSocket close.
+  //
+  // This is the close-race version of the silent-message-drop bug. WebSockets are supposed
+  // to be reliable; losing close frames is its own bug class. The unified-queue refactor's
+  // design (queue lives on the adapter, persists across IoContexts) addresses this
+  // incidentally — the close stays queued until actually delivered.
+  //
+  // The IR's destructor below logs a "failed to invoke drain()" warning because we drop it
+  // without draining (the pump task is stuck in waitUntilTasks; drain() would hang). Capture
+  // the warning so the test passes cleanly.
+  KJ_EXPECT_LOG(WARNING, "failed to invoke drain() on IncomingRequest before destroying it");
+
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("close-race-cross-ioc")));
+  auto hm = makeTestHm(fixture);
+  auto request1 = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request1, *hm);
+
+  fixture.enterContext(*request1, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("doomed-close")));
+  });
+  fixture.pollEventLoop();
+
+  // Hibernate, then drop the IR (destroying the IoContext). The pump's in-flight ws.close()
+  // is canceled.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+  request1 = nullptr;
+  fixture.resetActor();
+
+  // The eyeball's receive promise should NOT resolve to a Close — the close was canceled
+  // mid-send. Verify by polling: receive should not be ready immediately. (We can't easily
+  // assert "never resolves" in a test, so we observe the not-yet-ready state and move on.)
+  auto receivePromise = end1->receive();
+  fixture.pollEventLoop();
+  KJ_ASSERT(!receivePromise.poll(fixture.getWaitScope()),
+      "close was silently dropped across IoContext destruction; eyeball receives nothing");
+
+  // The new api::WebSocket has closedOutgoing=true (from the package), so the DO can't
+  // re-issue the close even if it wanted to. The eyeball is stuck.
+}
+
+KJ_TEST("HibernationManager: in-flight auto-response orphans BlockedSend across actor eviction") {
+  // Regression test for EW-10817 — the production failure mode. sendAutoResponse runs from
+  // the HM's readLoop (on the HM's TaskSet, NOT in an IoContext). It does a direct
+  // kj::WebSocket::send that creates a BlockedSend on the pipe. IoContext destruction cancels
+  // pump tasks but not sendAutoResponse, so the BlockedSend survives the IoContext's death.
+  // After actor eviction and revival, the new api::WebSocket's pump trips on the orphan. See
+  // the same-IoContext auto-response variant above for the EXPECT_LOG / lifecycle details.
+  KJ_EXPECT_LOG(ERROR, "another message send is already in progress");
+
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("ew-10817-cross-autoresp")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+
+  auto request1 = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request1, *hm);
+
+  // Eyeball sends ping → HM readLoop → sendAutoResponse → BlockedSend on the pipe.
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+
+  // Hibernate, drop the IR (IoContext1 is destroyed; the BlockedSend survives because
+  // sendAutoResponse runs outside any IoContext). Then evict the actor.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+  request1 = nullptr;
+  fixture.resetActor();
+
+  // Phase 3: under a brand-new actor + IoContext, do something that starts a fresh pump.
+  // The new pump trips on the orphaned BlockedSend.
+  auto request2 = fixture.newIncomingRequest();
+  fixture.enterContext(*request2, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("post-evict")));
+  });
+  fixture.pollEventLoop();
+
+  // Drain end1 to consume the orphaned pong (see same-IoContext variant above for why).
+  end1->receive().wait(fixture.getWaitScope());
+}
+
+KJ_TEST("HibernationManager: DO send waits for the actor's output gate") {
+  // The pump calls IoContext::waitForOutputLocksIfNecessary() before each kj::WebSocket::send.
+  // Locking the actor's OutputGate should hold a DO-side message until the gate releases.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("output-gate-do-send")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Lock the output gate. `blocker` is the wrapped promise; keep it in scope until we've
+  // either fulfilled the underlying promise or are otherwise done.
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
+
+  // DO sends a message. The pump should block on the gate.
+  sendFromDo(fixture, *request, *hm, "gated"_kj);
+
+  // Set up the eyeball's receive promise without waiting.
+  auto receivePromise = end1->receive();
+
+  // Drive the loop; receivePromise should NOT be ready (gate still locked).
+  fixture.pollEventLoop();
+  KJ_ASSERT(!receivePromise.poll(fixture.getWaitScope()),
+      "message should not have arrived while output gate is locked");
+
+  // Release the gate. The pump should now flush the message.
+  paf.fulfiller->fulfill();
+  auto msg = receivePromise.wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::String>() && msg.get<kj::String>() == "gated"_kj);
+
+  // blocker must outlive the gate-locking promise; let it die naturally at end of scope.
+  blocker.wait(fixture.getWaitScope());
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: DO close waits for the actor's output gate") {
+  // Like the DO-send-waits-for-gate test, but for close. close() goes through the same pump
+  // (it inserts a Close GatedMessage into outgoingMessages with the current output lock), so
+  // it must wait for the gate to release before the close frame reaches the eyeball.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("output-gate-do-close")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("gated-bye")));
+  });
+
+  auto receivePromise = end1->receive();
+  fixture.pollEventLoop();
+  KJ_ASSERT(!receivePromise.poll(fixture.getWaitScope()),
+      "close should not have arrived while output gate is locked");
+
+  paf.fulfiller->fulfill();
+  auto msg = receivePromise.wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::WebSocket::Close>());
+  auto& close = msg.get<kj::WebSocket::Close>();
+  KJ_ASSERT(close.code == 1001, close.code);
+  KJ_ASSERT(close.reason == "gated-bye"_kj, close.reason);
+
+  blocker.wait(fixture.getWaitScope());
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: auto-response (active) waits when pump is gate-blocked on a DO send") {
+  // When the pump is already running (isPumping == true) and stalled on the output gate for a
+  // queued DO message, an arriving auto-response request causes sendAutoResponse to push the
+  // pong onto pendingAutoResponseDeque. The pump only drains that deque after it finishes the
+  // outer outgoingMessages loop, so the pong waits for the gate to release transitively.
+  //
+  // Order at the eyeball: the gated DO message arrives first (after the gate releases), and
+  // the pong follows immediately after (line 998 in web-socket.c++).
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("output-gate-autoresp-gated")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
+
+  // DO sends "msg1" — pump starts, blocks on gate.
+  sendFromDo(fixture, *request, *hm, "msg1"_kj);
+
+  // Eyeball sends ping. sendAutoResponse sees isPumping=true and queues "pong".
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+
+  // Neither msg1 nor pong has arrived yet.
+  auto receivePromise = end1->receive();
+  fixture.pollEventLoop();
+  KJ_ASSERT(!receivePromise.poll(fixture.getWaitScope()),
+      "msg1 should not have arrived while output gate is locked");
+
+  // Release the gate. msg1 flushes, then pong follows.
+  paf.fulfiller->fulfill();
+  auto msg1 = receivePromise.wait(fixture.getWaitScope());
+  KJ_ASSERT(msg1.is<kj::String>() && msg1.get<kj::String>() == "msg1"_kj);
+  auto msg2 = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg2.is<kj::String>() && msg2.get<kj::String>() == "pong"_kj);
+
+  blocker.wait(fixture.getWaitScope());
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: auto-response (active) bypasses the output gate") {
+  // Documents CURRENT behavior: in active mode, sendAutoResponse uses a direct kj::WebSocket::send
+  // that doesn't go through the pump, and therefore doesn't check waitForOutputLocksIfNecessary.
+  // The unified-queue refactor planned for EW-10817 should change this so auto-response respects
+  // the output gate in active mode; flip this assertion when that lands.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("output-gate-autoresp-active")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
+
+  // Eyeball sends ping; auto-response should send pong despite the gate being locked.
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+  auto msg = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::String>() && msg.get<kj::String>() == "pong"_kj);
+
+  paf.fulfiller->fulfill();
+  blocker.wait(fixture.getWaitScope());
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: auto-response (hibernated) bypasses the output gate") {
+  // Documents CURRENT behavior. The hibernated-mode readLoop sends the pong directly on the
+  // kj::WebSocket without an IoContext, so the actor's output gate never enters the picture
+  // (and couldn't be checked anyway, since waitForOutputLocksIfNecessary needs an IoContext).
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("output-gate-autoresp-hib")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
+
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+  auto msg = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(msg.is<kj::String>() && msg.get<kj::String>() == "pong"_kj);
+
+  paf.fulfiller->fulfill();
+  blocker.wait(fixture.getWaitScope());
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -285,7 +285,8 @@ struct MockResponse final: public kj::HttpService::Response {
 class MockActorLoopback: public Worker::Actor::Loopback, public kj::Refcounted {
  public:
   kj::Own<WorkerInterface> getWorker(IoChannelFactory::SubrequestMetadata metadata) override {
-    return kj::Own<WorkerInterface>();
+    return WorkerInterface::fromException(
+        KJ_EXCEPTION(FAILED, "MockActorLoopback::getWorker() not available in test fixture"));
   };
 
   kj::Own<Worker::Actor::Loopback> addRef() override {
@@ -369,22 +370,46 @@ TestFixture::TestFixture(SetupParams&& params)
       headerTable(headerTableBuilder.build()),
       ioChannelFactory(kj::mv(params.ioChannelFactory)) {
   KJ_IF_SOME(id, params.actorId) {
-    auto makeActorCache = [](const ActorCache::SharedLru& sharedLru, OutputGate& outputGate,
-                              ActorCache::Hooks& hooks, SqliteObserver& sqliteObserver) {
-      return kj::heap<ActorCache>(
-          server::newEmptyReadOnlyActorStorage(), sharedLru, outputGate, hooks);
-    };
-    auto makeStorage = [](jsg::Lock& js, const Worker::Api& api,
-                           ActorCacheInterface& actorCache) -> jsg::Ref<api::DurableObjectStorage> {
-      return js.alloc<api::DurableObjectStorage>(
-          js, IoContext::current().addObject(actorCache), /*enableSql=*/false);
-    };
-    actor = kj::refcounted<Worker::Actor>(*worker, /*tracker=*/kj::none, kj::mv(id),
-        /*hasTransient=*/false, makeActorCache,
-        /*classname=*/kj::none, /*props=*/Frankenvalue(), makeStorage,
-        kj::refcounted<MockActorLoopback>(), *timerChannel, kj::refcounted<ActorObserver>(),
-        kj::none, kj::none);
+    KJ_IF_SOME(provided, params.actorLoopback) {
+      savedActorLoopback = kj::mv(provided);
+    } else {
+      savedActorLoopback = kj::refcounted<MockActorLoopback>();
+    }
+    actor = makeActor(kj::mv(id));
   }
+}
+
+namespace {
+
+// Factory functions used by TestFixture's actor construction; passed by name (decay to
+// function pointers) into kj::Function-typed parameters.
+kj::Maybe<kj::Own<ActorCacheInterface>> actorCacheFactory(const ActorCache::SharedLru& sharedLru,
+    OutputGate& outputGate,
+    ActorCache::Hooks& hooks,
+    SqliteObserver& sqliteObserver) {
+  return kj::heap<ActorCache>(server::newEmptyReadOnlyActorStorage(), sharedLru, outputGate, hooks);
+}
+
+jsg::Ref<api::DurableObjectStorage> storageFactory(
+    jsg::Lock& js, const Worker::Api& api, ActorCacheInterface& actorCache) {
+  return js.alloc<api::DurableObjectStorage>(
+      js, IoContext::current().addObject(actorCache), /*enableSql=*/false);
+}
+
+}  // namespace
+
+kj::Own<Worker::Actor> TestFixture::makeActor(Worker::Actor::Id id) {
+  auto& loopback = KJ_ASSERT_NONNULL(savedActorLoopback);
+  return kj::refcounted<Worker::Actor>(*worker, /*tracker=*/kj::none, kj::mv(id),
+      /*hasTransient=*/false, actorCacheFactory, /*classname=*/kj::none,
+      /*props=*/Frankenvalue(), storageFactory, loopback->addRef(), *timerChannel,
+      kj::refcounted<ActorObserver>(), kj::none, kj::none);
+}
+
+void TestFixture::resetActor() {
+  auto id = KJ_ASSERT_NONNULL(actor)->cloneId();
+  actor = kj::none;  // Drop the old Actor (and its OutputGate / InputGate / ActorCache).
+  actor = makeActor(kj::mv(id));
 }
 
 void TestFixture::runInIoContext(kj::Function<kj::Promise<void>(const Environment&)>&& callback,
@@ -418,16 +443,24 @@ void TestFixture::runInIoContext(kj::Function<kj::Promise<void>(const Environmen
   }
 }
 
-kj::Own<IoContext::IncomingRequest> TestFixture::createIncomingRequest() {
-  auto context = kj::refcounted<IoContext>(
+kj::Own<IoContext> TestFixture::newIoContext() {
+  return kj::refcounted<IoContext>(
       threadContext, kj::atomicAddRef(*worker), actor, kj::heap<MockLimitEnforcer>());
+}
+
+kj::Own<IoContext::IncomingRequest> TestFixture::newIncomingRequest() {
+  auto context = newIoContext();
+  return newIncomingRequest(*context);
+}
+
+kj::Own<IoContext::IncomingRequest> TestFixture::newIncomingRequest(IoContext& context) {
   kj::Own<IoChannelFactory> channelFactory;
   KJ_IF_SOME(factory, ioChannelFactory) {
     channelFactory = factory(*timerChannel);
   } else {
     channelFactory = kj::heap<DummyIoChannelFactory>(*timerChannel);
   }
-  auto incomingRequest = kj::heap<IoContext::IncomingRequest>(kj::addRef(*context),
+  auto incomingRequest = kj::heap<IoContext::IncomingRequest>(kj::addRef(context),
       kj::mv(channelFactory), kj::refcounted<RequestObserver>(), kj::none, kj::none);
   incomingRequest->delivered();
   return incomingRequest;

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -32,6 +32,12 @@ struct TestFixture {
     // If set, used instead of the default DummyIoChannelFactory when creating incoming requests.
     // The factory receives the TimerChannel reference.
     kj::Maybe<kj::Function<kj::Own<IoChannelFactory>(TimerChannel&)>> ioChannelFactory;
+    // If set, used as the actor's Loopback (only meaningful when actorId is set). Defaults to a
+    // MockActorLoopback that throws on getWorker(). Tests that need to intercept hibernation
+    // event dispatch can supply a custom Loopback here, then later retrieve it (or a fresh ref
+    // to it) via actor.getLoopback(). This way the actor and the HibernationManager share a
+    // single Loopback, mirroring production.
+    kj::Maybe<kj::Own<Worker::Actor::Loopback>> actorLoopback;
   };
 
   TestFixture(SetupParams&& params = {.useRealTimers = false});
@@ -63,7 +69,7 @@ struct TestFixture {
   template <typename CallBack>
   auto runInIoContext(CallBack&& callback)
       -> RunReturnType<decltype(callback(kj::instance<const Environment&>()))>::Type {
-    auto request = createIncomingRequest();
+    auto request = newIncomingRequest();
     kj::WaitScope* waitScope;
     KJ_IF_SOME(ws, this->waitScope) {
       waitScope = &ws;
@@ -94,6 +100,102 @@ struct TestFixture {
   // Performs HTTP request on the default module handler, and waits for full response.
   Response runRequest(kj::HttpMethod method, kj::StringPtr url, kj::StringPtr body);
 
+  // Create a new IoContext, owned by the caller. Use this when you need an IoContext that
+  // outlives a single IncomingRequest, e.g. to model an actor receiving multiple requests.
+  kj::Own<IoContext> newIoContext();
+
+  // Create a new IncomingRequest bound to a fresh IoContext. The caller owns the returned object;
+  // when it's destroyed the IoContext is also destroyed (assuming no other references). Use
+  // enterContext() to run code within this context.
+  kj::Own<IoContext::IncomingRequest> newIncomingRequest();
+
+  // Create a new IncomingRequest bound to an existing IoContext. Use this to model multiple
+  // IncomingRequests against the same actor (and hence the same IoContext). The IoContext must
+  // outlive the returned IncomingRequest.
+  kj::Own<IoContext::IncomingRequest> newIncomingRequest(IoContext& context);
+
+  // Enter an IoContext. Callback receives Environment& and must return void (NOT a
+  // Promise — the Worker::Lock is only valid for the synchronous duration of the
+  // callback). The context is NOT destroyed afterwards — the caller still owns the
+  // IncomingRequest.
+  template <typename CallBack>
+  void enterContext(IoContext::IncomingRequest& request, CallBack&& callback) {
+    auto& context = request.getContext();
+    context
+        .run([&](Worker::Lock& lock) {
+      auto& js = jsg::Lock::from(lock.getIsolate());
+      Environment env = {{.isolate = lock.getIsolate()}, context, lock, js};
+      callback(env);
+    }).wait(getWaitScope());
+  }
+
+  // Acquire a Worker::Lock without an IoContext. Useful for operations that need
+  // the V8 isolate lock but not a request context (e.g., hibernateWebSockets).
+  template <typename CallBack>
+  void enterWorkerLock(CallBack&& callback) {
+    auto asyncLock = worker->takeAsyncLockWithoutRequest(nullptr).wait(getWaitScope());
+    worker->runInLockScope(asyncLock, [&](Worker::Lock& lock) { callback(lock); });
+  }
+
+  kj::WaitScope& getWaitScope() {
+    KJ_IF_SOME(ws, waitScope) {
+      return ws;
+    } else {
+      return KJ_REQUIRE_NONNULL(io).waitScope;
+    }
+  }
+
+  // Drive the event loop for a duration. Useful when test progress depends on a real timer
+  // firing. For tests that just need pending work to run, prefer pollEventLoop() — it's
+  // deterministic and faster.
+  void pumpEventLoop(kj::Duration duration) {
+    KJ_REQUIRE_NONNULL(io).provider->getTimer().afterDelay(duration).wait(getWaitScope());
+  }
+
+  // Run any work pending on the event loop until idle (no blocking). Returns the number of
+  // events processed. Use this to deterministically drive background tasks (e.g. HM's
+  // readLoop) to a stable point.
+  uint pollEventLoop() {
+    return getWaitScope().poll();
+  }
+
+  // Drain an IncomingRequest (waiting on its waitUntil tasks) and then destroy it. Tests should
+  // use this rather than letting the IncomingRequest's Own go out of scope, otherwise the
+  // IncomingRequest destructor logs a warning about un-drained waitUntil tasks. Production code
+  // paths always drain.
+  //
+  // For actor IncomingRequests, drain() returns when all waitUntil tasks are empty, the actor is
+  // shut down, or a new IncomingRequest takes over. In tests the second is unlikely so we mostly
+  // rely on the first.
+  void drainAndDestroy(kj::Own<IoContext::IncomingRequest> request) {
+    auto drained = request->drain();
+    drained.wait(getWaitScope());
+  }
+
+  // Accessors for tests that want to construct objects (e.g. HibernationManagerImpl) outside any
+  // IoContext, to keep their construction paths free of ambient state. Production usually
+  // constructs such objects lazily inside an IoContext just because the trigger (a JS handler)
+  // happens to run there, but the constructors themselves don't need one.
+  Worker::Actor& getActor() {
+    return *KJ_ASSERT_NONNULL(actor);
+  }
+  TimerChannel& getTimerChannel() {
+    return *timerChannel;
+  }
+
+  // Destroy the current Worker::Actor and construct a fresh one with the same id and Loopback.
+  // Useful for simulating actor eviction: after this call, getActor() returns a different Actor
+  // with a fresh InputGate / OutputGate, so a new IoContext can be constructed against it. The
+  // previous IoContext (and any IncomingRequests still tied to it) MUST be torn down via
+  // drainAndDestroy before calling this; otherwise the old IoContext's non-owning Actor reference
+  // becomes dangling.
+  //
+  // Production has the actor's owning namespace pull the HibernationManager off the dying actor
+  // and pass it to the new actor's constructor (see Server's actor namespace handling). Tests
+  // here typically hold the HM directly and don't need to plumb it through the actor — the HM
+  // outlives the actor by virtue of the test holding it.
+  void resetActor();
+
  private:
   kj::Maybe<kj::WaitScope&> waitScope;
   capnp::MallocMessageBuilder configArena;
@@ -104,6 +206,10 @@ struct TestFixture {
   kj::Own<TimerChannel> timerChannel;
   kj::Own<kj::EntropySource> entropySource;
   kj::Maybe<kj::Own<Worker::Actor>> actor;
+  // Saved so resetActor() can construct a new actor with the same Loopback (mirroring production,
+  // where the namespace's Loopback outlives any single actor instance). Held via addRef so we
+  // can hand fresh refs to actors as we reconstruct them.
+  kj::Maybe<kj::Own<Worker::Actor::Loopback>> savedActorLoopback;
   capnp::ByteStreamFactory byteStreamFactory;
   kj::HttpHeaderTable::Builder headerTableBuilder;
   ThreadContext::HeaderIdBundle threadContextHeaderBundle;
@@ -121,7 +227,8 @@ struct TestFixture {
   kj::Own<kj::HttpHeaderTable> headerTable;
   kj::Maybe<kj::Function<kj::Own<IoChannelFactory>(TimerChannel&)>> ioChannelFactory;
 
-  kj::Own<IoContext::IncomingRequest> createIncomingRequest();
+  // Construct a fresh Worker::Actor with the given id, using the saved Loopback.
+  kj::Own<Worker::Actor> makeActor(Worker::Actor::Id id);
 
  public:
   // Default IoChannelFactory used by tests. Exposed so tests can subclass it


### PR DESCRIPTION
Owned text-or-binary message wrapper (and a non-owning Ptr counterpart) for the WebSocket auto-response and outgoing-message paths. Wraps `kj::OneOf<kj::String, kj::Array<byte>>` (and the pointer-shaped equivalent) with a domain-named, read-only inspection surface — `isText` / `isBinary` / `tryGetText` / `tryGetBinary` — plus `size()`, `sendVia(kj::WebSocket&)`, `asPtr()` / `toOwned()`, `asOneOf()` for KJ_SWITCH_ONEOF dispatch, and `operator==(kj::StringPtr)` / `operator==(kj::ArrayPtr<const byte>)` for content-equality checks at matching sites.

Inspection on `WebSocketDataMessage` delegates through a temporary `WebSocketDataMessagePtr`, so `KJ_SWITCH_ONEOF(msg.asOneOf())` cases bind to `kj::StringPtr` / `kj::ArrayPtr<const byte>` (not the owned types), and `tryGetText/Binary` return `Maybe<StringPtr/ArrayPtr<const byte>>`. This makes inspection implicitly read-only (no path to obtain a mutable reference into the owned storage) and hides the storage type from callers — owned-vs-borrowed is now purely a lifetime distinction.

This pattern — text-or-binary WebSocket payloads, never control frames — recurs across the codebase, and dealing with the equivalent `kj::OneOf` at every consuming site is awkward. The helper consolidates it into a single typed wrapper.

Assisted-by: OpenCode:claude-opus-4.7