### PR TITLE
Add RFC 9440 mTLS fields to `IncomingRequestCfPropertiesTLSClientAuth`

### DIFF
--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -763,6 +763,32 @@ interface IncomingRequestCfPropertiesTLSClientAuth {
    * @example "Dec 22 19:39:00 2018 GMT"
    */
   certNotAfter: string;
+  /**
+   * The client leaf certificate in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format (`:base64-DER:`). Empty if no client certificate was presented or if
+   * the leaf certificate exceeded 10 KB (see {@link certRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert` HTTP header.
+   */
+  certRFC9440: string;
+  /**
+   * `true` if the leaf certificate exceeded 10 KB and was omitted from
+   * {@link certRFC9440}.
+   */
+  certRFC9440TooLarge: boolean;
+  /**
+   * The intermediate certificate chain in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format as a comma-separated list. Empty if no intermediates were sent or
+   * if the chain exceeded 16 KB (see {@link certChainRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert-Chain` HTTP header.
+   */
+  certChainRFC9440: string;
+  /**
+   * `true` if the intermediate chain exceeded 16 KB and was omitted from
+   * {@link certChainRFC9440}.
+   */
+  certChainRFC9440TooLarge: boolean;
 }
 
 /** Placeholder values for TLS Client Authorization */
@@ -784,6 +810,10 @@ interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
   certFingerprintSHA256: "";
   certNotBefore: "";
   certNotAfter: "";
+  certRFC9440: "";
+  certRFC9440TooLarge: false;
+  certChainRFC9440: "";
+  certChainRFC9440TooLarge: false;
 }
 
 /** Possible outcomes of TLS verification */

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -12835,6 +12835,32 @@ interface IncomingRequestCfPropertiesTLSClientAuth {
    * @example "Dec 22 19:39:00 2018 GMT"
    */
   certNotAfter: string;
+  /**
+   * The client leaf certificate in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format (`:base64-DER:`). Empty if no client certificate was presented or if
+   * the leaf certificate exceeded 10 KB (see {@link certRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert` HTTP header.
+   */
+  certRFC9440: string;
+  /**
+   * `true` if the leaf certificate exceeded 10 KB and was omitted from
+   * {@link certRFC9440}.
+   */
+  certRFC9440TooLarge: boolean;
+  /**
+   * The intermediate certificate chain in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format as a comma-separated list. Empty if no intermediates were sent or
+   * if the chain exceeded 16 KB (see {@link certChainRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert-Chain` HTTP header.
+   */
+  certChainRFC9440: string;
+  /**
+   * `true` if the intermediate chain exceeded 16 KB and was omitted from
+   * {@link certChainRFC9440}.
+   */
+  certChainRFC9440TooLarge: boolean;
 }
 /** Placeholder values for TLS Client Authorization */
 interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
@@ -12855,6 +12881,10 @@ interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
   certFingerprintSHA256: "";
   certNotBefore: "";
   certNotAfter: "";
+  certRFC9440: "";
+  certRFC9440TooLarge: false;
+  certChainRFC9440: "";
+  certChainRFC9440TooLarge: false;
 }
 /** Possible outcomes of TLS verification */
 declare type CertVerificationStatus =

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -12852,6 +12852,32 @@ export interface IncomingRequestCfPropertiesTLSClientAuth {
    * @example "Dec 22 19:39:00 2018 GMT"
    */
   certNotAfter: string;
+  /**
+   * The client leaf certificate in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format (`:base64-DER:`). Empty if no client certificate was presented or if
+   * the leaf certificate exceeded 10 KB (see {@link certRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert` HTTP header.
+   */
+  certRFC9440: string;
+  /**
+   * `true` if the leaf certificate exceeded 10 KB and was omitted from
+   * {@link certRFC9440}.
+   */
+  certRFC9440TooLarge: boolean;
+  /**
+   * The intermediate certificate chain in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format as a comma-separated list. Empty if no intermediates were sent or
+   * if the chain exceeded 16 KB (see {@link certChainRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert-Chain` HTTP header.
+   */
+  certChainRFC9440: string;
+  /**
+   * `true` if the intermediate chain exceeded 16 KB and was omitted from
+   * {@link certChainRFC9440}.
+   */
+  certChainRFC9440TooLarge: boolean;
 }
 /** Placeholder values for TLS Client Authorization */
 export interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
@@ -12872,6 +12898,10 @@ export interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
   certFingerprintSHA256: "";
   certNotBefore: "";
   certNotAfter: "";
+  certRFC9440: "";
+  certRFC9440TooLarge: false;
+  certChainRFC9440: "";
+  certChainRFC9440TooLarge: false;
 }
 /** Possible outcomes of TLS verification */
 export declare type CertVerificationStatus =

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12167,6 +12167,32 @@ interface IncomingRequestCfPropertiesTLSClientAuth {
    * @example "Dec 22 19:39:00 2018 GMT"
    */
   certNotAfter: string;
+  /**
+   * The client leaf certificate in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format (`:base64-DER:`). Empty if no client certificate was presented or if
+   * the leaf certificate exceeded 10 KB (see {@link certRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert` HTTP header.
+   */
+  certRFC9440: string;
+  /**
+   * `true` if the leaf certificate exceeded 10 KB and was omitted from
+   * {@link certRFC9440}.
+   */
+  certRFC9440TooLarge: boolean;
+  /**
+   * The intermediate certificate chain in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format as a comma-separated list. Empty if no intermediates were sent or
+   * if the chain exceeded 16 KB (see {@link certChainRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert-Chain` HTTP header.
+   */
+  certChainRFC9440: string;
+  /**
+   * `true` if the intermediate chain exceeded 16 KB and was omitted from
+   * {@link certChainRFC9440}.
+   */
+  certChainRFC9440TooLarge: boolean;
 }
 /** Placeholder values for TLS Client Authorization */
 interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
@@ -12187,6 +12213,10 @@ interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
   certFingerprintSHA256: "";
   certNotBefore: "";
   certNotAfter: "";
+  certRFC9440: "";
+  certRFC9440TooLarge: false;
+  certChainRFC9440: "";
+  certChainRFC9440TooLarge: false;
 }
 /** Possible outcomes of TLS verification */
 declare type CertVerificationStatus =

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12184,6 +12184,32 @@ export interface IncomingRequestCfPropertiesTLSClientAuth {
    * @example "Dec 22 19:39:00 2018 GMT"
    */
   certNotAfter: string;
+  /**
+   * The client leaf certificate in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format (`:base64-DER:`). Empty if no client certificate was presented or if
+   * the leaf certificate exceeded 10 KB (see {@link certRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert` HTTP header.
+   */
+  certRFC9440: string;
+  /**
+   * `true` if the leaf certificate exceeded 10 KB and was omitted from
+   * {@link certRFC9440}.
+   */
+  certRFC9440TooLarge: boolean;
+  /**
+   * The intermediate certificate chain in [RFC 9440](https://www.rfc-editor.org/rfc/rfc9440)
+   * format as a comma-separated list. Empty if no intermediates were sent or
+   * if the chain exceeded 16 KB (see {@link certChainRFC9440TooLarge}).
+   *
+   * Suitable for forwarding to an origin via the `Client-Cert-Chain` HTTP header.
+   */
+  certChainRFC9440: string;
+  /**
+   * `true` if the intermediate chain exceeded 16 KB and was omitted from
+   * {@link certChainRFC9440}.
+   */
+  certChainRFC9440TooLarge: boolean;
 }
 /** Placeholder values for TLS Client Authorization */
 export interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
@@ -12204,6 +12230,10 @@ export interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
   certFingerprintSHA256: "";
   certNotBefore: "";
   certNotAfter: "";
+  certRFC9440: "";
+  certRFC9440TooLarge: false;
+  certChainRFC9440: "";
+  certChainRFC9440TooLarge: false;
 }
 /** Possible outcomes of TLS verification */
 export declare type CertVerificationStatus =


### PR DESCRIPTION
Adds four new fields to type the RFC 9440 mTLS certificate properties now exposed on `request.cf.tlsClientAuth`: `certRFC9440`, `certRFC9440TooLarge`, `certChainRFC9440`, and `certChainRFC9440TooLarge`. Matching placeholder values are added to `IncomingRequestCfPropertiesTLSClientAuthPlaceholder`.

See the [RFC 9440 mTLS fields changelog post][changelog].

[changelog]: https://developers.cloudflare.com/changelog/post/2026-03-27-rfc9440-mtls-fields/