### PR TITLE
fix(node:crypto): align scrypt error code with Node.js

### DIFF
--- a/src/node/internal/crypto_scrypt.ts
+++ b/src/node/internal/crypto_scrypt.ts
@@ -39,7 +39,10 @@ import { kMaxLength } from 'node-internal:internal_buffer';
 
 import { getArrayBufferOrView } from 'node-internal:crypto_util';
 
-import { ERR_INVALID_ARG_VALUE } from 'node-internal:internal_errors';
+import {
+  ERR_CRYPTO_INVALID_SCRYPT_PARAMS,
+  ERR_INVALID_ARG_VALUE,
+} from 'node-internal:internal_errors';
 
 export interface ValidatedScryptOptions {
   password: ArrayLike;
@@ -145,6 +148,41 @@ function validateParameters(
   };
 }
 
+// OpenSSL's EVP_PBE_scrypt enforces 128 * r * (N + p + 2) <= maxmem; BoringSSL
+// does not, so mirror the check here to match Node.js behaviour. Run alongside
+// the native call (sync inside scryptSync, inside the Promise body for scrypt)
+// so the failure surfaces the same way Node's C++ ScryptJob errors do, rather
+// than as a synchronous throw from the validator. Uses BigInt because
+// validateUint32 allows values up to 2**32 - 1, whose product would overflow a
+// JS Number's safe integer range.
+function checkScryptMemory(
+  N: number,
+  r: number,
+  p: number,
+  maxmem: number
+): void {
+  if (128n * BigInt(r) * (BigInt(N) + BigInt(p) + 2n) > BigInt(maxmem)) {
+    throw new ERR_CRYPTO_INVALID_SCRYPT_PARAMS();
+  }
+}
+
+// The native cryptoImpl.getScrypt throws a generic Error('Scrypt failed') with
+// no .code on invalid scrypt params; rewrap that exact error to carry Node's
+// standard ERR_CRYPTO_INVALID_SCRYPT_PARAMS code. Any other error (including
+// errors that already have a code, or errors with a different message) is
+// returned unchanged so unrelated failures and the already-coded error from
+// checkScryptMemory aren't suppressed.
+function normaliseScryptError(err: unknown): Error {
+  if (
+    err instanceof Error &&
+    err.message === 'Scrypt failed' &&
+    (err as { code?: unknown }).code === undefined
+  ) {
+    return new ERR_CRYPTO_INVALID_SCRYPT_PARAMS();
+  }
+  return err as Error;
+}
+
 type Callback = (err: Error | null, derivedKey?: Buffer) => void;
 type OptionsOrCallback = ScryptOptions | Callback;
 
@@ -175,9 +213,10 @@ export function scrypt(
 
   new Promise<ArrayBuffer>((res, rej) => {
     try {
+      checkScryptMemory(N, r, p, maxmem);
       res(cryptoImpl.getScrypt(password, salt, N, r, p, maxmem, keylen));
     } catch (err) {
-      rej(err as Error);
+      rej(normaliseScryptError(err));
     }
   }).then(
     (val: ArrayBuffer) => {
@@ -206,7 +245,12 @@ export function scryptSync(
     options
   ));
 
-  return Buffer.from(
-    cryptoImpl.getScrypt(password, salt, N, r, p, maxmem, keylen)
-  );
+  try {
+    checkScryptMemory(N, r, p, maxmem);
+    return Buffer.from(
+      cryptoImpl.getScrypt(password, salt, N, r, p, maxmem, keylen)
+    );
+  } catch (err) {
+    throw normaliseScryptError(err);
+  }
 }

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -248,6 +248,12 @@ export class ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE extends NodeError {
   }
 }
 
+export class ERR_CRYPTO_INVALID_SCRYPT_PARAMS extends NodeRangeError {
+  constructor() {
+    super('ERR_CRYPTO_INVALID_SCRYPT_PARAMS', 'Invalid scrypt params');
+  }
+}
+
 export class ERR_INVALID_ARG_TYPE_RANGE extends NodeRangeError {
   constructor(name: string, expected: string | string[], actual: unknown) {
     const msg = createInvalidArgType(name, expected);

--- a/src/workerd/api/node/tests/crypto_scrypt-test.js
+++ b/src/workerd/api/node/tests/crypto_scrypt-test.js
@@ -125,6 +125,7 @@ const toobig = [
   { N: 2, p: 2 ** 30, r: 1 }, // p > (2**30-1)/r
   { N: 2 ** 20, p: 1, r: 8 },
   { N: 2 ** 10, p: 1, r: 8, maxmem: 2 ** 20 },
+  { N: 32768, p: 1, r: 8, maxmem: 0 }, // maxmem coalesces to default; ratio still fails
 ];
 
 const badargs = [
@@ -200,8 +201,10 @@ export const badTests = {
         if (err) reject(err);
       });
       scrypt('pass', 'salt', 1, options, fn);
-      await rejects(promise);
-      throws(() => scryptSync('pass', 'salt', 1, options));
+      await rejects(promise, { code: 'ERR_CRYPTO_INVALID_SCRYPT_PARAMS' });
+      throws(() => scryptSync('pass', 'salt', 1, options), {
+        code: 'ERR_CRYPTO_INVALID_SCRYPT_PARAMS',
+      });
     }
     throws(() => scryptSync('pass', 'salt', 1, { N: 1, cost: 1 }));
     throws(() => scryptSync('pass', 'salt', 1, { p: 1, parallelization: 1 }));
@@ -217,10 +220,12 @@ export const tooBigTests = {
         if (err) reject(err);
       });
       scrypt('pass', 'salt', 1, options, fn);
-      await rejects(promise);
+      await rejects(promise, { code: 'ERR_CRYPTO_INVALID_SCRYPT_PARAMS' });
       strictEqual(fn.mock.calls.length, 1);
 
-      throws(() => scryptSync('pass', 'salt', 1, options));
+      throws(() => scryptSync('pass', 'salt', 1, options), {
+        code: 'ERR_CRYPTO_INVALID_SCRYPT_PARAMS',
+      });
     }
   },
 };


### PR DESCRIPTION
Fixes #6639. The native scrypt path threw a generic `Error('Scrypt failed')`, so `node:crypto.scrypt(...)` and `scryptSync(...)` came back without the `code: 'ERR_CRYPTO_INVALID_SCRYPT_PARAMS'` Node.js sets for invalid params. Wrapped the native call so the failure surfaces as a `RangeError` with that code and the `Invalid scrypt params` message.

Second part of the issue: BoringSSL's `EVP_PBE_scrypt` does not enforce `128 * r * (N + p + 2) <= maxmem` the way OpenSSL does, so cases like `{N:32768, r:8, p:1, maxmem:0}` (coalesced to the 32 MiB default) succeeded in workerd while throwing on Node. Added the missing memory check on the JS side, run alongside the native call so the error path matches Node's async (callback) and sync (throw) shapes. Uses BigInt because the operands can each be up to 2**32 - 1, and their product would overflow a JS Number's safe integer range.

Tests: `crypto_scrypt-test` now asserts `err.code` on the existing `bad` and `toobig` vectors, plus a regression case `{N:32768, p:1, r:8, maxmem:0}` straight from the issue. Verified locally with `bazel test //src/workerd/api/node/tests/...` (355 pass) and `bazel test //src/node:node@eslint`.