### PR TITLE
Make wd_tests run in predictable mode by default

### DIFF
--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -13,6 +13,7 @@ def wd_test(
         generate_all_autogates_variant = True,
         generate_all_compat_flags_variant = True,
         generate_gc_stress_variant = True,
+        predictable = True,
         compat_date = "",
         **kwargs):
     """Rule to define tests that run `workerd test` with a particular config.
@@ -28,6 +29,7 @@ def wd_test(
      generate_all_autogates_variant: If True (default), generate @all-autogates variants.
      generate_all_compat_flags_variant: If True (default), generate @all-compat-flags variants.
      generate_gc_stress_variant: If True (default), generate @gc-stress variant.
+     predictable: If True (default), pass `--predictable` to workerd.
      compat_date: If specified, use this compat date for the default variant instead of 2000-01-01.
         Does not affect the @all-compat-flags variant which always uses 2999-12-31.
 
@@ -87,6 +89,7 @@ def wd_test(
     base_args = [
         "$(location //src/workerd/server:workerd_cross)",
         "test",
+    ] + (["--predictable"] if predictable else []) + [
         "$(location {})".format(src),
     ] + args
 

--- a/build/wpt_test.bzl
+++ b/build/wpt_test.bzl
@@ -88,6 +88,10 @@ def wpt_test(name, wpt_directory, config, compat_date = "", compat_flags = [], a
         sidecar = "@wpt//:entrypoint" if start_server else None,
         compat_date = compat_date,
         generate_all_compat_flags_variant = False,  # Already using future date where possible.
+        # Predictable mode enables V8's --expose-gc, which can trigger additional JIT events
+        # that produce INFO log lines on stdout. Those lines land after the JSON report/stats
+        # blobs emitted by the WPT harness and break tools/cross/wpt_logs.py parsing.
+        predictable = False,
         data = data,
         **kwargs
     )

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -495,6 +495,14 @@ wd_test(
     src = "streams-consumer-reentry-gc-test.wd-test",
     args = ["--experimental"],
     data = ["streams-consumer-reentry-gc-test.js"],
+    # This test exercises a SIGSEGV regression (EDGEWORKER-RUNTIME-H40) by
+    # forcing reentrant controller.error() during the ReadableStream close
+    # drain. Predictable mode triggers an extra GC pass after every worker
+    # entrypoint in KJ_DEBUG builds (see maybeAddGcPassForTest), which
+    # surfaces a separate latent GC-traceability issue in the stream's
+    # state machine. Opt out of predictable mode here so this test only
+    # covers the regression it was written for.
+    predictable = False,
 )
 
 wd_test(

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -89,10 +89,12 @@ KJ_TEST("InvocationSpanContext") {
   FakeEntropySource fakeEntropySource;
   auto sc = InvocationSpanContext::newForInvocation(kj::none, fakeEntropySource);
 
-  // We can create an InvocationSpanContext...
-  static constexpr auto kCheck = TraceId(0x2a2a2a2a2a2a2a2a, 0x2a2a2a2a2a2a2a2a);
-  KJ_EXPECT(sc.getTraceId() == kCheck);
-  KJ_EXPECT(sc.getInvocationId() == kCheck);
+  // In predictable mode, TraceId::fromEntropy returns deterministic but
+  // call-distinct values (process-wide counter), so the traceId and invocationId
+  // of independent invocations differ from each other and across tests. Capture
+  // the IDs and assert the propagation chain rather than specific constants.
+  auto initialTraceId = sc.getTraceId();
+  auto initialInvocationId = sc.getInvocationId();
   KJ_EXPECT(sc.getSpanId() == SpanId(1));
 
   // And serialize that to a capnp struct...
@@ -102,8 +104,8 @@ KJ_TEST("InvocationSpanContext") {
 
   // Then back again...
   auto sc2 = KJ_ASSERT_NONNULL(InvocationSpanContext::fromCapnp(root.asReader()));
-  KJ_EXPECT(sc2.getTraceId() == kCheck);
-  KJ_EXPECT(sc2.getInvocationId() == kCheck);
+  KJ_EXPECT(sc2.getTraceId() == initialTraceId);
+  KJ_EXPECT(sc2.getInvocationId() == initialInvocationId);
   KJ_EXPECT(sc2.getSpanId() == SpanId(1));
   KJ_EXPECT(sc2.isTrigger());
 
@@ -116,19 +118,22 @@ KJ_TEST("InvocationSpanContext") {
         "expected !isTrigger(); unable to create child spans on this context"_kj);
   }
 
+  // Children inherit both the traceId and invocationId of their parent.
   auto sc3 = sc.newChild();
-  KJ_EXPECT(sc3.getTraceId() == kCheck);
-  KJ_EXPECT(sc3.getInvocationId() == kCheck);
+  KJ_EXPECT(sc3.getTraceId() == initialTraceId);
+  KJ_EXPECT(sc3.getInvocationId() == initialInvocationId);
   KJ_EXPECT(sc3.getSpanId() == SpanId(2));
 
+  // Trigger-context propagation: traceId is inherited from sc2, but the
+  // invocationId is freshly generated for the new invocation.
   auto sc4 = InvocationSpanContext::newForInvocation(sc2, fakeEntropySource);
-  KJ_EXPECT(sc4.getTraceId() == kCheck);
-  KJ_EXPECT(sc4.getInvocationId() == kCheck);
+  KJ_EXPECT(sc4.getTraceId() == initialTraceId);
+  KJ_EXPECT(sc4.getInvocationId() != initialInvocationId);
   KJ_EXPECT(sc4.getSpanId() == SpanId(3));
 
   auto& sc5 = KJ_ASSERT_NONNULL(sc4.getParent());
-  KJ_EXPECT(sc5.getTraceId() == kCheck);
-  KJ_EXPECT(sc5.getInvocationId() == kCheck);
+  KJ_EXPECT(sc5.getTraceId() == initialTraceId);
+  KJ_EXPECT(sc5.getInvocationId() == initialInvocationId);
   KJ_EXPECT(sc5.getSpanId() == SpanId(1));
   KJ_EXPECT(sc5.isTrigger());
 }
@@ -197,8 +202,9 @@ KJ_TEST("SpanContext") {
   auto sc =
       SpanContext(TraceId::fromEntropy(fakeEntropySource), SpanId::fromEntropy(fakeEntropySource));
 
-  static constexpr auto kCheck = TraceId(0x2a2a2a2a2a2a2a2a, 0x2a2a2a2a2a2a2a2a);
-  KJ_EXPECT(sc.getTraceId() == kCheck);
+  // In predictable mode, TraceId::fromEntropy returns deterministic but
+  // call-distinct values; capture the IDs and verify capnp round-trip.
+  auto initialTraceId = sc.getTraceId();
   KJ_EXPECT(sc.getSpanId() == SpanId(1));
   KJ_EXPECT(sc.getTraceFlags() == kj::none);
 
@@ -207,7 +213,7 @@ KJ_TEST("SpanContext") {
   sc.toCapnp(root);
 
   auto sc2 = SpanContext::fromCapnp(root.asReader());
-  KJ_EXPECT(sc2.getTraceId() == kCheck);
+  KJ_EXPECT(sc2.getTraceId() == initialTraceId);
   KJ_EXPECT(sc2.getSpanId() == SpanId(1));
   KJ_EXPECT(sc2.getTraceFlags() == kj::none);
 }

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -12,6 +12,7 @@
 #include <kj/debug.h>
 #include <kj/time.h>
 
+#include <atomic>
 #include <cstdlib>
 
 namespace workerd {
@@ -147,7 +148,14 @@ uint64_t getRandom64Bit(const kj::Maybe<kj::EntropySource&>& entropySource) {
 
 TraceId TraceId::fromEntropy(kj::Maybe<kj::EntropySource&> entropySource) {
   if (isPredictableModeForTest()) {
-    return TraceId(staticSpanId, staticSpanId);
+    // Produce deterministic but distinct IDs per call so that traceIds of
+    // independent (untriggered) invocations don't collide -- collisions confuse
+    // test fixtures that key spans by traceId or invocationId. Triggered
+    // invocations still inherit their caller's traceId via newForInvocation, so
+    // the propagation chain is preserved.
+    static std::atomic<uint64_t> counter{0};
+    uint64_t n = counter.fetch_add(1, std::memory_order_relaxed);
+    return TraceId(staticSpanId ^ n, staticSpanId ^ n);
   }
 
   return TraceId(getRandom64Bit(entropySource), getRandom64Bit(entropySource));

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1712,8 +1712,9 @@ class RequestObserverWithTracer final: public RequestObserver, public WorkerInte
 
 class SequentialSpanSubmitter final: public SpanSubmitter {
  public:
-  SequentialSpanSubmitter(kj::Own<BaseTracer::WeakRef> weakTracer)
-      : weakTracer(kj::mv(weakTracer)) {}
+  SequentialSpanSubmitter(kj::Own<BaseTracer::WeakRef> weakTracer, kj::EntropySource& entropySource)
+      : weakTracer(kj::mv(weakTracer)),
+        entropySource(entropySource) {}
   void submitSpanClose(
       tracing::SpanId spanId, kj::Date startTime, kj::Date endTime, Span::TagMap&& tags) override {
     weakTracer->runIfAlive([&](BaseTracer& tracer) {
@@ -1742,13 +1743,17 @@ class SequentialSpanSubmitter final: public SpanSubmitter {
   }
 
   tracing::SpanId makeSpanId() override {
-    return tracing::SpanId(nextSpanId++);
+    if (isPredictableModeForTest()) {
+      return tracing::SpanId(nextSpanId++);
+    }
+    return tracing::SpanId::fromEntropy(entropySource);
   }
   KJ_DISALLOW_COPY_AND_MOVE(SequentialSpanSubmitter);
 
  private:
   uint64_t nextSpanId = 1;
   kj::Own<BaseTracer::WeakRef> weakTracer;
+  kj::EntropySource& entropySource;
 };
 
 // IsolateLimitEnforcer that enforces no limits.
@@ -2211,9 +2216,11 @@ class Server::WorkerService final: public Service,
 
     KJ_IF_SOME(w, workerTracer) {
       w->setMakeUserRequestSpanFunc(
-          [&w = *w](tracing::TraceId traceId, kj::Maybe<tracing::TraceFlags> traceFlags) {
+          [&w = *w, &entropySource = threadContext.getEntropySource()](
+              tracing::TraceId traceId, kj::Maybe<tracing::TraceFlags> traceFlags) {
         return SpanParent(kj::refcounted<UserSpanObserver>(
-            kj::refcounted<SequentialSpanSubmitter>(w.getWeakRef()), kj::mv(traceId), traceFlags));
+            kj::refcounted<SequentialSpanSubmitter>(w.getWeakRef(), entropySource), kj::mv(traceId),
+            traceFlags));
       });
     }
     kj::Own<RequestObserver> observer =


### PR DESCRIPTION
Additionally, make SequentialSpanSubmitter use entropy-based span IDs outside predictable mode.
This is especially important for correct trace hierarchy in local dev now that USER_SPAN_CONTEXT_PROPAGATION makes multiple workers emit a combined trace.