### PR TITLE
Instrument jsrpc

### DIFF
--- a/src/cloudflare/internal/test/instrumentation-test-helper.js
+++ b/src/cloudflare/internal/test/instrumentation-test-helper.js
@@ -170,7 +170,7 @@ export function findSpanByName(state, name, filterFn = () => true) {
  * @param {Array} expectedSpans - The expected spans to compare against
  * @param {Object} options - Options for the test
  * @param {Function} options.mapFn - Map function to transform spans before comparison (default: x => x)
- * @param {Function} options.filterFn - Filter function for spans (default: filters out jsRpcSession)
+ * @param {Function} options.filterFn - Filter function for spans (default: filters out jsRpcSession and jsRpcCall)
  * @param {string} options.testName - Name for the test (default: 'instrumentation')
  * @param {boolean} options.logReceived - Log received spans for debugging (default: false)
  *
@@ -185,7 +185,8 @@ export async function runInstrumentationTest(
 ) {
   const {
     mapFn = (x) => x,
-    filterFn = (span) => span.name !== 'jsRpcSession',
+    filterFn = (span) =>
+      span.name !== 'jsRpcSession' && span.name !== 'jsRpcCall',
     testName = 'instrumentation',
     logReceived = false,
   } = options;

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -962,12 +962,14 @@ class FacetOutgoingFactory final: public Fetcher::OutgoingFactory {
         name(kj::mv(name)),
         getStartInfo(kj::mv(getStartInfo)) {}
 
-  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override {
+  Result newSingleUseClient(kj::Maybe<kj::String> cfStr) override {
     auto& context = IoContext::current();
 
-    return context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
+    kj::Maybe<TraceContextParent> spanParents;
+    auto client = context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
         [&](TraceContext& tracing, IoChannelFactory& ioChannelFactory) {
       tracing.setTag("facet_name"_kjc, name.asPtr());
+      spanParents = tracing.getSpanParents();
 
       // Lazily initialize actorChannel
       if (actorChannel == kj::none) {
@@ -982,6 +984,7 @@ class FacetOutgoingFactory final: public Fetcher::OutgoingFactory {
         {.inHouse = true,
           .wrapMetrics = true,
           .operationName = kj::ConstString("facet_subrequest"_kjc)}));
+    return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
   }
 
  private:

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -15,13 +15,15 @@
 
 namespace workerd::api {
 
-kj::Own<WorkerInterface> LocalActorOutgoingFactory::newSingleUseClient(
+Fetcher::OutgoingFactory::Result LocalActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr) {
   auto& context = IoContext::current();
 
-  return context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
+  kj::Maybe<TraceContextParent> spanParents;
+  auto client = context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
       [&](TraceContext& tracing, IoChannelFactory& ioChannelFactory) {
     tracing.setTag("objectId"_kjc, actorId.asPtr());
+    spanParents = tracing.getSpanParents();
 
     // Lazily initialize actorChannel
     if (actorChannel == kj::none) {
@@ -37,15 +39,18 @@ kj::Own<WorkerInterface> LocalActorOutgoingFactory::newSingleUseClient(
       {.inHouse = true,
         .wrapMetrics = true,
         .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
+  return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
 }
 
-kj::Own<WorkerInterface> GlobalActorOutgoingFactory::newSingleUseClient(
+Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr) {
   auto& context = IoContext::current();
 
-  return context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
+  kj::Maybe<TraceContextParent> spanParents;
+  auto client = context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
       [&](TraceContext& tracing, IoChannelFactory& ioChannelFactory) {
     tracing.setTag("objectId"_kjc, id->toString());
+    spanParents = tracing.getSpanParents();
 
     // Lazily initialize actorChannel
     if (actorChannel == kj::none) {
@@ -70,15 +75,18 @@ kj::Own<WorkerInterface> GlobalActorOutgoingFactory::newSingleUseClient(
       {.inHouse = true,
         .wrapMetrics = true,
         .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
+  return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
 }
 
-kj::Own<WorkerInterface> ReplicaActorOutgoingFactory::newSingleUseClient(
+Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr) {
   auto& context = IoContext::current();
 
-  return context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
+  kj::Maybe<TraceContextParent> spanParents;
+  auto client = context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
       [&](TraceContext& tracing, IoChannelFactory& ioChannelFactory) {
     tracing.setTag("objectId"_kjc, actorId.asPtr());
+    spanParents = tracing.getSpanParents();
 
     // Unlike in `GlobalActorOutgoingFactory`, we do not create this lazily, since our channel was
     // already open prior to this DO starting up.
@@ -89,6 +97,7 @@ kj::Own<WorkerInterface> ReplicaActorOutgoingFactory::newSingleUseClient(
       {.inHouse = true,
         .wrapMetrics = true,
         .operationName = kj::ConstString("durable_object_subrequest"_kjc)}));
+  return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
 }
 
 jsg::Ref<Fetcher> ColoLocalActorNamespace::get(jsg::Lock& js, kj::String actorId) {

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -309,7 +309,7 @@ class GlobalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
         routingMode(routingMode),
         version(kj::mv(version)) {}
 
-  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
+  Result newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
 
  private:
   ChannelIdOrFactory channelIdOrFactory;
@@ -329,7 +329,7 @@ class LocalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
       : channelId(channelId),
         actorId(kj::mv(actorId)) {}
 
-  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
+  Result newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
 
  private:
   uint channelId;
@@ -348,7 +348,7 @@ class ReplicaActorOutgoingFactory final: public Fetcher::OutgoingFactory {
       : actorChannel(kj::mv(channel)),
         actorId(kj::mv(actorId)) {}
 
-  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
+  Result newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
 
  private:
   kj::Own<IoChannelFactory::ActorChannel> actorChannel;

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -781,11 +781,13 @@ class Container::TcpPortOutgoingFactory final: public Fetcher::OutgoingFactory {
         headerTable(headerTable),
         port(kj::mv(port)) {}
 
-  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override {
+  Result newSingleUseClient(kj::Maybe<kj::String> cfStr) override {
     // At present we have no use for `cfStr`.
-    return IoContext::current().getSubrequestNoChecks([&](auto& tracing, auto& channelFactory) {
+    auto client = IoContext::current().getSubrequestNoChecks(
+        [&](auto& tracing, auto& channelFactory) -> kj::Own<WorkerInterface> {
       return kj::heap<TcpPortWorkerInterface>(byteStreamFactory, entropySource, headerTable, port);
     }, {.inHouse = false, .wrapMetrics = false});
+    return {.client = kj::mv(client), .spanParents = kj::none};
   }
 
  private:

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2118,10 +2118,19 @@ kj::Maybe<jsg::Ref<JsRpcProperty>> Fetcher::getRpcMethodInternal(jsg::Lock& js, 
   return js.alloc<JsRpcProperty>(JSG_THIS, kj::mv(name));
 }
 
-rpc::JsRpcTarget::Client Fetcher::getClientForOneCall(
+kj::LiteralStringConst Fetcher::getRpcTargetKind() {
+  return "fetcher"_kjc;
+}
+
+JsRpcClientProvider::ClientForOneCall Fetcher::getClientForOneCall(
     jsg::Lock& js, kj::Vector<kj::StringPtr>& path) {
   auto& ioContext = IoContext::current();
-  auto worker = getClient(ioContext, kj::none, "jsRpcSession"_kjc);
+  // The "jsRpcSession" trace context is attached to the customEvent task below so
+  // it covers the whole session.
+  auto clientWithTracing = getClientWithTracing(ioContext, kj::none, "jsRpcSession"_kjc);
+  kj::Maybe<TraceContextParent> callSpanParents =
+      clientWithTracing.traceContext.map([](TraceContext& tc) { return tc.getSpanParents(); });
+  auto worker = kj::mv(clientWithTracing.client);
   auto event = kj::heap<api::JsRpcSessionCustomEvent>(
       JsRpcSessionCustomEvent::WORKER_RPC_EVENT_TYPE);
 
@@ -2132,12 +2141,14 @@ rpc::JsRpcTarget::Client Fetcher::getClientForOneCall(
   // propagated the exception to any RPC calls that we're waiting on, so we even ignore errors
   // here -- otherwise they'll end up logged as "uncaught exceptions" even if they were, in fact,
   // caught elsewhere.
-  ioContext.addTask(worker->customEvent(kj::mv(event)).attach(kj::mv(worker)).then([](auto&&) {
-  }, [](kj::Exception&&) {}));
+  ioContext.addTask(
+      worker->customEvent(kj::mv(event))
+          .attach(kj::mv(worker), kj::mv(clientWithTracing.traceContext))
+          .then([](auto&&) {}, [](kj::Exception&&) {}));
 
   // (Don't extend `path` because we're the root.)
 
-  return result;
+  return {.client = kj::mv(result), .callSpanParents = kj::mv(callSpanParents)};
 }
 
 void Fetcher::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
@@ -2409,9 +2420,21 @@ kj::Own<WorkerInterface> Fetcher::getClient(
 
 Fetcher::ClientWithTracing Fetcher::getClientWithTracing(
     IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
+  return buildClient(ioContext, kj::mv(cfStr), kj::mv(operationName));
+}
+
+Fetcher::ClientWithTracing Fetcher::wrapWithInnerSpan(
+    OutgoingFactory::Result result, kj::ConstString operationName) {
+  KJ_IF_SOME(parents, result.spanParents) {
+    return ClientWithTracing{kj::mv(result.client), parents.newChild(kj::mv(operationName))};
+  }
+  return ClientWithTracing{kj::mv(result.client), kj::none};
+}
+
+Fetcher::ClientWithTracing Fetcher::buildClient(
+    IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
   KJ_SWITCH_ONEOF(channelOrClientFactory) {
     KJ_CASE_ONEOF(channel, uint) {
-      // For channels, create trace context
       auto traceContext = ioContext.makeUserTraceSpan(kj::mv(operationName));
       auto client = ioContext.getSubrequestChannel(channel, isInHouse, kj::mv(cfStr), traceContext);
       return ClientWithTracing{kj::mv(client), kj::mv(traceContext)};
@@ -2431,17 +2454,15 @@ Fetcher::ClientWithTracing Fetcher::getClientWithTracing(
       return ClientWithTracing{kj::mv(client), kj::mv(traceContext)};
     }
     KJ_CASE_ONEOF(outgoingFactory, IoOwn<OutgoingFactory>) {
-      // Outgoing factories are responsible for routing through getSubrequestNoChecks() (or
-      // getSubrequest()) internally if they create HTTP connections, to ensure external memory
-      // adjustment and other subrequest accounting are applied.
-      auto client = outgoingFactory->newSingleUseClient(kj::mv(cfStr));
-      return ClientWithTracing{kj::mv(client), kj::none};
+      // The factory creates its own outer dispatch span (e.g. durable_object_subrequest)
+      // and exposes it as `result.spanParents`. Nest our inner span under it so the trace
+      // tree shows `outerSpan -> operationName`.
+      auto result = outgoingFactory->newSingleUseClient(kj::mv(cfStr));
+      return wrapWithInnerSpan(kj::mv(result), kj::mv(operationName));
     }
     KJ_CASE_ONEOF(outgoingFactory, kj::Own<CrossContextOutgoingFactory>) {
-      // Same as OutgoingFactory above -- the factory is responsible for routing through
-      // getSubrequestNoChecks() internally.
-      auto client = outgoingFactory->newSingleUseClient(ioContext, kj::mv(cfStr));
-      return ClientWithTracing{kj::mv(client), kj::none};
+      auto result = outgoingFactory->newSingleUseClient(ioContext, kj::mv(cfStr));
+      return wrapWithInnerSpan(kj::mv(result), kj::mv(operationName));
     }
   }
   KJ_UNREACHABLE;

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -288,7 +288,15 @@ class Fetcher: public JsRpcClientProvider {
   //   is almost the same thing.
   class OutgoingFactory {
    public:
-    virtual kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) = 0;
+    struct Result {
+      kj::Own<WorkerInterface> client;
+      // Parents of the dispatch-site span (e.g. durable_object_subrequest) that the
+      // caller can use to nest an inner operation span underneath. SpanParent holds an
+      // owning refcount on the underlying SpanObserver, so these are independently
+      // valid regardless of `client`'s lifetime. kj::none if no span was created.
+      kj::Maybe<TraceContextParent> spanParents;
+    };
+    virtual Result newSingleUseClient(kj::Maybe<kj::String> cfStr) = 0;
 
     // Get a `SubrequestChannel` representing this Fetcher. This is used especially when the
     // Fetcher is being passed to another isolate.
@@ -306,7 +314,7 @@ class Fetcher: public JsRpcClientProvider {
   // IoContext::getSubrequestNoChecks() internally.
   class CrossContextOutgoingFactory {
    public:
-    virtual kj::Own<WorkerInterface> newSingleUseClient(
+    virtual OutgoingFactory::Result newSingleUseClient(
         IoContext& context, kj::Maybe<kj::String> cfStr) = 0;
 
     virtual kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel(IoContext& context) {
@@ -333,7 +341,7 @@ class Fetcher: public JsRpcClientProvider {
         requiresHost(requiresHost),
         isInHouse(isInHouse) {}
 
-  // Returns an `WorkerInterface` that is only valid for the lifetime of the current
+  // Returns a `WorkerInterface` that is only valid for the lifetime of the current
   // `IoContext`.
   kj::Own<WorkerInterface> getClient(
       IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName);
@@ -344,8 +352,8 @@ class Fetcher: public JsRpcClientProvider {
     kj::Maybe<TraceContext> traceContext;
   };
 
-  // Get client and optionally create trace context, all in one call
-  ClientWithTracing getClientWithTracing(
+  // Get client and optionally create trace context, all in one call.
+  [[nodiscard]] ClientWithTracing getClientWithTracing(
       IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName);
 
   // Get a SubrequestChannel representing this Fetcher.
@@ -437,8 +445,9 @@ class Fetcher: public JsRpcClientProvider {
     return getRpcMethod(js, kj::mv(name));
   }
 
-  rpc::JsRpcTarget::Client getClientForOneCall(
-      jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
+  ClientForOneCall getClientForOneCall(jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
+
+  kj::LiteralStringConst getRpcTargetKind() override;
 
   JSG_RESOURCE_TYPE(Fetcher, CompatibilityFlags::Reader flags) {
     // WARNING: New JSG_METHODs on Fetcher must be gated via compatibility flag to prevent
@@ -520,6 +529,14 @@ class Fetcher: public JsRpcClientProvider {
   JSG_SERIALIZABLE(rpc::SerializationTag::SERVICE_STUB);
 
  private:
+  [[nodiscard]] ClientWithTracing buildClient(
+      IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName);
+
+  // Wraps an OutgoingFactory result with an inner span nested under the factory's
+  // outer dispatch span (or under the request root if there is none).
+  [[nodiscard]] static ClientWithTracing wrapWithInnerSpan(
+      OutgoingFactory::Result result, kj::ConstString operationName);
+
   kj::OneOf<uint,
       IoOwn<IoChannelFactory::SubrequestChannel>,
       kj::Own<CrossContextOutgoingFactory>,

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -589,7 +589,7 @@ class StreamOutgoingFactory final: public Fetcher::OutgoingFactory, public kj::R
         httpClient(
             kj::newHttpClient(headerTable, *this->stream, {.entropySource = entropySource})) {}
 
-  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
+  Result newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
 
  private:
   kj::Own<kj::AsyncIoStream> stream;
@@ -654,14 +654,17 @@ class StreamWorkerInterface final: public WorkerInterface {
   kj::Own<StreamOutgoingFactory> factory;
 };
 
-kj::Own<WorkerInterface> StreamOutgoingFactory::newSingleUseClient(kj::Maybe<kj::String> cfStr) {
+Fetcher::OutgoingFactory::Result StreamOutgoingFactory::newSingleUseClient(
+    kj::Maybe<kj::String> cfStr) {
   JSG_ASSERT(stream.get() != nullptr, Error,
       "Fetcher created from internalNewHttpClient can only be used once");
   // Create a WorkerInterface that wraps the stream, routing through getSubrequestNoChecks to apply
   // external memory adjustment for GC pressure.
-  return IoContext::current().getSubrequestNoChecks([&](auto& tracing, auto& channelFactory) {
+  auto client = IoContext::current().getSubrequestNoChecks(
+      [&](auto& tracing, auto& channelFactory) -> kj::Own<WorkerInterface> {
     return kj::heap<StreamWorkerInterface>(kj::addRef(*this));
   }, {.inHouse = false, .wrapMetrics = false});
+  return {.client = kj::mv(client), .spanParents = kj::none};
 }
 
 jsg::Promise<jsg::Ref<Fetcher>> SocketsModule::internalNewHttpClient(

--- a/src/workerd/api/tests/actor-kv-test-tail.js
+++ b/src/workerd/api/tests/actor-kv-test-tail.js
@@ -20,6 +20,16 @@ export const test = {
         objectId:
           'aa299662980ce671dbcb09a5d7ab26ab30e45465bcd12f263f2bdd7d5edd804a',
       },
+      {
+        name: 'fetch',
+        closed: true,
+        'network.protocol.name': 'http',
+        'network.protocol.version': 'HTTP/1.1',
+        'http.request.method': 'GET',
+        'url.full': 'http://test.example/kv-test',
+        'http.response.status_code': 200n,
+        'http.response.body.size': 34n,
+      },
       { name: 'durable_object_storage_put', closed: true },
       { name: 'durable_object_storage_put', closed: true },
       { name: 'durable_object_storage_get', closed: true },

--- a/src/workerd/api/tests/sql-test-tail.js
+++ b/src/workerd/api/tests/sql-test-tail.js
@@ -29,6 +29,13 @@ export const test = {
       durable_object_storage_get: 18,
       durable_object_storage_transaction: 8,
       durable_object_subrequest: 47,
+      // Inner spans nested under durable_object_subrequest: jsRpcSession for RPC
+      // dispatches (one per call, client-side only -- the server's jsrpc-typed
+      // onset is its equivalent), fetch for fetch dispatches.
+      jsRpcSession: 35,
+      fetch: 12,
+      // jsRpcCall: 35 client-side + 35 server-side.
+      jsRpcCall: 70,
       durable_object_storage_deleteAll: 1,
       createStringTable: 4,
       runActorFunc: 4,

--- a/src/workerd/api/tests/tail-worker-test.js
+++ b/src/workerd/api/tests/tail-worker-test.js
@@ -174,15 +174,17 @@ const E = {
   wsClose:
     '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"DurableObjectExample","scriptTags":[],"info":{"type":"hibernatableWebSocket","info":{"type":"close","code":1000,"wasClean":true}}}{"type":"return"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
-  // jsrpc
+  // jsrpc -- the jsrpc-typed onset on the server already represents the session
+  // (delivered() to outcome), so no separate jsRpcSession user span is emitted
+  // server-side. Each method dispatch gets a jsRpcCall span.
   myActorJsrpc:
-    '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"MyActor","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"log","level":"log","message":["baz"]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"functionProperty"}]}{"type":"return"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+    '{"type":"onset","executionModel":"durableObject","spanId":"0000000000000000","entrypoint":"MyActor","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"log","level":"log","message":["baz"]}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000001"}{"type":"attributes","info":[{"name":"jsrpc.method","value":"functionProperty"}]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"functionProperty"},{"name":"jsrpc.target_kind","value":"entrypoint"},{"name":"jsrpc.operation","value":"call"}]}{"type":"spanClose","outcome":"ok"}{"type":"return"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
   jsrpcNonFunction:
-    '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"nonFunctionProperty"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["foo"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+    '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000001"}{"type":"attributes","info":[{"name":"jsrpc.method","value":"nonFunctionProperty"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["foo"]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"nonFunctionProperty"},{"name":"jsrpc.target_kind","value":"entrypoint"},{"name":"jsrpc.operation","value":"call"}]}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
   jsrpcGetCounter:
-    '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["getCounter called"]}{"type":"return"}{"type":"log","level":"log","message":["increment called on transient"]}{"type":"log","level":"log","message":["getValue called on transient"]}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+    '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","entrypoint":"MyService","scriptTags":[],"info":{"type":"jsrpc"}}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000001"}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"}]}{"type":"log","level":"log","message":["bar"]}{"type":"log","level":"log","message":["getCounter called"]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"getCounter"},{"name":"jsrpc.target_kind","value":"entrypoint"},{"name":"jsrpc.operation","value":"call"}]}{"type":"spanClose","outcome":"ok"}{"type":"return"}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000002"}{"type":"log","level":"log","message":["increment called on transient"]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"(this)"},{"name":"jsrpc.target_kind","value":"transient"},{"name":"jsrpc.operation","value":"call"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000003"}{"type":"log","level":"log","message":["getValue called on transient"]}{"type":"attributes","info":[{"name":"jsrpc.method","value":"(this)"},{"name":"jsrpc.target_kind","value":"transient"},{"name":"jsrpc.operation","value":"call"}]}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
   jsrpcDoSubrequest:
-    '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"custom"}}{"type":"spanOpen","name":"jsRpcSession","spanId":"0000000000000001"}{"type":"spanOpen","name":"durable_object_subrequest","spanId":"0000000000000002"}{"type":"spanOpen","name":"jsRpcSession","spanId":"0000000000000003"}{"type":"attributes","info":[{"name":"objectId","value":"af6dd8b6678e07bac992dae1bbbb3f385af19ebae7e5ea8c66d6341b246d3328"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanClose","outcome":"ok"}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
+    '{"type":"onset","executionModel":"stateless","spanId":"0000000000000000","scriptTags":[],"info":{"type":"custom"}}{"type":"spanOpen","name":"jsRpcSession","spanId":"0000000000000001"}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000002"}{"type":"spanOpen","name":"durable_object_subrequest","spanId":"0000000000000003"}{"type":"spanOpen","name":"jsRpcSession","spanId":"0000000000000004"}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000005"}{"type":"attributes","info":[{"name":"jsrpc.target_kind","value":"fetcher"},{"name":"jsrpc.operation","value":"call"},{"name":"jsrpc.method","value":"nonFunctionProperty"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"jsRpcSession","spanId":"0000000000000006"}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000007"}{"type":"attributes","info":[{"name":"jsrpc.target_kind","value":"fetcher"},{"name":"jsrpc.operation","value":"call"},{"name":"jsrpc.method","value":"functionProperty"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanClose","outcome":"ok"}{"type":"attributes","info":[{"name":"objectId","value":"af6dd8b6678e07bac992dae1bbbb3f385af19ebae7e5ea8c66d6341b246d3328"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000008"}{"type":"attributes","info":[{"name":"jsrpc.target_kind","value":"fetcher"},{"name":"jsrpc.operation","value":"call"},{"name":"jsrpc.method","value":"getCounter"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanOpen","name":"jsRpcCall","spanId":"0000000000000009"}{"type":"attributes","info":[{"name":"jsrpc.target_kind","value":"stub"},{"name":"jsrpc.operation","value":"call"},{"name":"jsrpc.method","value":"(this)"}]}{"type":"spanClose","outcome":"ok"}{"type":"attributes","info":[{"name":"jsrpc.target_kind","value":"stub"},{"name":"jsrpc.operation","value":"call"},{"name":"jsrpc.method","value":"(this)"}]}{"type":"spanClose","outcome":"ok"}{"type":"spanClose","outcome":"ok"}{"type":"spanClose","outcome":"ok"}{"type":"outcome","outcome":"ok","cpuTime":0,"wallTime":0}',
 
   // cacheMode
   cacheMode:
@@ -301,11 +303,21 @@ const expectedWithPropagation = [
   n(E.localAddressViaServiceBinding),
   n(E.connectTarget),
 
-  // jsrpc DO subrequest test: caller has children (MyService + MyActor DO calls)
+  // jsrpc DO subrequest test. The exact nesting is a workerd-standalone artifact:
+  // sibling callee invocations re-use sequential span IDs starting at
+  // 0000000000000001, so buildTree's spanId-based parent lookup mis-links them
+  // under each other rather than as siblings of the caller. Production span IDs
+  // are random 64-bit and don't collide.
+  // TODO: Once buildTree (in instrumentation-test-helper.js) disambiguates spans
+  // by (traceId, spanId) or otherwise handles workerd-standalone's sequential
+  // span-ID reuse, replace this with the natural sibling shape:
+  //   n(E.jsrpcDoSubrequest, [
+  //     n(E.myActorJsrpc),
+  //     n(E.jsrpcGetCounter),
+  //     n(E.jsrpcNonFunction),
+  //   ]),
   n(E.jsrpcDoSubrequest, [
-    n(E.myActorJsrpc),
-    n(E.jsrpcGetCounter),
-    n(E.jsrpcNonFunction),
+    n(E.jsrpcGetCounter, [n(E.myActorJsrpc), n(E.jsrpcNonFunction)]),
   ]),
 
   // http-test: main test handler with subrequest children

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -220,11 +220,12 @@ struct DeserializeResult {
 DeserializeResult deserializeJsValue(jsg::Lock& js,
     rpc::JsValue::Reader reader,
     kj::LiteralStringConst debugContext,
-    kj::Maybe<StreamSinkImpl&> streamSink = kj::none) {
+    kj::Maybe<StreamSinkImpl&> streamSink,
+    kj::Maybe<TraceContextParent> originatingCall) {
   auto disposalGroup = kj::heap<RpcStubDisposalGroup>();
 
   RpcDeserializerExternalHandler externalHandler(
-      reader.getExternals(), *disposalGroup, streamSink, debugContext);
+      reader.getExternals(), *disposalGroup, streamSink, debugContext, kj::mv(originatingCall));
 
   jsg::Deserializer deserializer(js, reader.getV8Serialized(), kj::none, kj::none,
       jsg::Deserializer::Options{
@@ -252,9 +253,10 @@ DeserializeResult deserializeJsValue(jsg::Lock& js,
 // an object) which disposes all stubs therein.
 jsg::JsValue deserializeRpcReturnValue(jsg::Lock& js,
     rpc::JsRpcTarget::CallResults::Reader callResults,
-    kj::Maybe<StreamSinkImpl&> streamSink) {
-  auto [value, disposalGroup, ss] =
-      deserializeJsValue(js, callResults.getResult(), "return"_kjc, streamSink);
+    kj::Maybe<StreamSinkImpl&> streamSink,
+    kj::Maybe<TraceContextParent> originatingCall) {
+  auto [value, disposalGroup, ss] = deserializeJsValue(
+      js, callResults.getResult(), "return"_kjc, streamSink, kj::mv(originatingCall));
 
   if (streamSink == kj::none) {
     KJ_REQUIRE(ss == kj::none,
@@ -368,13 +370,12 @@ void JsRpcPromise::dispose(jsg::Lock& js) {
 static rpc::JsRpcTarget::Client makeJsRpcTargetForSingleLoopbackCall(
     jsg::Lock& js, jsg::JsObject obj);
 
-rpc::JsRpcTarget::Client JsRpcPromise::getClientForOneCall(
+JsRpcClientProvider::ClientForOneCall JsRpcPromise::getClientForOneCall(
     jsg::Lock& js, kj::Vector<kj::StringPtr>& path) {
   // (Don't extend `path` because we're the root.)
-
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(pending, Pending) {
-      return pending.pipeline->getCallPipeline();
+      return {.client = pending.pipeline->getCallPipeline()};
     }
     KJ_CASE_ONEOF(resolved, Resolved) {
       // Dereference `ctxCheck` just to verify we're running in the correct context. (If not,
@@ -399,7 +400,7 @@ rpc::JsRpcTarget::Client JsRpcPromise::getClientForOneCall(
       // The easiest way to make this all just work is... to actually wrap the value in a one-off
       // RPC stub, and make a real RPC on it.
 
-      return js.withinHandleScope([&]() -> rpc::JsRpcTarget::Client {
+      return {.client = js.withinHandleScope([&]() -> rpc::JsRpcTarget::Client {
         auto value = jsg::JsValue(resolved.result.getHandle(js));
 
         KJ_IF_SOME(obj, value.tryCast<jsg::JsObject>()) {
@@ -413,16 +414,16 @@ rpc::JsRpcTarget::Client JsRpcPromise::getClientForOneCall(
         } else {
           JSG_FAIL_REQUIRE(TypeError, "Can't pipeline on RPC that did not return an object.");
         }
-      });
+      })};
     }
     KJ_CASE_ONEOF(disposed, Disposed) {
-      return JSG_KJ_EXCEPTION(FAILED, Error, "RPC promise used after being disposed.");
+      return {.client = JSG_KJ_EXCEPTION(FAILED, Error, "RPC promise used after being disposed.")};
     }
   }
   KJ_UNREACHABLE;
 }
 
-rpc::JsRpcTarget::Client JsRpcProperty::getClientForOneCall(
+JsRpcClientProvider::ClientForOneCall JsRpcProperty::getClientForOneCall(
     jsg::Lock& js, kj::Vector<kj::StringPtr>& path) {
   auto result = parent->getClientForOneCall(js, path);
   path.add(name);
@@ -441,6 +442,38 @@ struct JsRpcPromiseAndPipeline {
         IoContext::current().addObject(kj::heap(kj::mv(pipeline))));
   }
 };
+
+// Creates the per-call client-side `jsRpcCall` span, nested under `callSpanParents` when
+// provided (set by JsRpcStub for follow-up calls on a pipelined stub, and by Fetcher to
+// nest under the newly-opened session) or under the current async context's spans
+// otherwise. Tags are populated for `jsrpc.target_kind`, `jsrpc.operation`, and
+// `jsrpc.method` (joined property path, or "(this)" if the stub itself is being called).
+static TraceContext makeJsRpcCallSpan(IoContext& ioContext,
+    JsRpcClientProvider& parent,
+    kj::Maybe<const kj::String&> name,
+    kj::ArrayPtr<const kj::StringPtr> path,
+    kj::Maybe<TraceContextParent> callSpanParents,
+    bool isCall) {
+  TraceContextParent parents = kj::mv(callSpanParents).orDefault([&] {
+    return TraceContextParent(ioContext.getCurrentTraceSpan(), ioContext.getCurrentUserTraceSpan());
+  });
+  TraceContext span = parents.newChild("jsRpcCall"_kjc);
+
+  span.setTag("jsrpc.target_kind"_kjc, parent.getRpcTargetKind());
+  span.setTag("jsrpc.operation"_kjc, isCall ? "call"_kjc : "getProperty"_kjc);
+  // Empty path and no name means the stub itself is being invoked as a function.
+  if (path.size() == 0 && name == kj::none) {
+    span.setTag("jsrpc.method"_kjc, "(this)"_kjc);
+  } else {
+    kj::Vector<kj::StringPtr> fullPath(path.size() + 1);
+    fullPath.addAll(path);
+    KJ_IF_SOME(n, name) {
+      fullPath.add(n);
+    }
+    span.setTag("jsrpc.method"_kjc, kj::strArray(fullPath, "."));
+  }
+  return span;
+}
 
 // Core implementation of making an RPC call, reusable for many cases below.
 JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
@@ -467,12 +500,16 @@ JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
 
   try {
     return js.tryCatch([&]() -> JsRpcPromiseAndPipeline {
-      // `path` will be filled in with the path of property names leading from the stub represented by
-      // `client` to the specific property / method that we're trying to invoke.
-      kj::Vector<kj::StringPtr> path;
-      auto client = parent.getClientForOneCall(js, path);
-
       auto& ioContext = IoContext::current();
+
+      // `path` is filled in with the chain of property names leading to the method.
+      kj::Vector<kj::StringPtr> path;
+      auto [client, callSpanParents] = parent.getClientForOneCall(js, path);
+
+      // Per-call dispatch span, captured into the awaitIo callback below so it stays
+      // open until the response settles.
+      TraceContext jsRpcCallSpan = makeJsRpcCallSpan(
+          ioContext, parent, name, path.asPtr(), kj::mv(callSpanParents), maybeArgs != kj::none);
 
       KJ_IF_SOME(lock, ioContext.waitForOutputLocksIfNecessary()) {
         // Replace the client with a promise client that will delay the call until the output gate
@@ -579,10 +616,13 @@ JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
       // RemotePromise lets us consume its pipeline and promise portions independently; we consume
       // the promise here and we consume the pipeline below, both via kj::mv().
       auto jsPromise = ioContext.awaitIo(js, kj::mv(callResult),
-          [weakRef = kj::atomicAddRef(*weakRef), resultStreamSink = kj::mv(resultStreamSink)](
-              jsg::Lock& js,
+          [weakRef = kj::atomicAddRef(*weakRef), resultStreamSink = kj::mv(resultStreamSink),
+              jsRpcCallSpan = kj::mv(jsRpcCallSpan)](jsg::Lock& js,
               capnp::Response<rpc::JsRpcTarget::CallResults> response) mutable -> jsg::Value {
-        auto jsResult = deserializeRpcReturnValue(js, response, resultStreamSink);
+        // Stubs in the response record this call as their originating call so that
+        // follow-up calls on those stubs nest under it.
+        auto jsResult = deserializeRpcReturnValue(
+            js, response, resultStreamSink, jsRpcCallSpan.getSpanParents());
 
         if (weakRef->disposed) {
           // The promise was explicitly disposed before it even resolved. This means we must dispose
@@ -726,10 +766,12 @@ kj::Maybe<jsg::Ref<JsRpcProperty>> JsRpcPromise::getProperty(jsg::Lock& js, kj::
 
 JsRpcStub::JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient,
     RpcStubDisposalGroup& disposalGroup,
-    jsg::ExternalMemoryAdjustment externalMemoryAdjustment)
+    jsg::ExternalMemoryAdjustment externalMemoryAdjustment,
+    kj::Maybe<TraceContextParent> originatingCall)
     : capnpClient(kj::mv(capnpClient)),
       disposalGroup(disposalGroup),
-      externalMemoryAdjustment(kj::mv(externalMemoryAdjustment)) {
+      externalMemoryAdjustment(kj::mv(externalMemoryAdjustment)),
+      originatingCall(kj::mv(originatingCall)) {
   disposalGroup.list.add(*this);
 }
 
@@ -817,10 +859,13 @@ rpc::JsRpcTarget::Client JsRpcStub::getClient() {
   }
 }
 
-rpc::JsRpcTarget::Client JsRpcStub::getClientForOneCall(
+JsRpcClientProvider::ClientForOneCall JsRpcStub::getClientForOneCall(
     jsg::Lock& js, kj::Vector<kj::StringPtr>& path) {
   // (Don't extend `path` because we're the root.)
-  return getClient();
+  return {
+    .client = getClient(),
+    .callSpanParents = originatingCall.map([](TraceContextParent& p) { return p.addRef(); }),
+  };
 }
 
 jsg::Ref<JsRpcStub> JsRpcStub::dup(jsg::Lock& js) {
@@ -918,7 +963,8 @@ jsg::Ref<JsRpcStub> JsRpcStub::deserialize(
   auto externalMemory = js.getExternalMemoryAdjustment(ESTIMATED_EXTERNAL_MEMORY_PER_STUB);
 
   return js.alloc<JsRpcStub>(ioctx.addObject(kj::heap(reader.getRpcTarget())),
-      externalHandler->getDisposalGroup(), kj::mv(externalMemory));
+      externalHandler->getDisposalGroup(), kj::mv(externalMemory),
+      externalHandler->getOriginatingCall());
 }
 
 static bool isFunctionForRpc(jsg::Lock& js, v8::Local<v8::Function> func) {
@@ -1064,6 +1110,10 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
   // Returns true if the given name cannot be used as a method on this type.
   virtual bool isReservedName(kj::StringPtr name) = 0;
 
+  // Tracing tag value for jsrpc.target_kind on the server-side per-call span
+  // (see JsRpcClientProvider::getRpcTargetKind for the client-side equivalent).
+  virtual kj::LiteralStringConst getTargetKind() = 0;
+
   kj::Promise<void> callImpl(Worker::Lock& lock, IoContext& ctx, CallContext callContext) {
     jsg::Lock& js = lock;
     auto params = callContext.getParams();
@@ -1090,6 +1140,14 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
         break;
       }
     }
+
+    // Server-side jsRpcCall, attached to the dispatch promise below so it stays
+    // open through JS invocation and result serialization.
+    auto jsRpcCallSpan = ctx.makeUserTraceSpan("jsRpcCall"_kjc);
+    jsRpcCallSpan.setTag("jsrpc.method"_kjc, methodNameForTrace.asPtr());
+    jsRpcCallSpan.setTag("jsrpc.target_kind"_kjc, getTargetKind());
+    jsRpcCallSpan.setTag("jsrpc.operation"_kjc,
+        params.getOperation().isGetProperty() ? "getProperty"_kjc : "call"_kjc);
 
     maybeSetJsRpcInfo(ctx, methodNameForTrace);
 
@@ -1235,42 +1293,46 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       }
     };
 
-    switch (op.which()) {
-      case rpc::JsRpcTarget::CallParams::Operation::CALL_WITH_ARGS: {
-        // Note that using isFunctionForRpc(js, propHandle) here would be incorrect, since that
-        // decides whether it is a function *that can be serialized as a stub*. JsRpcProperty
-        // is (at present) considered non-serializable in itself, but when traversing the
-        // pipeline path, we may have descended into a stub and its properties, thus we could
-        // actually be invoking a JsRpcProperty here. As long as it is in fact callable, we will
-        // allow it.
-        JSG_REQUIRE(propHandle->IsFunction(), TypeError,
-            kj::str("\"", methodNameForTrace, "\" is not a function."));
-        auto fn = propHandle.As<v8::Function>();
+    auto dispatch = [&]() -> kj::Promise<void> {
+      switch (op.which()) {
+        case rpc::JsRpcTarget::CallParams::Operation::CALL_WITH_ARGS: {
+          // Note that using isFunctionForRpc(js, propHandle) here would be incorrect, since that
+          // decides whether it is a function *that can be serialized as a stub*. JsRpcProperty
+          // is (at present) considered non-serializable in itself, but when traversing the
+          // pipeline path, we may have descended into a stub and its properties, thus we could
+          // actually be invoking a JsRpcProperty here. As long as it is in fact callable, we will
+          // allow it.
+          JSG_REQUIRE(propHandle->IsFunction(), TypeError,
+              kj::str("\"", methodNameForTrace, "\" is not a function."));
+          auto fn = propHandle.As<v8::Function>();
 
-        kj::Maybe<rpc::JsValue::Reader> args;
-        if (op.hasCallWithArgs()) {
-          args = op.getCallWithArgs();
+          kj::Maybe<rpc::JsValue::Reader> args;
+          if (op.hasCallWithArgs()) {
+            args = op.getCallWithArgs();
+          }
+
+          InvocationResult invocationResult;
+          KJ_IF_SOME(envCtx, targetInfo.envCtx) {
+            invocationResult = invokeFnInsertingEnvCtx(
+                js, methodNameForTrace, fn, thisArg, args, envCtx.env, envCtx.ctx);
+          } else {
+            invocationResult = invokeFn(js, fn, thisArg, args);
+          }
+
+          // We have a function, so let's call it and serialize the result for RPC.
+          // If the function returns a promise we will wait for the promise to finish so we can
+          // serialize the result.
+          return handleResult(kj::mv(invocationResult));
         }
 
-        InvocationResult invocationResult;
-        KJ_IF_SOME(envCtx, targetInfo.envCtx) {
-          invocationResult = invokeFnInsertingEnvCtx(
-              js, methodNameForTrace, fn, thisArg, args, envCtx.env, envCtx.ctx);
-        } else {
-          invocationResult = invokeFn(js, fn, thisArg, args);
-        }
-
-        // We have a function, so let's call it and serialize the result for RPC.
-        // If the function returns a promise we will wait for the promise to finish so we can
-        // serialize the result.
-        return handleResult(kj::mv(invocationResult));
+        case rpc::JsRpcTarget::CallParams::Operation::GET_PROPERTY:
+          return handleResult({.returnValue = propHandle});
       }
 
-      case rpc::JsRpcTarget::CallParams::Operation::GET_PROPERTY:
-        return handleResult({.returnValue = propHandle});
-    }
+      KJ_FAIL_ASSERT("unknown JsRpcTarget::CallParams::Operation", (uint)op.which());
+    };
 
-    KJ_FAIL_ASSERT("unknown JsRpcTarget::CallParams::Operation", (uint)op.which());
+    return dispatch().attach(kj::mv(jsRpcCallSpan));
   }
 
   struct GetPropResult {
@@ -1427,7 +1489,8 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       kj::Maybe<rpc::JsValue::Reader> args) {
     // We received arguments from the client, deserialize them back to JS.
     KJ_IF_SOME(a, args) {
-      auto [value, disposalGroup, streamSink] = deserializeJsValue(js, a, "params"_kjc);
+      auto [value, disposalGroup, streamSink] =
+          deserializeJsValue(js, a, "params"_kjc, kj::none, kj::none);
       auto args = KJ_REQUIRE_NONNULL(
           value.tryCast<jsg::JsArray>(), "expected JsArray when deserializing arguments.");
       // Call() expects a `Local<Value> []`... so we populate an array.
@@ -1487,7 +1550,8 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
     kj::Maybe<jsg::JsArray> argsArrayFromClient;
     size_t argCountFromClient = 0;
     KJ_IF_SOME(a, args) {
-      auto [value, disposalGroup, ss] = deserializeJsValue(js, a, "paramsNonClass"_kjc);
+      auto [value, disposalGroup, ss] =
+          deserializeJsValue(js, a, "paramsNonClass"_kjc, kj::none, kj::none);
       streamSink = kj::mv(ss);
 
       auto array = KJ_REQUIRE_NONNULL(
@@ -1642,6 +1706,10 @@ class TransientJsRpcTarget final: public JsRpcTargetBase {
       return true;
     }
     return false;
+  }
+
+  kj::LiteralStringConst getTargetKind() override {
+    return "transient"_kjc;
   }
 
   void maybeSetJsRpcInfo(IoContext& ctx, const kj::ConstString& methodNameForTrace) override {}
@@ -2094,6 +2162,10 @@ class EntrypointJsRpcTarget final: public JsRpcTargetBase {
     return false;
   }
 
+  kj::LiteralStringConst getTargetKind() override {
+    return "entrypoint"_kjc;
+  }
+
   void maybeSetJsRpcInfo(IoContext& ctx, const kj::ConstString& methodNameForTrace) override {
     KJ_IF_SOME(tracer, ctx.getWorkerTracer()) {
       tracer.setJsRpcInfo(ctx.getInvocationSpanContext(), ctx.now(), methodNameForTrace);
@@ -2172,6 +2244,11 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::run(
     // disconnects.
     waitUntilTasks.add(incomingRequest->drain().attach(kj::mv(incomingRequest)));
   });
+
+  // No server-side user span: the jsrpc-typed onset already represents the session
+  // (delivered() to outcome). The internal span is still emitted for the legacy
+  // buffered tail.
+  auto jsRpcSessionInternalSpan = ioctx.makeTraceSpan("jsRpcSession"_kjc);
 
   EntrypointJsRpcTarget target(ioctx, entrypointName, kj::mv(versionInfo), kj::mv(props),
       kj::mv(wrapperModule), mapAddRef(incomingRequest->getWorkerTracer()), isDynamicDispatch);

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -126,14 +126,18 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
  public:
   // The `streamSink` parameter should be provided if a StreamSink already exists, e.g. when
   // deserializing results. If omitted, it will be constructed on-demand.
+  // `originatingCall`, when present, is recorded on any stubs deserialized so that
+  // follow-up calls on those stubs nest under the call that returned them.
   RpcDeserializerExternalHandler(capnp::List<rpc::JsValue::External>::Reader externals,
       RpcStubDisposalGroup& disposalGroup,
       kj::Maybe<StreamSinkImpl&> streamSink,
-      kj::LiteralStringConst debugContext)
+      kj::LiteralStringConst debugContext,
+      kj::Maybe<TraceContextParent> originatingCall)
       : externals(externals),
         disposalGroup(disposalGroup),
         streamSink(streamSink),
-        debugContext(debugContext) {}
+        debugContext(debugContext),
+        originatingCall(kj::mv(originatingCall)) {}
   ~RpcDeserializerExternalHandler() noexcept(false);
 
   // Read and return the next external.
@@ -162,6 +166,10 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
     return debugContext;
   }
 
+  kj::Maybe<TraceContextParent> getOriginatingCall() {
+    return originatingCall.map([](TraceContextParent& p) { return p.addRef(); });
+  }
+
  private:
   capnp::List<rpc::JsValue::External>::Reader externals;
   uint i = 0;
@@ -173,6 +181,7 @@ class RpcDeserializerExternalHandler final: public jsg::Deserializer::ExternalHa
   kj::Maybe<rpc::JsValue::StreamSink::Client> streamSinkCap;
 
   kj::LiteralStringConst debugContext;
+  kj::Maybe<TraceContextParent> originatingCall;
 };
 
 // Base class for objects which can be sent over RPC, but doing so actually sends a stub which
@@ -197,12 +206,23 @@ class JsRpcTarget: public jsg::Object {
 // it's only a C++ class used to abstract how to get a capnp client out of the object.
 class JsRpcClientProvider: public jsg::Object {
  public:
+  // Result of resolving a stub for one call's worth of dispatch.
+  struct ClientForOneCall {
+    rpc::JsRpcTarget::Client client;
+    // Spans to parent the per-call jsRpcCall under (Fetcher: the new session;
+    // JsRpcStub: the call that returned this stub).
+    kj::Maybe<TraceContextParent> callSpanParents;
+  };
+
   // Get a capnp client that can be used to dispatch one call.
   //
   // If this isn't the root object (i.e. this is a JsRpcProperty), the property path starting from
   // the root object will be appended to `path`.
-  virtual rpc::JsRpcTarget::Client getClientForOneCall(
-      jsg::Lock& js, kj::Vector<kj::StringPtr>& path) = 0;
+  virtual ClientForOneCall getClientForOneCall(jsg::Lock& js, kj::Vector<kj::StringPtr>& path) = 0;
+
+  // Tracing tag value for jsrpc.target_kind on the client-side per-call span
+  // (see JsRpcTargetBase::getTargetKind for the server-side equivalent).
+  virtual kj::LiteralStringConst getRpcTargetKind() = 0;
 };
 
 class JsRpcProperty;
@@ -234,8 +254,11 @@ class JsRpcPromise: public JsRpcClientProvider {
   void resolve(jsg::Lock& js, jsg::JsValue result);
   void dispose(jsg::Lock& js);
 
-  rpc::JsRpcTarget::Client getClientForOneCall(
-      jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
+  ClientForOneCall getClientForOneCall(jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
+
+  kj::LiteralStringConst getRpcTargetKind() override {
+    return "promise"_kjc;
+  }
 
   // Expect that the call is itself going to return a function... and call that.
   jsg::Ref<JsRpcPromise> call(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -313,8 +336,13 @@ class JsRpcProperty: public JsRpcClientProvider {
       : parent(kj::mv(parent)),
         name(kj::mv(name)) {}
 
-  rpc::JsRpcTarget::Client getClientForOneCall(
-      jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
+  ClientForOneCall getClientForOneCall(jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
+
+  // Forward to parent: a property chain dispatches to the root's target, and
+  // the property path itself is captured separately by jsrpc.method.
+  kj::LiteralStringConst getRpcTargetKind() override {
+    return parent->getRpcTargetKind();
+  }
 
   // Call the property as a method.
   jsg::Ref<JsRpcPromise> call(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -386,13 +414,17 @@ class JsRpcStub: public JsRpcClientProvider {
   JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient): capnpClient(kj::mv(capnpClient)) {}
   JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient,
       RpcStubDisposalGroup& disposalGroup,
-      jsg::ExternalMemoryAdjustment externalMemoryAdjustment);
+      jsg::ExternalMemoryAdjustment externalMemoryAdjustment,
+      kj::Maybe<TraceContextParent> originatingCall);
   ~JsRpcStub() noexcept(false);
 
   rpc::JsRpcTarget::Client getClient();
 
-  rpc::JsRpcTarget::Client getClientForOneCall(
-      jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
+  ClientForOneCall getClientForOneCall(jsg::Lock& js, kj::Vector<kj::StringPtr>& path) override;
+
+  kj::LiteralStringConst getRpcTargetKind() override {
+    return "stub"_kjc;
+  }
 
   jsg::Ref<JsRpcStub> dup(jsg::Lock& js);
   void dispose();
@@ -430,6 +462,17 @@ class JsRpcStub: public JsRpcClientProvider {
   kj::Maybe<RpcStubDisposalGroup&> disposalGroup;
   kj::ListLink<JsRpcStub> disposalGroupLink;
   kj::Maybe<jsg::ExternalMemoryAdjustment> externalMemoryAdjustment;
+
+  // The jsRpcCall of the call that returned this stub (set on stubs received via
+  // deserialization), used to parent follow-up calls on the stub under it.
+  //
+  // Note: the originating jsRpcCall span is normally already closed by the time we open
+  // a child here (the originating SpanBuilder is destroyed when the awaitIo callback that
+  // produced this stub returns). That's OK: SpanParent holds a refcount on the underlying
+  // refcounted SpanObserver, so the parent identity remains valid for newChild() even after
+  // the parent has been reported closed. Observers must tolerate children opening after
+  // their parent's onClose().
+  kj::Maybe<TraceContextParent> originatingCall;
 
   friend class RpcStubDisposalGroup;
 };

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -1286,6 +1286,30 @@ inline SpanBuilder SpanBuilder::newChild(
       kj::mv(operationName), startTime);
 }
 
+class TraceContext;
+
+// Pair of span parents (internal + user) used to express "open new spans nested
+// under these". Doesn't own SpanBuilders, unlike TraceContext.
+class TraceContextParent {
+ public:
+  TraceContextParent(SpanParent internalSpan, SpanParent userSpan)
+      : internalSpan(kj::mv(internalSpan)),
+        userSpan(kj::mv(userSpan)) {}
+  TraceContextParent(TraceContextParent&& other) = default;
+  TraceContextParent& operator=(TraceContextParent&& other) = default;
+  KJ_DISALLOW_COPY(TraceContextParent);
+
+  TraceContextParent addRef() {
+    return TraceContextParent(internalSpan.addRef(), userSpan.addRef());
+  }
+
+  [[nodiscard]] TraceContext newChild(kj::ConstString operationName);
+
+ private:
+  SpanParent internalSpan;
+  SpanParent userSpan;
+};
+
 // TraceContext to keep track of user tracing/existing tracing better
 class TraceContext {
  public:
@@ -1310,10 +1334,20 @@ class TraceContext {
     return SpanParent(userSpan);
   }
 
+  TraceContextParent getSpanParents() {
+    return TraceContextParent(SpanParent(span), SpanParent(userSpan));
+  }
+
  private:
   SpanBuilder span;
   SpanBuilder userSpan;
 };
+
+inline TraceContext TraceContextParent::newChild(kj::ConstString operationName) {
+  auto internalChild = internalSpan.newChild(operationName.clone());
+  auto userChild = userSpan.newChild(kj::mv(operationName));
+  return TraceContext(kj::mv(internalChild), kj::mv(userChild));
+}
 
 // RAII object that measures the time duration over its lifetime. It tags this duration onto a
 // given request span using a specified tag name. Ideal for automatically tracking and logging


### PR DESCRIPTION
Adds a `jsRpcCall` user trace span on every JS-RPC dispatch, on both sides of the wire, so that each method invocation is visible as its own span in tail traces. Spans are tagged with `jsrpc.method`, `jsrpc.target_kind` (fetcher / entrypoint / stub / transient / promise), and `jsrpc.operation` (call / getProperty).

Stub origin propagation: stubs returned via RPC now carry the `jsRpcCall` of the call that produced them. Follow-up calls on those stubs nest under the originating call rather than under the request root, restoring trace continuity across pipelined RPC chains. Plumbed through `RpcDeserializerExternalHandler`, `JsRpcStub`, and a new `JsRpcClientProvider::ClientForOneCall { client, callSpanParents }` return shape from `getClientForOneCall`.

OutgoingFactory result redesign: `Fetcher::OutgoingFactory::Result` now returns `{ client, spanParents }` so `Fetcher::buildClient` can nest its inner operation span under the factory's outer dispatch span (e.g. `durable_object_subrequest`). This is what gives `durable_object_subrequest` correct attribution as a parent of the per-call spans inside a DO stub invocation. Cascades through actor.{h,c++}, actor-state.c++, container.c++, sockets.c++ (the latter two return `spanParents = kj::none` since they don't open an outer dispatch span). New `TraceContextParent` helper in `trace.h` carries a borrowed (internalSpan, userSpan) pair without owning SpanBuilders.

Server side: `JsRpcSessionCustomEvent::run` emits an internal-only `jsRpcSession` span for the legacy buffered tail. No user-visible `jsRpcSession` is emitted on the server because the jsrpc-typed onset already represents the session (delivered() to outcome).

Test fixtures updated: tail-worker-test gains `jsRpcCall` open/close events with the new tags on each callee, jsrpcDoSubrequest reflects the nested `jsRpcSession -> jsRpcCall -> durable_object_subrequest -> jsRpcSession -> jsRpcCall` shape, sql-test-tail and actor-kv-test-tail adjust span counts, and `runInstrumentationTest` filters `jsRpcCall` alongside `jsRpcSession` by default.