### PR TITLE
Bump capnp-cpp past AnyStruct schema change and fix compatibility-date

### DIFF
--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -27,10 +27,10 @@ bazel_dep(name = "brotli", version = "1.2.0.bcr.1")
 # capnp-cpp
 http.archive(
     name = "capnp-cpp",
-    sha256 = "16bc50865c40448f16b10bea21098e12a175cd1046aa1518e04b9e4f4ad13670",
-    strip_prefix = "capnproto-capnproto-23bb5b9/c++",
+    sha256 = "a87651d1772c138643e1fc28ca0cbc8eda0445ca265bc200c083c31a75919386",
+    strip_prefix = "capnproto-capnproto-911e53d/c++",
     type = "tgz",
-    url = "https://github.com/capnproto/capnproto/tarball/23bb5b957cb1ab9f92734341b5664150e71890f2",
+    url = "https://github.com/capnproto/capnproto/tarball/911e53d67841687afe9a349fd8c0d39fe024515a",
 )
 use_repo(http, "capnp-cpp")
 

--- a/src/workerd/io/compatibility-date-test.c++
+++ b/src/workerd/io/compatibility-date-test.c++
@@ -502,7 +502,7 @@ KJ_TEST("compatibility dates must be Tuesday, Wednesday, or Thursday") {
         maybeDateStr = annotation.getValue().getText();
       } else if (annotation.getId() == IMPLIED_BY_AFTER_DATE_ANNOTATION_ID) {
         auto value = annotation.getValue();
-        auto s = value.getStruct().getAs<workerd::ImpliedByAfterDate>();
+        auto s = value.getStruct().as<workerd::ImpliedByAfterDate>();
         maybeDateStr = s.getDate();
       }
 

--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -183,7 +183,7 @@ static void compileCompatibilityFlags(kj::StringPtr compatDate,
         isExperimental = true;
       } else if (annotation.getId() == IMPLIED_BY_AFTER_DATE_ANNOTATION_ID) {
         auto value = annotation.getValue();
-        auto s = value.getStruct().getAs<workerd::ImpliedByAfterDate>();
+        auto s = value.getStruct().as<workerd::ImpliedByAfterDate>();
         auto parsedDate = KJ_ASSERT_NONNULL(CompatDate::parse(s.getDate()));
         // This flag will be marked as enabled if the flag identified by
         // s.getName() is enabled, but only on or after the specified date.


### PR DESCRIPTION
capnproto/capnproto#2501 introduced a source-breaking change: schema::Value::Reader::getStruct() now returns capnp::AnyStruct::Reader (with as<T>()) instead of capnp::AnyPointer::Reader (with getAs<T>()).

Bump capnp-cpp past it and update the two getStruct().getAs<T>() callers in compatibility-date.{c++,-test.c++} to use as<T>().

Assisted-by: OpenCode:claude-opus-4.7