### PR TITLE
bonk.yml: drop token push permission on plain-issue invocations

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -39,6 +39,10 @@ jobs:
           mentions: '/bonk,@ask-bonk'
           permissions: write
           opencode_version: "1.14.33"
-          # token_permissions defaults to WRITE (i.e. Bonk can push commits).
-          # We intentionally leave it that way here because users may ask Bonk
-          # to update their PR via /bonk.
+          # token_permissions stays WRITE on PR-context invocations because
+          # users may ask Bonk to update their PR via /bonk. The `issue_comment`
+          # event, however, also fires on plain issue comments — where there is
+          # no PR branch to push to — so for that path we drop to NO_PUSH so a
+          # supply-chain or prompt-injection mishap cannot turn an issue
+          # comment into a write to the repo.
+          token_permissions: ${{ (github.event_name == 'issue_comment' && !github.event.issue.pull_request) && 'NO_PUSH' || 'WRITE' }}


### PR DESCRIPTION
This is a defense-in-depth follow-up to my review comment on #6564. Per @erezrokah's reply — *"hard to validate by external contributors"* — this version of the change is the one path where `NO_PUSH` is unambiguously safe regardless of the action's runtime behavior.

## Summary

The Bonk workflow listens to three events: `issue_comment`, `pull_request_review_comment`, and `pull_request_review`. Of those, `issue_comment` fires for comments on both PRs and plain issues. On a plain issue, there is no PR branch for Bonk to push to, so the default `token_permissions: WRITE` is broader than that path can actually use.

This sets `token_permissions: NO_PUSH` when (and only when) `github.event_name == 'issue_comment'` and `github.event.issue.pull_request` is `null`. Every other invocation — PR comments via `issue_comment`, `pull_request_review_comment`, and `pull_request_review` — continues to receive `WRITE` so users can still ask Bonk to update their PR via \`/bonk\`.

The job-level \`permissions:\` block is unchanged.

## Why this is safe to merge without runtime validation

`token_permissions: NO_PUSH` only restricts what the action will accept doing with the GitHub token; the path it is restricted on (plain issue, no PR) does not, by definition, have a PR branch to push to. There is no scenario where dropping push permission on that path can regress a feature, because the feature it would gate — \"update my PR\" — cannot apply to a plain issue.

If Bonk's plain-issue behavior is to comment back on the issue, the relevant permission is \`issues: write\`, which is granted at the job level and unaffected by \`token_permissions\`. The token-permissions input is specifically the git push gate.

## Why this is worth doing

Narrows the blast radius of a supply-chain or prompt-injection mishap on the plain-issue path: an issue-comment invocation cannot be turned into a write to the repository through the GITHUB_TOKEN. The PR-context path retains its current capability, so the user-facing \"ask Bonk to update my PR\" flow is unchanged.

The same defense-in-depth shape that \`new-pr-review.yml\` already applies (\`token_permissions: 'NO_PUSH'\` with the comment *\"NO_PUSH enforces that at the token level so it holds even if the model ignores the instruction\"*), just gated on event context here so the PR-update path keeps WRITE.

## Diff

\`\`\`diff
-          # token_permissions defaults to WRITE (i.e. Bonk can push commits).
-          # We intentionally leave it that way here because users may ask Bonk
-          # to update their PR via /bonk.
+          # token_permissions stays WRITE on PR-context invocations because
+          # users may ask Bonk to update their PR via /bonk. The \`issue_comment\`
+          # event, however, also fires on plain issue comments — where there is
+          # no PR branch to push to — so for that path we drop to NO_PUSH so a
+          # supply-chain or prompt-injection mishap cannot turn an issue
+          # comment into a write to the repo.
+          token_permissions: \${{ (github.event_name == 'issue_comment' && !github.event.issue.pull_request) && 'NO_PUSH' || 'WRITE' }}
\`\`\`

Happy to close if you'd rather not narrow this particular path.