### PR TITLE
[Workflows] Add sensitive step output option

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -296,6 +296,8 @@ declare namespace CloudflareWorkersModule {
 
   export type WorkflowBackoff = 'constant' | 'linear' | 'exponential';
 
+  export type WorkflowStepSensitivity = 'output';
+
   export type WorkflowStepConfig = {
     retries?: {
       limit: number;
@@ -303,6 +305,7 @@ declare namespace CloudflareWorkersModule {
       backoff?: WorkflowBackoff;
     };
     timeout?: WorkflowTimeoutDuration | number;
+    sensitive?: WorkflowStepSensitivity;
   };
 
   export type WorkflowEvent<T> = {
@@ -315,6 +318,7 @@ declare namespace CloudflareWorkersModule {
     payload: Readonly<T>;
     timestamp: Date;
     type: string;
+    sensitive?: WorkflowStepSensitivity;
   };
 
   export type WorkflowStepContext = {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14400,6 +14400,7 @@ declare namespace CloudflareWorkersModule {
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
   export type WorkflowRetentionDuration = WorkflowSleepDuration;
   export type WorkflowBackoff = "constant" | "linear" | "exponential";
+  export type WorkflowStepSensitivity = "output";
   export type WorkflowStepConfig = {
     retries?: {
       limit: number;
@@ -14407,6 +14408,7 @@ declare namespace CloudflareWorkersModule {
       backoff?: WorkflowBackoff;
     };
     timeout?: WorkflowTimeoutDuration | number;
+    sensitive?: WorkflowStepSensitivity;
   };
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
@@ -14417,6 +14419,7 @@ declare namespace CloudflareWorkersModule {
     payload: Readonly<T>;
     timestamp: Date;
     type: string;
+    sensitive?: WorkflowStepSensitivity;
   };
   export type WorkflowStepContext = {
     step: {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14371,6 +14371,7 @@ export declare namespace CloudflareWorkersModule {
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
   export type WorkflowRetentionDuration = WorkflowSleepDuration;
   export type WorkflowBackoff = "constant" | "linear" | "exponential";
+  export type WorkflowStepSensitivity = "output";
   export type WorkflowStepConfig = {
     retries?: {
       limit: number;
@@ -14378,6 +14379,7 @@ export declare namespace CloudflareWorkersModule {
       backoff?: WorkflowBackoff;
     };
     timeout?: WorkflowTimeoutDuration | number;
+    sensitive?: WorkflowStepSensitivity;
   };
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
@@ -14388,6 +14390,7 @@ export declare namespace CloudflareWorkersModule {
     payload: Readonly<T>;
     timestamp: Date;
     type: string;
+    sensitive?: WorkflowStepSensitivity;
   };
   export type WorkflowStepContext = {
     step: {

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -13732,6 +13732,7 @@ declare namespace CloudflareWorkersModule {
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
   export type WorkflowRetentionDuration = WorkflowSleepDuration;
   export type WorkflowBackoff = "constant" | "linear" | "exponential";
+  export type WorkflowStepSensitivity = "output";
   export type WorkflowStepConfig = {
     retries?: {
       limit: number;
@@ -13739,6 +13740,7 @@ declare namespace CloudflareWorkersModule {
       backoff?: WorkflowBackoff;
     };
     timeout?: WorkflowTimeoutDuration | number;
+    sensitive?: WorkflowStepSensitivity;
   };
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
@@ -13749,6 +13751,7 @@ declare namespace CloudflareWorkersModule {
     payload: Readonly<T>;
     timestamp: Date;
     type: string;
+    sensitive?: WorkflowStepSensitivity;
   };
   export type WorkflowStepContext = {
     step: {

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -13703,6 +13703,7 @@ export declare namespace CloudflareWorkersModule {
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
   export type WorkflowRetentionDuration = WorkflowSleepDuration;
   export type WorkflowBackoff = "constant" | "linear" | "exponential";
+  export type WorkflowStepSensitivity = "output";
   export type WorkflowStepConfig = {
     retries?: {
       limit: number;
@@ -13710,6 +13711,7 @@ export declare namespace CloudflareWorkersModule {
       backoff?: WorkflowBackoff;
     };
     timeout?: WorkflowTimeoutDuration | number;
+    sensitive?: WorkflowStepSensitivity;
   };
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
@@ -13720,6 +13722,7 @@ export declare namespace CloudflareWorkersModule {
     payload: Readonly<T>;
     timestamp: Date;
     type: string;
+    sensitive?: WorkflowStepSensitivity;
   };
   export type WorkflowStepContext = {
     step: {


### PR DESCRIPTION
Adds an optional `sensitive` field to `WorkflowStepConfig` and `WorkflowStepEvent`.

This lets workflow users mark a step's output (or an incoming step event payload) as sensitive so the Workflows runtime can redact it from logs and observability surfaces.

```
 const token = await step.do('get-api-token',
      { sensitive: 'output', timeout: '30 seconds' },
      async () => {
        return await getToken(event.payload.userId);
      }
);
```