### PR TITLE
R2 binding should throw when Range is provided with no properties

### DIFF
--- a/src/workerd/api/r2-bucket.c++
+++ b/src/workerd/api/r2-bucket.c++
@@ -378,6 +378,8 @@ void initGetOptions(TraceContext& traceContext, jsg::Lock& js, Builder& builder,
   KJ_IF_SOME(range, o.range) {
     KJ_SWITCH_ONEOF(range) {
       KJ_CASE_ONEOF(r, R2Bucket::Range) {
+        JSG_REQUIRE(r.offset != kj::none || r.length != kj::none || r.suffix != kj::none,
+            TypeError, "Range must specify at least one of offset, length, or suffix.");
         auto rangeBuilder = builder.initRange();
         KJ_IF_SOME(offset, r.offset) {
           JSG_REQUIRE(offset >= 0, RangeError, "Invalid range. Starting offset (", offset,

--- a/src/workerd/api/tests/r2-test.js
+++ b/src/workerd/api/tests/r2-test.js
@@ -490,6 +490,20 @@ export default {
               body: 'nt',
             });
           }
+          case 'rangeOffsetOnly': {
+            assert.deepEqual(jsonRequest.range, {
+              offset: '5',
+            });
+            return buildGetResponse({
+              head: {
+                range: {
+                  offset: 5,
+                  length: 3,
+                },
+              },
+              body: 'ent',
+            });
+          }
           case 'onlyIfStrongEtag': {
             assert.deepStrictEqual(jsonRequest.onlyIf, {
               etagMatches: [
@@ -701,6 +715,52 @@ export default {
         },
         'nt'
       );
+      // Offset only (no length)
+      {
+        await compareResponse(
+          env.BUCKET.get('rangeOffsetOnly', {
+            range: { offset: 5 },
+          }),
+          {
+            head: {
+              range: {
+                offset: 5,
+                length: 3,
+              },
+            },
+          },
+          'ent'
+        );
+      }
+      // Empty range should throw TypeError
+      {
+        try {
+          await env.BUCKET.get('basicKey', { range: {} });
+          throw new Error('This should have thrown');
+        } catch (e) {
+          assert(e.message.includes('Range must specify at least one of'));
+        }
+      }
+      // Unrecognized properties only should throw TypeError
+      {
+        try {
+          await env.BUCKET.get('basicKey', { range: { invalid: 1 } });
+          throw new Error('This should have thrown');
+        } catch (e) {
+          assert(e.message.includes('Range must specify at least one of'));
+        }
+      }
+      // Suffix with offset should throw TypeError
+      {
+        try {
+          await env.BUCKET.get('basicKey', {
+            range: { suffix: 2, offset: 1 },
+          });
+          throw new Error('This should have thrown');
+        } catch (e) {
+          assert(e.message.includes('Suffix is incompatible with offset'));
+        }
+      }
     }
     // Conditionals
     {


### PR DESCRIPTION
R2 will reject a range that does not contain one of offset, length, or suffix, and users would see "Error: get: We encountered an internal error. Please try again. (10001)".

This change is to catch the issue early and throw a TypeError prior to sending an invalid request to R2.