### PR TITLE
ci: declare permissions on 5 workflows (lint, issues, semgrep, release-python-*)

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, labeled, transferred]
 
+# The project mutation uses secrets.DEVPROD_PAT, not GITHUB_TOKEN.
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to GH project

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ concurrency:
   group: lint.yml-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-python-runtime.yml
+++ b/.github/workflows/release-python-runtime.yml
@@ -9,6 +9,12 @@ on:
         default: false
         type: boolean
 
+# The "Check for open PR and commit changes" step uses gh + git push,
+# both via GITHUB_TOKEN. R2 uploads use their own R2_* secrets.
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-python-snapshots.yml
+++ b/.github/workflows/release-python-snapshots.yml
@@ -9,6 +9,14 @@ on:
         default: false
         type: boolean
 
+# The "Check for open PR and commit changes" step uses gh + git push.
+# R2 uploads use their own R2_* secrets. The reusable _bazel.yml caller
+# declares its own permissions; this top-level block applies only to
+# the in-file jobs.
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   build-linux:
     uses: ./.github/workflows/_bazel.yml

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
 name: Semgrep config
+permissions:
+  contents: read
 jobs:
   semgrep:
     name: semgrep/ci


### PR DESCRIPTION
Five of the six workerd workflows that still inherit default `GITHUB_TOKEN` scopes get an explicit `permissions:` block here:

| Workflow | Scope | Why |
|----------|-------|-----|
| `lint.yml` | `contents: read` | bazel-driven format + lint check |
| `semgrep.yml` | `contents: read` | scheduled scan, findings go to cloudflare's Semgrep AppSec via `SEMGREP_APP_TOKEN` |
| `issues.yml` | `permissions: {}` | `actions/add-to-project` uses `secrets.DEVPROD_PAT`; the default token is unused |
| `release-python-runtime.yml` | `contents: write` + `pull-requests: read` | the 'Check for open PR and commit changes' step uses `gh pr list` and `git push origin $BRANCH_NAME` |
| `release-python-snapshots.yml` | `contents: write` + `pull-requests: read` | same fixup-commit pattern as runtime |

The R2 uploads in both release workflows use their own `R2_*` secrets, not `GITHUB_TOKEN`, so they don't influence the scope.

`cla.yml` is intentionally **not** included — `contributor-assistant/github-action` runs in `pull_request_target` context and its permission set (actions/contents/pull-requests/issues/statuses) needs a focused review by the team to avoid breaking the CLA flow. Happy to follow up in a separate PR if you'd like a recommended set.

YAML validated locally for each edited file.