### PR TITLE
crypto: chunk randomFillSync to exceed Web Crypto 64 KiB quota

### DIFF
--- a/src/node/internal/crypto_random.ts
+++ b/src/node/internal/crypto_random.ts
@@ -92,8 +92,20 @@ export function randomFillSync(
     buffer = Buffer.from(buffer);
   }
   buffer = (buffer as Buffer).subarray(offset, offset + size);
-  return crypto.getRandomValues(buffer as Uint8Array<ArrayBuffer>);
+  // crypto.getRandomValues() enforces the Web Crypto 64 KiB-per-call quota,
+  // but Node's crypto.randomBytes/randomFill have no such limit. Fill in
+  // 64 KiB chunks to stay spec-compliant on both sides.
+  // Ref: https://github.com/cloudflare/workerd/issues/6749
+  const view = buffer as Uint8Array<ArrayBuffer>;
+  for (let i = 0; i < view.length; i += kWebCryptoMaxRandomBytes) {
+    crypto.getRandomValues(view.subarray(i, i + kWebCryptoMaxRandomBytes));
+  }
+  return view;
 }
+
+// Web Crypto getRandomValues() per-call quota, per the spec and enforced in
+// src/workerd/api/crypto/crypto.c++ (Crypto::getRandomValues).
+const kWebCryptoMaxRandomBytes = 65536;
 
 export type RandomFillCallback = (
   err: Error | null,

--- a/src/node/internal/crypto_random.ts
+++ b/src/node/internal/crypto_random.ts
@@ -69,6 +69,10 @@ export function randomBytes(
   }
 }
 
+// Web Crypto getRandomValues() per-call quota, per the spec and enforced in
+// src/workerd/api/crypto/crypto.c++ (Crypto::getRandomValues).
+const kWebCryptoMaxRandomBytes = 65536;
+
 export function randomFillSync(
   buffer: NodeJS.ArrayBufferView,
   offset?: number,
@@ -102,10 +106,6 @@ export function randomFillSync(
   }
   return view;
 }
-
-// Web Crypto getRandomValues() per-call quota, per the spec and enforced in
-// src/workerd/api/crypto/crypto.c++ (Crypto::getRandomValues).
-const kWebCryptoMaxRandomBytes = 65536;
 
 export type RandomFillCallback = (
   err: Error | null,

--- a/src/workerd/api/node/tests/crypto_random-test.js
+++ b/src/workerd/api/node/tests/crypto_random-test.js
@@ -438,6 +438,58 @@ export const randomFillSyncTest = {
   },
 };
 
+// Ref: https://github.com/cloudflare/workerd/issues/6749
+// Node's crypto.randomBytes / randomFill must accept sizes above the 64 KiB
+// Web-Crypto getRandomValues quota. The polyfill must chunk internally.
+export const randomBytesAboveWebCryptoQuotaTest = {
+  async test() {
+    const { randomBytes, randomFill, randomFillSync } =
+      await import('node:crypto');
+
+    // Just past the 64 KiB boundary — the original bug repro.
+    const buf1 = randomBytes(65537);
+    strictEqual(buf1.length, 65537);
+    ok(
+      buf1.some((b) => b !== 0),
+      'buf1 should not be all-zero'
+    );
+
+    // Multi-chunk: 200000 = 3 chunks (65536 + 65536 + 68928).
+    const buf2 = randomBytes(200000);
+    strictEqual(buf2.length, 200000);
+    ok(
+      buf2.some((b) => b !== 0),
+      'buf2 should not be all-zero'
+    );
+
+    // randomFillSync with offset+size spanning a chunk boundary.
+    const buf3 = Buffer.alloc(70000, 0);
+    randomFillSync(buf3, 100, 65500);
+    strictEqual(buf3[0], 0, 'pre-offset byte untouched');
+    strictEqual(buf3[99], 0, 'last pre-offset byte untouched');
+    strictEqual(buf3[65600], 0, 'first post-range byte untouched');
+    strictEqual(buf3[69999], 0, 'tail byte untouched');
+    ok(
+      buf3.subarray(100, 65600).some((b) => b !== 0),
+      'filled range should not be all-zero'
+    );
+
+    // Async path.
+    await new Promise((resolve, reject) => {
+      randomFill(Buffer.alloc(80000, 0), (err, b) => {
+        if (err) return reject(err);
+        try {
+          strictEqual(b.length, 80000);
+          ok(b.some((x) => x !== 0));
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  },
+};
+
 // Ref: https://github.com/cloudflare/workerd/issues/2716
 export const getRandomValuesIllegalInvocation = {
   async test() {

--- a/src/workerd/api/node/tests/crypto_random-test.js
+++ b/src/workerd/api/node/tests/crypto_random-test.js
@@ -446,6 +446,10 @@ export const randomBytesAboveWebCryptoQuotaTest = {
     const { randomBytes, randomFill, randomFillSync } =
       await import('node:crypto');
 
+    // Exact 64 KiB boundary — single full chunk, off-by-one guard.
+    const bufBoundary = randomBytes(65536);
+    strictEqual(bufBoundary.length, 65536);
+
     // Just past the 64 KiB boundary — the original bug repro.
     const buf1 = randomBytes(65537);
     strictEqual(buf1.length, 65537);
@@ -472,6 +476,16 @@ export const randomBytesAboveWebCryptoQuotaTest = {
     ok(
       buf3.subarray(100, 65600).some((b) => b !== 0),
       'filled range should not be all-zero'
+    );
+
+    // ArrayBuffer input — exercises the isAnyArrayBuffer branch in
+    // randomFillSync (the input is internally wrapped with Buffer.from()).
+    const ab = new ArrayBuffer(70000);
+    const filled = randomFillSync(ab);
+    strictEqual(filled.length, 70000);
+    ok(
+      filled.some((b) => b !== 0),
+      'ArrayBuffer should be filled with non-zero bytes'
     );
 
     // Async path.


### PR DESCRIPTION
Fixes #6749.

## Summary

`crypto.randomBytes(n)` (and `randomFill`/`randomFillSync`) under `nodejs_compat` throws `QuotaExceededError: getRandomValues() only accepts buffers of size <= 64K but provided <N> bytes` for any `n > 65536`. Node.js has no such limit.

## Root cause

`randomFillSync` in `src/node/internal/crypto_random.ts` routes the entire requested span through a single call to `crypto.getRandomValues()`. The C++ implementation at `src/workerd/api/crypto/crypto.c++` (`Crypto::getRandomValues`) correctly enforces the Web Crypto spec's 64 KiB per-call cap (`buffer.size() <= 0x10000`). Node's `randomBytes`/`randomFill` are a different API and do not share that limit.

## Why Node has no 64 KiB cap (upstream evidence)

All references pinned to nodejs/node @ [`a159b57`](https://github.com/nodejs/node/tree/a159b57078cb72cc7b4f951b38ef637d9481aed0):

1. The only size cap in the JS layer is `kMaxPossibleLength = min(kMaxLength, 2**31 - 1)` — about 2 GiB:
   [`lib/internal/crypto/random.js#L70`](https://github.com/nodejs/node/blob/a159b57078cb72cc7b4f951b38ef637d9481aed0/lib/internal/crypto/random.js#L70)
   `randomBytes`'s only size check: [`#L100-L101`](https://github.com/nodejs/node/blob/a159b57078cb72cc7b4f951b38ef637d9481aed0/lib/internal/crypto/random.js#L100-L101)
   `randomFillSync` (no further size cap; whole `size` passed to `RandomBytesJob`): [`#L120-L148`](https://github.com/nodejs/node/blob/a159b57078cb72cc7b4f951b38ef637d9481aed0/lib/internal/crypto/random.js#L120-L148)

2. The C++ binding forwards the entire buffer to `ncrypto::CSPRNG`:
   [`src/crypto/crypto_random.cc#L68-L74`](https://github.com/nodejs/node/blob/a159b57078cb72cc7b4f951b38ef637d9481aed0/src/crypto/crypto_random.cc#L68-L74)

3. `CSPRNG` calls OpenSSL `RAND_bytes_ex` (OpenSSL ≥ 3) or chunks with `RAND_bytes` at `INT_MAX` (~2 GiB) for older OpenSSL — never at 65536:
   [`deps/ncrypto/ncrypto.cc#L559-L593`](https://github.com/nodejs/node/blob/a159b57078cb72cc7b4f951b38ef637d9481aed0/deps/ncrypto/ncrypto.cc#L559-L593)

So in Node, the 64 KiB cap applies only to `crypto.getRandomValues` (which is a separate Web Crypto API surface), not to `crypto.randomBytes`/`randomFill`.

## Fix

Chunk the fill in `randomFillSync` so each `crypto.getRandomValues()` call is ≤ 65 536 bytes. The cap and behavior of `crypto.getRandomValues()` itself are unchanged.

```ts
const view = buffer as Uint8Array<ArrayBuffer>;
for (let i = 0; i < view.length; i += kWebCryptoMaxRandomBytes) {
  crypto.getRandomValues(view.subarray(i, i + kWebCryptoMaxRandomBytes));
}
return view;
```

This was preferred over a new C++ `cryptoImpl.randomBytes` binding because it (a) requires no schema change, (b) keeps `IoContext::getEntropySource()` as the single entropy source (matters for workerd's predictable-test mode), and (c) is the same pattern used by Node's own browser polyfills (e.g. `randombytes` on npm).

## Test plan

- [x] New test `randomBytesAboveWebCryptoQuotaTest` in `src/workerd/api/node/tests/crypto_random-test.js` covers:
  - `randomBytes(65537)` — the original repro from #6749
  - `randomBytes(200000)` — multi-chunk path (3 chunks)
  - `randomFillSync(buf, offset=100, size=65500)` — chunk-spanning offset + bytes outside the range untouched
  - `randomFill(buf, cb)` — async path
- [x] `just stream-test //src/workerd/api/node/tests:crypto_random-test@`
- [ ] CI on `@all-compat-flags` and `@all-autogates` variants