### PR TITLE
types: clarify DispatchNamespace.get does not throw on missing worker (fixes #5263)

### DIFF
--- a/types/defines/wfp.d.ts
+++ b/types/defines/wfp.d.ts
@@ -26,7 +26,11 @@ interface DispatchNamespace {
   * @param args Arguments to Worker script.
   * @param options Options for Dynamic Dispatch invocation.
   * @returns A Fetcher object that allows you to send requests to the Worker script.
-  * @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown.
+  *
+  * Note: `get` does not validate that the named Worker script exists in the
+  * dispatch namespace. It always returns a Fetcher; if the script is missing,
+  * the resulting "Worker not found" error is surfaced when `fetch()` is
+  * invoked on the returned Fetcher.
   */
   get(name: string, args?: {[key: string]: any}, options?: DynamicDispatchOptions ): Fetcher;
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -16771,7 +16771,11 @@ interface DispatchNamespace {
    * @param args Arguments to Worker script.
    * @param options Options for Dynamic Dispatch invocation.
    * @returns A Fetcher object that allows you to send requests to the Worker script.
-   * @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown.
+   *
+   * Note: `get` does not validate that the named Worker script exists in the
+   * dispatch namespace. It always returns a Fetcher; if the script is missing,
+   * the resulting "Worker not found" error is surfaced when `fetch()` is
+   * invoked on the returned Fetcher.
    */
   get(
     name: string,

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -16732,7 +16732,11 @@ export interface DispatchNamespace {
    * @param args Arguments to Worker script.
    * @param options Options for Dynamic Dispatch invocation.
    * @returns A Fetcher object that allows you to send requests to the Worker script.
-   * @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown.
+   *
+   * Note: `get` does not validate that the named Worker script exists in the
+   * dispatch namespace. It always returns a Fetcher; if the script is missing,
+   * the resulting "Worker not found" error is surfaced when `fetch()` is
+   * invoked on the returned Fetcher.
    */
   get(
     name: string,

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -16103,7 +16103,11 @@ interface DispatchNamespace {
    * @param args Arguments to Worker script.
    * @param options Options for Dynamic Dispatch invocation.
    * @returns A Fetcher object that allows you to send requests to the Worker script.
-   * @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown.
+   *
+   * Note: `get` does not validate that the named Worker script exists in the
+   * dispatch namespace. It always returns a Fetcher; if the script is missing,
+   * the resulting "Worker not found" error is surfaced when `fetch()` is
+   * invoked on the returned Fetcher.
    */
   get(
     name: string,

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -16064,7 +16064,11 @@ export interface DispatchNamespace {
    * @param args Arguments to Worker script.
    * @param options Options for Dynamic Dispatch invocation.
    * @returns A Fetcher object that allows you to send requests to the Worker script.
-   * @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown.
+   *
+   * Note: `get` does not validate that the named Worker script exists in the
+   * dispatch namespace. It always returns a Fetcher; if the script is missing,
+   * the resulting "Worker not found" error is surfaced when `fetch()` is
+   * invoked on the returned Fetcher.
    */
   get(
     name: string,


### PR DESCRIPTION
### Summary

The JSDoc for `DispatchNamespace.get` in `types/defines/wfp.d.ts` claimed:

> `@throws If the Worker script does not exist in this dispatch namespace, an error will be thrown.`

In practice, `get` always returns a `Fetcher`; the "Worker not found" error is only surfaced when the returned Fetcher's `fetch()` is invoked. The reporter demonstrated this with a clear repro in #5263. The [dynamic dispatch example in the Cloudflare docs](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/get-started/dynamic-dispatch/#subdomain-based-routing) already documents the workaround (`e.message.startsWith('Worker not found')` inside the `fetch()` try/catch), which confirms the runtime behavior is intentional — only the JSDoc was misleading.

### Fix

Replaced the inaccurate `@throws` line with a note describing the actual behavior and where the error surfaces. This is a docs-only change; no runtime behavior is affected.

Updated:

- `types/defines/wfp.d.ts` — the source definition (the file the issue links to is generated from this).
- The four corresponding generated snapshots under `types/generated-snapshot/{latest,experimental}/index.{ts,d.ts}` so the snapshot check stays green. (I do not have a Bazel build environment to regenerate them via `bazel build //types:types`; if reviewers prefer the snapshots be regenerated, please tell me and I'll redo locally.)

### Verification

- `grep -rn "@throws If the Worker script does not exist" types/` returns no remaining matches after the patch.
- Patch is comments-only — no source/runtime change.

### Issue

Fixes #5263