### PR TITLE
workflows: rollback types

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -326,15 +326,32 @@ declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
 
+  export type WorkflowRollbackContext<T = unknown> = {
+    error: Error;
+    output: T;
+    stepName: string;
+  };
+
+  export type WorkflowRollbackHandler<T = unknown> = (
+    ctx: WorkflowRollbackContext<T>
+  ) => Promise<void>;
+
+  export type WorkflowStepRollbackOptions<T = unknown> = {
+    rollback?: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepConfig;
+  };
+
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
-      callback: (ctx: WorkflowStepContext) => Promise<T>
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
-      callback: (ctx: WorkflowStepContext) => Promise<T>
+      callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -328,7 +328,7 @@ declare namespace CloudflareWorkersModule {
 
   export type WorkflowRollbackContext<T = unknown> = {
     error: Error;
-    output: T;
+    output: T | undefined;
     stepName: string;
   };
 

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -345,13 +345,13 @@ declare namespace CloudflareWorkersModule {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions
+      rollbackOptions?: WorkflowStepRollbackOptions<T>
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions
+      rollbackOptions?: WorkflowStepRollbackOptions<T>
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -11411,7 +11411,7 @@ declare abstract class Base_Ai_Cf_Nvidia_Nemotron_3_120B_A12B {
   postProcessedOutputs: ChatCompletionsOutput;
 }
 declare abstract class Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT {
-  inputs: ChatCompletionsInput;
+  inputs: ChatCompletionsBase;
   postProcessedOutputs: ChatCompletionsOutput;
 }
 interface AiModels {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14442,13 +14442,13 @@ declare namespace CloudflareWorkersModule {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14428,7 +14428,7 @@ declare namespace CloudflareWorkersModule {
   };
   export type WorkflowRollbackContext<T = unknown> = {
     error: Error;
-    output: T;
+    output: T | undefined;
     stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14426,15 +14426,29 @@ declare namespace CloudflareWorkersModule {
     attempt: number;
     config: WorkflowStepConfig;
   };
+  export type WorkflowRollbackContext<T = unknown> = {
+    error: Error;
+    output: T;
+    stepName: string;
+  };
+  export type WorkflowRollbackHandler<T = unknown> = (
+    ctx: WorkflowRollbackContext<T>,
+  ) => Promise<void>;
+  export type WorkflowStepRollbackOptions<T = unknown> = {
+    rollback?: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepConfig;
+  };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14399,7 +14399,7 @@ export declare namespace CloudflareWorkersModule {
   };
   export type WorkflowRollbackContext<T = unknown> = {
     error: Error;
-    output: T;
+    output: T | undefined;
     stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -11421,7 +11421,7 @@ export declare abstract class Base_Ai_Cf_Nvidia_Nemotron_3_120B_A12B {
   postProcessedOutputs: ChatCompletionsOutput;
 }
 export declare abstract class Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT {
-  inputs: ChatCompletionsInput;
+  inputs: ChatCompletionsBase;
   postProcessedOutputs: ChatCompletionsOutput;
 }
 export interface AiModels {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14413,13 +14413,13 @@ export declare namespace CloudflareWorkersModule {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14397,15 +14397,29 @@ export declare namespace CloudflareWorkersModule {
     attempt: number;
     config: WorkflowStepConfig;
   };
+  export type WorkflowRollbackContext<T = unknown> = {
+    error: Error;
+    output: T;
+    stepName: string;
+  };
+  export type WorkflowRollbackHandler<T = unknown> = (
+    ctx: WorkflowRollbackContext<T>,
+  ) => Promise<void>;
+  export type WorkflowStepRollbackOptions<T = unknown> = {
+    rollback?: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepConfig;
+  };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -13758,15 +13758,29 @@ declare namespace CloudflareWorkersModule {
     attempt: number;
     config: WorkflowStepConfig;
   };
+  export type WorkflowRollbackContext<T = unknown> = {
+    error: Error;
+    output: T;
+    stepName: string;
+  };
+  export type WorkflowRollbackHandler<T = unknown> = (
+    ctx: WorkflowRollbackContext<T>,
+  ) => Promise<void>;
+  export type WorkflowStepRollbackOptions<T = unknown> = {
+    rollback?: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepConfig;
+  };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -13774,13 +13774,13 @@ declare namespace CloudflareWorkersModule {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -10743,7 +10743,7 @@ declare abstract class Base_Ai_Cf_Nvidia_Nemotron_3_120B_A12B {
   postProcessedOutputs: ChatCompletionsOutput;
 }
 declare abstract class Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT {
-  inputs: ChatCompletionsInput;
+  inputs: ChatCompletionsBase;
   postProcessedOutputs: ChatCompletionsOutput;
 }
 interface AiModels {

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -13760,7 +13760,7 @@ declare namespace CloudflareWorkersModule {
   };
   export type WorkflowRollbackContext<T = unknown> = {
     error: Error;
-    output: T;
+    output: T | undefined;
     stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -13729,15 +13729,29 @@ export declare namespace CloudflareWorkersModule {
     attempt: number;
     config: WorkflowStepConfig;
   };
+  export type WorkflowRollbackContext<T = unknown> = {
+    error: Error;
+    output: T;
+    stepName: string;
+  };
+  export type WorkflowRollbackHandler<T = unknown> = (
+    ctx: WorkflowRollbackContext<T>,
+  ) => Promise<void>;
+  export type WorkflowStepRollbackOptions<T = unknown> = {
+    rollback?: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepConfig;
+  };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
+      rollbackOptions?: WorkflowStepRollbackOptions,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -10753,7 +10753,7 @@ export declare abstract class Base_Ai_Cf_Nvidia_Nemotron_3_120B_A12B {
   postProcessedOutputs: ChatCompletionsOutput;
 }
 export declare abstract class Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT {
-  inputs: ChatCompletionsInput;
+  inputs: ChatCompletionsBase;
   postProcessedOutputs: ChatCompletionsOutput;
 }
 export interface AiModels {

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -13745,13 +13745,13 @@ export declare namespace CloudflareWorkersModule {
     do<T extends Rpc.Serializable<T>>(
       name: string,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>,
     ): Promise<T>;
     do<T extends Rpc.Serializable<T>>(
       name: string,
       config: WorkflowStepConfig,
       callback: (ctx: WorkflowStepContext) => Promise<T>,
-      rollbackOptions?: WorkflowStepRollbackOptions,
+      rollbackOptions?: WorkflowStepRollbackOptions<T>,
     ): Promise<T>;
     sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
     sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -13731,7 +13731,7 @@ export declare namespace CloudflareWorkersModule {
   };
   export type WorkflowRollbackContext<T = unknown> = {
     error: Error;
-    output: T;
+    output: T | undefined;
     stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -9,6 +9,7 @@ import {
   RpcTarget,
   WorkerEntrypoint,
 } from 'cloudflare:workers';
+import type {WorkflowStep} from 'cloudflare:workers';
 import { expectTypeOf } from 'expect-type';
 
 // Check `cache` export from `cloudflare:workers` has the expected type.
@@ -794,3 +795,29 @@ export default <ExportedHandler<Env>>{
     return new Response();
   },
 };
+
+declare const workflowStep: WorkflowStep;
+
+expectTypeOf(
+  workflowStep.do('step with rollback', async () => 'ok', {
+    rollback: async (ctx) => {
+      expectTypeOf(ctx.error).toEqualTypeOf<Error>();
+      expectTypeOf(ctx.output).toEqualTypeOf<unknown>();
+      expectTypeOf(ctx.stepName).toEqualTypeOf<string>();
+    },
+  })
+).toMatchTypeOf<Promise<string>>();
+
+workflowStep.do(
+  'configured rollback',
+  {retries: {limit: 0, delay: 0}},
+  async () => 'ok',
+  {
+    rollback: async (ctx) => {
+      expectTypeOf(ctx.output).toEqualTypeOf<unknown>();
+    },
+    rollbackConfig: {retries: {limit: 0, delay: 0}},
+  }
+);
+
+workflowStep.do('empty rollback options', async () => 'ok', {});

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -8,8 +8,8 @@ import {
   RpcStub,
   RpcTarget,
   WorkerEntrypoint,
+  type WorkflowStep,
 } from 'cloudflare:workers';
-import type {WorkflowStep} from 'cloudflare:workers';
 import { expectTypeOf } from 'expect-type';
 
 // Check `cache` export from `cloudflare:workers` has the expected type.
@@ -821,3 +821,15 @@ workflowStep.do(
 );
 
 workflowStep.do('empty rollback options', async () => 'ok', {});
+
+expectTypeOf(
+  workflowStep.do('no rollback 2-arg', async (): Promise<string> => 'ok')
+).toMatchTypeOf<Promise<string>>();
+
+expectTypeOf(
+  workflowStep.do(
+    'no rollback 3-arg',
+    {retries: {limit: 1, delay: 0}},
+    async (): Promise<string> => 'ok'
+  )
+).toMatchTypeOf<Promise<string>>();

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -802,7 +802,7 @@ expectTypeOf(
   workflowStep.do('step with rollback', async (): Promise<string> => 'ok', {
     rollback: async (ctx) => {
       expectTypeOf(ctx.error).toEqualTypeOf<Error>();
-      expectTypeOf(ctx.output).toEqualTypeOf<string>();
+      expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
       expectTypeOf(ctx.stepName).toEqualTypeOf<string>();
     },
   })
@@ -814,7 +814,7 @@ workflowStep.do(
   async (): Promise<string> => 'ok',
   {
     rollback: async (ctx) => {
-      expectTypeOf(ctx.output).toEqualTypeOf<string>();
+      expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
     },
     rollbackConfig: {retries: {limit: 0, delay: 0}},
   }

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -799,10 +799,10 @@ export default <ExportedHandler<Env>>{
 declare const workflowStep: WorkflowStep;
 
 expectTypeOf(
-  workflowStep.do('step with rollback', async () => 'ok', {
+  workflowStep.do('step with rollback', async (): Promise<string> => 'ok', {
     rollback: async (ctx) => {
       expectTypeOf(ctx.error).toEqualTypeOf<Error>();
-      expectTypeOf(ctx.output).toEqualTypeOf<unknown>();
+      expectTypeOf(ctx.output).toEqualTypeOf<string>();
       expectTypeOf(ctx.stepName).toEqualTypeOf<string>();
     },
   })
@@ -811,10 +811,10 @@ expectTypeOf(
 workflowStep.do(
   'configured rollback',
   {retries: {limit: 0, delay: 0}},
-  async () => 'ok',
+  async (): Promise<string> => 'ok',
   {
     rollback: async (ctx) => {
-      expectTypeOf(ctx.output).toEqualTypeOf<unknown>();
+      expectTypeOf(ctx.output).toEqualTypeOf<string>();
     },
     rollbackConfig: {retries: {limit: 0, delay: 0}},
   }


### PR DESCRIPTION
Adds Workers types for optional `step.do(name, config?, callback, { rollback, rollbackConfig })` Workflow rollback options.