### PR TITLE
feat(types): EMAIL-1692 accept EmailAddress objects in to/cc/bcc

### DIFF
--- a/types/defines/email.d.ts
+++ b/types/defines/email.d.ts
@@ -77,11 +77,11 @@ interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
   send(builder: {
 		from: string | EmailAddress;
-		to: string | string[];
+		to: string | EmailAddress | (string | EmailAddress)[];
 		subject: string;
 		replyTo?: string | EmailAddress;
-		cc?: string | string[];
-		bcc?: string | string[];
+		cc?: string | EmailAddress | (string | EmailAddress)[];
+		bcc?: string | EmailAddress | (string | EmailAddress)[];
 		headers?: Record<string, string>;
 		text?: string;
 		html?: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -13385,11 +13385,11 @@ interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
   send(builder: {
     from: string | EmailAddress;
-    to: string | string[];
+    to: string | EmailAddress | (string | EmailAddress)[];
     subject: string;
     replyTo?: string | EmailAddress;
-    cc?: string | string[];
-    bcc?: string | string[];
+    cc?: string | EmailAddress | (string | EmailAddress)[];
+    bcc?: string | EmailAddress | (string | EmailAddress)[];
     headers?: Record<string, string>;
     text?: string;
     html?: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -13409,11 +13409,11 @@ export interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
   send(builder: {
     from: string | EmailAddress;
-    to: string | string[];
+    to: string | EmailAddress | (string | EmailAddress)[];
     subject: string;
     replyTo?: string | EmailAddress;
-    cc?: string | string[];
-    bcc?: string | string[];
+    cc?: string | EmailAddress | (string | EmailAddress)[];
+    bcc?: string | EmailAddress | (string | EmailAddress)[];
     headers?: Record<string, string>;
     text?: string;
     html?: string;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12717,11 +12717,11 @@ interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
   send(builder: {
     from: string | EmailAddress;
-    to: string | string[];
+    to: string | EmailAddress | (string | EmailAddress)[];
     subject: string;
     replyTo?: string | EmailAddress;
-    cc?: string | string[];
-    bcc?: string | string[];
+    cc?: string | EmailAddress | (string | EmailAddress)[];
+    bcc?: string | EmailAddress | (string | EmailAddress)[];
     headers?: Record<string, string>;
     text?: string;
     html?: string;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12741,11 +12741,11 @@ export interface SendEmail {
   send(message: EmailMessage): Promise<EmailSendResult>;
   send(builder: {
     from: string | EmailAddress;
-    to: string | string[];
+    to: string | EmailAddress | (string | EmailAddress)[];
     subject: string;
     replyTo?: string | EmailAddress;
-    cc?: string | string[];
-    bcc?: string | string[];
+    cc?: string | EmailAddress | (string | EmailAddress)[];
+    bcc?: string | EmailAddress | (string | EmailAddress)[];
     headers?: Record<string, string>;
     text?: string;
     html?: string;


### PR DESCRIPTION
Changes have been fully released upstream and in workers-sdk with https://github.com/cloudflare/workers-sdk/pull/13836, this is solely a types change to reflect the new behaviour available.