### PR TITLE
RAG-1300: Add Web Search binding types

### DIFF
--- a/types/defines/web-search.d.ts
+++ b/types/defines/web-search.d.ts
@@ -1,0 +1,104 @@
+// ============ Web Search Request Types ============
+
+/**
+ * Options for a Web Search query.
+ */
+export type WebSearchSearchOptions = {
+  /** The search query. */
+  query: string;
+  /**
+   * Maximum number of results to return. Defaults to 10, capped at 20.
+   * The actual count may be lower if fewer matches exist.
+   */
+  limit?: number;
+};
+
+// ============ Web Search Response Types ============
+
+/**
+ * A single Web Search result.
+ *
+ * Web Search is discovery-only -- results carry catalog metadata about a page
+ * but never the page body. To read a result's content the caller invokes the
+ * global `fetch()` API against the result's `url`, at which point the
+ * destination's own access controls apply (including Cloudflare Pay-per-Crawl).
+ */
+export type WebSearchResult = {
+  /** Canonical URL. */
+  url: string;
+  /** Page title. */
+  title: string;
+  /** Page-level description. May be absent. */
+  description?: string;
+  /**
+   * Last-modified date for the page, when known. Naive (no timezone)
+   * ISO-8601 datetime, e.g. `"2025-11-30T04:39:48"`.
+   */
+  lastModifiedDate?: string;
+  /**
+   * Page meta image URL (typically the `og:image`). May be absent.
+   */
+  imageUrl?: string;
+  /** Optional favicon URL for UI hints. */
+  faviconUrl?: string;
+};
+
+/**
+ * Per-response metadata for a Web Search query. Carries operational
+ * fields useful for support and debugging.
+ */
+export type WebSearchResponseMetadata = {
+  /** The query that was executed. */
+  query: string;
+  /** Opaque request identifier used for support and debugging. */
+  requestId: string;
+  /** End-to-end latency for this search request, in milliseconds. */
+  latencyMs: number;
+};
+
+/**
+ * Response from a Web Search query.
+ */
+export type WebSearchSearchResponse = {
+  items: WebSearchResult[];
+  metadata: WebSearchResponseMetadata;
+};
+
+// ============ Web Search Binding Class ============
+
+/**
+ * Cloudflare Web Search binding.
+ *
+ * Discovery-only primitive for agents and Workers. Returns URLs and catalog
+ * metadata for a query; never returns page content or excerpts. To read a
+ * result's body, fetch the URL with the global `fetch()` API.
+ *
+ * Declared in wrangler with a single object (there is exactly one corpus, the
+ * public web, so there is no name, namespace, or instance to specify):
+ *
+ * ```jsonc
+ * { "web_search": { "binding": "WEBSEARCH" } }
+ * ```
+ *
+ * @example
+ * ```ts
+ * const { items, metadata } = await env.WEBSEARCH.search({
+ *   query: "Cloudflare Workers",
+ * });
+ *
+ * const top = items[0];
+ * console.log(top.url, top.title, metadata.latencyMs);
+ *
+ * // Read content yourself; pay-per-crawl and other publisher
+ * // controls apply at the fetch site, not at search time.
+ * const page = await fetch(top.url);
+ * ```
+ */
+export declare abstract class WebSearch {
+  /**
+   * Run a Web Search query.
+   * @param options Search options. Only `query` is required.
+   * @returns The matching results plus per-response metadata.
+   */
+  search(options: WebSearchSearchOptions): Promise<WebSearchSearchResponse>;
+}

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -11411,7 +11411,7 @@ declare abstract class Base_Ai_Cf_Nvidia_Nemotron_3_120B_A12B {
   postProcessedOutputs: ChatCompletionsOutput;
 }
 declare abstract class Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT {
-  inputs: ChatCompletionsInput;
+  inputs: ChatCompletionsBase;
   postProcessedOutputs: ChatCompletionsOutput;
 }
 interface AiModels {
@@ -15826,6 +15826,103 @@ type WorkerVersionMetadata = {
   /** The timestamp of when the Worker Version was uploaded */
   timestamp: string;
 };
+// ============ Web Search Request Types ============
+/**
+ * Options for a Web Search query.
+ */
+type WebSearchSearchOptions = {
+  /** The search query. */
+  query: string;
+  /**
+   * Maximum number of results to return. Defaults to 10, capped at 20.
+   * The actual count may be lower if fewer matches exist.
+   */
+  limit?: number;
+};
+// ============ Web Search Response Types ============
+/**
+ * A single Web Search result.
+ *
+ * Web Search is discovery-only -- results carry catalog metadata about a page
+ * but never the page body. To read a result's content the caller invokes the
+ * global `fetch()` API against the result's `url`, at which point the
+ * destination's own access controls apply (including Cloudflare Pay-per-Crawl).
+ */
+type WebSearchResult = {
+  /** Canonical URL. */
+  url: string;
+  /** Page title. */
+  title: string;
+  /** Page-level description. May be absent. */
+  description?: string;
+  /**
+   * Last-modified date for the page, when known. Naive (no timezone)
+   * ISO-8601 datetime, e.g. `"2025-11-30T04:39:48"`.
+   */
+  lastModifiedDate?: string;
+  /**
+   * Page meta image URL (typically the `og:image`). May be absent.
+   */
+  imageUrl?: string;
+  /** Optional favicon URL for UI hints. */
+  faviconUrl?: string;
+};
+/**
+ * Per-response metadata for a Web Search query. Carries operational
+ * fields useful for support and debugging.
+ */
+type WebSearchResponseMetadata = {
+  /** The query that was executed. */
+  query: string;
+  /** Opaque request identifier used for support and debugging. */
+  requestId: string;
+  /** End-to-end latency for this search request, in milliseconds. */
+  latencyMs: number;
+};
+/**
+ * Response from a Web Search query.
+ */
+type WebSearchSearchResponse = {
+  items: WebSearchResult[];
+  metadata: WebSearchResponseMetadata;
+};
+// ============ Web Search Binding Class ============
+/**
+ * Cloudflare Web Search binding.
+ *
+ * Discovery-only primitive for agents and Workers. Returns URLs and catalog
+ * metadata for a query; never returns page content or excerpts. To read a
+ * result's body, fetch the URL with the global `fetch()` API.
+ *
+ * Declared in wrangler with a single object (there is exactly one corpus, the
+ * public web, so there is no name, namespace, or instance to specify):
+ *
+ * ```jsonc
+ * { "web_search": { "binding": "WEBSEARCH" } }
+ * ```
+ *
+ * @example
+ * ```ts
+ * const { items, metadata } = await env.WEBSEARCH.search({
+ *   query: "Cloudflare Workers",
+ * });
+ *
+ * const top = items[0];
+ * console.log(top.url, top.title, metadata.latencyMs);
+ *
+ * // Read content yourself; pay-per-crawl and other publisher
+ * // controls apply at the fetch site, not at search time.
+ * const page = await fetch(top.url);
+ * ```
+ */
+declare abstract class WebSearch {
+  /**
+   * Run a Web Search query.
+   * @param options Search options. Only `query` is required.
+   * @returns The matching results plus per-response metadata.
+   */
+  search(options: WebSearchSearchOptions): Promise<WebSearchSearchResponse>;
+}
 interface DynamicDispatchLimits {
   /**
    * Limit CPU time in milliseconds.

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -11421,7 +11421,7 @@ export declare abstract class Base_Ai_Cf_Nvidia_Nemotron_3_120B_A12B {
   postProcessedOutputs: ChatCompletionsOutput;
 }
 export declare abstract class Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT {
-  inputs: ChatCompletionsInput;
+  inputs: ChatCompletionsBase;
   postProcessedOutputs: ChatCompletionsOutput;
 }
 export interface AiModels {
@@ -15787,6 +15787,103 @@ export type WorkerVersionMetadata = {
   /** The timestamp of when the Worker Version was uploaded */
   timestamp: string;
 };
+// ============ Web Search Request Types ============
+/**
+ * Options for a Web Search query.
+ */
+export type WebSearchSearchOptions = {
+  /** The search query. */
+  query: string;
+  /**
+   * Maximum number of results to return. Defaults to 10, capped at 20.
+   * The actual count may be lower if fewer matches exist.
+   */
+  limit?: number;
+};
+// ============ Web Search Response Types ============
+/**
+ * A single Web Search result.
+ *
+ * Web Search is discovery-only -- results carry catalog metadata about a page
+ * but never the page body. To read a result's content the caller invokes the
+ * global `fetch()` API against the result's `url`, at which point the
+ * destination's own access controls apply (including Cloudflare Pay-per-Crawl).
+ */
+export type WebSearchResult = {
+  /** Canonical URL. */
+  url: string;
+  /** Page title. */
+  title: string;
+  /** Page-level description. May be absent. */
+  description?: string;
+  /**
+   * Last-modified date for the page, when known. Naive (no timezone)
+   * ISO-8601 datetime, e.g. `"2025-11-30T04:39:48"`.
+   */
+  lastModifiedDate?: string;
+  /**
+   * Page meta image URL (typically the `og:image`). May be absent.
+   */
+  imageUrl?: string;
+  /** Optional favicon URL for UI hints. */
+  faviconUrl?: string;
+};
+/**
+ * Per-response metadata for a Web Search query. Carries operational
+ * fields useful for support and debugging.
+ */
+export type WebSearchResponseMetadata = {
+  /** The query that was executed. */
+  query: string;
+  /** Opaque request identifier used for support and debugging. */
+  requestId: string;
+  /** End-to-end latency for this search request, in milliseconds. */
+  latencyMs: number;
+};
+/**
+ * Response from a Web Search query.
+ */
+export type WebSearchSearchResponse = {
+  items: WebSearchResult[];
+  metadata: WebSearchResponseMetadata;
+};
+// ============ Web Search Binding Class ============
+/**
+ * Cloudflare Web Search binding.
+ *
+ * Discovery-only primitive for agents and Workers. Returns URLs and catalog
+ * metadata for a query; never returns page content or excerpts. To read a
+ * result's body, fetch the URL with the global `fetch()` API.
+ *
+ * Declared in wrangler with a single object (there is exactly one corpus, the
+ * public web, so there is no name, namespace, or instance to specify):
+ *
+ * ```jsonc
+ * { "web_search": { "binding": "WEBSEARCH" } }
+ * ```
+ *
+ * @example
+ * ```ts
+ * const { items, metadata } = await env.WEBSEARCH.search({
+ *   query: "Cloudflare Workers",
+ * });
+ *
+ * const top = items[0];
+ * console.log(top.url, top.title, metadata.latencyMs);
+ *
+ * // Read content yourself; pay-per-crawl and other publisher
+ * // controls apply at the fetch site, not at search time.
+ * const page = await fetch(top.url);
+ * ```
+ */
+export declare abstract class WebSearch {
+  /**
+   * Run a Web Search query.
+   * @param options Search options. Only `query` is required.
+   * @returns The matching results plus per-response metadata.
+   */
+  search(options: WebSearchSearchOptions): Promise<WebSearchSearchResponse>;
+}
 export interface DynamicDispatchLimits {
   /**
    * Limit CPU time in milliseconds.

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -10743,7 +10743,7 @@ declare abstract class Base_Ai_Cf_Nvidia_Nemotron_3_120B_A12B {
   postProcessedOutputs: ChatCompletionsOutput;
 }
 declare abstract class Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT {
-  inputs: ChatCompletionsInput;
+  inputs: ChatCompletionsBase;
   postProcessedOutputs: ChatCompletionsOutput;
 }
 interface AiModels {
@@ -15158,6 +15158,103 @@ type WorkerVersionMetadata = {
   /** The timestamp of when the Worker Version was uploaded */
   timestamp: string;
 };
+// ============ Web Search Request Types ============
+/**
+ * Options for a Web Search query.
+ */
+type WebSearchSearchOptions = {
+  /** The search query. */
+  query: string;
+  /**
+   * Maximum number of results to return. Defaults to 10, capped at 20.
+   * The actual count may be lower if fewer matches exist.
+   */
+  limit?: number;
+};
+// ============ Web Search Response Types ============
+/**
+ * A single Web Search result.
+ *
+ * Web Search is discovery-only -- results carry catalog metadata about a page
+ * but never the page body. To read a result's content the caller invokes the
+ * global `fetch()` API against the result's `url`, at which point the
+ * destination's own access controls apply (including Cloudflare Pay-per-Crawl).
+ */
+type WebSearchResult = {
+  /** Canonical URL. */
+  url: string;
+  /** Page title. */
+  title: string;
+  /** Page-level description. May be absent. */
+  description?: string;
+  /**
+   * Last-modified date for the page, when known. Naive (no timezone)
+   * ISO-8601 datetime, e.g. `"2025-11-30T04:39:48"`.
+   */
+  lastModifiedDate?: string;
+  /**
+   * Page meta image URL (typically the `og:image`). May be absent.
+   */
+  imageUrl?: string;
+  /** Optional favicon URL for UI hints. */
+  faviconUrl?: string;
+};
+/**
+ * Per-response metadata for a Web Search query. Carries operational
+ * fields useful for support and debugging.
+ */
+type WebSearchResponseMetadata = {
+  /** The query that was executed. */
+  query: string;
+  /** Opaque request identifier used for support and debugging. */
+  requestId: string;
+  /** End-to-end latency for this search request, in milliseconds. */
+  latencyMs: number;
+};
+/**
+ * Response from a Web Search query.
+ */
+type WebSearchSearchResponse = {
+  items: WebSearchResult[];
+  metadata: WebSearchResponseMetadata;
+};
+// ============ Web Search Binding Class ============
+/**
+ * Cloudflare Web Search binding.
+ *
+ * Discovery-only primitive for agents and Workers. Returns URLs and catalog
+ * metadata for a query; never returns page content or excerpts. To read a
+ * result's body, fetch the URL with the global `fetch()` API.
+ *
+ * Declared in wrangler with a single object (there is exactly one corpus, the
+ * public web, so there is no name, namespace, or instance to specify):
+ *
+ * ```jsonc
+ * { "web_search": { "binding": "WEBSEARCH" } }
+ * ```
+ *
+ * @example
+ * ```ts
+ * const { items, metadata } = await env.WEBSEARCH.search({
+ *   query: "Cloudflare Workers",
+ * });
+ *
+ * const top = items[0];
+ * console.log(top.url, top.title, metadata.latencyMs);
+ *
+ * // Read content yourself; pay-per-crawl and other publisher
+ * // controls apply at the fetch site, not at search time.
+ * const page = await fetch(top.url);
+ * ```
+ */
+declare abstract class WebSearch {
+  /**
+   * Run a Web Search query.
+   * @param options Search options. Only `query` is required.
+   * @returns The matching results plus per-response metadata.
+   */
+  search(options: WebSearchSearchOptions): Promise<WebSearchSearchResponse>;
+}
 interface DynamicDispatchLimits {
   /**
    * Limit CPU time in milliseconds.

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -10753,7 +10753,7 @@ export declare abstract class Base_Ai_Cf_Nvidia_Nemotron_3_120B_A12B {
   postProcessedOutputs: ChatCompletionsOutput;
 }
 export declare abstract class Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT {
-  inputs: ChatCompletionsInput;
+  inputs: ChatCompletionsBase;
   postProcessedOutputs: ChatCompletionsOutput;
 }
 export interface AiModels {
@@ -15119,6 +15119,103 @@ export type WorkerVersionMetadata = {
   /** The timestamp of when the Worker Version was uploaded */
   timestamp: string;
 };
+// ============ Web Search Request Types ============
+/**
+ * Options for a Web Search query.
+ */
+export type WebSearchSearchOptions = {
+  /** The search query. */
+  query: string;
+  /**
+   * Maximum number of results to return. Defaults to 10, capped at 20.
+   * The actual count may be lower if fewer matches exist.
+   */
+  limit?: number;
+};
+// ============ Web Search Response Types ============
+/**
+ * A single Web Search result.
+ *
+ * Web Search is discovery-only -- results carry catalog metadata about a page
+ * but never the page body. To read a result's content the caller invokes the
+ * global `fetch()` API against the result's `url`, at which point the
+ * destination's own access controls apply (including Cloudflare Pay-per-Crawl).
+ */
+export type WebSearchResult = {
+  /** Canonical URL. */
+  url: string;
+  /** Page title. */
+  title: string;
+  /** Page-level description. May be absent. */
+  description?: string;
+  /**
+   * Last-modified date for the page, when known. Naive (no timezone)
+   * ISO-8601 datetime, e.g. `"2025-11-30T04:39:48"`.
+   */
+  lastModifiedDate?: string;
+  /**
+   * Page meta image URL (typically the `og:image`). May be absent.
+   */
+  imageUrl?: string;
+  /** Optional favicon URL for UI hints. */
+  faviconUrl?: string;
+};
+/**
+ * Per-response metadata for a Web Search query. Carries operational
+ * fields useful for support and debugging.
+ */
+export type WebSearchResponseMetadata = {
+  /** The query that was executed. */
+  query: string;
+  /** Opaque request identifier used for support and debugging. */
+  requestId: string;
+  /** End-to-end latency for this search request, in milliseconds. */
+  latencyMs: number;
+};
+/**
+ * Response from a Web Search query.
+ */
+export type WebSearchSearchResponse = {
+  items: WebSearchResult[];
+  metadata: WebSearchResponseMetadata;
+};
+// ============ Web Search Binding Class ============
+/**
+ * Cloudflare Web Search binding.
+ *
+ * Discovery-only primitive for agents and Workers. Returns URLs and catalog
+ * metadata for a query; never returns page content or excerpts. To read a
+ * result's body, fetch the URL with the global `fetch()` API.
+ *
+ * Declared in wrangler with a single object (there is exactly one corpus, the
+ * public web, so there is no name, namespace, or instance to specify):
+ *
+ * ```jsonc
+ * { "web_search": { "binding": "WEBSEARCH" } }
+ * ```
+ *
+ * @example
+ * ```ts
+ * const { items, metadata } = await env.WEBSEARCH.search({
+ *   query: "Cloudflare Workers",
+ * });
+ *
+ * const top = items[0];
+ * console.log(top.url, top.title, metadata.latencyMs);
+ *
+ * // Read content yourself; pay-per-crawl and other publisher
+ * // controls apply at the fetch site, not at search time.
+ * const page = await fetch(top.url);
+ * ```
+ */
+export declare abstract class WebSearch {
+  /**
+   * Run a Web Search query.
+   * @param options Search options. Only `query` is required.
+   * @returns The matching results plus per-response metadata.
+   */
+  search(options: WebSearchSearchOptions): Promise<WebSearchSearchResponse>;
+}
 export interface DynamicDispatchLimits {
   /**
    * Limit CPU time in milliseconds.


### PR DESCRIPTION
Adds TypeScript types for the new `web_search` Workers binding.

- `WebSearch.search({ query, limit? })` → `{ items, metadata }`
- `WebSearchResult`: `url`, `title`, `description?`, `lastModifiedDate?`, `imageUrl?`, `faviconUrl?`
- `WebSearchResponseMetadata`: `query`, `requestId`, `latencyMs`
- `limit` defaults to 10, capped at 20

Discovery-only — no page bodies. Callers `fetch()` URLs themselves; Pay-per-Crawl and publisher controls apply at the fetch site.

Wrangler binding is a single object (one shared web corpus, no namespace/instance):

```jsonc
{ "web_search": { "binding": "WEBSEARCH" } }
```

Snapshot also contains a 2-line `ChatCompletionsBase` fix on `Base_Ai_Cf_Google_Gemma_4_26B_A4B_IT.inputs` — matches what bazel generates from current `ai.d.ts`; needed for `check-snapshot` to pass. Pre-existing drift from `fff20c4f0`. Happy to split out if preferred.
