### PR TITLE
[Workflows] Add workflowName and schedule to WorkflowEvent

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -305,10 +305,19 @@ declare namespace CloudflareWorkersModule {
     timeout?: WorkflowTimeoutDuration | number;
   };
 
+  export type WorkflowCronSchedule = {
+    /** Cron expression that triggered this event. */
+    cron: string;
+    /** Timestamp of the scheduled trigger, in milliseconds since the Unix epoch. */
+    scheduledTime: number;
+  };
+
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
     instanceId: string;
+    workflowName: string;
+    schedule?: WorkflowCronSchedule;
   };
 
   export type WorkflowStepEvent<T> = {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14408,10 +14408,18 @@ declare namespace CloudflareWorkersModule {
     };
     timeout?: WorkflowTimeoutDuration | number;
   };
+  export type WorkflowCronSchedule = {
+    /** Cron expression that triggered this event. */
+    cron: string;
+    /** Timestamp of the scheduled trigger, in milliseconds since the Unix epoch. */
+    scheduledTime: number;
+  };
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
     instanceId: string;
+    workflowName: string;
+    schedule?: WorkflowCronSchedule;
   };
   export type WorkflowStepEvent<T> = {
     payload: Readonly<T>;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14379,10 +14379,18 @@ export declare namespace CloudflareWorkersModule {
     };
     timeout?: WorkflowTimeoutDuration | number;
   };
+  export type WorkflowCronSchedule = {
+    /** Cron expression that triggered this event. */
+    cron: string;
+    /** Timestamp of the scheduled trigger, in milliseconds since the Unix epoch. */
+    scheduledTime: number;
+  };
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
     instanceId: string;
+    workflowName: string;
+    schedule?: WorkflowCronSchedule;
   };
   export type WorkflowStepEvent<T> = {
     payload: Readonly<T>;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -13740,10 +13740,18 @@ declare namespace CloudflareWorkersModule {
     };
     timeout?: WorkflowTimeoutDuration | number;
   };
+  export type WorkflowCronSchedule = {
+    /** Cron expression that triggered this event. */
+    cron: string;
+    /** Timestamp of the scheduled trigger, in milliseconds since the Unix epoch. */
+    scheduledTime: number;
+  };
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
     instanceId: string;
+    workflowName: string;
+    schedule?: WorkflowCronSchedule;
   };
   export type WorkflowStepEvent<T> = {
     payload: Readonly<T>;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -13711,10 +13711,18 @@ export declare namespace CloudflareWorkersModule {
     };
     timeout?: WorkflowTimeoutDuration | number;
   };
+  export type WorkflowCronSchedule = {
+    /** Cron expression that triggered this event. */
+    cron: string;
+    /** Timestamp of the scheduled trigger, in milliseconds since the Unix epoch. */
+    scheduledTime: number;
+  };
   export type WorkflowEvent<T> = {
     payload: Readonly<T>;
     timestamp: Date;
     instanceId: string;
+    workflowName: string;
+    schedule?: WorkflowCronSchedule;
   };
   export type WorkflowStepEvent<T> = {
     payload: Readonly<T>;

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -8,6 +8,8 @@ import {
   RpcStub,
   RpcTarget,
   WorkerEntrypoint,
+  type WorkflowCronSchedule,
+  type WorkflowEvent,
   type WorkflowStep,
 } from 'cloudflare:workers';
 import { expectTypeOf } from 'expect-type';
@@ -833,3 +835,27 @@ expectTypeOf(
     async (): Promise<string> => 'ok'
   )
 ).toMatchTypeOf<Promise<string>>();
+
+declare const cronSchedule: WorkflowCronSchedule;
+expectTypeOf(cronSchedule.cron).toEqualTypeOf<string>();
+expectTypeOf(cronSchedule.scheduledTime).toEqualTypeOf<number>();
+
+type WorkflowPayload = {foo: string};
+declare const workflowEvent: WorkflowEvent<WorkflowPayload>;
+expectTypeOf(workflowEvent.payload).toEqualTypeOf<Readonly<WorkflowPayload>>();
+expectTypeOf(workflowEvent.timestamp).toEqualTypeOf<Date>();
+expectTypeOf(workflowEvent.instanceId).toEqualTypeOf<string>();
+expectTypeOf(workflowEvent.workflowName).toEqualTypeOf<string>();
+expectTypeOf(workflowEvent.schedule).toEqualTypeOf<
+  WorkflowCronSchedule | undefined
+>();
+
+const withoutSchedule: WorkflowEvent<WorkflowPayload> = {
+  payload: {foo: 'bar'},
+  timestamp: new Date(),
+  instanceId: 'abc',
+  workflowName: 'my-workflow',
+};
+expectTypeOf(withoutSchedule.schedule).toEqualTypeOf<
+  WorkflowCronSchedule | undefined
+>();


### PR DESCRIPTION
Adds two fields to `WorkflowEvent`:
- `workflowName: string` — name of the workflow the event belongs to
- `schedule?: WorkflowCronSchedule` — present when the instance was triggered by a cron schedule
Also adds the new `WorkflowCronSchedule` type (`cron`, `scheduledTime`).

```ts
export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
  async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
    console.log(event.workflowName); // e.g. "my-workflow"
    if (event.schedule) {
      console.log(event.schedule.cron);          // "0 * * * *"
      console.log(event.schedule.scheduledTime); // 1737000000000
    }
  }
}
```