### PR TITLE
fix(containers): bypass Docker bridge traffic before sidecar TPROXY

### DIFF
--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -1612,6 +1612,15 @@ kj::Promise<kj::Maybe<ContainerClient::SidecarInspectResponse>> ContainerClient:
   };
 }
 
+kj::Promise<void> ContainerClient::ensureSidecarBridgeBypass(kj::String networkCidr) {
+  auto script = kj::str("cidr=$1\n"
+      "iptables -t mangle -C PREROUTING -s \"$cidr\" -d \"$cidr\" -j RETURN 2>/dev/null || "
+      "iptables -t mangle -I PREROUTING 1 -s \"$cidr\" -d \"$cidr\" -j RETURN\n");
+  auto cmd =
+      kj::arr(kj::str("sh"), kj::str("-c"), kj::mv(script), kj::str("sh"), kj::mv(networkCidr));
+  co_await runSimpleExecInContainer(sidecarContainerName, cmd.asPtr());
+}
+
 kj::Promise<void> ContainerClient::updateSidecarEgressPort(
     uint16_t ingressHostPort, uint16_t egressPort) {
   capnp::JsonCodec codec;
@@ -1844,7 +1853,8 @@ kj::Promise<ContainerClient::ExecInspectResponse> ContainerClient::inspectExec(
   };
 }
 
-kj::Promise<void> ContainerClient::runSimpleExec(kj::ArrayPtr<const kj::String> cmd) {
+kj::Promise<void> ContainerClient::runSimpleExecInContainer(
+    kj::StringPtr targetContainerName, kj::ArrayPtr<const kj::String> cmd) {
   capnp::JsonCodec codec;
   codec.handleByAnnotation<docker_api::Docker::ExecCreateRequest>();
 
@@ -1862,7 +1872,7 @@ kj::Promise<void> ContainerClient::runSimpleExec(kj::ArrayPtr<const kj::String> 
 
   auto createResponse =
       co_await dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::POST,
-          kj::str("/containers/", containerName, "/exec"), codec.encode(createRequest));
+          kj::str("/containers/", targetContainerName, "/exec"), codec.encode(createRequest));
   JSG_REQUIRE(createResponse.statusCode == 201, Error, "Creating helper Docker exec failed with [",
       createResponse.statusCode, "] ", createResponse.body);
 
@@ -1892,6 +1902,10 @@ kj::Promise<void> ContainerClient::runSimpleExec(kj::ArrayPtr<const kj::String> 
     }
     co_await timer.afterDelay(50 * kj::MILLISECONDS);
   }
+}
+
+kj::Promise<void> ContainerClient::runSimpleExec(kj::ArrayPtr<const kj::String> cmd) {
+  co_await runSimpleExecInContainer(containerName, cmd);
 }
 
 kj::Promise<void> ContainerClient::startContainer() {
@@ -2202,6 +2216,8 @@ kj::Promise<void> ContainerClient::status(StatusContext context) {
     containerSidecarStarted.store(true, std::memory_order_release);
     this->sidecarIngressHostPort = sidecar.ingressHostPort;
     co_await ensureEgressListenerStarted();
+    auto ipamConfig = co_await getDockerBridgeIPAMConfig();
+    co_await ensureSidecarBridgeBypass(kj::mv(ipamConfig.subnet));
     co_await updateSidecarEgressPort(sidecar.ingressHostPort, egressListenerPort);
     co_await readCACert();
   }
@@ -2673,8 +2689,10 @@ kj::Promise<void> ContainerClient::ensureSidecarStarted() {
   KJ_ON_SCOPE_FAILURE(containerSidecarStarted.store(false, std::memory_order_release));
 
   auto ipamConfig = co_await getDockerBridgeIPAMConfig();
+  auto networkCidr = kj::str(ipamConfig.subnet);
   co_await createSidecarContainer(egressListenerPort, kj::mv(ipamConfig.subnet));
   co_await startSidecarContainer();
+  co_await ensureSidecarBridgeBypass(kj::mv(networkCidr));
 
   auto sidecar = KJ_REQUIRE_NONNULL(co_await inspectSidecar(), "started sidecar not running");
   this->sidecarIngressHostPort = sidecar.ingressHostPort;

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -163,6 +163,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
 
   kj::Promise<kj::Maybe<InspectResponse>> inspectContainer();
 
+  kj::Promise<void> ensureSidecarBridgeBypass(kj::String networkCidr);
   kj::Promise<void> updateSidecarEgressPort(uint16_t ingressHostPort, uint16_t egressPort);
   kj::Promise<void> updateSidecarEgressConfig(uint16_t ingressHostPort, uint16_t egressPort);
   kj::Promise<void> createContainer(kj::StringPtr effectiveImage,
@@ -176,6 +177,8 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
       bool attachStderr);
   kj::Promise<kj::Own<kj::AsyncIoStream>> startExec(kj::String execId);
   kj::Promise<ExecInspectResponse> inspectExec(kj::StringPtr execId);
+  kj::Promise<void> runSimpleExecInContainer(kj::StringPtr targetContainerName,
+      kj::ArrayPtr<const kj::String> cmd);
   kj::Promise<void> runSimpleExec(kj::ArrayPtr<const kj::String> cmd);
   kj::Promise<void> startContainer();
   kj::Promise<void> stopContainer();


### PR DESCRIPTION
## Summary

Fix local Containers sidecar startup/readiness failures caused by the proxy-everything sidecar intercepting Docker bridge traffic with its TPROXY/DIVERT rules.

The sidecar installs `mangle PREROUTING` rules for transparent proxying. In local Docker bridge mode, traffic whose source and destination are both inside the Docker bridge CIDR can hit those rules before the container readiness and egress configuration path completes. That can make the local container path time out or fail even though the application container itself is otherwise runnable.

This change installs an idempotent first-position `RETURN` rule for bridge-CIDR-to-bridge-CIDR traffic inside the sidecar network namespace. The rule is applied after fresh sidecar startup and again when recovering an already-running sidecar after workerd restarts.

## Reproduction

Minimal repro: https://github.com/iGmainC/workerd-container-sidecar-tproxy-repro

## Validation

- `bazel build --action_env=PATH=/home/linuxbrew/.linuxbrew/bin:/bin:/usr/bin:/usr/local/bin --host_linkopt=-L/home/linuxbrew/.linuxbrew/Cellar/llvm/22.1.6/lib --linkopt=-L/home/linuxbrew/.linuxbrew/Cellar/llvm/22.1.6/lib //src/workerd/server:workerd`
- Verified locally in a real app using the rebuilt workerd binary: the sidecar now has the bridge bypass rule before the DIVERT/TPROXY rules, and the session stream progresses to assistant/result events instead of hanging at heartbeats.

Fixes #6793

Related to #6790, but this PR targets the distinct sidecar bridge traffic interception issue.