### PR TITLE
docs: fix duplicate word typo in security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,10 @@ https://www.cloudflare.com/disclosure
 
 ## Reporting a Vulnerability
 
-* https://hackerone.com/cloudflare
-  * All Cloudflare products are in scope for reporting. If you submit a valid report on bounty-eligible assets through our disclosure program, we will transfer your report to our private bug bounty program and invite you as a participant.
-* `mailto:security@cloudflare.com`
-  * If you'd like to encrypt your message, please do so within the the body of the message. Our email system doesn't handle PGP-MIME well.
-  * https://www.cloudflare.com/gpg/security-at-cloudflare-pubkey-06A67236.txt
+- https://hackerone.com/cloudflare
+  - All Cloudflare products are in scope for reporting. If you submit a valid report on bounty-eligible assets through our disclosure program, we will transfer your report to our private bug bounty program and invite you as a participant.
+- `mailto:security@cloudflare.com`
+  - If you'd like to encrypt your message, please do so within the body of the message. Our email system doesn't handle PGP-MIME well.
+  - https://www.cloudflare.com/gpg/security-at-cloudflare-pubkey-06A67236.txt
 
 All abuse reports should be submitted to our Trust & Safety team through our dedicated page: https://www.cloudflare.com/abuse/
-


### PR DESCRIPTION
I noticed a duplicate word ("the the") while reading the security policy.