### PR TITLE
IMAGES-2332: Add all supported transforms to draws

### DIFF
--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -1,86 +1,3 @@
-interface BasicImageTransformations {
-  /**
-   * Maximum width in image pixels. The value must be an integer.
-   */
-  width?: number;
-  /**
-   * Maximum height in image pixels. The value must be an integer.
-   */
-  height?: number;
-  /**
-   * Resizing mode as a string. It affects interpretation of width and height
-   * options:
-   *  - scale-down: Similar to contain, but the image is never enlarged. If
-   *    the image is larger than given width or height, it will be resized.
-   *    Otherwise its original size will be kept.
-   *  - contain: Resizes to maximum size that fits within the given width and
-   *    height. If only a single dimension is given (e.g. only width), the
-   *    image will be shrunk or enlarged to exactly match that dimension.
-   *    Aspect ratio is always preserved.
-   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
-   *    and height. If the image has an aspect ratio different from the ratio
-   *    of width and height, it will be cropped to fit.
-   *  - crop: The image will be shrunk and cropped to fit within the area
-   *    specified by width and height. The image will not be enlarged. For images
-   *    smaller than the given dimensions it's the same as scale-down. For
-   *    images larger than the given dimensions, it's the same as cover.
-   *    See also trim.
-   *  - pad: Resizes to the maximum size that fits within the given width and
-   *    height, and then fills the remaining area with a background color
-   *    (white by default). Use of this mode is not recommended, as the same
-   *    effect can be more efficiently achieved with the contain mode and the
-   *    CSS object-fit: contain property.
-   *  - squeeze: Stretches and deforms to the width and height given, even if it
-   *    breaks aspect ratio
-   */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
-  /**
-   * Image segmentation using artificial intelligence models. Sets pixels not
-   * within selected segment area to transparent e.g "foreground" sets every
-   * background pixel as transparent.
-   */
-  segment?: "foreground";
-  /**
-   * When cropping with fit: "cover", this defines the side or point that should
-   * be left uncropped. The value is either a string
-   * "left", "right", "top", "bottom", "auto", or "center" (the default),
-   * or an object {x, y} containing focal point coordinates in the original
-   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
-   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
-   * crop bottom or left and right sides as necessary, but won’t crop anything
-   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
-   * preserve as much as possible around a point at 20% of the height of the
-   * source image.
-   */
-  gravity?:
-    | 'face'
-    | 'left'
-    | 'right'
-    | 'top'
-    | 'bottom'
-    | 'center'
-    | 'auto'
-    | 'entropy'
-    | BasicImageTransformationsGravityCoordinates;
-  /**
-   * Background color to add underneath the image. Applies only to images with
-   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
-   * hsl(…), etc.)
-   */
-  background?: string;
-  /**
-   * Number of degrees (90, 180, 270) to rotate the image by. width and height
-   * options refer to axes after rotation.
-   */
-  rotate?: 0 | 90 | 180 | 270 | 360;
-}
-
-interface BasicImageTransformationsGravityCoordinates {
-  x?: number;
-  y?: number;
-  mode?: 'remainder' | 'box-center';
-}
-
 /**
  * In addition to the properties you can set in the RequestInit dict
  * that you pass as an argument to the Request constructor, you can
@@ -177,6 +94,188 @@ interface RequestInitCfProperties extends Record<string, unknown> {
   resolveOverride?: string;
 }
 
+interface BasicImageTransformations {
+  /**
+   * Maximum width in image pixels. The value must be an integer.
+   */
+  width?: number;
+  /**
+   * Maximum height in image pixels. The value must be an integer.
+   */
+  height?: number;
+  /**
+   * When cropping with fit: "cover", this defines the side or point that should
+   * be left uncropped. The value is either a string
+   * "left", "right", "top", "bottom", "auto", or "center" (the default),
+   * or an object {x, y} containing focal point coordinates in the original
+   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
+   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
+   * crop bottom or left and right sides as necessary, but won’t crop anything
+   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
+   * preserve as much as possible around a point at 20% of the height of the
+   * source image.
+   */
+  gravity?:
+    | 'face'
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'bottom'
+    | 'center'
+    | 'auto'
+    | 'entropy'
+    | BasicImageTransformationsGravityCoordinates;
+  /**
+   * Specifies how closely the image is cropped toward detected faces when combined
+   * with the gravity=face option. Accepts a valid range between 0.0 (includes as much
+   * of the background as possible) and 1.0 (crops the image as closely to the face as
+   * possible). The default is 0.
+   */
+  zoom?: number;
+  /**
+   * Resizing mode as a string. It affects interpretation of width and height
+   * options:
+   *  - scale-down: Similar to contain, but the image is never enlarged. If
+   *    the image is larger than given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
+   *  - contain: Resizes to maximum size that fits within the given width and
+   *    height. If only a single dimension is given (e.g. only width), the
+   *    image will be shrunk or enlarged to exactly match that dimension.
+   *    Aspect ratio is always preserved.
+   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
+   *    and height. If the image has an aspect ratio different from the ratio
+   *    of width and height, it will be cropped to fit.
+   *  - crop: The image will be shrunk and cropped to fit within the area
+   *    specified by width and height. The image will not be enlarged. For images
+   *    smaller than the given dimensions it's the same as scale-down. For
+   *    images larger than the given dimensions, it's the same as cover.
+   *    See also trim.
+   *  - pad: Resizes to the maximum size that fits within the given width and
+   *    height, and then fills the remaining area with a background color
+   *    (white by default). Use of this mode is not recommended, as the same
+   *    effect can be more efficiently achieved with the contain mode and the
+   *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
+   */
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  /**
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
+   */
+  trim?: "border" | {
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
+    width?: number;
+    height?: number;
+    border?:
+      | boolean
+      | {
+          color?: string;
+          tolerance?: number;
+          keep?: number;
+        };
+  };
+  /**
+   * Background color to add underneath the image. Applies only to images with
+   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
+   * hsl(…), etc.)
+   */
+  background?: string;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: 'h' | 'v' | 'hv';
+  /**
+   * Number of degrees (90, 180, 270) to rotate the image by. width and height
+   * options refer to axes after rotation.
+   */
+  rotate?: 0 | 90 | 180 | 270 | 360;
+  /**
+   * Strength of sharpening filter to apply to the image. Floating-point
+   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
+   * recommended value for downscaled images.
+   */
+  sharpen?: number;
+  /**
+   * Radius of a blur filter (approximate gaussian). Maximum supported radius
+   * is 250.
+   */
+  blur?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  contrast?: number;
+  /**
+   * Increase brightness by a factor. A value of 1.0 equals no change, a value
+   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
+   * 0 is ignored.
+   */
+  brightness?: number;
+  /**
+   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
+   */
+  gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
+   * easier to specify higher-DPI sizes in <img srcset>.
+   */
+  dpr?: number;
+  /**
+   * Adds a border around the image. The border is added after resizing. Border
+   * width takes dpr into account, and can be specified either using a single
+   * width property, or individually for each side.
+   */
+  border?:
+    | {
+        color: string;
+        width: number;
+      }
+    | {
+        color: string;
+        top: number;
+        right: number;
+        bottom: number;
+        left: number;
+      };
+  /**
+   * Image segmentation using artificial intelligence models. Sets pixels not
+   * within selected segment area to transparent e.g "foreground" sets every
+   * background pixel as transparent.
+   */
+  segment?: "foreground";
+}
+
+interface BasicImageTransformationsGravityCoordinates {
+  x?: number;
+  y?: number;
+  mode?: 'remainder' | 'box-center';
+}
+
 interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
   /**
    * Absolute URL of the image file to use for the drawing. It can be any of
@@ -234,41 +333,6 @@ interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
 
 interface RequestInitCfPropertiesImage extends BasicImageTransformations {
   /**
-   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
-   * easier to specify higher-DPI sizes in <img srcset>.
-   */
-  dpr?: number;
-  /**
-   * Allows you to trim your image. Takes dpr into account and is performed before
-   * resizing or rotation.
-   *
-   * It can be used as:
-   * - left, top, right, bottom - it will specify the number of pixels to cut
-   *   off each side
-   * - width, height - the width/height you'd like to end up with - can be used
-   *   in combination with the properties above
-   * - border - this will automatically trim the surroundings of an image based on
-   *   it's color. It consists of three properties:
-   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
-   *    - tolerance: difference from color to treat as color
-   *    - keep: the number of pixels of border to keep
-   */
-  trim?: "border" | {
-    top?: number;
-    bottom?: number;
-    left?: number;
-    right?: number;
-    width?: number;
-    height?: number;
-    border?:
-      | boolean
-      | {
-          color?: string;
-          tolerance?: number;
-          keep?: number;
-        };
-  };
-  /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
@@ -310,17 +374,6 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   metadata?: "keep" | "copyright" | "none";
   /**
-   * Strength of sharpening filter to apply to the image. Floating-point
-   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
-   * recommended value for downscaled images.
-   */
-  sharpen?: number;
-  /**
-   * Radius of a blur filter (approximate gaussian). Maximum supported radius
-   * is 250.
-   */
-  blur?: number;
-  /**
    * Overlays are drawn in the order they appear in the array (last array
    * entry is the topmost layer).
    */
@@ -332,55 +385,6 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   "origin-auth"?: "share-publicly";
   /**
-   * Adds a border around the image. The border is added after resizing. Border
-   * width takes dpr into account, and can be specified either using a single
-   * width property, or individually for each side.
-   */
-  border?:
-    | {
-        color: string;
-        width: number;
-      }
-    | {
-        color: string;
-        top: number;
-        right: number;
-        bottom: number;
-        left: number;
-      };
-  /**
-   * Increase brightness by a factor. A value of 1.0 equals no change, a value
-   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
-   * 0 is ignored.
-   */
-  brightness?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  contrast?: number;
-  /**
-   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
-   */
-  gamma?: number;
-
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  saturation?: number;
-
-  /**
-   * Flips the images horizontally, vertically, or both. Flipping is applied before
-   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
-   * horizontally, then rotated by 90 degrees.
-   */
-  flip?: 'h' | 'v' | 'hv',
-
-  /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and
    * lower image quality. It will usually override the format option and choose
@@ -389,6 +393,9 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * images.
    */
   compression?: "fast";
+
+  // You probably want to add new properties to BasicImageTransformations, unless
+  // you are absolutely sure they are only valid on the top level request
 }
 
 interface RequestInitCfPropertiesImageMinify {

--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -138,6 +138,9 @@ interface BasicImageTransformations {
    *  - scale-down: Similar to contain, but the image is never enlarged. If
    *    the image is larger than given width or height, it will be resized.
    *    Otherwise its original size will be kept.
+   *  - scale-up: Similar to contain, but the image is never shrunk. If the
+   *    image is smaller than the given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
    *  - contain: Resizes to maximum size that fits within the given width and
    *    height. If only a single dimension is given (e.g. only width), the
    *    image will be shrunk or enlarged to exactly match that dimension.
@@ -158,7 +161,14 @@ interface BasicImageTransformations {
    *  - squeeze: Stretches and deforms to the width and height given, even if it
    *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  fit?:
+    | "scale-down"
+    | "scale-up"
+    | "contain"
+    | "cover"
+    | "crop"
+    | "pad"
+    | "squeeze";
   /**
    * Allows you to trim your image. Takes dpr into account and is performed before
    * resizing or rotation.
@@ -268,6 +278,17 @@ interface BasicImageTransformations {
    * background pixel as transparent.
    */
   segment?: "foreground";
+  /**
+   * Controls the algorithm used when an image needs to be enlarged. This
+   * parameter works with any fit mode that upscales, such as `contain`,
+   * `cover`, and `scale-up`. It has no effect when `fit=scale-down` or when
+   * the target dimensions are smaller than the source.
+   * - interpolate: Uses bicubic interpolation, which may reduce image quality.
+   *   This is the default behavior when `upscale` is not specified.
+   * - generate: Uses AI upscaling to produce sharper, more detailed results
+   *   when enlarging images.
+   */
+  upscale?: "interpolate" | "generate";
 }
 
 interface BasicImageTransformationsGravityCoordinates {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -12883,87 +12883,6 @@ declare abstract class BrowserRun {
     options: BrowserRunMarkdownOptions,
   ): Promise<Response>;
 }
-interface BasicImageTransformations {
-  /**
-   * Maximum width in image pixels. The value must be an integer.
-   */
-  width?: number;
-  /**
-   * Maximum height in image pixels. The value must be an integer.
-   */
-  height?: number;
-  /**
-   * Resizing mode as a string. It affects interpretation of width and height
-   * options:
-   *  - scale-down: Similar to contain, but the image is never enlarged. If
-   *    the image is larger than given width or height, it will be resized.
-   *    Otherwise its original size will be kept.
-   *  - contain: Resizes to maximum size that fits within the given width and
-   *    height. If only a single dimension is given (e.g. only width), the
-   *    image will be shrunk or enlarged to exactly match that dimension.
-   *    Aspect ratio is always preserved.
-   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
-   *    and height. If the image has an aspect ratio different from the ratio
-   *    of width and height, it will be cropped to fit.
-   *  - crop: The image will be shrunk and cropped to fit within the area
-   *    specified by width and height. The image will not be enlarged. For images
-   *    smaller than the given dimensions it's the same as scale-down. For
-   *    images larger than the given dimensions, it's the same as cover.
-   *    See also trim.
-   *  - pad: Resizes to the maximum size that fits within the given width and
-   *    height, and then fills the remaining area with a background color
-   *    (white by default). Use of this mode is not recommended, as the same
-   *    effect can be more efficiently achieved with the contain mode and the
-   *    CSS object-fit: contain property.
-   *  - squeeze: Stretches and deforms to the width and height given, even if it
-   *    breaks aspect ratio
-   */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
-  /**
-   * Image segmentation using artificial intelligence models. Sets pixels not
-   * within selected segment area to transparent e.g "foreground" sets every
-   * background pixel as transparent.
-   */
-  segment?: "foreground";
-  /**
-   * When cropping with fit: "cover", this defines the side or point that should
-   * be left uncropped. The value is either a string
-   * "left", "right", "top", "bottom", "auto", or "center" (the default),
-   * or an object {x, y} containing focal point coordinates in the original
-   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
-   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
-   * crop bottom or left and right sides as necessary, but won’t crop anything
-   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
-   * preserve as much as possible around a point at 20% of the height of the
-   * source image.
-   */
-  gravity?:
-    | "face"
-    | "left"
-    | "right"
-    | "top"
-    | "bottom"
-    | "center"
-    | "auto"
-    | "entropy"
-    | BasicImageTransformationsGravityCoordinates;
-  /**
-   * Background color to add underneath the image. Applies only to images with
-   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
-   * hsl(…), etc.)
-   */
-  background?: string;
-  /**
-   * Number of degrees (90, 180, 270) to rotate the image by. width and height
-   * options refer to axes after rotation.
-   */
-  rotate?: 0 | 90 | 180 | 270 | 360;
-}
-interface BasicImageTransformationsGravityCoordinates {
-  x?: number;
-  y?: number;
-  mode?: "remainder" | "box-center";
-}
 /**
  * In addition to the properties you can set in the RequestInit dict
  * that you pass as an argument to the Request constructor, you can
@@ -13059,6 +12978,188 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    */
   resolveOverride?: string;
 }
+interface BasicImageTransformations {
+  /**
+   * Maximum width in image pixels. The value must be an integer.
+   */
+  width?: number;
+  /**
+   * Maximum height in image pixels. The value must be an integer.
+   */
+  height?: number;
+  /**
+   * When cropping with fit: "cover", this defines the side or point that should
+   * be left uncropped. The value is either a string
+   * "left", "right", "top", "bottom", "auto", or "center" (the default),
+   * or an object {x, y} containing focal point coordinates in the original
+   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
+   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
+   * crop bottom or left and right sides as necessary, but won’t crop anything
+   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
+   * preserve as much as possible around a point at 20% of the height of the
+   * source image.
+   */
+  gravity?:
+    | "face"
+    | "left"
+    | "right"
+    | "top"
+    | "bottom"
+    | "center"
+    | "auto"
+    | "entropy"
+    | BasicImageTransformationsGravityCoordinates;
+  /**
+   * Specifies how closely the image is cropped toward detected faces when combined
+   * with the gravity=face option. Accepts a valid range between 0.0 (includes as much
+   * of the background as possible) and 1.0 (crops the image as closely to the face as
+   * possible). The default is 0.
+   */
+  zoom?: number;
+  /**
+   * Resizing mode as a string. It affects interpretation of width and height
+   * options:
+   *  - scale-down: Similar to contain, but the image is never enlarged. If
+   *    the image is larger than given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
+   *  - contain: Resizes to maximum size that fits within the given width and
+   *    height. If only a single dimension is given (e.g. only width), the
+   *    image will be shrunk or enlarged to exactly match that dimension.
+   *    Aspect ratio is always preserved.
+   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
+   *    and height. If the image has an aspect ratio different from the ratio
+   *    of width and height, it will be cropped to fit.
+   *  - crop: The image will be shrunk and cropped to fit within the area
+   *    specified by width and height. The image will not be enlarged. For images
+   *    smaller than the given dimensions it's the same as scale-down. For
+   *    images larger than the given dimensions, it's the same as cover.
+   *    See also trim.
+   *  - pad: Resizes to the maximum size that fits within the given width and
+   *    height, and then fills the remaining area with a background color
+   *    (white by default). Use of this mode is not recommended, as the same
+   *    effect can be more efficiently achieved with the contain mode and the
+   *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
+   */
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  /**
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
+   */
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
+  /**
+   * Background color to add underneath the image. Applies only to images with
+   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
+   * hsl(…), etc.)
+   */
+  background?: string;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
+  /**
+   * Number of degrees (90, 180, 270) to rotate the image by. width and height
+   * options refer to axes after rotation.
+   */
+  rotate?: 0 | 90 | 180 | 270 | 360;
+  /**
+   * Strength of sharpening filter to apply to the image. Floating-point
+   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
+   * recommended value for downscaled images.
+   */
+  sharpen?: number;
+  /**
+   * Radius of a blur filter (approximate gaussian). Maximum supported radius
+   * is 250.
+   */
+  blur?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  contrast?: number;
+  /**
+   * Increase brightness by a factor. A value of 1.0 equals no change, a value
+   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
+   * 0 is ignored.
+   */
+  brightness?: number;
+  /**
+   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
+   */
+  gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
+   * easier to specify higher-DPI sizes in <img srcset>.
+   */
+  dpr?: number;
+  /**
+   * Adds a border around the image. The border is added after resizing. Border
+   * width takes dpr into account, and can be specified either using a single
+   * width property, or individually for each side.
+   */
+  border?:
+    | {
+        color: string;
+        width: number;
+      }
+    | {
+        color: string;
+        top: number;
+        right: number;
+        bottom: number;
+        left: number;
+      };
+  /**
+   * Image segmentation using artificial intelligence models. Sets pixels not
+   * within selected segment area to transparent e.g "foreground" sets every
+   * background pixel as transparent.
+   */
+  segment?: "foreground";
+}
+interface BasicImageTransformationsGravityCoordinates {
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
+}
 interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
   /**
    * Absolute URL of the image file to use for the drawing. It can be any of
@@ -13113,43 +13214,6 @@ interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
 }
 interface RequestInitCfPropertiesImage extends BasicImageTransformations {
   /**
-   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
-   * easier to specify higher-DPI sizes in <img srcset>.
-   */
-  dpr?: number;
-  /**
-   * Allows you to trim your image. Takes dpr into account and is performed before
-   * resizing or rotation.
-   *
-   * It can be used as:
-   * - left, top, right, bottom - it will specify the number of pixels to cut
-   *   off each side
-   * - width, height - the width/height you'd like to end up with - can be used
-   *   in combination with the properties above
-   * - border - this will automatically trim the surroundings of an image based on
-   *   it's color. It consists of three properties:
-   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
-   *    - tolerance: difference from color to treat as color
-   *    - keep: the number of pixels of border to keep
-   */
-  trim?:
-    | "border"
-    | {
-        top?: number;
-        bottom?: number;
-        left?: number;
-        right?: number;
-        width?: number;
-        height?: number;
-        border?:
-          | boolean
-          | {
-              color?: string;
-              tolerance?: number;
-              keep?: number;
-            };
-      };
-  /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
@@ -13199,17 +13263,6 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   metadata?: "keep" | "copyright" | "none";
   /**
-   * Strength of sharpening filter to apply to the image. Floating-point
-   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
-   * recommended value for downscaled images.
-   */
-  sharpen?: number;
-  /**
-   * Radius of a blur filter (approximate gaussian). Maximum supported radius
-   * is 250.
-   */
-  blur?: number;
-  /**
    * Overlays are drawn in the order they appear in the array (last array
    * entry is the topmost layer).
    */
@@ -13220,52 +13273,6 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * the origin.
    */
   "origin-auth"?: "share-publicly";
-  /**
-   * Adds a border around the image. The border is added after resizing. Border
-   * width takes dpr into account, and can be specified either using a single
-   * width property, or individually for each side.
-   */
-  border?:
-    | {
-        color: string;
-        width: number;
-      }
-    | {
-        color: string;
-        top: number;
-        right: number;
-        bottom: number;
-        left: number;
-      };
-  /**
-   * Increase brightness by a factor. A value of 1.0 equals no change, a value
-   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
-   * 0 is ignored.
-   */
-  brightness?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  contrast?: number;
-  /**
-   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
-   */
-  gamma?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  saturation?: number;
-  /**
-   * Flips the images horizontally, vertically, or both. Flipping is applied before
-   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
-   * horizontally, then rotated by 90 degrees.
-   */
-  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -13022,6 +13022,9 @@ interface BasicImageTransformations {
    *  - scale-down: Similar to contain, but the image is never enlarged. If
    *    the image is larger than given width or height, it will be resized.
    *    Otherwise its original size will be kept.
+   *  - scale-up: Similar to contain, but the image is never shrunk. If the
+   *    image is smaller than the given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
    *  - contain: Resizes to maximum size that fits within the given width and
    *    height. If only a single dimension is given (e.g. only width), the
    *    image will be shrunk or enlarged to exactly match that dimension.
@@ -13042,7 +13045,14 @@ interface BasicImageTransformations {
    *  - squeeze: Stretches and deforms to the width and height given, even if it
    *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  fit?:
+    | "scale-down"
+    | "scale-up"
+    | "contain"
+    | "cover"
+    | "crop"
+    | "pad"
+    | "squeeze";
   /**
    * Allows you to trim your image. Takes dpr into account and is performed before
    * resizing or rotation.
@@ -13154,6 +13164,17 @@ interface BasicImageTransformations {
    * background pixel as transparent.
    */
   segment?: "foreground";
+  /**
+   * Controls the algorithm used when an image needs to be enlarged. This
+   * parameter works with any fit mode that upscales, such as `contain`,
+   * `cover`, and `scale-up`. It has no effect when `fit=scale-down` or when
+   * the target dimensions are smaller than the source.
+   * - interpolate: Uses bicubic interpolation, which may reduce image quality.
+   *   This is the default behavior when `upscale` is not specified.
+   * - generate: Uses AI upscaling to produce sharper, more detailed results
+   *   when enlarging images.
+   */
+  upscale?: "interpolate" | "generate";
 }
 interface BasicImageTransformationsGravityCoordinates {
   x?: number;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -13034,6 +13034,9 @@ export interface BasicImageTransformations {
    *  - scale-down: Similar to contain, but the image is never enlarged. If
    *    the image is larger than given width or height, it will be resized.
    *    Otherwise its original size will be kept.
+   *  - scale-up: Similar to contain, but the image is never shrunk. If the
+   *    image is smaller than the given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
    *  - contain: Resizes to maximum size that fits within the given width and
    *    height. If only a single dimension is given (e.g. only width), the
    *    image will be shrunk or enlarged to exactly match that dimension.
@@ -13054,7 +13057,14 @@ export interface BasicImageTransformations {
    *  - squeeze: Stretches and deforms to the width and height given, even if it
    *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  fit?:
+    | "scale-down"
+    | "scale-up"
+    | "contain"
+    | "cover"
+    | "crop"
+    | "pad"
+    | "squeeze";
   /**
    * Allows you to trim your image. Takes dpr into account and is performed before
    * resizing or rotation.
@@ -13166,6 +13176,17 @@ export interface BasicImageTransformations {
    * background pixel as transparent.
    */
   segment?: "foreground";
+  /**
+   * Controls the algorithm used when an image needs to be enlarged. This
+   * parameter works with any fit mode that upscales, such as `contain`,
+   * `cover`, and `scale-up`. It has no effect when `fit=scale-down` or when
+   * the target dimensions are smaller than the source.
+   * - interpolate: Uses bicubic interpolation, which may reduce image quality.
+   *   This is the default behavior when `upscale` is not specified.
+   * - generate: Uses AI upscaling to produce sharper, more detailed results
+   *   when enlarging images.
+   */
+  upscale?: "interpolate" | "generate";
 }
 export interface BasicImageTransformationsGravityCoordinates {
   x?: number;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -12895,87 +12895,6 @@ export declare abstract class BrowserRun {
     options: BrowserRunMarkdownOptions,
   ): Promise<Response>;
 }
-export interface BasicImageTransformations {
-  /**
-   * Maximum width in image pixels. The value must be an integer.
-   */
-  width?: number;
-  /**
-   * Maximum height in image pixels. The value must be an integer.
-   */
-  height?: number;
-  /**
-   * Resizing mode as a string. It affects interpretation of width and height
-   * options:
-   *  - scale-down: Similar to contain, but the image is never enlarged. If
-   *    the image is larger than given width or height, it will be resized.
-   *    Otherwise its original size will be kept.
-   *  - contain: Resizes to maximum size that fits within the given width and
-   *    height. If only a single dimension is given (e.g. only width), the
-   *    image will be shrunk or enlarged to exactly match that dimension.
-   *    Aspect ratio is always preserved.
-   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
-   *    and height. If the image has an aspect ratio different from the ratio
-   *    of width and height, it will be cropped to fit.
-   *  - crop: The image will be shrunk and cropped to fit within the area
-   *    specified by width and height. The image will not be enlarged. For images
-   *    smaller than the given dimensions it's the same as scale-down. For
-   *    images larger than the given dimensions, it's the same as cover.
-   *    See also trim.
-   *  - pad: Resizes to the maximum size that fits within the given width and
-   *    height, and then fills the remaining area with a background color
-   *    (white by default). Use of this mode is not recommended, as the same
-   *    effect can be more efficiently achieved with the contain mode and the
-   *    CSS object-fit: contain property.
-   *  - squeeze: Stretches and deforms to the width and height given, even if it
-   *    breaks aspect ratio
-   */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
-  /**
-   * Image segmentation using artificial intelligence models. Sets pixels not
-   * within selected segment area to transparent e.g "foreground" sets every
-   * background pixel as transparent.
-   */
-  segment?: "foreground";
-  /**
-   * When cropping with fit: "cover", this defines the side or point that should
-   * be left uncropped. The value is either a string
-   * "left", "right", "top", "bottom", "auto", or "center" (the default),
-   * or an object {x, y} containing focal point coordinates in the original
-   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
-   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
-   * crop bottom or left and right sides as necessary, but won’t crop anything
-   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
-   * preserve as much as possible around a point at 20% of the height of the
-   * source image.
-   */
-  gravity?:
-    | "face"
-    | "left"
-    | "right"
-    | "top"
-    | "bottom"
-    | "center"
-    | "auto"
-    | "entropy"
-    | BasicImageTransformationsGravityCoordinates;
-  /**
-   * Background color to add underneath the image. Applies only to images with
-   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
-   * hsl(…), etc.)
-   */
-  background?: string;
-  /**
-   * Number of degrees (90, 180, 270) to rotate the image by. width and height
-   * options refer to axes after rotation.
-   */
-  rotate?: 0 | 90 | 180 | 270 | 360;
-}
-export interface BasicImageTransformationsGravityCoordinates {
-  x?: number;
-  y?: number;
-  mode?: "remainder" | "box-center";
-}
 /**
  * In addition to the properties you can set in the RequestInit dict
  * that you pass as an argument to the Request constructor, you can
@@ -13071,6 +12990,188 @@ export interface RequestInitCfProperties extends Record<string, unknown> {
    */
   resolveOverride?: string;
 }
+export interface BasicImageTransformations {
+  /**
+   * Maximum width in image pixels. The value must be an integer.
+   */
+  width?: number;
+  /**
+   * Maximum height in image pixels. The value must be an integer.
+   */
+  height?: number;
+  /**
+   * When cropping with fit: "cover", this defines the side or point that should
+   * be left uncropped. The value is either a string
+   * "left", "right", "top", "bottom", "auto", or "center" (the default),
+   * or an object {x, y} containing focal point coordinates in the original
+   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
+   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
+   * crop bottom or left and right sides as necessary, but won’t crop anything
+   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
+   * preserve as much as possible around a point at 20% of the height of the
+   * source image.
+   */
+  gravity?:
+    | "face"
+    | "left"
+    | "right"
+    | "top"
+    | "bottom"
+    | "center"
+    | "auto"
+    | "entropy"
+    | BasicImageTransformationsGravityCoordinates;
+  /**
+   * Specifies how closely the image is cropped toward detected faces when combined
+   * with the gravity=face option. Accepts a valid range between 0.0 (includes as much
+   * of the background as possible) and 1.0 (crops the image as closely to the face as
+   * possible). The default is 0.
+   */
+  zoom?: number;
+  /**
+   * Resizing mode as a string. It affects interpretation of width and height
+   * options:
+   *  - scale-down: Similar to contain, but the image is never enlarged. If
+   *    the image is larger than given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
+   *  - contain: Resizes to maximum size that fits within the given width and
+   *    height. If only a single dimension is given (e.g. only width), the
+   *    image will be shrunk or enlarged to exactly match that dimension.
+   *    Aspect ratio is always preserved.
+   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
+   *    and height. If the image has an aspect ratio different from the ratio
+   *    of width and height, it will be cropped to fit.
+   *  - crop: The image will be shrunk and cropped to fit within the area
+   *    specified by width and height. The image will not be enlarged. For images
+   *    smaller than the given dimensions it's the same as scale-down. For
+   *    images larger than the given dimensions, it's the same as cover.
+   *    See also trim.
+   *  - pad: Resizes to the maximum size that fits within the given width and
+   *    height, and then fills the remaining area with a background color
+   *    (white by default). Use of this mode is not recommended, as the same
+   *    effect can be more efficiently achieved with the contain mode and the
+   *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
+   */
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  /**
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
+   */
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
+  /**
+   * Background color to add underneath the image. Applies only to images with
+   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
+   * hsl(…), etc.)
+   */
+  background?: string;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
+  /**
+   * Number of degrees (90, 180, 270) to rotate the image by. width and height
+   * options refer to axes after rotation.
+   */
+  rotate?: 0 | 90 | 180 | 270 | 360;
+  /**
+   * Strength of sharpening filter to apply to the image. Floating-point
+   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
+   * recommended value for downscaled images.
+   */
+  sharpen?: number;
+  /**
+   * Radius of a blur filter (approximate gaussian). Maximum supported radius
+   * is 250.
+   */
+  blur?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  contrast?: number;
+  /**
+   * Increase brightness by a factor. A value of 1.0 equals no change, a value
+   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
+   * 0 is ignored.
+   */
+  brightness?: number;
+  /**
+   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
+   */
+  gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
+   * easier to specify higher-DPI sizes in <img srcset>.
+   */
+  dpr?: number;
+  /**
+   * Adds a border around the image. The border is added after resizing. Border
+   * width takes dpr into account, and can be specified either using a single
+   * width property, or individually for each side.
+   */
+  border?:
+    | {
+        color: string;
+        width: number;
+      }
+    | {
+        color: string;
+        top: number;
+        right: number;
+        bottom: number;
+        left: number;
+      };
+  /**
+   * Image segmentation using artificial intelligence models. Sets pixels not
+   * within selected segment area to transparent e.g "foreground" sets every
+   * background pixel as transparent.
+   */
+  segment?: "foreground";
+}
+export interface BasicImageTransformationsGravityCoordinates {
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
+}
 export interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
   /**
    * Absolute URL of the image file to use for the drawing. It can be any of
@@ -13125,43 +13226,6 @@ export interface RequestInitCfPropertiesImageDraw extends BasicImageTransformati
 }
 export interface RequestInitCfPropertiesImage extends BasicImageTransformations {
   /**
-   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
-   * easier to specify higher-DPI sizes in <img srcset>.
-   */
-  dpr?: number;
-  /**
-   * Allows you to trim your image. Takes dpr into account and is performed before
-   * resizing or rotation.
-   *
-   * It can be used as:
-   * - left, top, right, bottom - it will specify the number of pixels to cut
-   *   off each side
-   * - width, height - the width/height you'd like to end up with - can be used
-   *   in combination with the properties above
-   * - border - this will automatically trim the surroundings of an image based on
-   *   it's color. It consists of three properties:
-   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
-   *    - tolerance: difference from color to treat as color
-   *    - keep: the number of pixels of border to keep
-   */
-  trim?:
-    | "border"
-    | {
-        top?: number;
-        bottom?: number;
-        left?: number;
-        right?: number;
-        width?: number;
-        height?: number;
-        border?:
-          | boolean
-          | {
-              color?: string;
-              tolerance?: number;
-              keep?: number;
-            };
-      };
-  /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
@@ -13211,17 +13275,6 @@ export interface RequestInitCfPropertiesImage extends BasicImageTransformations 
    */
   metadata?: "keep" | "copyright" | "none";
   /**
-   * Strength of sharpening filter to apply to the image. Floating-point
-   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
-   * recommended value for downscaled images.
-   */
-  sharpen?: number;
-  /**
-   * Radius of a blur filter (approximate gaussian). Maximum supported radius
-   * is 250.
-   */
-  blur?: number;
-  /**
    * Overlays are drawn in the order they appear in the array (last array
    * entry is the topmost layer).
    */
@@ -13232,52 +13285,6 @@ export interface RequestInitCfPropertiesImage extends BasicImageTransformations 
    * the origin.
    */
   "origin-auth"?: "share-publicly";
-  /**
-   * Adds a border around the image. The border is added after resizing. Border
-   * width takes dpr into account, and can be specified either using a single
-   * width property, or individually for each side.
-   */
-  border?:
-    | {
-        color: string;
-        width: number;
-      }
-    | {
-        color: string;
-        top: number;
-        right: number;
-        bottom: number;
-        left: number;
-      };
-  /**
-   * Increase brightness by a factor. A value of 1.0 equals no change, a value
-   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
-   * 0 is ignored.
-   */
-  brightness?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  contrast?: number;
-  /**
-   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
-   */
-  gamma?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  saturation?: number;
-  /**
-   * Flips the images horizontally, vertically, or both. Flipping is applied before
-   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
-   * horizontally, then rotated by 90 degrees.
-   */
-  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12354,6 +12354,9 @@ interface BasicImageTransformations {
    *  - scale-down: Similar to contain, but the image is never enlarged. If
    *    the image is larger than given width or height, it will be resized.
    *    Otherwise its original size will be kept.
+   *  - scale-up: Similar to contain, but the image is never shrunk. If the
+   *    image is smaller than the given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
    *  - contain: Resizes to maximum size that fits within the given width and
    *    height. If only a single dimension is given (e.g. only width), the
    *    image will be shrunk or enlarged to exactly match that dimension.
@@ -12374,7 +12377,14 @@ interface BasicImageTransformations {
    *  - squeeze: Stretches and deforms to the width and height given, even if it
    *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  fit?:
+    | "scale-down"
+    | "scale-up"
+    | "contain"
+    | "cover"
+    | "crop"
+    | "pad"
+    | "squeeze";
   /**
    * Allows you to trim your image. Takes dpr into account and is performed before
    * resizing or rotation.
@@ -12486,6 +12496,17 @@ interface BasicImageTransformations {
    * background pixel as transparent.
    */
   segment?: "foreground";
+  /**
+   * Controls the algorithm used when an image needs to be enlarged. This
+   * parameter works with any fit mode that upscales, such as `contain`,
+   * `cover`, and `scale-up`. It has no effect when `fit=scale-down` or when
+   * the target dimensions are smaller than the source.
+   * - interpolate: Uses bicubic interpolation, which may reduce image quality.
+   *   This is the default behavior when `upscale` is not specified.
+   * - generate: Uses AI upscaling to produce sharper, more detailed results
+   *   when enlarging images.
+   */
+  upscale?: "interpolate" | "generate";
 }
 interface BasicImageTransformationsGravityCoordinates {
   x?: number;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12215,87 +12215,6 @@ declare abstract class BrowserRun {
     options: BrowserRunMarkdownOptions,
   ): Promise<Response>;
 }
-interface BasicImageTransformations {
-  /**
-   * Maximum width in image pixels. The value must be an integer.
-   */
-  width?: number;
-  /**
-   * Maximum height in image pixels. The value must be an integer.
-   */
-  height?: number;
-  /**
-   * Resizing mode as a string. It affects interpretation of width and height
-   * options:
-   *  - scale-down: Similar to contain, but the image is never enlarged. If
-   *    the image is larger than given width or height, it will be resized.
-   *    Otherwise its original size will be kept.
-   *  - contain: Resizes to maximum size that fits within the given width and
-   *    height. If only a single dimension is given (e.g. only width), the
-   *    image will be shrunk or enlarged to exactly match that dimension.
-   *    Aspect ratio is always preserved.
-   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
-   *    and height. If the image has an aspect ratio different from the ratio
-   *    of width and height, it will be cropped to fit.
-   *  - crop: The image will be shrunk and cropped to fit within the area
-   *    specified by width and height. The image will not be enlarged. For images
-   *    smaller than the given dimensions it's the same as scale-down. For
-   *    images larger than the given dimensions, it's the same as cover.
-   *    See also trim.
-   *  - pad: Resizes to the maximum size that fits within the given width and
-   *    height, and then fills the remaining area with a background color
-   *    (white by default). Use of this mode is not recommended, as the same
-   *    effect can be more efficiently achieved with the contain mode and the
-   *    CSS object-fit: contain property.
-   *  - squeeze: Stretches and deforms to the width and height given, even if it
-   *    breaks aspect ratio
-   */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
-  /**
-   * Image segmentation using artificial intelligence models. Sets pixels not
-   * within selected segment area to transparent e.g "foreground" sets every
-   * background pixel as transparent.
-   */
-  segment?: "foreground";
-  /**
-   * When cropping with fit: "cover", this defines the side or point that should
-   * be left uncropped. The value is either a string
-   * "left", "right", "top", "bottom", "auto", or "center" (the default),
-   * or an object {x, y} containing focal point coordinates in the original
-   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
-   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
-   * crop bottom or left and right sides as necessary, but won’t crop anything
-   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
-   * preserve as much as possible around a point at 20% of the height of the
-   * source image.
-   */
-  gravity?:
-    | "face"
-    | "left"
-    | "right"
-    | "top"
-    | "bottom"
-    | "center"
-    | "auto"
-    | "entropy"
-    | BasicImageTransformationsGravityCoordinates;
-  /**
-   * Background color to add underneath the image. Applies only to images with
-   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
-   * hsl(…), etc.)
-   */
-  background?: string;
-  /**
-   * Number of degrees (90, 180, 270) to rotate the image by. width and height
-   * options refer to axes after rotation.
-   */
-  rotate?: 0 | 90 | 180 | 270 | 360;
-}
-interface BasicImageTransformationsGravityCoordinates {
-  x?: number;
-  y?: number;
-  mode?: "remainder" | "box-center";
-}
 /**
  * In addition to the properties you can set in the RequestInit dict
  * that you pass as an argument to the Request constructor, you can
@@ -12391,6 +12310,188 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    */
   resolveOverride?: string;
 }
+interface BasicImageTransformations {
+  /**
+   * Maximum width in image pixels. The value must be an integer.
+   */
+  width?: number;
+  /**
+   * Maximum height in image pixels. The value must be an integer.
+   */
+  height?: number;
+  /**
+   * When cropping with fit: "cover", this defines the side or point that should
+   * be left uncropped. The value is either a string
+   * "left", "right", "top", "bottom", "auto", or "center" (the default),
+   * or an object {x, y} containing focal point coordinates in the original
+   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
+   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
+   * crop bottom or left and right sides as necessary, but won’t crop anything
+   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
+   * preserve as much as possible around a point at 20% of the height of the
+   * source image.
+   */
+  gravity?:
+    | "face"
+    | "left"
+    | "right"
+    | "top"
+    | "bottom"
+    | "center"
+    | "auto"
+    | "entropy"
+    | BasicImageTransformationsGravityCoordinates;
+  /**
+   * Specifies how closely the image is cropped toward detected faces when combined
+   * with the gravity=face option. Accepts a valid range between 0.0 (includes as much
+   * of the background as possible) and 1.0 (crops the image as closely to the face as
+   * possible). The default is 0.
+   */
+  zoom?: number;
+  /**
+   * Resizing mode as a string. It affects interpretation of width and height
+   * options:
+   *  - scale-down: Similar to contain, but the image is never enlarged. If
+   *    the image is larger than given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
+   *  - contain: Resizes to maximum size that fits within the given width and
+   *    height. If only a single dimension is given (e.g. only width), the
+   *    image will be shrunk or enlarged to exactly match that dimension.
+   *    Aspect ratio is always preserved.
+   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
+   *    and height. If the image has an aspect ratio different from the ratio
+   *    of width and height, it will be cropped to fit.
+   *  - crop: The image will be shrunk and cropped to fit within the area
+   *    specified by width and height. The image will not be enlarged. For images
+   *    smaller than the given dimensions it's the same as scale-down. For
+   *    images larger than the given dimensions, it's the same as cover.
+   *    See also trim.
+   *  - pad: Resizes to the maximum size that fits within the given width and
+   *    height, and then fills the remaining area with a background color
+   *    (white by default). Use of this mode is not recommended, as the same
+   *    effect can be more efficiently achieved with the contain mode and the
+   *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
+   */
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  /**
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
+   */
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
+  /**
+   * Background color to add underneath the image. Applies only to images with
+   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
+   * hsl(…), etc.)
+   */
+  background?: string;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
+  /**
+   * Number of degrees (90, 180, 270) to rotate the image by. width and height
+   * options refer to axes after rotation.
+   */
+  rotate?: 0 | 90 | 180 | 270 | 360;
+  /**
+   * Strength of sharpening filter to apply to the image. Floating-point
+   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
+   * recommended value for downscaled images.
+   */
+  sharpen?: number;
+  /**
+   * Radius of a blur filter (approximate gaussian). Maximum supported radius
+   * is 250.
+   */
+  blur?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  contrast?: number;
+  /**
+   * Increase brightness by a factor. A value of 1.0 equals no change, a value
+   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
+   * 0 is ignored.
+   */
+  brightness?: number;
+  /**
+   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
+   */
+  gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
+   * easier to specify higher-DPI sizes in <img srcset>.
+   */
+  dpr?: number;
+  /**
+   * Adds a border around the image. The border is added after resizing. Border
+   * width takes dpr into account, and can be specified either using a single
+   * width property, or individually for each side.
+   */
+  border?:
+    | {
+        color: string;
+        width: number;
+      }
+    | {
+        color: string;
+        top: number;
+        right: number;
+        bottom: number;
+        left: number;
+      };
+  /**
+   * Image segmentation using artificial intelligence models. Sets pixels not
+   * within selected segment area to transparent e.g "foreground" sets every
+   * background pixel as transparent.
+   */
+  segment?: "foreground";
+}
+interface BasicImageTransformationsGravityCoordinates {
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
+}
 interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
   /**
    * Absolute URL of the image file to use for the drawing. It can be any of
@@ -12445,43 +12546,6 @@ interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
 }
 interface RequestInitCfPropertiesImage extends BasicImageTransformations {
   /**
-   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
-   * easier to specify higher-DPI sizes in <img srcset>.
-   */
-  dpr?: number;
-  /**
-   * Allows you to trim your image. Takes dpr into account and is performed before
-   * resizing or rotation.
-   *
-   * It can be used as:
-   * - left, top, right, bottom - it will specify the number of pixels to cut
-   *   off each side
-   * - width, height - the width/height you'd like to end up with - can be used
-   *   in combination with the properties above
-   * - border - this will automatically trim the surroundings of an image based on
-   *   it's color. It consists of three properties:
-   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
-   *    - tolerance: difference from color to treat as color
-   *    - keep: the number of pixels of border to keep
-   */
-  trim?:
-    | "border"
-    | {
-        top?: number;
-        bottom?: number;
-        left?: number;
-        right?: number;
-        width?: number;
-        height?: number;
-        border?:
-          | boolean
-          | {
-              color?: string;
-              tolerance?: number;
-              keep?: number;
-            };
-      };
-  /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
@@ -12531,17 +12595,6 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   metadata?: "keep" | "copyright" | "none";
   /**
-   * Strength of sharpening filter to apply to the image. Floating-point
-   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
-   * recommended value for downscaled images.
-   */
-  sharpen?: number;
-  /**
-   * Radius of a blur filter (approximate gaussian). Maximum supported radius
-   * is 250.
-   */
-  blur?: number;
-  /**
    * Overlays are drawn in the order they appear in the array (last array
    * entry is the topmost layer).
    */
@@ -12552,52 +12605,6 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * the origin.
    */
   "origin-auth"?: "share-publicly";
-  /**
-   * Adds a border around the image. The border is added after resizing. Border
-   * width takes dpr into account, and can be specified either using a single
-   * width property, or individually for each side.
-   */
-  border?:
-    | {
-        color: string;
-        width: number;
-      }
-    | {
-        color: string;
-        top: number;
-        right: number;
-        bottom: number;
-        left: number;
-      };
-  /**
-   * Increase brightness by a factor. A value of 1.0 equals no change, a value
-   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
-   * 0 is ignored.
-   */
-  brightness?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  contrast?: number;
-  /**
-   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
-   */
-  gamma?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  saturation?: number;
-  /**
-   * Flips the images horizontally, vertically, or both. Flipping is applied before
-   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
-   * horizontally, then rotated by 90 degrees.
-   */
-  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12366,6 +12366,9 @@ export interface BasicImageTransformations {
    *  - scale-down: Similar to contain, but the image is never enlarged. If
    *    the image is larger than given width or height, it will be resized.
    *    Otherwise its original size will be kept.
+   *  - scale-up: Similar to contain, but the image is never shrunk. If the
+   *    image is smaller than the given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
    *  - contain: Resizes to maximum size that fits within the given width and
    *    height. If only a single dimension is given (e.g. only width), the
    *    image will be shrunk or enlarged to exactly match that dimension.
@@ -12386,7 +12389,14 @@ export interface BasicImageTransformations {
    *  - squeeze: Stretches and deforms to the width and height given, even if it
    *    breaks aspect ratio
    */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  fit?:
+    | "scale-down"
+    | "scale-up"
+    | "contain"
+    | "cover"
+    | "crop"
+    | "pad"
+    | "squeeze";
   /**
    * Allows you to trim your image. Takes dpr into account and is performed before
    * resizing or rotation.
@@ -12498,6 +12508,17 @@ export interface BasicImageTransformations {
    * background pixel as transparent.
    */
   segment?: "foreground";
+  /**
+   * Controls the algorithm used when an image needs to be enlarged. This
+   * parameter works with any fit mode that upscales, such as `contain`,
+   * `cover`, and `scale-up`. It has no effect when `fit=scale-down` or when
+   * the target dimensions are smaller than the source.
+   * - interpolate: Uses bicubic interpolation, which may reduce image quality.
+   *   This is the default behavior when `upscale` is not specified.
+   * - generate: Uses AI upscaling to produce sharper, more detailed results
+   *   when enlarging images.
+   */
+  upscale?: "interpolate" | "generate";
 }
 export interface BasicImageTransformationsGravityCoordinates {
   x?: number;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12227,87 +12227,6 @@ export declare abstract class BrowserRun {
     options: BrowserRunMarkdownOptions,
   ): Promise<Response>;
 }
-export interface BasicImageTransformations {
-  /**
-   * Maximum width in image pixels. The value must be an integer.
-   */
-  width?: number;
-  /**
-   * Maximum height in image pixels. The value must be an integer.
-   */
-  height?: number;
-  /**
-   * Resizing mode as a string. It affects interpretation of width and height
-   * options:
-   *  - scale-down: Similar to contain, but the image is never enlarged. If
-   *    the image is larger than given width or height, it will be resized.
-   *    Otherwise its original size will be kept.
-   *  - contain: Resizes to maximum size that fits within the given width and
-   *    height. If only a single dimension is given (e.g. only width), the
-   *    image will be shrunk or enlarged to exactly match that dimension.
-   *    Aspect ratio is always preserved.
-   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
-   *    and height. If the image has an aspect ratio different from the ratio
-   *    of width and height, it will be cropped to fit.
-   *  - crop: The image will be shrunk and cropped to fit within the area
-   *    specified by width and height. The image will not be enlarged. For images
-   *    smaller than the given dimensions it's the same as scale-down. For
-   *    images larger than the given dimensions, it's the same as cover.
-   *    See also trim.
-   *  - pad: Resizes to the maximum size that fits within the given width and
-   *    height, and then fills the remaining area with a background color
-   *    (white by default). Use of this mode is not recommended, as the same
-   *    effect can be more efficiently achieved with the contain mode and the
-   *    CSS object-fit: contain property.
-   *  - squeeze: Stretches and deforms to the width and height given, even if it
-   *    breaks aspect ratio
-   */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
-  /**
-   * Image segmentation using artificial intelligence models. Sets pixels not
-   * within selected segment area to transparent e.g "foreground" sets every
-   * background pixel as transparent.
-   */
-  segment?: "foreground";
-  /**
-   * When cropping with fit: "cover", this defines the side or point that should
-   * be left uncropped. The value is either a string
-   * "left", "right", "top", "bottom", "auto", or "center" (the default),
-   * or an object {x, y} containing focal point coordinates in the original
-   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
-   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
-   * crop bottom or left and right sides as necessary, but won’t crop anything
-   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
-   * preserve as much as possible around a point at 20% of the height of the
-   * source image.
-   */
-  gravity?:
-    | "face"
-    | "left"
-    | "right"
-    | "top"
-    | "bottom"
-    | "center"
-    | "auto"
-    | "entropy"
-    | BasicImageTransformationsGravityCoordinates;
-  /**
-   * Background color to add underneath the image. Applies only to images with
-   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
-   * hsl(…), etc.)
-   */
-  background?: string;
-  /**
-   * Number of degrees (90, 180, 270) to rotate the image by. width and height
-   * options refer to axes after rotation.
-   */
-  rotate?: 0 | 90 | 180 | 270 | 360;
-}
-export interface BasicImageTransformationsGravityCoordinates {
-  x?: number;
-  y?: number;
-  mode?: "remainder" | "box-center";
-}
 /**
  * In addition to the properties you can set in the RequestInit dict
  * that you pass as an argument to the Request constructor, you can
@@ -12403,6 +12322,188 @@ export interface RequestInitCfProperties extends Record<string, unknown> {
    */
   resolveOverride?: string;
 }
+export interface BasicImageTransformations {
+  /**
+   * Maximum width in image pixels. The value must be an integer.
+   */
+  width?: number;
+  /**
+   * Maximum height in image pixels. The value must be an integer.
+   */
+  height?: number;
+  /**
+   * When cropping with fit: "cover", this defines the side or point that should
+   * be left uncropped. The value is either a string
+   * "left", "right", "top", "bottom", "auto", or "center" (the default),
+   * or an object {x, y} containing focal point coordinates in the original
+   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
+   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
+   * crop bottom or left and right sides as necessary, but won’t crop anything
+   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
+   * preserve as much as possible around a point at 20% of the height of the
+   * source image.
+   */
+  gravity?:
+    | "face"
+    | "left"
+    | "right"
+    | "top"
+    | "bottom"
+    | "center"
+    | "auto"
+    | "entropy"
+    | BasicImageTransformationsGravityCoordinates;
+  /**
+   * Specifies how closely the image is cropped toward detected faces when combined
+   * with the gravity=face option. Accepts a valid range between 0.0 (includes as much
+   * of the background as possible) and 1.0 (crops the image as closely to the face as
+   * possible). The default is 0.
+   */
+  zoom?: number;
+  /**
+   * Resizing mode as a string. It affects interpretation of width and height
+   * options:
+   *  - scale-down: Similar to contain, but the image is never enlarged. If
+   *    the image is larger than given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
+   *  - contain: Resizes to maximum size that fits within the given width and
+   *    height. If only a single dimension is given (e.g. only width), the
+   *    image will be shrunk or enlarged to exactly match that dimension.
+   *    Aspect ratio is always preserved.
+   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
+   *    and height. If the image has an aspect ratio different from the ratio
+   *    of width and height, it will be cropped to fit.
+   *  - crop: The image will be shrunk and cropped to fit within the area
+   *    specified by width and height. The image will not be enlarged. For images
+   *    smaller than the given dimensions it's the same as scale-down. For
+   *    images larger than the given dimensions, it's the same as cover.
+   *    See also trim.
+   *  - pad: Resizes to the maximum size that fits within the given width and
+   *    height, and then fills the remaining area with a background color
+   *    (white by default). Use of this mode is not recommended, as the same
+   *    effect can be more efficiently achieved with the contain mode and the
+   *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
+   */
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  /**
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
+   */
+  trim?:
+    | "border"
+    | {
+        top?: number;
+        bottom?: number;
+        left?: number;
+        right?: number;
+        width?: number;
+        height?: number;
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
+  /**
+   * Background color to add underneath the image. Applies only to images with
+   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
+   * hsl(…), etc.)
+   */
+  background?: string;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
+  /**
+   * Number of degrees (90, 180, 270) to rotate the image by. width and height
+   * options refer to axes after rotation.
+   */
+  rotate?: 0 | 90 | 180 | 270 | 360;
+  /**
+   * Strength of sharpening filter to apply to the image. Floating-point
+   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
+   * recommended value for downscaled images.
+   */
+  sharpen?: number;
+  /**
+   * Radius of a blur filter (approximate gaussian). Maximum supported radius
+   * is 250.
+   */
+  blur?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  contrast?: number;
+  /**
+   * Increase brightness by a factor. A value of 1.0 equals no change, a value
+   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
+   * 0 is ignored.
+   */
+  brightness?: number;
+  /**
+   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
+   */
+  gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
+   * easier to specify higher-DPI sizes in <img srcset>.
+   */
+  dpr?: number;
+  /**
+   * Adds a border around the image. The border is added after resizing. Border
+   * width takes dpr into account, and can be specified either using a single
+   * width property, or individually for each side.
+   */
+  border?:
+    | {
+        color: string;
+        width: number;
+      }
+    | {
+        color: string;
+        top: number;
+        right: number;
+        bottom: number;
+        left: number;
+      };
+  /**
+   * Image segmentation using artificial intelligence models. Sets pixels not
+   * within selected segment area to transparent e.g "foreground" sets every
+   * background pixel as transparent.
+   */
+  segment?: "foreground";
+}
+export interface BasicImageTransformationsGravityCoordinates {
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
+}
 export interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
   /**
    * Absolute URL of the image file to use for the drawing. It can be any of
@@ -12457,43 +12558,6 @@ export interface RequestInitCfPropertiesImageDraw extends BasicImageTransformati
 }
 export interface RequestInitCfPropertiesImage extends BasicImageTransformations {
   /**
-   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
-   * easier to specify higher-DPI sizes in <img srcset>.
-   */
-  dpr?: number;
-  /**
-   * Allows you to trim your image. Takes dpr into account and is performed before
-   * resizing or rotation.
-   *
-   * It can be used as:
-   * - left, top, right, bottom - it will specify the number of pixels to cut
-   *   off each side
-   * - width, height - the width/height you'd like to end up with - can be used
-   *   in combination with the properties above
-   * - border - this will automatically trim the surroundings of an image based on
-   *   it's color. It consists of three properties:
-   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
-   *    - tolerance: difference from color to treat as color
-   *    - keep: the number of pixels of border to keep
-   */
-  trim?:
-    | "border"
-    | {
-        top?: number;
-        bottom?: number;
-        left?: number;
-        right?: number;
-        width?: number;
-        height?: number;
-        border?:
-          | boolean
-          | {
-              color?: string;
-              tolerance?: number;
-              keep?: number;
-            };
-      };
-  /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
    * to JPEG and WebP images. It doesn’t have any effect on PNG.
@@ -12543,17 +12607,6 @@ export interface RequestInitCfPropertiesImage extends BasicImageTransformations 
    */
   metadata?: "keep" | "copyright" | "none";
   /**
-   * Strength of sharpening filter to apply to the image. Floating-point
-   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
-   * recommended value for downscaled images.
-   */
-  sharpen?: number;
-  /**
-   * Radius of a blur filter (approximate gaussian). Maximum supported radius
-   * is 250.
-   */
-  blur?: number;
-  /**
    * Overlays are drawn in the order they appear in the array (last array
    * entry is the topmost layer).
    */
@@ -12564,52 +12617,6 @@ export interface RequestInitCfPropertiesImage extends BasicImageTransformations 
    * the origin.
    */
   "origin-auth"?: "share-publicly";
-  /**
-   * Adds a border around the image. The border is added after resizing. Border
-   * width takes dpr into account, and can be specified either using a single
-   * width property, or individually for each side.
-   */
-  border?:
-    | {
-        color: string;
-        width: number;
-      }
-    | {
-        color: string;
-        top: number;
-        right: number;
-        bottom: number;
-        left: number;
-      };
-  /**
-   * Increase brightness by a factor. A value of 1.0 equals no change, a value
-   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
-   * 0 is ignored.
-   */
-  brightness?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  contrast?: number;
-  /**
-   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
-   */
-  gamma?: number;
-  /**
-   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-   * ignored.
-   */
-  saturation?: number;
-  /**
-   * Flips the images horizontally, vertically, or both. Flipping is applied before
-   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
-   * horizontally, then rotated by 90 degrees.
-   */
-  flip?: "h" | "v" | "hv";
   /**
    * Slightly reduces latency on a cache miss by selecting a
    * quickest-to-compress file format, at a cost of increased file size and


### PR DESCRIPTION
These are all supported on draws as well as the root image. Properties supported on both:

Fit related options:
- width
- height
- gravity
- zoom (totally missing before, now supported on both root and draws)
- fit
- upscale

Other transforms:
- background
- flip
- rotate
- sharpen
- blur
- contrast
- brightness
- gamma
- saturation
- dpr
- border
- segment