### PR TITLE
(workflows): update rollback context types

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -340,9 +340,9 @@ declare namespace CloudflareWorkersModule {
   };
 
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
 
   export type WorkflowRollbackHandler<T = unknown> = (

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -15233,9 +15233,9 @@ declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -15204,9 +15204,9 @@ export declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14565,9 +14565,9 @@ declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14536,9 +14536,9 @@ export declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -803,10 +803,10 @@ declare const workflowStep: WorkflowStep;
 
 expectTypeOf(
   workflowStep.do('step with rollback', async (): Promise<string> => 'ok', {
-    rollback: async (ctx) => {
-      expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
-      expectTypeOf(ctx.error).toEqualTypeOf<Error>();
-      expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
+    rollback: async (rollbackCtx) => {
+      expectTypeOf(rollbackCtx.ctx).toEqualTypeOf<WorkflowStepContext>();
+      expectTypeOf(rollbackCtx.error).toEqualTypeOf<Error>();
+      expectTypeOf(rollbackCtx.output).toEqualTypeOf<string | undefined>();
     },
   })
 ).toMatchTypeOf<Promise<string>>();
@@ -816,9 +816,9 @@ workflowStep.do(
   {retries: {limit: 0, delay: 0}},
   async (): Promise<string> => 'ok',
   {
-    rollback: async (ctx) => {
-      expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
-      expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
+    rollback: async (rollbackCtx) => {
+      expectTypeOf(rollbackCtx.ctx).toEqualTypeOf<WorkflowStepContext>();
+      expectTypeOf(rollbackCtx.output).toEqualTypeOf<string | undefined>();
     },
     rollbackConfig: {retries: {limit: 0, delay: 0}},
   }

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -11,6 +11,8 @@ import {
   type WorkflowCronSchedule,
   type WorkflowEvent,
   type WorkflowStep,
+  type WorkflowStepConfig,
+  type WorkflowStepContext,
 } from 'cloudflare:workers';
 import { expectTypeOf } from 'expect-type';
 
@@ -803,9 +805,13 @@ declare const workflowStep: WorkflowStep;
 expectTypeOf(
   workflowStep.do('step with rollback', async (): Promise<string> => 'ok', {
     rollback: async (ctx) => {
+      expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
+      expectTypeOf(ctx.ctx.step.name).toEqualTypeOf<string>();
+      expectTypeOf(ctx.ctx.step.count).toEqualTypeOf<number>();
+      expectTypeOf(ctx.ctx.attempt).toEqualTypeOf<number>();
+      expectTypeOf(ctx.ctx.config).toEqualTypeOf<WorkflowStepConfig>();
       expectTypeOf(ctx.error).toEqualTypeOf<Error>();
       expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
-      expectTypeOf(ctx.stepName).toEqualTypeOf<string>();
     },
   })
 ).toMatchTypeOf<Promise<string>>();
@@ -816,6 +822,7 @@ workflowStep.do(
   async (): Promise<string> => 'ok',
   {
     rollback: async (ctx) => {
+      expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
       expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
     },
     rollbackConfig: {retries: {limit: 0, delay: 0}},

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -11,7 +11,6 @@ import {
   type WorkflowCronSchedule,
   type WorkflowEvent,
   type WorkflowStep,
-  type WorkflowStepConfig,
   type WorkflowStepContext,
 } from 'cloudflare:workers';
 import { expectTypeOf } from 'expect-type';
@@ -806,10 +805,6 @@ expectTypeOf(
   workflowStep.do('step with rollback', async (): Promise<string> => 'ok', {
     rollback: async (ctx) => {
       expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
-      expectTypeOf(ctx.ctx.step.name).toEqualTypeOf<string>();
-      expectTypeOf(ctx.ctx.step.count).toEqualTypeOf<number>();
-      expectTypeOf(ctx.ctx.attempt).toEqualTypeOf<number>();
-      expectTypeOf(ctx.ctx.config).toEqualTypeOf<WorkflowStepConfig>();
       expectTypeOf(ctx.error).toEqualTypeOf<Error>();
       expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
     },


### PR DESCRIPTION
Adds ctx: WorkflowStepContext to WorkflowRollbackContext and removes legacy stepName. Updates generated type snapshots and RPC type tests.