### PR TITLE
(workflows): update rollback context types

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -308,6 +308,11 @@ declare namespace CloudflareWorkersModule {
     sensitive?: WorkflowStepSensitivity;
   };
 
+  export type WorkflowStepRollbackConfig = Pick<
+    WorkflowStepConfig,
+    'retries' | 'timeout'
+  >;
+
   export type WorkflowCronSchedule = {
     /** Cron expression that triggered this event. */
     cron: string;
@@ -343,6 +348,8 @@ declare namespace CloudflareWorkersModule {
     ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
+    /** @deprecated Use `ctx.step.name` and `ctx.step.count` instead. */
+    stepName: string;
   };
 
   export type WorkflowRollbackHandler<T = unknown> = (
@@ -350,8 +357,8 @@ declare namespace CloudflareWorkersModule {
   ) => Promise<void>;
 
   export type WorkflowStepRollbackOptions<T = unknown> = {
-    rollback?: WorkflowRollbackHandler<T>;
-    rollbackConfig?: WorkflowStepConfig;
+    rollback: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepRollbackConfig;
   };
 
   export abstract class WorkflowStep {

--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -340,9 +340,9 @@ declare namespace CloudflareWorkersModule {
   };
 
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
 
   export type WorkflowRollbackHandler<T = unknown> = (

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -15205,6 +15205,10 @@ declare namespace CloudflareWorkersModule {
     timeout?: WorkflowTimeoutDuration | number;
     sensitive?: WorkflowStepSensitivity;
   };
+  export type WorkflowStepRollbackConfig = Pick<
+    WorkflowStepConfig,
+    "retries" | "timeout"
+  >;
   export type WorkflowCronSchedule = {
     /** Cron expression that triggered this event. */
     cron: string;
@@ -15236,13 +15240,15 @@ declare namespace CloudflareWorkersModule {
     ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
+    /** @deprecated Use `ctx.step.name` and `ctx.step.count` instead. */
+    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,
   ) => Promise<void>;
   export type WorkflowStepRollbackOptions<T = unknown> = {
-    rollback?: WorkflowRollbackHandler<T>;
-    rollbackConfig?: WorkflowStepConfig;
+    rollback: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepRollbackConfig;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -15233,9 +15233,9 @@ declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -15176,6 +15176,10 @@ export declare namespace CloudflareWorkersModule {
     timeout?: WorkflowTimeoutDuration | number;
     sensitive?: WorkflowStepSensitivity;
   };
+  export type WorkflowStepRollbackConfig = Pick<
+    WorkflowStepConfig,
+    "retries" | "timeout"
+  >;
   export type WorkflowCronSchedule = {
     /** Cron expression that triggered this event. */
     cron: string;
@@ -15207,13 +15211,15 @@ export declare namespace CloudflareWorkersModule {
     ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
+    /** @deprecated Use `ctx.step.name` and `ctx.step.count` instead. */
+    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,
   ) => Promise<void>;
   export type WorkflowStepRollbackOptions<T = unknown> = {
-    rollback?: WorkflowRollbackHandler<T>;
-    rollbackConfig?: WorkflowStepConfig;
+    rollback: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepRollbackConfig;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -15204,9 +15204,9 @@ export declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14565,9 +14565,9 @@ declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14537,6 +14537,10 @@ declare namespace CloudflareWorkersModule {
     timeout?: WorkflowTimeoutDuration | number;
     sensitive?: WorkflowStepSensitivity;
   };
+  export type WorkflowStepRollbackConfig = Pick<
+    WorkflowStepConfig,
+    "retries" | "timeout"
+  >;
   export type WorkflowCronSchedule = {
     /** Cron expression that triggered this event. */
     cron: string;
@@ -14568,13 +14572,15 @@ declare namespace CloudflareWorkersModule {
     ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
+    /** @deprecated Use `ctx.step.name` and `ctx.step.count` instead. */
+    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,
   ) => Promise<void>;
   export type WorkflowStepRollbackOptions<T = unknown> = {
-    rollback?: WorkflowRollbackHandler<T>;
-    rollbackConfig?: WorkflowStepConfig;
+    rollback: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepRollbackConfig;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14536,9 +14536,9 @@ export declare namespace CloudflareWorkersModule {
     config: WorkflowStepConfig;
   };
   export type WorkflowRollbackContext<T = unknown> = {
+    ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
-    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14508,6 +14508,10 @@ export declare namespace CloudflareWorkersModule {
     timeout?: WorkflowTimeoutDuration | number;
     sensitive?: WorkflowStepSensitivity;
   };
+  export type WorkflowStepRollbackConfig = Pick<
+    WorkflowStepConfig,
+    "retries" | "timeout"
+  >;
   export type WorkflowCronSchedule = {
     /** Cron expression that triggered this event. */
     cron: string;
@@ -14539,13 +14543,15 @@ export declare namespace CloudflareWorkersModule {
     ctx: WorkflowStepContext;
     error: Error;
     output: T | undefined;
+    /** @deprecated Use `ctx.step.name` and `ctx.step.count` instead. */
+    stepName: string;
   };
   export type WorkflowRollbackHandler<T = unknown> = (
     ctx: WorkflowRollbackContext<T>,
   ) => Promise<void>;
   export type WorkflowStepRollbackOptions<T = unknown> = {
-    rollback?: WorkflowRollbackHandler<T>;
-    rollbackConfig?: WorkflowStepConfig;
+    rollback: WorkflowRollbackHandler<T>;
+    rollbackConfig?: WorkflowStepRollbackConfig;
   };
   export abstract class WorkflowStep {
     do<T extends Rpc.Serializable<T>>(

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -807,6 +807,7 @@ expectTypeOf(
       expectTypeOf(rollbackCtx.ctx).toEqualTypeOf<WorkflowStepContext>();
       expectTypeOf(rollbackCtx.error).toEqualTypeOf<Error>();
       expectTypeOf(rollbackCtx.output).toEqualTypeOf<string | undefined>();
+      expectTypeOf(rollbackCtx.stepName).toEqualTypeOf<string>();
     },
   })
 ).toMatchTypeOf<Promise<string>>();
@@ -819,12 +820,30 @@ workflowStep.do(
     rollback: async (rollbackCtx) => {
       expectTypeOf(rollbackCtx.ctx).toEqualTypeOf<WorkflowStepContext>();
       expectTypeOf(rollbackCtx.output).toEqualTypeOf<string | undefined>();
+      expectTypeOf(rollbackCtx.stepName).toEqualTypeOf<string>();
     },
     rollbackConfig: {retries: {limit: 0, delay: 0}},
   }
 );
 
+workflowStep.do('rollback with timeout only', async (): Promise<string> => 'ok', {
+  rollback: async () => {},
+  rollbackConfig: {timeout: '10 seconds'},
+});
+
+// @ts-expect-error rollbackConfig only accepts retries and timeout
+workflowStep.do('rollback config with sensitivity', async () => 'ok', {
+  rollback: async () => {},
+  rollbackConfig: {sensitive: 'output'},
+});
+
+// @ts-expect-error rollback options require a rollback handler
 workflowStep.do('empty rollback options', async () => 'ok', {});
+
+// @ts-expect-error rollbackConfig requires a rollback handler
+workflowStep.do('rollback config without handler', async () => 'ok', {
+  rollbackConfig: {retries: {limit: 0, delay: 0}},
+});
 
 expectTypeOf(
   workflowStep.do('no rollback 2-arg', async (): Promise<string> => 'ok')

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -803,10 +803,10 @@ declare const workflowStep: WorkflowStep;
 
 expectTypeOf(
   workflowStep.do('step with rollback', async (): Promise<string> => 'ok', {
-    rollback: async (ctx) => {
-      expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
-      expectTypeOf(ctx.error).toEqualTypeOf<Error>();
-      expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
+    rollback: async (rollbackCtx) => {
+      expectTypeOf(rollbackCtx.ctx).toEqualTypeOf<WorkflowStepContext>();
+      expectTypeOf(rollbackCtx.error).toEqualTypeOf<Error>();
+      expectTypeOf(rollbackCtx.output).toEqualTypeOf<string | undefined>();
     },
   })
 ).toMatchTypeOf<Promise<string>>();
@@ -816,9 +816,9 @@ workflowStep.do(
   {retries: {limit: 0, delay: 0}},
   async (): Promise<string> => 'ok',
   {
-    rollback: async (ctx) => {
-      expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
-      expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
+    rollback: async (rollbackCtx) => {
+      expectTypeOf(rollbackCtx.ctx).toEqualTypeOf<WorkflowStepContext>();
+      expectTypeOf(rollbackCtx.output).toEqualTypeOf<string | undefined>();
     },
     rollbackConfig: {retries: {limit: 0, delay: 0}},
   }

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -11,6 +11,8 @@ import {
   type WorkflowCronSchedule,
   type WorkflowEvent,
   type WorkflowStep,
+  type WorkflowStepConfig,
+  type WorkflowStepContext,
 } from 'cloudflare:workers';
 import { expectTypeOf } from 'expect-type';
 
@@ -803,9 +805,13 @@ declare const workflowStep: WorkflowStep;
 expectTypeOf(
   workflowStep.do('step with rollback', async (): Promise<string> => 'ok', {
     rollback: async (ctx) => {
+      expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
+      expectTypeOf(ctx.ctx.step.name).toEqualTypeOf<string>();
+      expectTypeOf(ctx.ctx.step.count).toEqualTypeOf<number>();
+      expectTypeOf(ctx.ctx.attempt).toEqualTypeOf<number>();
+      expectTypeOf(ctx.ctx.config).toEqualTypeOf<WorkflowStepConfig>();
       expectTypeOf(ctx.error).toEqualTypeOf<Error>();
       expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
-      expectTypeOf(ctx.stepName).toEqualTypeOf<string>();
     },
   })
 ).toMatchTypeOf<Promise<string>>();
@@ -816,6 +822,7 @@ workflowStep.do(
   async (): Promise<string> => 'ok',
   {
     rollback: async (ctx) => {
+      expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
       expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
     },
     rollbackConfig: {retries: {limit: 0, delay: 0}},

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -11,7 +11,6 @@ import {
   type WorkflowCronSchedule,
   type WorkflowEvent,
   type WorkflowStep,
-  type WorkflowStepConfig,
   type WorkflowStepContext,
 } from 'cloudflare:workers';
 import { expectTypeOf } from 'expect-type';
@@ -806,10 +805,6 @@ expectTypeOf(
   workflowStep.do('step with rollback', async (): Promise<string> => 'ok', {
     rollback: async (ctx) => {
       expectTypeOf(ctx.ctx).toEqualTypeOf<WorkflowStepContext>();
-      expectTypeOf(ctx.ctx.step.name).toEqualTypeOf<string>();
-      expectTypeOf(ctx.ctx.step.count).toEqualTypeOf<number>();
-      expectTypeOf(ctx.ctx.attempt).toEqualTypeOf<number>();
-      expectTypeOf(ctx.ctx.config).toEqualTypeOf<WorkflowStepConfig>();
       expectTypeOf(ctx.error).toEqualTypeOf<Error>();
       expectTypeOf(ctx.output).toEqualTypeOf<string | undefined>();
     },


### PR DESCRIPTION
adds `ctx: WorkflowStepContext` and deprecated legacy `stepName` to `WorkflowRollbackContext`. Makes rollback required when rollback options are provided, narrows rollbackConfig to retries and timeout, and updates generated type snapshots plus RPC type tests