### PR TITLE
Don't use JSRPC for AI binding's toMarkdown() API.

### DIFF
--- a/src/cloudflare/internal/ai-api.ts
+++ b/src/cloudflare/internal/ai-api.ts
@@ -427,9 +427,9 @@ export class Ai {
     files?: MarkdownDocument | MarkdownDocument[],
     options?: ConversionRequestOptions
   ): ToMarkdownService | Promise<ConversionResponse | ConversionResponse[]> {
-    const service = aiBindingExperimental
-      ? this.#fetcher.toMarkdown()
-      : new ToMarkdownService(this.#fetcher);
+    // TODO(soon): Experimentally use RPC via `this.#fetcher.toMarkdown()`. Does not work correctly
+    //   because `Blob` is not serializable; we'll need to fix that in the runtime first.
+    const service = new ToMarkdownService(this.#fetcher);
 
     if (arguments.length < 1 || !files) return service;
 


### PR DESCRIPTION
This API does not work over JSRPC, because it uses `Blob`, which is not serializable. Thus this API is currently broken for all users of `experimental`, including Gadgets.

We can and should make `Blob` serializable, but that is a bigger change.