### PR TITLE
CC-7953: expose container image url to user

### DIFF
--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -303,6 +303,7 @@ jsg::Promise<kj::Maybe<Container::Info>> Container::inspect(jsg::Lock& js) {
       };
     },
           },
+      .image = kj::str(info.getStarted().getImage()),
     };
   });
 }

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -185,8 +185,9 @@ class Container: public jsg::Object {
 
   struct Info {
     jsg::Dict<kj::String> labels;
+    kj::String image;
 
-    JSG_STRUCT(labels);
+    JSG_STRUCT(labels, image);
   };
 
   struct StartupOptions {

--- a/src/workerd/io/container.capnp
+++ b/src/workerd/io/container.capnp
@@ -259,6 +259,11 @@ interface Container @0x9aaceefc06523bca {
       started :group {
         labels @1 :List(Label);
         # Echo of StartParams.labels. Empty list means start() was called with no labels.
+
+        image @2 :Text;
+        # The container's image registry reference, e.g.
+        # "registry.example.com/namespace/image:latest". Empty when the image is
+        # unknown (e.g. an older launcher that does not report it).
       }
     }
   }

--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -1561,7 +1561,13 @@ kj::Promise<kj::Maybe<ContainerClient::InspectResponse>> ContainerClient::inspec
     }
   }
 
-  co_return InspectResponse{.isRunning = running, .labels = labels.releaseAsArray()};
+  kj::String image;
+  if (jsonRoot.hasConfig() && jsonRoot.getConfig().hasImage()) {
+    image = kj::str(jsonRoot.getConfig().getImage());
+  }
+
+  co_return InspectResponse{
+    .isRunning = running, .labels = labels.releaseAsArray(), .image = kj::mv(image)};
 }
 
 kj::Promise<kj::Maybe<ContainerClient::SidecarInspectResponse>> ContainerClient::inspectSidecar() {
@@ -2220,6 +2226,7 @@ kj::Promise<void> ContainerClient::inspect(InspectContext context) {
         list[i].setName(resp.labels[i].name);
         list[i].setValue(resp.labels[i].value);
       }
+      started.setImage(resp.image);
       co_return;
     }
   }

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -133,6 +133,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   struct InspectResponse {
     bool isRunning;
     kj::Array<Label> labels;
+    kj::String image;
   };
 
   struct IPAMConfigResult {

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -570,6 +570,11 @@ export class DurableObjectExample extends DurableObject {
 
     const info = await container.inspect();
     assert.deepStrictEqual(info.labels, labels);
+    assert.strictEqual(typeof info.image, 'string');
+    assert.ok(
+      info.image.includes('cloudflare/workerd/container-client-test'),
+      `unexpected image reference: ${info.image}`
+    );
 
     await container.destroy();
     await monitor;


### PR DESCRIPTION
Expose the container's image's registry url to the user under the inspect() function.

> [!WARNING]
> Not ready to merge - waiting on internal mrs