### PR TITLE
add Workers cf.vary types

### DIFF
--- a/src/workerd/api/tests/cf-cache-control-test.js
+++ b/src/workerd/api/tests/cf-cache-control-test.js
@@ -139,6 +139,16 @@ export const additionalCacheSettings = {
           stripLastModified: false,
           cacheDeceptionArmor: true,
           cacheReserveMinimumFileSize: 1024,
+          vary: {
+            default: { action: 'bypass' },
+            headers: {
+              accept: {
+                action: 'normalize',
+                media_types: ['image/webp', 'image/avif'],
+              },
+              'x-custom-header': { action: 'passthrough' },
+            },
+          },
         },
       });
       assert.ok(req.cf);
@@ -148,6 +158,16 @@ export const additionalCacheSettings = {
       assert.strictEqual(req.cf.stripLastModified, false);
       assert.strictEqual(req.cf.cacheDeceptionArmor, true);
       assert.strictEqual(req.cf.cacheReserveMinimumFileSize, 1024);
+      assert.deepStrictEqual(req.cf.vary, {
+        default: { action: 'bypass' },
+        headers: {
+          accept: {
+            action: 'normalize',
+            media_types: ['image/webp', 'image/avif'],
+          },
+          'x-custom-header': { action: 'passthrough' },
+        },
+      });
     }
 
     // Additional cache settings should work alongside cacheControl

--- a/types/defines/cf.d.ts
+++ b/types/defines/cf.d.ts
@@ -36,6 +36,8 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
    */
   cacheTtlByStatus?: Record<string, number>;
+  /** Controls how responses with a `Vary` header are cached for this request. */
+  vary?: RequestInitCfPropertiesVary;
   /**
    * Explicit Cache-Control header value to set on the response stored in cache.
    * This gives full control over cache directives (e.g. 'public, max-age=3600, s-maxage=86400').
@@ -92,6 +94,52 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    * to point to that CNAME record.
    */
   resolveOverride?: string;
+}
+
+type RequestInitCfPropertiesVaryAction =
+  | "normalize"
+  | "passthrough"
+  | "bypass";
+
+/** Configuration for Workers Standard Vary support. */
+interface RequestInitCfPropertiesVary {
+  /** The fallback action for varied request headers not listed in `headers`. */
+  default: RequestInitCfPropertiesVaryHeader;
+  /**
+   * Lowercase request header names and their Vary configuration.
+   *
+   * The `accept` header can include `media_types`, the `accept-language`
+   * header can include `languages`, and other headers support only `action`.
+   */
+  headers?: RequestInitCfPropertiesVaryHeaders;
+}
+
+/** Common Vary behavior for a single request header. */
+interface RequestInitCfPropertiesVaryHeader {
+  action: RequestInitCfPropertiesVaryAction;
+}
+
+/** Vary behavior for the `accept` request header. */
+interface RequestInitCfPropertiesVaryAcceptHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  media_types?: string[];
+}
+
+/** Vary behavior for the `accept-language` request header. */
+interface RequestInitCfPropertiesVaryAcceptLanguageHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  languages?: string[];
+}
+
+/** Lowercase request header names and their Vary behavior. */
+interface RequestInitCfPropertiesVaryHeaders {
+  accept?: RequestInitCfPropertiesVaryAcceptHeader;
+  "accept-language"?: RequestInitCfPropertiesVaryAcceptLanguageHeader;
+  [header: string]:
+    | RequestInitCfPropertiesVaryHeader
+    | RequestInitCfPropertiesVaryAcceptHeader
+    | RequestInitCfPropertiesVaryAcceptLanguageHeader
+    | undefined;
 }
 
 interface BasicImageTransformations {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -12921,6 +12921,8 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
    */
   cacheTtlByStatus?: Record<string, number>;
+  /** Controls how responses with a `Vary` header are cached for this request. */
+  vary?: RequestInitCfPropertiesVary;
   /**
    * Explicit Cache-Control header value to set on the response stored in cache.
    * This gives full control over cache directives (e.g. 'public, max-age=3600, s-maxage=86400').
@@ -12977,6 +12979,46 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    * to point to that CNAME record.
    */
   resolveOverride?: string;
+}
+type RequestInitCfPropertiesVaryAction =
+  | "normalize"
+  | "passthrough"
+  | "bypass";
+/** Configuration for Workers Standard Vary support. */
+interface RequestInitCfPropertiesVary {
+  /** The fallback action for varied request headers not listed in `headers`. */
+  default: RequestInitCfPropertiesVaryHeader;
+  /**
+   * Lowercase request header names and their Vary configuration.
+   *
+   * The `accept` header can include `media_types`, the `accept-language`
+   * header can include `languages`, and other headers support only `action`.
+   */
+  headers?: RequestInitCfPropertiesVaryHeaders;
+}
+/** Common Vary behavior for a single request header. */
+interface RequestInitCfPropertiesVaryHeader {
+  action: RequestInitCfPropertiesVaryAction;
+}
+/** Vary behavior for the `accept` request header. */
+interface RequestInitCfPropertiesVaryAcceptHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  media_types?: string[];
+}
+/** Vary behavior for the `accept-language` request header. */
+interface RequestInitCfPropertiesVaryAcceptLanguageHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  languages?: string[];
+}
+/** Lowercase request header names and their Vary behavior. */
+interface RequestInitCfPropertiesVaryHeaders {
+  accept?: RequestInitCfPropertiesVaryAcceptHeader;
+  "accept-language"?: RequestInitCfPropertiesVaryAcceptLanguageHeader;
+  [header: string]:
+    | RequestInitCfPropertiesVaryHeader
+    | RequestInitCfPropertiesVaryAcceptHeader
+    | RequestInitCfPropertiesVaryAcceptLanguageHeader
+    | undefined;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -12933,6 +12933,8 @@ export interface RequestInitCfProperties extends Record<string, unknown> {
    * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
    */
   cacheTtlByStatus?: Record<string, number>;
+  /** Controls how responses with a `Vary` header are cached for this request. */
+  vary?: RequestInitCfPropertiesVary;
   /**
    * Explicit Cache-Control header value to set on the response stored in cache.
    * This gives full control over cache directives (e.g. 'public, max-age=3600, s-maxage=86400').
@@ -12989,6 +12991,42 @@ export interface RequestInitCfProperties extends Record<string, unknown> {
    * to point to that CNAME record.
    */
   resolveOverride?: string;
+}
+export type RequestInitCfPropertiesVaryAction =
+  | "normalize"
+  | "passthrough"
+  | "bypass";
+/** Configuration for Workers Standard Vary support. */
+export interface RequestInitCfPropertiesVary {
+  /** The fallback action for varied request headers not listed in `headers`. */
+  default: RequestInitCfPropertiesVaryHeader;
+  /**
+   * Lowercase request header names and their Vary configuration.
+   *
+   * The `accept` header can include `media_types`, the `accept-language`
+   * header can include `languages`, and other headers support only `action`.
+   */
+  headers?: RequestInitCfPropertiesVaryHeaders;
+}
+/** Common Vary behavior for a single request header. */
+export interface RequestInitCfPropertiesVaryHeader {
+  action: RequestInitCfPropertiesVaryAction;
+}
+/** Vary behavior for the `accept` request header. */
+export interface RequestInitCfPropertiesVaryAcceptHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  media_types?: string[];
+}
+/** Vary behavior for the `accept-language` request header. */
+export interface RequestInitCfPropertiesVaryAcceptLanguageHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  languages?: string[];
+}
+/** Lowercase request header names and their Vary behavior. */
+export interface RequestInitCfPropertiesVaryHeaders
+  extends Record<string, RequestInitCfPropertiesVaryHeader | undefined> {
+  accept?: RequestInitCfPropertiesVaryAcceptHeader;
+  "accept-language"?: RequestInitCfPropertiesVaryAcceptLanguageHeader;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12253,6 +12253,8 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
    */
   cacheTtlByStatus?: Record<string, number>;
+  /** Controls how responses with a `Vary` header are cached for this request. */
+  vary?: RequestInitCfPropertiesVary;
   /**
    * Explicit Cache-Control header value to set on the response stored in cache.
    * This gives full control over cache directives (e.g. 'public, max-age=3600, s-maxage=86400').
@@ -12309,6 +12311,46 @@ interface RequestInitCfProperties extends Record<string, unknown> {
    * to point to that CNAME record.
    */
   resolveOverride?: string;
+}
+type RequestInitCfPropertiesVaryAction =
+  | "normalize"
+  | "passthrough"
+  | "bypass";
+/** Configuration for Workers Standard Vary support. */
+interface RequestInitCfPropertiesVary {
+  /** The fallback action for varied request headers not listed in `headers`. */
+  default: RequestInitCfPropertiesVaryHeader;
+  /**
+   * Lowercase request header names and their Vary configuration.
+   *
+   * The `accept` header can include `media_types`, the `accept-language`
+   * header can include `languages`, and other headers support only `action`.
+   */
+  headers?: RequestInitCfPropertiesVaryHeaders;
+}
+/** Common Vary behavior for a single request header. */
+interface RequestInitCfPropertiesVaryHeader {
+  action: RequestInitCfPropertiesVaryAction;
+}
+/** Vary behavior for the `accept` request header. */
+interface RequestInitCfPropertiesVaryAcceptHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  media_types?: string[];
+}
+/** Vary behavior for the `accept-language` request header. */
+interface RequestInitCfPropertiesVaryAcceptLanguageHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  languages?: string[];
+}
+/** Lowercase request header names and their Vary behavior. */
+interface RequestInitCfPropertiesVaryHeaders {
+  accept?: RequestInitCfPropertiesVaryAcceptHeader;
+  "accept-language"?: RequestInitCfPropertiesVaryAcceptLanguageHeader;
+  [header: string]:
+    | RequestInitCfPropertiesVaryHeader
+    | RequestInitCfPropertiesVaryAcceptHeader
+    | RequestInitCfPropertiesVaryAcceptLanguageHeader
+    | undefined;
 }
 interface BasicImageTransformations {
   /**

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12265,6 +12265,8 @@ export interface RequestInitCfProperties extends Record<string, unknown> {
    * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
    */
   cacheTtlByStatus?: Record<string, number>;
+  /** Controls how responses with a `Vary` header are cached for this request. */
+  vary?: RequestInitCfPropertiesVary;
   /**
    * Explicit Cache-Control header value to set on the response stored in cache.
    * This gives full control over cache directives (e.g. 'public, max-age=3600, s-maxage=86400').
@@ -12321,6 +12323,42 @@ export interface RequestInitCfProperties extends Record<string, unknown> {
    * to point to that CNAME record.
    */
   resolveOverride?: string;
+}
+export type RequestInitCfPropertiesVaryAction =
+  | "normalize"
+  | "passthrough"
+  | "bypass";
+/** Configuration for Workers Standard Vary support. */
+export interface RequestInitCfPropertiesVary {
+  /** The fallback action for varied request headers not listed in `headers`. */
+  default: RequestInitCfPropertiesVaryHeader;
+  /**
+   * Lowercase request header names and their Vary configuration.
+   *
+   * The `accept` header can include `media_types`, the `accept-language`
+   * header can include `languages`, and other headers support only `action`.
+   */
+  headers?: RequestInitCfPropertiesVaryHeaders;
+}
+/** Common Vary behavior for a single request header. */
+export interface RequestInitCfPropertiesVaryHeader {
+  action: RequestInitCfPropertiesVaryAction;
+}
+/** Vary behavior for the `accept` request header. */
+export interface RequestInitCfPropertiesVaryAcceptHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  media_types?: string[];
+}
+/** Vary behavior for the `accept-language` request header. */
+export interface RequestInitCfPropertiesVaryAcceptLanguageHeader
+  extends RequestInitCfPropertiesVaryHeader {
+  languages?: string[];
+}
+/** Lowercase request header names and their Vary behavior. */
+export interface RequestInitCfPropertiesVaryHeaders
+  extends Record<string, RequestInitCfPropertiesVaryHeader | undefined> {
+  accept?: RequestInitCfPropertiesVaryAcceptHeader;
+  "accept-language"?: RequestInitCfPropertiesVaryAcceptLanguageHeader;
 }
 export interface BasicImageTransformations {
   /**

--- a/types/test/types/cf.ts
+++ b/types/test/types/cf.ts
@@ -22,6 +22,64 @@ export const handler: ExportedHandler<{ SERVICE: Fetcher }> = {
       cf: { cacheEverything: true },
     });
 
+    await fetch("https://example.com", {
+      cf: {
+        vary: {
+          default: { action: "bypass" },
+          headers: {
+            accept: {
+              action: "normalize",
+              media_types: ["image/webp", "image/avif"],
+            },
+            "accept-language": {
+              action: "normalize",
+              languages: ["en", "fr"],
+            },
+            "x-custom-header": { action: "passthrough" },
+          },
+        },
+      },
+    });
+
+    await fetch("https://example.com", {
+      cf: {
+        // @ts-expect-error: default is required for vary
+        vary: {
+          headers: {
+            accept: { action: "normalize" },
+          },
+        },
+      },
+    });
+
+    await fetch("https://example.com", {
+      cf: {
+        vary: {
+          // @ts-expect-error: action must be normalize, passthrough, or bypass
+          default: { action: "invalid" },
+        },
+      },
+    });
+
+    // @ts-expect-error: media_types and languages values must be strings
+    await fetch("https://example.com", {
+      cf: {
+        vary: {
+          default: { action: "bypass" },
+          headers: {
+            accept: {
+              action: "normalize",
+              media_types: [123],
+            },
+            "accept-language": {
+              action: "normalize",
+              languages: [123],
+            },
+          },
+        },
+      },
+    });
+
     // Can fetch to service binding with incoming properties to simulate incoming request
     await env.SERVICE.fetch("https://example.com", {
       cf: { colo: "LHR" },


### PR DESCRIPTION
## What

Adds Workers `cf.vary` typing support for request init `cf` options and covers the value shape in the existing `cf-cache-control` runtime test.

This mirrors the cache Rulesets Vary shape for Workers callers:
- `default.action`
- per-header `action`
- `accept.media_types`
- `accept-language.languages`

Also updates the checked-in generated type snapshots.