### PR TITLE
node: harden tls, dns, net, and WebCrypto checks

### DIFF
--- a/src/node/internal/internal_dns.ts
+++ b/src/node/internal/internal_dns.ts
@@ -31,6 +31,7 @@ import {
 } from 'node-internal:internal_errors';
 import {
   validateString,
+  validateStringWithoutNullBytes,
   validateFunction,
   validateOneOf,
   validateNumber,
@@ -72,7 +73,7 @@ export function lookup(
 
   // Parse arguments
   if (hostname) {
-    validateString(hostname, 'hostname');
+    validateStringWithoutNullBytes(hostname, 'hostname');
   }
 
   if (typeof options === 'function') {

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -53,6 +53,7 @@ import {
   validateOneOf,
   validateBoolean,
   validateString,
+  validateStringWithoutNullBytes,
   validateUint32,
 } from 'node-internal:validators';
 
@@ -1139,7 +1140,6 @@ function initializeConnection(
   options: TcpSocketConnectOpts
 ): void {
   const {
-    host = 'localhost',
     family,
     hints,
     autoSelectFamily,
@@ -1148,7 +1148,9 @@ function initializeConnection(
     localAddress,
     localPort,
   } = options;
+  const host = options.host || 'localhost';
   let { port } = options;
+  validateStringWithoutNullBytes(host, 'options.host');
   if (localAddress && !isIP(localAddress)) {
     throw new ERR_INVALID_IP_ADDRESS(localAddress);
   }

--- a/src/node/internal/internal_tls.ts
+++ b/src/node/internal/internal_tls.ts
@@ -152,6 +152,11 @@ export function checkServerIdentity(
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion
   hostname = '' + hostname;
+  const hostnameASCII = urlUtil.domainToASCII(hostname);
+
+  // Remove trailing dot for error messages and matching.
+  hostname = unfqdn(hostname);
+  const hostnameASCIIWithoutFQDN = unfqdn(hostnameASCII);
 
   if (altNames) {
     const splitAltNames = altNames.includes('"')
@@ -169,14 +174,12 @@ export function checkServerIdentity(
   let valid = false;
   let reason = 'Unknown reason';
 
-  hostname = unfqdn(hostname); // Remove trailing dot for error messages.
-
-  if (isIP(hostname)) {
-    valid = ips.includes(urlUtil.canonicalizeIp(hostname));
+  if (isIP(hostnameASCIIWithoutFQDN)) {
+    valid = ips.includes(urlUtil.canonicalizeIp(hostnameASCIIWithoutFQDN));
     if (!valid)
       reason = `IP: ${hostname} is not in the cert's list: ` + ips.join(', ');
   } else if (dnsNames.length > 0 || subject?.CN) {
-    const hostParts = splitHost(hostname);
+    const hostParts = splitHost(hostnameASCIIWithoutFQDN);
     const wildcard = (pattern: string): boolean =>
       check(hostParts, pattern, true);
 

--- a/src/node/internal/validators.ts
+++ b/src/node/internal/validators.ts
@@ -178,6 +178,20 @@ export function validateString(
   }
 }
 
+export function validateStringWithoutNullBytes(
+  value: unknown,
+  name: string
+): asserts value is string {
+  validateString(value, name);
+  if (value.includes('\u0000')) {
+    throw new ERR_INVALID_ARG_VALUE(
+      name,
+      value,
+      'must be a string without null bytes'
+    );
+  }
+}
+
 export function validateStringArray(
   value: unknown,
   name: string

--- a/src/workerd/api/crypto/aes-test.c++
+++ b/src/workerd/api/crypto/aes-test.c++
@@ -24,6 +24,14 @@ struct CryptoContext: public jsg::Object, public jsg::ContextGlobal {
 };
 JSG_DECLARE_ISOLATE_TYPE(CryptoIsolate, CryptoContext);
 
+KJ_TEST("OpenSSL input size guard rejects oversized buffers") {
+  KJ_EXPECT(isOpenSslInputSizeValid(0));
+  KJ_EXPECT(isOpenSslInputSizeValid(INT_MAX));
+  KJ_EXPECT(isOpenSslInputSizeValid(INT_MAX - 1, 1));
+  KJ_EXPECT(!isOpenSslInputSizeValid(static_cast<size_t>(INT_MAX) + 1));
+  KJ_EXPECT(!isOpenSslInputSizeValid(INT_MAX, 1));
+}
+
 KJ_TEST("AES-KW key wrap") {
   // Basic test that I wrote when I was seeing heap corruption. Found it easier to iterate on with
   // ASAN/valgrind than using our conformance tests with test-runner.

--- a/src/workerd/api/crypto/aes.c++
+++ b/src/workerd/api/crypto/aes.c++
@@ -254,6 +254,8 @@ class AesGcmKey final: public AesKeyBase {
     // a stream cipher in that it does not add padding and can process partial blocks, meaning that
     // we know the exact ciphertext size in advance.
     auto tagByteSize = tagLength / 8;
+    JSG_REQUIRE(isOpenSslInputSizeValid(plainText.size(), tagByteSize), DOMOperationError,
+        "Data is too large.");
     auto cipherText = jsg::JsArrayBuffer::create(js, plainText.size() + tagByteSize);
 
     // Perform the actual encryption.
@@ -324,6 +326,8 @@ class AesGcmKey final: public AesKeyBase {
     auto actualCipherText = cipherText.first(cipherText.size() - tagLength / 8);
     auto tagText = cipherText.slice(actualCipherText.size(), cipherText.size());
 
+    JSG_REQUIRE(
+        isOpenSslInputSizeValid(actualCipherText.size()), DOMOperationError, "Data is too large.");
     auto plainText = jsg::JsArrayBuffer::create(js, actualCipherText.size());
 
     // Perform the actual decryption.
@@ -378,6 +382,8 @@ class AesCbcKey final: public AesKeyBase {
 
     auto blockSize = EVP_CIPHER_CTX_block_size(cipherCtx.get());
     size_t paddingSize = blockSize - (plainText.size() % blockSize);
+    JSG_REQUIRE(isOpenSslInputSizeValid(plainText.size(), paddingSize), DOMOperationError,
+        "Data is too large.");
     auto cipherText = jsg::JsArrayBuffer::create(js, plainText.size() + paddingSize);
 
     // Perform the actual encryption.
@@ -420,6 +426,9 @@ class AesCbcKey final: public AesKeyBase {
 
     int plainSize = 0;
     auto blockSize = EVP_CIPHER_CTX_block_size(cipherCtx.get());
+    auto maxFinalBlockSize = blockSize > 1 ? static_cast<size_t>(blockSize) : 0;
+    JSG_REQUIRE(isOpenSslInputSizeValid(cipherText.size(), maxFinalBlockSize), DOMOperationError,
+        "Data is too large.");
 
     KJ_STACK_ARRAY(
         kj::byte, plainText, cipherText.size() + ((blockSize > 1) ? blockSize : 0), 1024, 4096);

--- a/src/workerd/api/crypto/impl.h
+++ b/src/workerd/api/crypto/impl.h
@@ -12,6 +12,7 @@
 #include <workerd/api/util.h>
 #include <workerd/jsg/jsvalue.h>
 
+#include <limits.h>
 #include <ncrypto.h>
 #include <openssl/base.h>
 #include <openssl/bn.h>
@@ -77,6 +78,10 @@ std::pair<kj::StringPtr, const EVP_MD*> lookupDigestAlgorithm(kj::StringPtr algo
 // implement as a wrapper. Could be sufficient to just add a "urlEncoded" boolean so that
 // kj::decodeBase64 can do this in-situ for both cases.
 kj::EncodingResult<kj::Array<kj::byte>> decodeBase64Url(kj::String text);
+
+inline bool isOpenSslInputSizeValid(size_t inputSize, size_t extraOutputSize = 0) {
+  return inputSize <= INT_MAX && extraOutputSize <= INT_MAX - inputSize;
+}
 
 // WebCrypto likes to allow algorithms to be specified as a simple string name, or as a struct
 // containing a `name` field and possibly other fields. This helper collapses that.

--- a/src/workerd/api/node/tests/dns-nodejs-test.js
+++ b/src/workerd/api/node/tests/dns-nodejs-test.js
@@ -475,6 +475,16 @@ export const testDnsLookup = {
       throws(() => dnsPromises.lookup(1, {}), err);
     }
 
+    {
+      const err = {
+        code: 'ERR_INVALID_ARG_VALUE',
+        name: 'TypeError',
+      };
+
+      throws(() => dns.lookup('nodejs.org\u0000', () => {}), err);
+      throws(() => dnsPromises.lookup('nodejs.org\u0000'), err);
+    }
+
     throws(
       () => {
         dns.lookup(false, 'cb');

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -574,6 +574,22 @@ export const testNetConnectOptionsInvalid = {
         });
       }
     );
+
+    const err = {
+      code: 'ERR_INVALID_ARG_VALUE',
+      name: 'TypeError',
+    };
+
+    throws(() => net.connect({ host: 'localhost\u0000', port: 8080 }), err);
+    throws(
+      () => net.createConnection({ host: 'localhost\u0000', port: 8080 }),
+      err
+    );
+
+    for (const host of [null, '', undefined, 0, false]) {
+      const socket = net.connect({ host, port: 8080 });
+      socket.destroy();
+    }
   },
 };
 

--- a/src/workerd/api/node/tests/tls-nodejs-test.js
+++ b/src/workerd/api/node/tests/tls-nodejs-test.js
@@ -639,6 +639,20 @@ export const testCheckServerIdentity = {
         host: 'xn--bcher-kva.example.com',
         cert: { subject: { CN: '*.example.com' } },
       },
+      {
+        host: 'b\u00fccher.example.com',
+        cert: { subject: { CN: 'xn--bcher-kva.example.com' } },
+      },
+      {
+        host: 'foo\u3002bar.example.com',
+        cert: {
+          subjectaltname: 'DNS:*.example.com',
+          subject: {},
+        },
+        error:
+          "Host: foo\u3002bar.example.com. is not in the cert's altnames: " +
+          'DNS:*.example.com',
+      },
       // RFC 6125, section 6.4.3: "[...] the client SHOULD NOT attempt to match
       // a presented identifier where the wildcard character is embedded within
       // an A-label [...]"


### PR DESCRIPTION
Normalize hostnames in tls.checkServerIdentity() before matching certificate names.

Reject hostnames containing NUL bytes in node:dns and node:net. Preserve Node's localhost fallback for falsy net host values.

Add missing AES size guards before OpenSSL calls in WebCrypto paths used by node:crypto.

Tests:
- //src/workerd/api:crypto/aes-test@
- //src/workerd/api/node/tests:dns-nodejs-test@
- //src/workerd/api/node/tests:net-nodejs-test@
- //src/workerd/api/node/tests:tls-nodejs-test@