### PR TITLE
fix: zstd compat flag, DevTools inspector, empty-body edge case, RPC hardening

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -604,6 +604,7 @@ kj_test(
     deps = [
         "//src/workerd/io",
         "//src/workerd/tests:test-fixture",
+        "@zstd",
     ],
 )
 

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -688,6 +688,7 @@ kj_test(
         "//src/workerd/io",
         "//src/workerd/jsg",
         "//src/workerd/tests:test-fixture",
+        "@capnp-cpp//src/kj/compat:kj-gzip",
     ],
 )
 

--- a/src/workerd/api/streams/readable-source-test.c++
+++ b/src/workerd/api/streams/readable-source-test.c++
@@ -7,6 +7,7 @@
 #include <workerd/util/stream-utils.h>
 
 #include <kj/async-io.h>
+#include <kj/compat/gzip.h>
 #include <kj/test.h>
 
 // We Thank Claude for Tests.
@@ -971,6 +972,81 @@ KJ_TEST("Gzip encoded stream (pumpTo different encoding)") {
   static const kj::byte expected[] = {
     5, 8, 128, 115, 111, 109, 101, 32, 100, 97, 116, 97, 32, 116, 111, 32, 103, 122, 105, 112, 3};
   KJ_ASSERT(inner.data == expected);
+}
+
+KJ_TEST("Zstd encoded stream") {
+  TestFixture fixture;
+  // zstd-compressed "some data to zstd"
+  static constexpr kj::byte data[] = {
+    40, 181, 47, 253, 36, 17, 137, 0, 0, 115, 111, 109, 101, 32, 100, 97,
+    116, 97, 32, 116, 111, 32, 122, 115, 116, 100, 89, 232, 89, 209};
+  auto inner = newMemoryInputStream(data);
+  auto source = newEncodedReadableSource(rpc::StreamEncoding::ZSTD, kj::mv(inner));
+
+  fixture.runInIoContext([&](const auto& environment) -> kj::Promise<void> {
+    auto allBytes = co_await source->readAllBytes(kj::maxValue);
+    KJ_ASSERT(allBytes == "some data to zstd"_kjb);
+  });
+}
+
+KJ_TEST("Zstd encoded stream (pumpTo)") {
+  TestFixture fixture;
+  static constexpr kj::byte data[] = {
+    40, 181, 47, 253, 36, 17, 137, 0, 0, 115, 111, 109, 101, 32, 100, 97,
+    116, 97, 32, 116, 111, 32, 122, 115, 116, 100, 89, 232, 89, 209};
+  auto inner = newMemoryInputStream(data);
+  auto source = newEncodedReadableSource(rpc::StreamEncoding::ZSTD, kj::mv(inner));
+
+  MockWritableSink sink;
+
+  fixture.runInIoContext([&](const auto& environment) -> kj::Promise<void> {
+    co_await environment.context.waitForDeferredProxy(source->pumpTo(sink, EndAfterPump::YES));
+  });
+
+  KJ_ASSERT(sink.writtenData == "some data to zstd"_kjb);
+}
+
+KJ_TEST("Zstd encoded stream (pumpTo same encoding)") {
+  TestFixture fixture;
+  static const kj::byte data[] = {
+    40, 181, 47, 253, 36, 17, 137, 0, 0, 115, 111, 109, 101, 32, 100, 97,
+    116, 97, 32, 116, 111, 32, 122, 115, 116, 100, 89, 232, 89, 209};
+  auto in = newMemoryInputStream(data);
+  auto source = newEncodedReadableSource(rpc::StreamEncoding::ZSTD, kj::mv(in));
+
+  MemoryAsyncOutputStream inner;
+  auto fakeOwn = kj::Own<MemoryAsyncOutputStream>(&inner, kj::NullDisposer::instance);
+  auto sink = newEncodedWritableSink(rpc::StreamEncoding::ZSTD, kj::mv(fakeOwn));
+
+  fixture.runInIoContext([&](const auto& environment) -> kj::Promise<void> {
+    co_await environment.context.waitForDeferredProxy(source->pumpTo(*sink, EndAfterPump::YES));
+  });
+
+  // The data should pass through unchanged (no decompress/recompress).
+  KJ_ASSERT(inner.data == data);
+}
+
+KJ_TEST("Zstd encoded stream (pumpTo different encoding)") {
+  TestFixture fixture;
+  static const kj::byte data[] = {
+    40, 181, 47, 253, 36, 17, 137, 0, 0, 115, 111, 109, 101, 32, 100, 97,
+    116, 97, 32, 116, 111, 32, 122, 115, 116, 100, 89, 232, 89, 209};
+  auto in = newMemoryInputStream(data);
+  auto source = newEncodedReadableSource(rpc::StreamEncoding::ZSTD, kj::mv(in));
+
+  MemoryAsyncOutputStream inner;
+  auto fakeOwn = kj::Own<MemoryAsyncOutputStream>(&inner, kj::NullDisposer::instance);
+  auto sink = newEncodedWritableSink(rpc::StreamEncoding::GZIP, kj::mv(fakeOwn));
+
+  fixture.runInIoContext([&](const auto& environment) -> kj::Promise<void> {
+    co_await environment.context.waitForDeferredProxy(source->pumpTo(*sink, EndAfterPump::YES));
+
+    // Verify the output is valid gzip containing the original plaintext.
+    auto mem = newMemoryInputStream(inner.data);
+    kj::GzipAsyncInputStream gunzip(*mem);
+    auto text = co_await gunzip.readAllText(kj::maxValue);
+    KJ_ASSERT(text == "some data to zstd"_kj);
+  });
 }
 
 // ======================================================================================

--- a/src/workerd/api/streams/readable-source.c++
+++ b/src/workerd/api/streams/readable-source.c++
@@ -14,6 +14,7 @@
 #include <kj/async-io.h>
 #include <kj/compat/brotli.h>
 #include <kj/compat/gzip.h>
+#include <zstd.h>
 
 #include <bit>
 
@@ -665,6 +666,63 @@ class NoDeferredProxySource final: public ReadableSourceWrapper {
   IoContext& ioctx;
 };
 
+class ZstdAsyncInputStream final: public kj::AsyncInputStream {
+ public:
+  explicit ZstdAsyncInputStream(kj::AsyncInputStream& inner)
+      : inner(inner), dctx(ZSTD_createDCtx()) {
+    KJ_ASSERT(dctx != nullptr, "failed to allocate ZSTD_DCtx");
+  }
+  ~ZstdAsyncInputStream() noexcept(false) {
+    ZSTD_freeDCtx(dctx);
+  }
+  KJ_DISALLOW_COPY_AND_MOVE(ZstdAsyncInputStream);
+
+  kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+    return readImpl(reinterpret_cast<kj::byte*>(buffer), minBytes, maxBytes, 0);
+  }
+
+ private:
+  kj::AsyncInputStream& inner;
+  ZSTD_DCtx* dctx;
+  bool atValidEndpoint = false;
+  static constexpr size_t IN_BUFFER_SIZE = 16384;
+  kj::byte inBuffer[IN_BUFFER_SIZE];
+  size_t inAvail = 0;
+  size_t inPos = 0;
+
+  kj::Promise<size_t> readImpl(
+      kj::byte* out, size_t minBytes, size_t maxBytes, size_t alreadyRead) {
+    while (inAvail > 0 && alreadyRead < maxBytes) {
+      ZSTD_inBuffer input = {inBuffer + inPos, inAvail, 0};
+      ZSTD_outBuffer output = {out, maxBytes, alreadyRead};
+      size_t result = ZSTD_decompressStream(dctx, &output, &input);
+      inPos += input.pos;
+      inAvail -= input.pos;
+      alreadyRead = output.pos;
+      KJ_REQUIRE(!ZSTD_isError(result), "zstd decompression error", ZSTD_getErrorName(result));
+      if (result == 0) {
+        atValidEndpoint = true;
+        if (inAvail == 0) break;
+        atValidEndpoint = false;
+      }
+      if (alreadyRead >= minBytes) return alreadyRead;
+    }
+    if (alreadyRead >= minBytes) return alreadyRead;
+    inPos = 0;
+    inAvail = 0;
+    return inner.tryRead(inBuffer, 1, IN_BUFFER_SIZE)
+        .then([this, out, minBytes, maxBytes, alreadyRead](size_t n) -> kj::Promise<size_t> {
+      if (n == 0) {
+        KJ_REQUIRE(atValidEndpoint, "zstd-compressed stream ended prematurely");
+        return alreadyRead;
+      }
+      inAvail = n;
+      inPos = 0;
+      return readImpl(out, minBytes, maxBytes, alreadyRead);
+    });
+  }
+};
+
 // A ReadableSource implementation that lazily wraps an innner Gzip or Brotli
 // encoded AsyncInputStream when the first read() is called, or when pumpTo is called,
 // the encoding will be selectively and lazily applied to the inner stream.
@@ -694,6 +752,9 @@ class EncodedAsyncInputStream final: public ReadableSourceImpl {
                 {"brotli compression failed"_kj, "Brotli compression failed."},
                 {"brotli compressed stream ended prematurely"_kj,
                   "Brotli compressed stream ended prematurely."},
+                {"zstd decompression error"_kj, "Zstd decompression failed."},
+                {"zstd-compressed stream ended prematurely"_kj,
+                  "Zstd compressed stream ended prematurely."},
               })) {
         kj::throwFatalException(kj::mv(translated));
       } else {
@@ -738,6 +799,9 @@ class EncodedAsyncInputStream final: public ReadableSourceImpl {
       }
       case rpc::StreamEncoding::BROTLI: {
         return kj::heap<kj::BrotliAsyncInputStream>(*inner).attach(kj::mv(inner));
+      }
+      case rpc::StreamEncoding::ZSTD: {
+        return kj::heap<ZstdAsyncInputStream>(*inner).attach(kj::mv(inner));
       }
     }
     KJ_UNREACHABLE;

--- a/src/workerd/api/streams/writable-sink-test.c++
+++ b/src/workerd/api/streams/writable-sink-test.c++
@@ -539,6 +539,46 @@ KJ_TEST("Gzip-encoding sink (identity)") {
   KJ_ASSERT(inner.data == kj::arrayPtr(check, sizeof(check)));
 }
 
+KJ_TEST("Zstd-encoding sink") {
+  // zstd output compression is not supported; verify it throws.
+  TestFixture fixture;
+  MemoryAsyncOutputStream inner;
+  auto fakeOwn = kj::Own<MemoryAsyncOutputStream>(&inner, kj::NullDisposer::instance);
+  auto sink = newEncodedWritableSink(rpc::StreamEncoding::ZSTD, kj::mv(fakeOwn));
+
+  fixture.runInIoContext([&](const auto& environment) -> kj::Promise<void> {
+    bool threw = false;
+    try {
+      co_await sink->write("some data to zstd"_kjb);
+    } catch (kj::Exception& e) {
+      KJ_ASSERT(kj::StringPtr(e.getDescription()).contains("zstd output compression is not supported"));
+      threw = true;
+    }
+    KJ_ASSERT(threw, "expected write() to throw for unsupported zstd compression");
+  });
+}
+
+KJ_TEST("Zstd-encoding sink (identity)") {
+  TestFixture fixture;
+  MemoryAsyncOutputStream inner;
+  auto fakeOwn = kj::Own<MemoryAsyncOutputStream>(&inner, kj::NullDisposer::instance);
+  auto sink = newEncodedWritableSink(rpc::StreamEncoding::ZSTD, kj::mv(fakeOwn));
+
+  static const kj::byte check[] = {
+    40, 181, 47, 253, 36, 17, 137, 0, 0, 115, 111, 109, 101, 32, 100, 97,
+    116, 97, 32, 116, 111, 32, 122, 115, 116, 100, 89, 232, 89, 209};
+
+  // When encoding is disowned, the data should be passed through unmodified.
+  sink->disownEncodingResponsibility();
+
+  fixture.runInIoContext([&](const auto& environment) -> kj::Promise<void> {
+    co_await sink->write(check);
+    co_await sink->end();
+  });
+
+  KJ_ASSERT(inner.data == kj::arrayPtr(check, sizeof(check)));
+}
+
 // ======================================================================================
 // IoContext-aware WritableSinkWrapper Tests
 

--- a/src/workerd/api/streams/writable-sink.c++
+++ b/src/workerd/api/streams/writable-sink.c++
@@ -8,6 +8,7 @@
 #include <kj/async-io.h>
 #include <kj/compat/brotli.h>
 #include <kj/compat/gzip.h>
+#include <zstd.h>
 
 namespace workerd::api::streams {
 
@@ -225,6 +226,9 @@ class EncodedAsyncOutputStream final: public WritableSinkImpl {
       }
       case rpc::StreamEncoding::IDENTITY: {
         return setStream(kj::mv(inner));
+      }
+      case rpc::StreamEncoding::ZSTD: {
+        KJ_FAIL_REQUIRE("zstd output compression is not supported; use encodeResponseBody: manual");
       }
     }
     KJ_UNREACHABLE;

--- a/src/workerd/api/streams/writable-sink.c++
+++ b/src/workerd/api/streams/writable-sink.c++
@@ -204,6 +204,10 @@ class EncodedAsyncOutputStream final: public WritableSinkImpl {
       : WritableSinkImpl(kj::mv(inner), encoding) {}
 
   kj::Promise<void> endImpl(kj::AsyncOutputStream& output) override {
+    // If prepareWrite() was never called (empty body), encoding hasn't been
+    // disowned yet. Reject unsupported encodings here for consistency.
+    KJ_REQUIRE(getEncoding() != rpc::StreamEncoding::ZSTD,
+        "zstd output compression is not supported; use encodeResponseBody: manual");
     if (auto gzip = dynamic_cast<kj::GzipAsyncOutputStream*>(&output)) {
       co_await gzip->end();
     } else if (auto br = dynamic_cast<kj::BrotliAsyncOutputStream*>(&output)) {

--- a/src/workerd/api/system-streams-test.c++
+++ b/src/workerd/api/system-streams-test.c++
@@ -8,6 +8,7 @@
 #include <workerd/tests/test-fixture.h>
 
 #include <kj/test.h>
+#include <zstd.h>
 
 namespace workerd::api {
 namespace {
@@ -48,6 +49,46 @@ KJ_TEST("EncodedAsyncInputStream cancel with pending read on AsyncPipe") {
         [](size_t) { KJ_FAIL_ASSERT("read should have been cancelled"); }, [](kj::Exception&& e) {
       // Expected the read to be cancelled
     });
+  });
+}
+
+KJ_TEST("ZstdAsyncInputStream decompresses correctly") {
+  TestFixture fixture;
+  fixture.runInIoContext([](const TestFixture::Environment& env) -> kj::Promise<void> {
+    constexpr kj::StringPtr plaintext = "hello zstd"_kj;
+
+    // Compress synchronously using the zstd one-shot API.
+    size_t bound = ZSTD_compressBound(plaintext.size());
+    auto compressed = kj::heapArray<kj::byte>(bound);
+    size_t compressedSize = ZSTD_compress(compressed.begin(), compressed.size(),
+        plaintext.begin(), plaintext.size(), ZSTD_CLEVEL_DEFAULT);
+    KJ_REQUIRE(!ZSTD_isError(compressedSize), ZSTD_getErrorName(compressedSize));
+
+    // Wrap the compressed bytes in a synchronous AsyncInputStream.
+    struct ArrayStream: kj::AsyncInputStream {
+      kj::Array<kj::byte> data;
+      size_t pos = 0;
+      ArrayStream(kj::Array<kj::byte> d): data(kj::mv(d)) {}
+      virtual ~ArrayStream() = default;
+      kj::Promise<size_t> tryRead(void* buf, size_t, size_t max) override {
+        size_t n = kj::min(max, data.size() - pos);
+        memcpy(buf, data.begin() + pos, n);
+        pos += n;
+        return n;
+      }
+    };
+    auto inner = kj::heap<ArrayStream>(kj::heapArray(compressed.slice(0, compressedSize)));
+
+    // Decode through a ZSTD-encoded system stream.
+    auto stream = newSystemStream(kj::mv(inner), StreamEncoding::ZSTD, env.context);
+    auto outBuf = kj::heapArray<kj::byte>(64);
+    size_t expectedSize = plaintext.size();
+    return stream->tryRead(outBuf.begin(), expectedSize, outBuf.size())
+        .then([outBuf = kj::mv(outBuf), stream = kj::mv(stream), expectedSize](size_t n) {
+          KJ_EXPECT(n == expectedSize);
+          KJ_EXPECT(
+              kj::StringPtr(reinterpret_cast<const char*>(outBuf.begin()), n) == "hello zstd"_kj);
+        });
   });
 }
 

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -9,6 +9,7 @@
 #include <kj/compat/brotli.h>
 #include <kj/compat/gzip.h>
 #include <kj/one-of.h>
+#include <zstd.h>
 
 namespace workerd::api {
 
@@ -89,6 +90,9 @@ kj::Promise<size_t> EncodedAsyncInputStream::tryRead(
               {"brotli compression failed"_kj, "Brotli compression failed."},
               {"brotli compressed stream ended prematurely"_kj,
                 "Brotli compressed stream ended prematurely."},
+              {"zstd decompression error"_kj, "Zstd decompression failed."},
+              {"zstd-compressed stream ended prematurely"_kj,
+                "Zstd compressed stream ended prematurely."},
             })) {
       return kj::mv(e);
     }
@@ -129,6 +133,79 @@ void EncodedAsyncInputStream::cancel(kj::Exception reason) {
   canceler.cancel(kj::mv(reason));
 }
 
+// =======================================================================================
+// ZstdAsyncInputStream
+
+// Streaming zstd decompressor wrapping an AsyncInputStream. Modeled after
+// kj::GzipAsyncInputStream / kj::BrotliAsyncInputStream in capnp-cpp.
+class ZstdAsyncInputStream final: public kj::AsyncInputStream {
+ public:
+  explicit ZstdAsyncInputStream(kj::AsyncInputStream& inner)
+      : inner(inner),
+        dctx(ZSTD_createDCtx()) {
+    KJ_ASSERT(dctx != nullptr, "failed to allocate ZSTD_DCtx");
+  }
+  ~ZstdAsyncInputStream() noexcept(false) {
+    ZSTD_freeDCtx(dctx);
+  }
+  KJ_DISALLOW_COPY_AND_MOVE(ZstdAsyncInputStream);
+
+  kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+    return readImpl(reinterpret_cast<kj::byte*>(buffer), minBytes, maxBytes, 0);
+  }
+
+ private:
+  kj::AsyncInputStream& inner;
+  ZSTD_DCtx* dctx;
+  bool atValidEndpoint = false;
+
+  static constexpr size_t IN_BUFFER_SIZE = 16384;
+  kj::byte inBuffer[IN_BUFFER_SIZE];
+  size_t inAvail = 0;
+  size_t inPos = 0;
+
+  kj::Promise<size_t> readImpl(
+      kj::byte* out, size_t minBytes, size_t maxBytes, size_t alreadyRead) {
+    // Drain any buffered compressed input.
+    while (inAvail > 0 && alreadyRead < maxBytes) {
+      ZSTD_inBuffer input = {inBuffer + inPos, inAvail, 0};
+      ZSTD_outBuffer output = {out, maxBytes, alreadyRead};
+
+      size_t result = ZSTD_decompressStream(dctx, &output, &input);
+      inPos += input.pos;
+      inAvail -= input.pos;
+      alreadyRead = output.pos;
+
+      KJ_REQUIRE(!ZSTD_isError(result), "zstd decompression error", ZSTD_getErrorName(result));
+
+      if (result == 0) {
+        // Frame complete. ZSTD_DCtx auto-resets for the next frame.
+        atValidEndpoint = true;
+        if (inAvail == 0) break;
+        atValidEndpoint = false;  // more compressed data follows; could be another frame
+      }
+
+      if (alreadyRead >= minBytes) return alreadyRead;
+    }
+
+    if (alreadyRead >= minBytes) return alreadyRead;
+
+    // Need more compressed input from the underlying stream.
+    inPos = 0;
+    inAvail = 0;
+    return inner.tryRead(inBuffer, 1, IN_BUFFER_SIZE)
+        .then([this, out, minBytes, maxBytes, alreadyRead](size_t n) -> kj::Promise<size_t> {
+      if (n == 0) {
+        KJ_REQUIRE(atValidEndpoint, "zstd-compressed stream ended prematurely");
+        return alreadyRead;
+      }
+      inAvail = n;
+      inPos = 0;
+      return readImpl(out, minBytes, maxBytes, alreadyRead);
+    });
+  }
+};
+
 void EncodedAsyncInputStream::ensureIdentityEncoding() {
   // Decompression gets added to the stream here if needed based on the content encoding.
   if (encoding == StreamEncoding::GZIP) {
@@ -137,8 +214,10 @@ void EncodedAsyncInputStream::ensureIdentityEncoding() {
   } else if (encoding == StreamEncoding::BROTLI) {
     inner = kj::heap<kj::BrotliAsyncInputStream>(*inner).attach(kj::mv(inner));
     encoding = StreamEncoding::IDENTITY;
+  } else if (encoding == StreamEncoding::ZSTD) {
+    inner = kj::heap<ZstdAsyncInputStream>(*inner).attach(kj::mv(inner));
+    encoding = StreamEncoding::IDENTITY;
   } else {
-    // We currently support gzip and brotli as non-identity content encodings.
     KJ_ASSERT(encoding == StreamEncoding::IDENTITY);
   }
 }
@@ -344,8 +423,12 @@ void EncodedAsyncOutputStream::ensureIdentityEncoding() {
 
     inner = kj::heap<kj::BrotliAsyncOutputStream>(*stream).attach(kj::mv(stream));
     encoding = StreamEncoding::IDENTITY;
+  } else if (encoding == StreamEncoding::ZSTD) {
+    // Zstd output compression is not yet implemented. This path is only reachable if a worker
+    // sends a response with Content-Encoding: zstd while using encodeResponseBody: "auto".
+    // Workers that need to write zstd-compressed bodies should use encodeResponseBody: "manual".
+    KJ_FAIL_REQUIRE("zstd output compression is not supported; use encodeResponseBody: manual");
   } else {
-    // We currently support gzip and brotli as non-identity content encodings.
     KJ_ASSERT(encoding == StreamEncoding::IDENTITY);
   }
 }
@@ -404,6 +487,8 @@ StreamEncoding getContentEncoding(IoContext& context,
       return StreamEncoding::GZIP;
     } else if (options.brotliEnabled && encodingStr == "br") {
       return StreamEncoding::BROTLI;
+    } else if (encodingStr == "zstd") {
+      return StreamEncoding::ZSTD;
     }
   }
   return StreamEncoding::IDENTITY;

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -217,8 +217,8 @@ void EncodedAsyncInputStream::ensureIdentityEncoding() {
   } else if (encoding == StreamEncoding::ZSTD) {
     inner = kj::heap<ZstdAsyncInputStream>(*inner).attach(kj::mv(inner));
     encoding = StreamEncoding::IDENTITY;
-  } else {
-    KJ_ASSERT(encoding == StreamEncoding::IDENTITY);
+  } else if (encoding != StreamEncoding::IDENTITY) {
+    KJ_FAIL_REQUIRE("unsupported content encoding received over RPC", (uint)encoding);
   }
 }
 
@@ -428,8 +428,8 @@ void EncodedAsyncOutputStream::ensureIdentityEncoding() {
     // sends a response with Content-Encoding: zstd while using encodeResponseBody: "auto".
     // Workers that need to write zstd-compressed bodies should use encodeResponseBody: "manual".
     KJ_FAIL_REQUIRE("zstd output compression is not supported; use encodeResponseBody: manual");
-  } else {
-    KJ_ASSERT(encoding == StreamEncoding::IDENTITY);
+  } else if (encoding != StreamEncoding::IDENTITY) {
+    KJ_FAIL_REQUIRE("unsupported content encoding received over RPC", (uint)encoding);
   }
 }
 
@@ -473,7 +473,8 @@ SystemMultiStream newSystemMultiStream(
 }
 
 ContentEncodingOptions::ContentEncodingOptions(CompatibilityFlags::Reader flags)
-    : brotliEnabled(flags.getBrotliContentEncoding()) {}
+    : brotliEnabled(flags.getBrotliContentEncoding()),
+      zstdEnabled(flags.getZstdContentEncoding()) {}
 
 StreamEncoding getContentEncoding(IoContext& context,
     const kj::HttpHeaders& headers,
@@ -487,7 +488,7 @@ StreamEncoding getContentEncoding(IoContext& context,
       return StreamEncoding::GZIP;
     } else if (options.brotliEnabled && encodingStr == "br") {
       return StreamEncoding::BROTLI;
-    } else if (encodingStr == "zstd") {
+    } else if (options.zstdEnabled && encodingStr == "zstd") {
       return StreamEncoding::ZSTD;
     }
   }

--- a/src/workerd/api/system-streams.h
+++ b/src/workerd/api/system-streams.h
@@ -44,6 +44,7 @@ SystemMultiStream newSystemMultiStream(kj::RefcountedWrapper<kj::Own<kj::AsyncIo
 
 struct ContentEncodingOptions {
   bool brotliEnabled = false;
+  bool zstdEnabled = false;
   ContentEncodingOptions() = default;
   ContentEncodingOptions(CompatibilityFlags::Reader flags);
 };

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -76,6 +76,7 @@ wd_cc_library(
         "@capnp-cpp//src/kj/compat:kj-brotli",
         "@capnp-cpp//src/kj/compat:kj-gzip",
         "@nbytes",
+        "@zstd",
         "@simdutf",
     ],
     visibility = ["//visibility:public"],

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1555,4 +1555,13 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $experimental;
   # When enabled, a Worker's outbound gRPC-web subrequest is converted to gRPC at
   # the edge.
+
+  zstdContentEncoding @179 :Bool
+      $compatEnableFlag("zstd_content_encoding")
+      $compatEnableDate("2026-06-21")
+      $compatDisableFlag("no_zstd_content_encoding")
+      $neededByFl;
+  # Enables decompression support for the zstd compression algorithm.
+  # With the flag enabled workerd will support the "zstd" content encoding in the Request and
+  # Response APIs and decompress data accordingly, as with gzip.
 }

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -493,6 +493,7 @@ enum StreamEncoding {
   identity @0;
   gzip @1;
   brotli @2;
+  zstd @3;
 }
 
 interface Handle {

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -44,6 +44,7 @@
 #include <capnp/message.h>
 #include <kj/compat/brotli.h>
 #include <kj/compat/gzip.h>
+#include <zstd.h>
 #include <kj/encoding.h>
 #include <kj/filesystem.h>
 #include <kj/map.h>
@@ -4466,6 +4467,37 @@ double getWallTimeForProcessSandboxOnly() {
 }
 }  // namespace
 
+// Synchronous zstd decompressor used by ResponseStreamWrapper for DevTools inspection.
+// Mirrors the GzipOutputStream/BrotliOutputStream pattern: write() pushes compressed chunks
+// through ZSTD_decompressStream() and emits decompressed bytes into `output`.
+class Worker::Isolate::ZstdDecompressor {
+ public:
+  explicit ZstdDecompressor(LimitedBodyWrapper& output)
+      : output(output), dctx(ZSTD_createDCtx()) {
+    KJ_ASSERT(dctx != nullptr, "failed to allocate ZSTD_DCtx");
+  }
+  ~ZstdDecompressor() noexcept(false) {
+    ZSTD_freeDCtx(dctx);
+  }
+  KJ_DISALLOW_COPY_AND_MOVE(ZstdDecompressor);
+
+  void write(kj::ArrayPtr<const kj::byte> data) {
+    kj::byte outBuf[16384];
+    ZSTD_inBuffer input = {data.begin(), data.size(), 0};
+    while (input.pos < input.size) {
+      ZSTD_outBuffer out = {outBuf, sizeof(outBuf), 0};
+      size_t result = ZSTD_decompressStream(dctx, &out, &input);
+      KJ_REQUIRE(!ZSTD_isError(result), "zstd decompression error", ZSTD_getErrorName(result));
+      output.write(kj::ArrayPtr<const kj::byte>(outBuf, out.pos));
+    }
+  }
+  void flush() {}
+
+ private:
+  LimitedBodyWrapper& output;
+  ZSTD_DCtx* dctx;
+};
+
 class Worker::Isolate::ResponseStreamWrapper final: public kj::AsyncOutputStream {
  public:
   ResponseStreamWrapper(kj::Own<const Isolate> isolate,
@@ -4482,6 +4514,8 @@ class Worker::Isolate::ResponseStreamWrapper final: public kj::AsyncOutputStream
     } else if (encoding == api::StreamEncoding::BROTLI) {
       compStream.emplace().init<kj::BrotliOutputStream>(
           decodedBuf, kj::BrotliOutputStream::DECOMPRESS);
+    } else if (encoding == api::StreamEncoding::ZSTD) {
+      compStream.emplace().init<ZstdDecompressor>(decodedBuf);
     }
   }
 
@@ -4544,6 +4578,12 @@ class Worker::Isolate::ResponseStreamWrapper final: public kj::AsyncOutputStream
           brotli.write(buffer);
           brotli.flush();
         }
+        KJ_CASE_ONEOF(zstd, ZstdDecompressor) {
+          KJ_ON_SCOPE_FAILURE(decodedBuf.reset());
+
+          zstd.write(buffer);
+          zstd.flush();
+        }
       }
     } else {
       decodedBuf.write(buffer);
@@ -4585,7 +4625,7 @@ class Worker::Isolate::ResponseStreamWrapper final: public kj::AsyncOutputStream
   kj::Own<kj::AsyncOutputStream> inner;
   size_t rawSize = 0;
   LimitedBodyWrapper decodedBuf;
-  kj::Maybe<kj::OneOf<kj::GzipOutputStream, kj::BrotliOutputStream>> compStream;
+  kj::Maybe<kj::OneOf<kj::GzipOutputStream, kj::BrotliOutputStream, ZstdDecompressor>> compStream;
   RequestObserver& requestMetrics;
 
   // Called when the wrapper is destroyed.
@@ -4770,6 +4810,8 @@ kj::Promise<void> Worker::Isolate::SubrequestClient::request(kj::HttpMethod meth
         encoding = api::StreamEncoding::GZIP;
       } else if (encodingStr == "br") {
         encoding = api::StreamEncoding::BROTLI;
+      } else if (encodingStr == "zstd") {
+        encoding = api::StreamEncoding::ZSTD;
       }
     }
 

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -579,6 +579,7 @@ class Worker::Isolate: public kj::AtomicRefcounted {
   class SubrequestClient;
   class ResponseStreamWrapper;
   class LimitedBodyWrapper;
+  class ZstdDecompressor;
 
   size_t nextRequestId = 0;
   kj::Own<jsg::AsyncContextFrame::StorageKey> traceAsyncContextKey;

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4875,6 +4875,66 @@ KJ_TEST("Server: encodeResponseBody: manual pass-through") {
     fake-gzipped-content)"_blockquote);
 }
 
+KJ_TEST("Server: encodeResponseBody: auto strips Content-Encoding header for zstd") {
+  // Regression test for https://github.com/cloudflare/workerd/issues/5112
+  // zstd was not recognized by getContentEncoding() at all, so responses with
+  // Content-Encoding: zstd passed through without decompression and without header stripping.
+  // This caused the Cache API to see an undecompressed body labeled as zstd-compressed.
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2022-08-17",
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `export default {
+                `  async fetch(request, env) {
+                `    let response = await fetch("http://subhost/foo");
+                `    let ce = response.headers.get("Content-Encoding");
+                `    return new Response("Content-Encoding: " + ce);
+                `  }
+                `}
+            )
+          ]
+        )
+      )
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = "hello"
+      )
+    ]
+  ))"_kj);
+
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.sendHttpGet("/");
+
+  auto subreq = test.receiveInternetSubrequest("subhost");
+  subreq.recv(R"(
+    GET /foo HTTP/1.1
+    Host: subhost
+
+  )"_blockquote);
+
+  // Send a response with Content-Encoding: zstd. Body bytes aren't real zstd data, but the
+  // decompressor is lazy and won't run until the body is consumed — we only check headers here.
+  subreq.send(R"(
+    HTTP/1.1 200 OK
+    Content-Length: 20
+    Content-Encoding: zstd
+
+    fake-zstd-content!
+  )"_blockquote);
+
+  // Content-Encoding should be null after auto-decoding strips the header.
+  conn.recvHttp200(R"(
+    Content-Encoding: null)"_blockquote);
+}
+
+
 KJ_TEST("Server: Catch websocket server errors") {
   TestServer test(R"((
     services = [

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -104,6 +104,9 @@ class TestStream {
   void send(kj::StringPtr data, kj::SourceLocation loc = {}) {
     stream->write(data.asBytes()).wait(ws);
   }
+  void sendBytes(kj::ArrayPtr<const kj::byte> data) {
+    stream->write(data).wait(ws);
+  }
   void recv(kj::StringPtr expected, kj::SourceLocation loc = {}) {
     auto actual = readAllAvailable();
     if (actual == nullptr) {
@@ -4875,11 +4878,10 @@ KJ_TEST("Server: encodeResponseBody: manual pass-through") {
     fake-gzipped-content)"_blockquote);
 }
 
-KJ_TEST("Server: encodeResponseBody: auto strips Content-Encoding header for zstd") {
+KJ_TEST("Server: encodeResponseBody: zstd response body is decompressed") {
   // Regression test for https://github.com/cloudflare/workerd/issues/5112
-  // zstd was not recognized by getContentEncoding() at all, so responses with
-  // Content-Encoding: zstd passed through without decompression and without header stripping.
-  // This caused the Cache API to see an undecompressed body labeled as zstd-compressed.
+  // zstd was not recognized by getContentEncoding(), so responses with Content-Encoding: zstd
+  // passed through with raw compressed bytes instead of being decompressed.
   TestServer test(R"((
     services = [
       ( name = "hello",
@@ -4891,8 +4893,8 @@ KJ_TEST("Server: encodeResponseBody: auto strips Content-Encoding header for zst
                 `export default {
                 `  async fetch(request, env) {
                 `    let response = await fetch("http://subhost/foo");
-                `    let ce = response.headers.get("Content-Encoding");
-                `    return new Response("Content-Encoding: " + ce);
+                `    let text = await response.text();
+                `    return new Response(text);
                 `  }
                 `}
             )
@@ -4919,19 +4921,22 @@ KJ_TEST("Server: encodeResponseBody: auto strips Content-Encoding header for zst
 
   )"_blockquote);
 
-  // Send a response with Content-Encoding: zstd. Body bytes aren't real zstd data, but the
-  // decompressor is lazy and won't run until the body is consumed — we only check headers here.
-  subreq.send(R"(
-    HTTP/1.1 200 OK
-    Content-Length: 20
-    Content-Encoding: zstd
+  // zstd-compressed "zstd body ok"
+  static constexpr kj::byte zstdFrame[] = {
+    0x28, 0xb5, 0x2f, 0xfd, 0x24, 0x0c, 0x61, 0x00, 0x00, 0x7a,
+    0x73, 0x74, 0x64, 0x20, 0x62, 0x6f, 0x64, 0x79, 0x20, 0x6f,
+    0x6b, 0x88, 0x94, 0x46, 0x0e,
+  };
+  kj::String httpHeader = kj::str(
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: ", sizeof(zstdFrame), "\r\n"
+      "Content-Encoding: zstd\r\n"
+      "\r\n");
+  subreq.send(httpHeader);
+  subreq.sendBytes(zstdFrame);
 
-    fake-zstd-content!
-  )"_blockquote);
-
-  // Content-Encoding should be null after auto-decoding strips the header.
-  conn.recvHttp200(R"(
-    Content-Encoding: null)"_blockquote);
+  // The worker should receive the decompressed plaintext, not the raw compressed bytes.
+  conn.recvHttp200("zstd body ok"_blockquote);
 }
 
 

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -4887,6 +4887,7 @@ KJ_TEST("Server: encodeResponseBody: zstd response body is decompressed") {
       ( name = "hello",
         worker = (
           compatibilityDate = "2022-08-17",
+          compatibilityFlags = ["zstd_content_encoding"],
           modules = [
             ( name = "main.js",
               esModule =


### PR DESCRIPTION
## Summary

Hardening fixes from code review, stacked on top of #6837. None of these are correctness fixes for the happy path — they close edge cases and improve robustness.

- **Compat flag**: gate zstd behind `zstd_content_encoding` (enabled 2026-06-21) to match the `brotli_content_encoding` pattern; workers pinned to old compat dates are unaffected
- **DevTools inspector**: `ResponseStreamWrapper` now decompresses zstd response bodies for accurate network panel byte counts, matching the existing gzip/brotli handling
- **Empty-body edge case**: `EncodedAsyncOutputStream::endImpl()` now rejects ZSTD encoding even when no `write()` was called, consistent with the `prepareWrite()` error path for non-empty bodies
- **RPC robustness**: replace `KJ_ASSERT(encoding == IDENTITY)` with `KJ_FAIL_REQUIRE` in both `ensureIdentityEncoding()` fallthrough branches so unknown future encoding values from a newer RPC peer throw a catchable error instead of aborting (debug) or silently corrupting (release)

Depends on #6837.

## Test plan

- [ ] All tests from #6837 continue to pass
- [ ] `server-test`: zstd test uses `compatibilityFlags = ["zstd_content_encoding"]` to opt in

🤖 Generated with [Claude Code](https://claude.com/claude-code)