### PR TITLE
Add metadata filtering to the Images binding hosted.list()

### DIFF
--- a/src/cloudflare/internal/images.d.ts
+++ b/src/cloudflare/internal/images.d.ts
@@ -155,12 +155,16 @@ type ImageMetadataFilterValue =
   | boolean
   | ImageMetadataFilterOperators;
 
+interface ImageListFilter {
+  metadata?: Record<string, ImageMetadataFilterValue>;
+}
+
 interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: 'asc' | 'desc';
   creator?: string;
-  metadataFilters?: Record<string, ImageMetadataFilterValue>;
+  filter?: ImageListFilter;
 }
 
 interface ImageList {

--- a/src/cloudflare/internal/images.d.ts
+++ b/src/cloudflare/internal/images.d.ts
@@ -141,25 +141,14 @@ interface ImageUpdateOptions {
 }
 
 type ImageMetadataFilterOperators = {
-  /** Matches a field exactly. */
   eq?: string | number | boolean;
-  /** Matches a field against any value in the list (maximum 10 values). */
   in?: string[] | number[];
-  /** Greater than (numbers only). */
   gt?: number;
-  /** Greater than or equal to (numbers only). */
   gte?: number;
-  /** Less than (numbers only). */
   lt?: number;
-  /** Less than or equal to (numbers only). */
   lte?: number;
 };
 
-/**
- * A condition applied to a single metadata field. A bare value is shorthand
- * for `eq`, so `{ status: 'active' }` is equivalent to
- * `{ status: { eq: 'active' } }`.
- */
 type ImageMetadataFilterValue =
   | string
   | number
@@ -171,12 +160,6 @@ interface ImageListOptions {
   cursor?: string;
   sortOrder?: 'asc' | 'desc';
   creator?: string;
-  /**
-   * Filter images by custom metadata fields. Each key is a metadata field
-   * name and its value is the condition the field must meet. Use dot notation
-   * in the field name to filter on a nested field (e.g. `region.name`).
-   * When multiple fields are provided, an image must match all of them.
-   */
   metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 

--- a/src/cloudflare/internal/images.d.ts
+++ b/src/cloudflare/internal/images.d.ts
@@ -140,11 +140,44 @@ interface ImageUpdateOptions {
   creator?: string;
 }
 
+type ImageMetadataFilterOperators = {
+  /** Matches a field exactly. */
+  eq?: string | number | boolean;
+  /** Matches a field against any value in the list (maximum 10 values). */
+  in?: string[] | number[];
+  /** Greater than (numbers only). */
+  gt?: number;
+  /** Greater than or equal to (numbers only). */
+  gte?: number;
+  /** Less than (numbers only). */
+  lt?: number;
+  /** Less than or equal to (numbers only). */
+  lte?: number;
+};
+
+/**
+ * A condition applied to a single metadata field. A bare value is shorthand
+ * for `eq`, so `{ status: 'active' }` is equivalent to
+ * `{ status: { eq: 'active' } }`.
+ */
+type ImageMetadataFilterValue =
+  | string
+  | number
+  | boolean
+  | ImageMetadataFilterOperators;
+
 interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: 'asc' | 'desc';
   creator?: string;
+  /**
+   * Filter images by custom metadata fields. Each key is a metadata field
+   * name and its value is the condition the field must meet. Use dot notation
+   * in the field name to filter on a nested field (e.g. `region.name`).
+   * When multiple fields are provided, an image must match all of them.
+   */
+  metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 
 interface ImageList {

--- a/src/cloudflare/internal/test/images/images-api-test.js
+++ b/src/cloudflare/internal/test/images/images-api-test.js
@@ -645,6 +645,25 @@ export const test_images_list_with_options = {
   },
 };
 
+export const test_images_list_metadata_filter_forwards_correctly = {
+  /**
+   * @param {unknown} _
+   * @param {Env} env
+   */
+  async test(_, env) {
+    const result = await env.images.hosted.list({
+      metadataFilters: {
+        status: 'active',
+        priority: { gte: 1, lte: 3 },
+        'config.region': 'eu-west',
+      },
+    });
+
+    assert.equal(result.images.length, 1);
+    assert.equal(result.images[0].id, 'image-1');
+  },
+};
+
 // UPLOAD with base64 encoding
 export const test_images_upload_base64_stream = {
   /**

--- a/src/cloudflare/internal/test/images/images-api-test.js
+++ b/src/cloudflare/internal/test/images/images-api-test.js
@@ -652,10 +652,12 @@ export const test_images_list_metadata_filter_forwards_correctly = {
    */
   async test(_, env) {
     const result = await env.images.hosted.list({
-      metadataFilters: {
-        status: 'active',
-        priority: { gte: 1, lte: 3 },
-        'config.region': 'eu-west',
+      filter: {
+        metadata: {
+          status: 'active',
+          priority: { gte: 1, lte: 3 },
+          'config.region': 'eu-west',
+        },
       },
     });
 

--- a/src/cloudflare/internal/test/images/images-upstream-mock.js
+++ b/src/cloudflare/internal/test/images/images-upstream-mock.js
@@ -203,7 +203,7 @@ export class ServiceEntrypoint extends WorkerEntrypoint {
     ];
 
     const filtered = images.filter((image) =>
-      matchesMetadataFilters(image, options?.metadataFilters)
+      matchesMetadataFilters(image, options?.filter?.metadata)
     );
 
     const limit = options?.limit || 50;

--- a/src/cloudflare/internal/test/images/images-upstream-mock.js
+++ b/src/cloudflare/internal/test/images/images-upstream-mock.js
@@ -20,6 +20,57 @@ async function imageAsString(blob) {
   return blob.text();
 }
 
+function resolveMetaPath(obj, path) {
+  return path
+    .split('.')
+    .reduce(
+      (acc, key) => (acc && typeof acc === 'object' ? acc[key] : undefined),
+      obj
+    );
+}
+
+function matchesCondition(actual, condition) {
+  if (
+    condition === null ||
+    typeof condition !== 'object' ||
+    Array.isArray(condition)
+  ) {
+    return actual === condition;
+  }
+
+  return Object.entries(condition).every(([op, expected]) => {
+    switch (op) {
+      case 'eq':
+        return actual === expected;
+      case 'in':
+        return (
+          Array.isArray(expected) &&
+          expected.some((candidate) => candidate === actual)
+        );
+      case 'gt':
+        return typeof actual === 'number' && actual > expected;
+      case 'gte':
+        return typeof actual === 'number' && actual >= expected;
+      case 'lt':
+        return typeof actual === 'number' && actual < expected;
+      case 'lte':
+        return typeof actual === 'number' && actual <= expected;
+      default:
+        return false;
+    }
+  });
+}
+
+function matchesMetadataFilters(image, filters) {
+  if (!filters) {
+    return true;
+  }
+
+  return Object.entries(filters).every(([field, condition]) =>
+    matchesCondition(resolveMetaPath(image.meta ?? {}, field), condition)
+  );
+}
+
 class ImageHandleMock extends RpcTarget {
   /** @type {string} */
   #imageId;
@@ -133,7 +184,7 @@ export class ServiceEntrypoint extends WorkerEntrypoint {
         uploaded: '2024-01-01T00:00:00Z',
         requireSignedURLs: false,
         variants: ['public'],
-        meta: {},
+        meta: { status: 'active', priority: 1, config: { region: 'eu-west' } },
         creator: 'test-creator',
       },
       {
@@ -142,13 +193,21 @@ export class ServiceEntrypoint extends WorkerEntrypoint {
         uploaded: '2024-01-02T00:00:00Z',
         requireSignedURLs: false,
         variants: ['public'],
-        meta: {},
+        meta: {
+          status: 'archived',
+          priority: 5,
+          config: { region: 'us-east' },
+        },
         creator: 'test-creator',
       },
     ];
 
+    const filtered = images.filter((image) =>
+      matchesMetadataFilters(image, options?.metadataFilters)
+    );
+
     const limit = options?.limit || 50;
-    const slicedImages = images.slice(0, limit);
+    const slicedImages = filtered.slice(0, limit);
 
     return {
       images: slicedImages,

--- a/types/defines/images.d.ts
+++ b/types/defines/images.d.ts
@@ -152,12 +152,16 @@ type ImageMetadataFilterValue =
   | boolean
   | ImageMetadataFilterOperators;
 
+interface ImageListFilter {
+  metadata?: Record<string, ImageMetadataFilterValue>;
+}
+
 interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: 'asc' | 'desc';
   creator?: string;
-  metadataFilters?: Record<string, ImageMetadataFilterValue>;
+  filter?: ImageListFilter;
 }
 
 interface ImageList {

--- a/types/defines/images.d.ts
+++ b/types/defines/images.d.ts
@@ -138,25 +138,14 @@ interface ImageUpdateOptions {
 }
 
 type ImageMetadataFilterOperators = {
-  /** Matches a field exactly. */
   eq?: string | number | boolean;
-  /** Matches a field against any value in the list (maximum 10 values). */
   in?: string[] | number[];
-  /** Greater than (numbers only). */
   gt?: number;
-  /** Greater than or equal to (numbers only). */
   gte?: number;
-  /** Less than (numbers only). */
   lt?: number;
-  /** Less than or equal to (numbers only). */
   lte?: number;
 };
 
-/**
- * A condition applied to a single metadata field. A bare value is shorthand
- * for `eq`, so `{ status: 'active' }` is equivalent to
- * `{ status: { eq: 'active' } }`.
- */
 type ImageMetadataFilterValue =
   | string
   | number
@@ -168,12 +157,6 @@ interface ImageListOptions {
   cursor?: string;
   sortOrder?: 'asc' | 'desc';
   creator?: string;
-  /**
-   * Filter images by custom metadata fields. Each key is a metadata field
-   * name and its value is the condition the field must meet. Use dot notation
-   * in the field name to filter on a nested field (e.g. `region.name`).
-   * When multiple fields are provided, an image must match all of them.
-   */
   metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 

--- a/types/defines/images.d.ts
+++ b/types/defines/images.d.ts
@@ -137,11 +137,44 @@ interface ImageUpdateOptions {
   creator?: string;
 }
 
+type ImageMetadataFilterOperators = {
+  /** Matches a field exactly. */
+  eq?: string | number | boolean;
+  /** Matches a field against any value in the list (maximum 10 values). */
+  in?: string[] | number[];
+  /** Greater than (numbers only). */
+  gt?: number;
+  /** Greater than or equal to (numbers only). */
+  gte?: number;
+  /** Less than (numbers only). */
+  lt?: number;
+  /** Less than or equal to (numbers only). */
+  lte?: number;
+};
+
+/**
+ * A condition applied to a single metadata field. A bare value is shorthand
+ * for `eq`, so `{ status: 'active' }` is equivalent to
+ * `{ status: { eq: 'active' } }`.
+ */
+type ImageMetadataFilterValue =
+  | string
+  | number
+  | boolean
+  | ImageMetadataFilterOperators;
+
 interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: 'asc' | 'desc';
   creator?: string;
+  /**
+   * Filter images by custom metadata fields. Each key is a metadata field
+   * name and its value is the condition the field must meet. Use dot notation
+   * in the field name to filter on a nested field (e.g. `region.name`).
+   * When multiple fields are provided, an image must match all of them.
+   */
+  metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 
 interface ImageList {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14703,12 +14703,15 @@ type ImageMetadataFilterValue =
   | number
   | boolean
   | ImageMetadataFilterOperators;
+interface ImageListFilter {
+  metadata?: Record<string, ImageMetadataFilterValue>;
+}
 interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
-  metadataFilters?: Record<string, ImageMetadataFilterValue>;
+  filter?: ImageListFilter;
 }
 interface ImageList {
   images: ImageMetadata[];

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14690,11 +14690,42 @@ interface ImageUpdateOptions {
   metadata?: Record<string, unknown>;
   creator?: string;
 }
+type ImageMetadataFilterOperators = {
+  /** Matches a field exactly. */
+  eq?: string | number | boolean;
+  /** Matches a field against any value in the list (maximum 10 values). */
+  in?: string[] | number[];
+  /** Greater than (numbers only). */
+  gt?: number;
+  /** Greater than or equal to (numbers only). */
+  gte?: number;
+  /** Less than (numbers only). */
+  lt?: number;
+  /** Less than or equal to (numbers only). */
+  lte?: number;
+};
+/**
+ * A condition applied to a single metadata field. A bare value is shorthand
+ * for `eq`, so `{ status: 'active' }` is equivalent to
+ * `{ status: { eq: 'active' } }`.
+ */
+type ImageMetadataFilterValue =
+  | string
+  | number
+  | boolean
+  | ImageMetadataFilterOperators;
 interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
+  /**
+   * Filter images by custom metadata fields. Each key is a metadata field
+   * name and its value is the condition the field must meet. Use dot notation
+   * in the field name to filter on a nested field (e.g. `region.name`).
+   * When multiple fields are provided, an image must match all of them.
+   */
+  metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 interface ImageList {
   images: ImageMetadata[];

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14691,24 +14691,13 @@ interface ImageUpdateOptions {
   creator?: string;
 }
 type ImageMetadataFilterOperators = {
-  /** Matches a field exactly. */
   eq?: string | number | boolean;
-  /** Matches a field against any value in the list (maximum 10 values). */
   in?: string[] | number[];
-  /** Greater than (numbers only). */
   gt?: number;
-  /** Greater than or equal to (numbers only). */
   gte?: number;
-  /** Less than (numbers only). */
   lt?: number;
-  /** Less than or equal to (numbers only). */
   lte?: number;
 };
-/**
- * A condition applied to a single metadata field. A bare value is shorthand
- * for `eq`, so `{ status: 'active' }` is equivalent to
- * `{ status: { eq: 'active' } }`.
- */
 type ImageMetadataFilterValue =
   | string
   | number
@@ -14719,12 +14708,6 @@ interface ImageListOptions {
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
-  /**
-   * Filter images by custom metadata fields. Each key is a metadata field
-   * name and its value is the condition the field must meet. Use dot notation
-   * in the field name to filter on a nested field (e.g. `region.name`).
-   * When multiple fields are provided, an image must match all of them.
-   */
   metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 interface ImageList {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14714,24 +14714,13 @@ export interface ImageUpdateOptions {
   creator?: string;
 }
 export type ImageMetadataFilterOperators = {
-  /** Matches a field exactly. */
   eq?: string | number | boolean;
-  /** Matches a field against any value in the list (maximum 10 values). */
   in?: string[] | number[];
-  /** Greater than (numbers only). */
   gt?: number;
-  /** Greater than or equal to (numbers only). */
   gte?: number;
-  /** Less than (numbers only). */
   lt?: number;
-  /** Less than or equal to (numbers only). */
   lte?: number;
 };
-/**
- * A condition applied to a single metadata field. A bare value is shorthand
- * for `eq`, so `{ status: 'active' }` is equivalent to
- * `{ status: { eq: 'active' } }`.
- */
 export type ImageMetadataFilterValue =
   | string
   | number
@@ -14742,12 +14731,6 @@ export interface ImageListOptions {
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
-  /**
-   * Filter images by custom metadata fields. Each key is a metadata field
-   * name and its value is the condition the field must meet. Use dot notation
-   * in the field name to filter on a nested field (e.g. `region.name`).
-   * When multiple fields are provided, an image must match all of them.
-   */
   metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 export interface ImageList {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14713,11 +14713,42 @@ export interface ImageUpdateOptions {
   metadata?: Record<string, unknown>;
   creator?: string;
 }
+export type ImageMetadataFilterOperators = {
+  /** Matches a field exactly. */
+  eq?: string | number | boolean;
+  /** Matches a field against any value in the list (maximum 10 values). */
+  in?: string[] | number[];
+  /** Greater than (numbers only). */
+  gt?: number;
+  /** Greater than or equal to (numbers only). */
+  gte?: number;
+  /** Less than (numbers only). */
+  lt?: number;
+  /** Less than or equal to (numbers only). */
+  lte?: number;
+};
+/**
+ * A condition applied to a single metadata field. A bare value is shorthand
+ * for `eq`, so `{ status: 'active' }` is equivalent to
+ * `{ status: { eq: 'active' } }`.
+ */
+export type ImageMetadataFilterValue =
+  | string
+  | number
+  | boolean
+  | ImageMetadataFilterOperators;
 export interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
+  /**
+   * Filter images by custom metadata fields. Each key is a metadata field
+   * name and its value is the condition the field must meet. Use dot notation
+   * in the field name to filter on a nested field (e.g. `region.name`).
+   * When multiple fields are provided, an image must match all of them.
+   */
+  metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 export interface ImageList {
   images: ImageMetadata[];

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14726,12 +14726,15 @@ export type ImageMetadataFilterValue =
   | number
   | boolean
   | ImageMetadataFilterOperators;
+export interface ImageListFilter {
+  metadata?: Record<string, ImageMetadataFilterValue>;
+}
 export interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
-  metadataFilters?: Record<string, ImageMetadataFilterValue>;
+  filter?: ImageListFilter;
 }
 export interface ImageList {
   images: ImageMetadata[];

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14043,24 +14043,13 @@ interface ImageUpdateOptions {
   creator?: string;
 }
 type ImageMetadataFilterOperators = {
-  /** Matches a field exactly. */
   eq?: string | number | boolean;
-  /** Matches a field against any value in the list (maximum 10 values). */
   in?: string[] | number[];
-  /** Greater than (numbers only). */
   gt?: number;
-  /** Greater than or equal to (numbers only). */
   gte?: number;
-  /** Less than (numbers only). */
   lt?: number;
-  /** Less than or equal to (numbers only). */
   lte?: number;
 };
-/**
- * A condition applied to a single metadata field. A bare value is shorthand
- * for `eq`, so `{ status: 'active' }` is equivalent to
- * `{ status: { eq: 'active' } }`.
- */
 type ImageMetadataFilterValue =
   | string
   | number
@@ -14071,12 +14060,6 @@ interface ImageListOptions {
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
-  /**
-   * Filter images by custom metadata fields. Each key is a metadata field
-   * name and its value is the condition the field must meet. Use dot notation
-   * in the field name to filter on a nested field (e.g. `region.name`).
-   * When multiple fields are provided, an image must match all of them.
-   */
   metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 interface ImageList {

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14042,11 +14042,42 @@ interface ImageUpdateOptions {
   metadata?: Record<string, unknown>;
   creator?: string;
 }
+type ImageMetadataFilterOperators = {
+  /** Matches a field exactly. */
+  eq?: string | number | boolean;
+  /** Matches a field against any value in the list (maximum 10 values). */
+  in?: string[] | number[];
+  /** Greater than (numbers only). */
+  gt?: number;
+  /** Greater than or equal to (numbers only). */
+  gte?: number;
+  /** Less than (numbers only). */
+  lt?: number;
+  /** Less than or equal to (numbers only). */
+  lte?: number;
+};
+/**
+ * A condition applied to a single metadata field. A bare value is shorthand
+ * for `eq`, so `{ status: 'active' }` is equivalent to
+ * `{ status: { eq: 'active' } }`.
+ */
+type ImageMetadataFilterValue =
+  | string
+  | number
+  | boolean
+  | ImageMetadataFilterOperators;
 interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
+  /**
+   * Filter images by custom metadata fields. Each key is a metadata field
+   * name and its value is the condition the field must meet. Use dot notation
+   * in the field name to filter on a nested field (e.g. `region.name`).
+   * When multiple fields are provided, an image must match all of them.
+   */
+  metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 interface ImageList {
   images: ImageMetadata[];

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14055,12 +14055,15 @@ type ImageMetadataFilterValue =
   | number
   | boolean
   | ImageMetadataFilterOperators;
+interface ImageListFilter {
+  metadata?: Record<string, ImageMetadataFilterValue>;
+}
 interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
-  metadataFilters?: Record<string, ImageMetadataFilterValue>;
+  filter?: ImageListFilter;
 }
 interface ImageList {
   images: ImageMetadata[];

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14065,11 +14065,42 @@ export interface ImageUpdateOptions {
   metadata?: Record<string, unknown>;
   creator?: string;
 }
+export type ImageMetadataFilterOperators = {
+  /** Matches a field exactly. */
+  eq?: string | number | boolean;
+  /** Matches a field against any value in the list (maximum 10 values). */
+  in?: string[] | number[];
+  /** Greater than (numbers only). */
+  gt?: number;
+  /** Greater than or equal to (numbers only). */
+  gte?: number;
+  /** Less than (numbers only). */
+  lt?: number;
+  /** Less than or equal to (numbers only). */
+  lte?: number;
+};
+/**
+ * A condition applied to a single metadata field. A bare value is shorthand
+ * for `eq`, so `{ status: 'active' }` is equivalent to
+ * `{ status: { eq: 'active' } }`.
+ */
+export type ImageMetadataFilterValue =
+  | string
+  | number
+  | boolean
+  | ImageMetadataFilterOperators;
 export interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
+  /**
+   * Filter images by custom metadata fields. Each key is a metadata field
+   * name and its value is the condition the field must meet. Use dot notation
+   * in the field name to filter on a nested field (e.g. `region.name`).
+   * When multiple fields are provided, an image must match all of them.
+   */
+  metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 export interface ImageList {
   images: ImageMetadata[];

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14078,12 +14078,15 @@ export type ImageMetadataFilterValue =
   | number
   | boolean
   | ImageMetadataFilterOperators;
+export interface ImageListFilter {
+  metadata?: Record<string, ImageMetadataFilterValue>;
+}
 export interface ImageListOptions {
   limit?: number;
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
-  metadataFilters?: Record<string, ImageMetadataFilterValue>;
+  filter?: ImageListFilter;
 }
 export interface ImageList {
   images: ImageMetadata[];

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14066,24 +14066,13 @@ export interface ImageUpdateOptions {
   creator?: string;
 }
 export type ImageMetadataFilterOperators = {
-  /** Matches a field exactly. */
   eq?: string | number | boolean;
-  /** Matches a field against any value in the list (maximum 10 values). */
   in?: string[] | number[];
-  /** Greater than (numbers only). */
   gt?: number;
-  /** Greater than or equal to (numbers only). */
   gte?: number;
-  /** Less than (numbers only). */
   lt?: number;
-  /** Less than or equal to (numbers only). */
   lte?: number;
 };
-/**
- * A condition applied to a single metadata field. A bare value is shorthand
- * for `eq`, so `{ status: 'active' }` is equivalent to
- * `{ status: { eq: 'active' } }`.
- */
 export type ImageMetadataFilterValue =
   | string
   | number
@@ -14094,12 +14083,6 @@ export interface ImageListOptions {
   cursor?: string;
   sortOrder?: "asc" | "desc";
   creator?: string;
-  /**
-   * Filter images by custom metadata fields. Each key is a metadata field
-   * name and its value is the condition the field must meet. Use dot notation
-   * in the field name to filter on a nested field (e.g. `region.name`).
-   * When multiple fields are provided, an image must match all of them.
-   */
   metadataFilters?: Record<string, ImageMetadataFilterValue>;
 }
 export interface ImageList {


### PR DESCRIPTION
Adds an optional `metadataFilters` option to `env.IMAGES.hosted.list()` so
Workers can filter hosted-image lists by custom metadata, matching the Images
REST API. Operators: `eq` (also the implicit form), `in`, `gt`, `gte`, `lt`,
`lte`; dot-notation for nested fields; multiple fields combined with AND. Shape
follows the Vectorize metadata-filtering API.

`hosted.list()` forwards options to the hosted-images service over RPC
unchanged, so this is the type definition plus test coverage; the upstream
service does the filtering. `images-api-test` exercises each operator through
the mocked upstream.

Draft: companion to workers-sdk [#14510](https://github.com/cloudflare/workers-sdk/pull/14510); API shape still being finalised.