### PR TITLE
Add signedUrl to Images binding types

### DIFF
--- a/src/cloudflare/internal/images.d.ts
+++ b/src/cloudflare/internal/images.d.ts
@@ -147,6 +147,12 @@ interface ImageListOptions {
   creator?: string;
 }
 
+interface ImageSignedUrlOptions {
+  variant: string;
+  expiresIn?: number;
+  keyName?: string;
+}
+
 interface ImageList {
   images: ImageMetadata[];
   cursor?: string;
@@ -165,6 +171,14 @@ interface ImageHandle {
    * @returns ReadableStream of image bytes, or null if not found
    */
   bytes(): Promise<ReadableStream<Uint8Array> | null>;
+
+  /**
+   * Generate a signed delivery URL for this hosted image.
+   * @param options Signing configuration
+   * @returns A signed image delivery URL
+   * @throws {@link ImagesError} if signing fails
+   */
+  signedUrl(options: ImageSignedUrlOptions): Promise<string>;
 
   /**
    * Update hosted image metadata

--- a/src/cloudflare/internal/test/images/images-api-test.js
+++ b/src/cloudflare/internal/test/images/images-api-test.js
@@ -511,6 +511,23 @@ export const test_images_getImage_not_found = {
   },
 };
 
+export const test_images_signed_url = {
+  /**
+   * @param {unknown} _
+   * @param {Env} env
+   */
+  async test(_, env) {
+    const url = await env.images.hosted
+      .image('test-image-id')
+      .signedUrl({ variant: 'private' });
+
+    assert.equal(
+      url,
+      'https://imagedelivery.example/test-image-id/private?sig=mock-signature'
+    );
+  },
+};
+
 // UPLOAD
 export const test_images_upload_with_options = {
   /**

--- a/src/cloudflare/internal/test/images/images-upstream-mock.js
+++ b/src/cloudflare/internal/test/images/images-upstream-mock.js
@@ -56,6 +56,10 @@ class ImageHandleMock extends RpcTarget {
     return new Blob([mockData]).stream();
   }
 
+  async signedUrl(options) {
+    return `https://imagedelivery.example/${this.#imageId}/${options.variant}?sig=mock-signature`;
+  }
+
   /**
    * @param {ImageUpdateOptions} body
    * @returns {Promise<ImageMetadata>}

--- a/types/defines/images.d.ts
+++ b/types/defines/images.d.ts
@@ -144,6 +144,12 @@ interface ImageListOptions {
   creator?: string;
 }
 
+interface ImageSignedUrlOptions {
+  variant: string;
+  expiresIn?: number;
+  keyName?: string;
+}
+
 interface ImageList {
   images: ImageMetadata[];
   cursor?: string;
@@ -162,6 +168,14 @@ interface ImageHandle {
    * @returns ReadableStream of image bytes, or null if not found
    */
   bytes(): Promise<ReadableStream<Uint8Array> | null>;
+
+  /**
+   * Generate a signed delivery URL for this hosted image.
+   * @param options Signing configuration
+   * @returns A signed image delivery URL
+   * @throws {@link ImagesError} if signing fails
+   */
+  signedUrl(options: ImageSignedUrlOptions): Promise<string>;
 
   /**
    * Update hosted image metadata

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -14696,6 +14696,11 @@ interface ImageListOptions {
   sortOrder?: "asc" | "desc";
   creator?: string;
 }
+interface ImageSignedUrlOptions {
+  variant: string;
+  expiresIn?: number;
+  keyName?: string;
+}
 interface ImageList {
   images: ImageMetadata[];
   cursor?: string;
@@ -14712,6 +14717,13 @@ interface ImageHandle {
    * @returns ReadableStream of image bytes, or null if not found
    */
   bytes(): Promise<ReadableStream<Uint8Array> | null>;
+  /**
+   * Generate a signed delivery URL for this hosted image.
+   * @param options Signing configuration
+   * @returns A signed image delivery URL
+   * @throws {@link ImagesError} if signing fails
+   */
+  signedUrl(options: ImageSignedUrlOptions): Promise<string>;
   /**
    * Update hosted image metadata
    * @param options Properties to update

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -14719,6 +14719,11 @@ export interface ImageListOptions {
   sortOrder?: "asc" | "desc";
   creator?: string;
 }
+export interface ImageSignedUrlOptions {
+  variant: string;
+  expiresIn?: number;
+  keyName?: string;
+}
 export interface ImageList {
   images: ImageMetadata[];
   cursor?: string;
@@ -14735,6 +14740,13 @@ export interface ImageHandle {
    * @returns ReadableStream of image bytes, or null if not found
    */
   bytes(): Promise<ReadableStream<Uint8Array> | null>;
+  /**
+   * Generate a signed delivery URL for this hosted image.
+   * @param options Signing configuration
+   * @returns A signed image delivery URL
+   * @throws {@link ImagesError} if signing fails
+   */
+  signedUrl(options: ImageSignedUrlOptions): Promise<string>;
   /**
    * Update hosted image metadata
    * @param options Properties to update

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -14048,6 +14048,11 @@ interface ImageListOptions {
   sortOrder?: "asc" | "desc";
   creator?: string;
 }
+interface ImageSignedUrlOptions {
+  variant: string;
+  expiresIn?: number;
+  keyName?: string;
+}
 interface ImageList {
   images: ImageMetadata[];
   cursor?: string;
@@ -14064,6 +14069,13 @@ interface ImageHandle {
    * @returns ReadableStream of image bytes, or null if not found
    */
   bytes(): Promise<ReadableStream<Uint8Array> | null>;
+  /**
+   * Generate a signed delivery URL for this hosted image.
+   * @param options Signing configuration
+   * @returns A signed image delivery URL
+   * @throws {@link ImagesError} if signing fails
+   */
+  signedUrl(options: ImageSignedUrlOptions): Promise<string>;
   /**
    * Update hosted image metadata
    * @param options Properties to update

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -14071,6 +14071,11 @@ export interface ImageListOptions {
   sortOrder?: "asc" | "desc";
   creator?: string;
 }
+export interface ImageSignedUrlOptions {
+  variant: string;
+  expiresIn?: number;
+  keyName?: string;
+}
 export interface ImageList {
   images: ImageMetadata[];
   cursor?: string;
@@ -14087,6 +14092,13 @@ export interface ImageHandle {
    * @returns ReadableStream of image bytes, or null if not found
    */
   bytes(): Promise<ReadableStream<Uint8Array> | null>;
+  /**
+   * Generate a signed delivery URL for this hosted image.
+   * @param options Signing configuration
+   * @returns A signed image delivery URL
+   * @throws {@link ImagesError} if signing fails
+   */
+  signedUrl(options: ImageSignedUrlOptions): Promise<string>;
   /**
    * Update hosted image metadata
    * @param options Properties to update


### PR DESCRIPTION
Adds the Hosted Images `signedUrl()` method to the Images binding type surface and generated workers types.

Also updates the Images binding mock test to verify that `env.IMAGES.hosted.image(id).signedUrl(...)` forwards through the hosted image handle.

Tests:
- `just generate-types`
- `bazel run //src/cloudflare/internal/test/images:images-api-test@`