### PR TITLE
Add synthetic IP for Hyperdrive bindings, resolvable via node:dns

### DIFF
--- a/src/node/internal/internal_dns.ts
+++ b/src/node/internal/internal_dns.ts
@@ -38,6 +38,7 @@ import {
 } from 'node-internal:validators';
 import * as errorCodes from 'node-internal:internal_dns_constants';
 import { isIP } from 'node-internal:internal_net';
+import inner from 'cloudflare-internal:sockets';
 import type dns from 'node:dns';
 
 type DnsOrder = 'verbatim' | 'ipv4first' | 'ipv6first';
@@ -140,6 +141,25 @@ export function lookup(
       process.nextTick(callback, null, hostname, matchedFamily);
     }
     return;
+  }
+
+  // Magic hostnames such as Hyperdrive's `.hyperdrive.local` resolve to a synthetic IPv4 address
+  // that routes back to the corresponding service via a connect override. Since the address is
+  // IPv4, only honor the override when an IPv4 result is acceptable (family 0 or 4).
+  if (family !== 6) {
+    const overrideIp = inner.getCallerDnsOverride(hostname);
+    if (overrideIp != null) {
+      // Deliver asynchronously (as Node.js does) without depending on `process`, which may not be
+      // available depending on the Worker's compatibility settings.
+      queueMicrotask(() => {
+        if (all) {
+          callback(null, [{ address: overrideIp, family: 4 }]);
+        } else {
+          callback(null, overrideIp, 4);
+        }
+      });
+      return;
+    }
   }
 
   // If all is true and family is 0, we need to query both A and AAAA records

--- a/src/node/internal/sockets.d.ts
+++ b/src/node/internal/sockets.d.ts
@@ -37,5 +37,9 @@ declare namespace sockets {
       secureTransport: 'on' | 'off' | 'starttls';
     }
   ): Socket;
+
+  // Returns the synthetic IP registered for a magic hostname (e.g. a Hyperdrive
+  // `.hyperdrive.local` hostname), or undefined if there is no override.
+  function getCallerDnsOverride(hostname: string): string | undefined;
 }
 export default sockets;

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -852,6 +852,14 @@ kj::Maybe<ServiceWorkerGlobalScope::ConnectFn&> ServiceWorkerGlobalScope::getCon
   return connectOverrides.find(networkAddress);
 }
 
+void ServiceWorkerGlobalScope::setDnsOverride(kj::String hostname, kj::String ip) {
+  dnsOverrides.upsert(kj::mv(hostname), kj::mv(ip));
+}
+
+kj::Maybe<kj::StringPtr> ServiceWorkerGlobalScope::getDnsOverride(kj::StringPtr hostname) {
+  return dnsOverrides.find(hostname).map([](kj::String& ip) -> kj::StringPtr { return ip; });
+}
+
 jsg::JsString ServiceWorkerGlobalScope::btoa(jsg::Lock& js, jsg::JsString str) {
   // We could implement btoa() by accepting a kj::String, but then we'd have to check that it
   // doesn't have any multibyte code points. Easier to perform that test using v8::String's

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -664,6 +664,14 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
   void setConnectOverride(kj::String networkAddress, ConnectFn connectFn);
   kj::Maybe<ConnectFn&> getConnectOverride(kj::StringPtr networkAddress);
 
+  // Track a set of hostname->IP overrides so that the Node.js DNS resolver (node:dns) can resolve
+  // the magic hostnames used by e.g. Hyperdrive to a synthetic IP address. The returned IP has a
+  // corresponding connect override (see above) registered for it, so connecting to the resolved IP
+  // routes to the same place as the hostname. This lets database drivers that require an IP literal
+  // rather than a hostname work against these services.
+  void setDnsOverride(kj::String hostname, kj::String ip);
+  kj::Maybe<kj::StringPtr> getDnsOverride(kj::StringPtr hostname);
+
   // ---------------------------------------------------------------------------
   // JS API
 
@@ -1079,6 +1087,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
   kj::Maybe<jsg::JsRef<jsg::JsValue>> bufferValue;
   kj::Maybe<jsg::Ref<Fetcher>> defaultFetcher;
   kj::HashMap<kj::String, ConnectFn> connectOverrides;
+  kj::HashMap<kj::String, kj::String> dnsOverrides;
 
   // Global properties such as scheduler, crypto, caches, self, and origin should
   // be monkeypatchable / mutable at the global scope.

--- a/src/workerd/api/hyperdrive.c++
+++ b/src/workerd/api/hyperdrive.c++
@@ -24,6 +24,13 @@ Hyperdrive::Hyperdrive(
   kj::FixedArray<kj::byte, 16> randomBytes;
   getEntropy(randomBytes.asPtr());
   randomHost = kj::str(kj::encodeHex(randomBytes), ".hyperdrive.local");
+
+  // A synthetic IPv4 address for drivers that require an IP literal. We use the reserved
+  // 240.0.0.0/4 block (240.0.0.0 - 255.255.255.255) so the address can never collide with a real
+  // host the Worker might legitimately connect to; the two random octets identify this binding.
+  kj::FixedArray<kj::byte, 2> ipBytes;
+  getEntropy(ipBytes.asPtr());
+  randomIp = kj::str("240.0.", static_cast<uint>(ipBytes[0]), ".", static_cast<uint>(ipBytes[1]));
 }
 
 jsg::Ref<Socket> Hyperdrive::connect(jsg::Lock& js) {
@@ -66,18 +73,36 @@ kj::StringPtr Hyperdrive::getScheme() {
   return this->scheme;
 }
 
-kj::StringPtr Hyperdrive::getHost() {
-  if (!registeredConnectOverride) {
-    // Returns the random hostname and ensures the connect override is registered on the
-    // ServiceWorkerGlobalScope for the Worker. This getter has a side effect: it registers (or
-    // re-registers) an entry in the ServiceWorkerGlobalScope's connectOverrides HashMap so that
-    // cloudflare:sockets's connect() will route connections to this magic hostname through Hyperdrive.
-    auto& globalScope = IoContext::current().getCurrentLock().getGlobalScope();
-    globalScope.setConnectOverride(kj::str(randomHost, ":", getPort()),
-        [self = JSG_THIS](jsg::Lock& js) mutable { return self->connect(js); });
-    registeredConnectOverride = true;
+void Hyperdrive::registerConnectOverride() {
+  if (registeredConnectOverride) {
+    return;
   }
+  // Registers entries in the ServiceWorkerGlobalScope's connectOverrides HashMap so that
+  // cloudflare:sockets's connect() routes connections to either the magic hostname or the
+  // synthetic IP through Hyperdrive.
+  auto& globalScope = IoContext::current().getCurrentLock().getGlobalScope();
+  globalScope.setConnectOverride(kj::str(randomHost, ":", getPort()),
+      [self = JSG_THIS](jsg::Lock& js) mutable { return self->connect(js); });
+  globalScope.setConnectOverride(kj::str(randomIp, ":", getPort()),
+      [self = JSG_THIS](jsg::Lock& js) mutable { return self->connect(js); });
+  // Register the hostname->IP mapping so that node:dns can resolve the magic hostname to the
+  // synthetic IP (which itself has a connect override registered above).
+  globalScope.setDnsOverride(kj::str(randomHost), kj::str(randomIp));
+  registeredConnectOverride = true;
+}
+
+kj::StringPtr Hyperdrive::getHost() {
+  // This getter has a side effect: it ensures the connect overrides are registered so that
+  // connecting to the returned hostname routes through Hyperdrive.
+  registerConnectOverride();
   return randomHost;
+}
+
+kj::StringPtr Hyperdrive::getIP() {
+  // As with getHost(), reading the IP registers the connect overrides so that connecting to the
+  // returned address routes through Hyperdrive.
+  registerConnectOverride();
+  return randomIp;
 }
 
 // We currently only support Postgres and MySQL

--- a/src/workerd/api/hyperdrive.h
+++ b/src/workerd/api/hyperdrive.h
@@ -34,6 +34,12 @@ class Hyperdrive: public jsg::Object {
   kj::StringPtr getScheme();
 
   kj::StringPtr getHost();
+
+  // A synthetic IPv4 address (in the reserved 240.0.0.0/4 block) that routes to this Hyperdrive
+  // binding. Some database drivers require the host to be an IP literal rather than a hostname;
+  // connecting to this address via `connect()` reaches the same place as `getHost()`.
+  kj::StringPtr getIP();
+
   uint16_t getPort();
 
   kj::String getConnectionString();
@@ -43,6 +49,7 @@ class Hyperdrive: public jsg::Object {
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(user, getUser);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(password, getPassword);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(host, getHost);
+    JSG_LAZY_READONLY_INSTANCE_PROPERTY(ip, getIP);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(port, getPort);
     JSG_LAZY_READONLY_INSTANCE_PROPERTY(connectionString, getConnectionString);
 
@@ -51,6 +58,7 @@ class Hyperdrive: public jsg::Object {
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
     tracker.trackField("randomHost", randomHost);
+    tracker.trackField("randomIp", randomIp);
     tracker.trackField("database", database);
     tracker.trackField("user", user);
     tracker.trackField("password", password);
@@ -60,11 +68,17 @@ class Hyperdrive: public jsg::Object {
  private:
   uint clientIndex;
   kj::String randomHost;
+  kj::String randomIp;
   kj::String database;
   kj::String user;
   kj::String password;
   kj::String scheme;
   bool registeredConnectOverride = false;
+
+  // Registers connect() overrides for both the magic hostname and the synthetic IP so that
+  // cloudflare:sockets's connect() routes either of them through Hyperdrive. Requires an active
+  // IoContext, so this is done lazily on first access rather than in the constructor.
+  void registerConnectOverride();
 
   kj::Promise<kj::Own<kj::AsyncIoStream>> connectToDb();
 };

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -557,6 +557,14 @@ jsg::Ref<Socket> SocketsModule::connect(
   return connectImpl(js, kj::none, kj::mv(address), kj::mv(options));
 }
 
+jsg::Optional<kj::String> SocketsModule::getCallerDnsOverride(jsg::Lock& js, kj::String hostname) {
+  auto& ioContext = IoContext::current();
+  KJ_IF_SOME(ip, ioContext.getCurrentLock().getGlobalScope().getDnsOverride(hostname)) {
+    return kj::str(ip);
+  }
+  return kj::none;
+}
+
 kj::Own<kj::AsyncIoStream> Socket::takeConnectionStream(jsg::Lock& js) {
   // Set this so that if `close` is called after this, that no closure steps are taken and instead
   // the `close` is a no-op.

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -281,8 +281,13 @@ class SocketsModule final: public jsg::Object {
   // Creates a Fetcher from a Socket that can perform HTTP requests over the socket connection
   jsg::Promise<jsg::Ref<Fetcher>> internalNewHttpClient(jsg::Lock& js, jsg::Ref<Socket> socket);
 
+  // Returns the synthetic IP registered for a magic hostname (e.g. a Hyperdrive `.hyperdrive.local`
+  // hostname), or null if there is no override. Used by node:dns to resolve such hostnames.
+  jsg::Optional<kj::String> getCallerDnsOverride(jsg::Lock& js, kj::String hostname);
+
   JSG_RESOURCE_TYPE(SocketsModule, CompatibilityFlags::Reader flags) {
     JSG_METHOD(connect);
+    JSG_METHOD(getCallerDnsOverride);
 
     if (flags.getWorkerdExperimental()) {
       JSG_METHOD(internalNewHttpClient);

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -1482,6 +1482,132 @@ KJ_TEST("Server: capability bindings") {
   )"_blockquote);
 }
 
+KJ_TEST("Server: Hyperdrive connect via synthetic IP") {
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2022-08-17",
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `import { connect } from 'cloudflare:sockets';
+                `export default {
+                `  async fetch(request, env) {
+                `    const ip = env.hyperdrive.ip;
+                `    if (!/^240\.0\.\d{1,3}\.\d{1,3}$/.test(ip)) {
+                `      throw new Error(`unexpected hyperdrive ip: ${ip}`);
+                `    }
+                `    const connection = connect(`${ip}:5432`);
+                `    const encoded = new TextEncoder().encode("hyperdrive-ip-test");
+                `    await connection.writable.getWriter().write(new Uint8Array(encoded));
+                `    return new Response("OK");
+                `  }
+                `}
+            )
+          ],
+          bindings = [
+            ( name = "hyperdrive",
+              hyperdrive = (
+                designator = "hyperdrive-outbound",
+                database = "test-db",
+                user = "test-user",
+                password = "test-password",
+                scheme = "postgresql"
+              )
+            )
+          ]
+        )
+      ),
+      ( name = "hyperdrive-outbound", external = (
+        address = "hyperdrive-host",
+        tcp = ()
+      ))
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = "hello"
+      )
+    ]
+  ))"_kj);
+
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.sendHttpGet("/");
+
+  {
+    auto subreq = test.receiveSubrequest("hyperdrive-host");
+    subreq.recv("hyperdrive-ip-test");
+  }
+  conn.recvHttp200("OK");
+}
+
+KJ_TEST("Server: Hyperdrive host resolves via node:dns to synthetic IP") {
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2022-08-17",
+          compatibilityFlags = ["nodejs_compat"],
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `import { connect } from 'cloudflare:sockets';
+                `import { promises as dns } from 'node:dns';
+                `export default {
+                `  async fetch(request, env) {
+                `    // Reading host primes the connect/dns overrides.
+                `    const host = env.hyperdrive.host;
+                `    const { address, family } = await dns.lookup(host);
+                `    if (family !== 4 || !/^240\.0\.\d{1,3}\.\d{1,3}$/.test(address)) {
+                `      throw new Error(`unexpected lookup result: ${address}/${family}`);
+                `    }
+                `    const connection = connect(`${address}:5432`);
+                `    const encoded = new TextEncoder().encode("hyperdrive-dns-test");
+                `    await connection.writable.getWriter().write(new Uint8Array(encoded));
+                `    return new Response("OK");
+                `  }
+                `}
+            )
+          ],
+          bindings = [
+            ( name = "hyperdrive",
+              hyperdrive = (
+                designator = "hyperdrive-outbound",
+                database = "test-db",
+                user = "test-user",
+                password = "test-password",
+                scheme = "postgresql"
+              )
+            )
+          ]
+        )
+      ),
+      ( name = "hyperdrive-outbound", external = (
+        address = "hyperdrive-host",
+        tcp = ()
+      ))
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = "hello"
+      )
+    ]
+  ))"_kj);
+
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.sendHttpGet("/");
+
+  {
+    auto subreq = test.receiveSubrequest("hyperdrive-host");
+    subreq.recv("hyperdrive-dns-test");
+  }
+  conn.recvHttp200("OK");
+}
+
 KJ_TEST("Server: cyclic bindings") {
   TestServer test(R"((
     services = [

--- a/types/defines/hyperdrive.d.ts
+++ b/types/defines/hyperdrive.d.ts
@@ -27,6 +27,15 @@ interface Hyperdrive {
    */
   readonly host: string;
   /*
+   * A synthetic IPv4 address (in the reserved 240.0.0.0/4 range) that, like the
+   * host field, is only valid within the context of the currently running
+   * Worker and, when passed into the `connect()` function from the
+   * "cloudflare:sockets" module, will connect to the Hyperdrive instance for
+   * your database. This is provided for database drivers that require the host
+   * to be an IP literal rather than a hostname.
+   */
+  readonly ip: string;
+  /*
    * The port that must be paired the the host field when connecting.
    */
   readonly port: number;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -13527,6 +13527,15 @@ interface Hyperdrive {
    */
   readonly host: string;
   /*
+   * A synthetic IPv4 address (in the reserved 240.0.0.0/4 range) that, like the
+   * host field, is only valid within the context of the currently running
+   * Worker and, when passed into the `connect()` function from the
+   * "cloudflare:sockets" module, will connect to the Hyperdrive instance for
+   * your database. This is provided for database drivers that require the host
+   * to be an IP literal rather than a hostname.
+   */
+  readonly ip: string;
+  /*
    * The port that must be paired the the host field when connecting.
    */
   readonly port: number;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -13547,6 +13547,15 @@ export interface Hyperdrive {
    */
   readonly host: string;
   /*
+   * A synthetic IPv4 address (in the reserved 240.0.0.0/4 range) that, like the
+   * host field, is only valid within the context of the currently running
+   * Worker and, when passed into the `connect()` function from the
+   * "cloudflare:sockets" module, will connect to the Hyperdrive instance for
+   * your database. This is provided for database drivers that require the host
+   * to be an IP literal rather than a hostname.
+   */
+  readonly ip: string;
+  /*
    * The port that must be paired the the host field when connecting.
    */
   readonly port: number;

--- a/types/generated-snapshot/latest/index.d.ts
+++ b/types/generated-snapshot/latest/index.d.ts
@@ -12859,6 +12859,15 @@ interface Hyperdrive {
    */
   readonly host: string;
   /*
+   * A synthetic IPv4 address (in the reserved 240.0.0.0/4 range) that, like the
+   * host field, is only valid within the context of the currently running
+   * Worker and, when passed into the `connect()` function from the
+   * "cloudflare:sockets" module, will connect to the Hyperdrive instance for
+   * your database. This is provided for database drivers that require the host
+   * to be an IP literal rather than a hostname.
+   */
+  readonly ip: string;
+  /*
    * The port that must be paired the the host field when connecting.
    */
   readonly port: number;

--- a/types/generated-snapshot/latest/index.ts
+++ b/types/generated-snapshot/latest/index.ts
@@ -12879,6 +12879,15 @@ export interface Hyperdrive {
    */
   readonly host: string;
   /*
+   * A synthetic IPv4 address (in the reserved 240.0.0.0/4 range) that, like the
+   * host field, is only valid within the context of the currently running
+   * Worker and, when passed into the `connect()` function from the
+   * "cloudflare:sockets" module, will connect to the Hyperdrive instance for
+   * your database. This is provided for database drivers that require the host
+   * to be an IP literal rather than a hostname.
+   */
+  readonly ip: string;
+  /*
    * The port that must be paired the the host field when connecting.
    */
   readonly port: number;


### PR DESCRIPTION
This lets database drivers reach a Hyperdrive binding when they require the connection host to be an IP literal rather than a hostname.

Today `Hyperdrive.host` returns a magic `<random>.hyperdrive.local` hostname, and `cloudflare:sockets` `connect()` routes `host:port` to Hyperdrive via a connect override. Some drivers validate/parse the host as an IP and reject hostnames, so they can't use it.

Each Hyperdrive binding now also generates a synthetic IPv4 address, exposed as a new `Hyperdrive.ip` readonly property:

* The address lives in the reserved `240.0.0.0/4` block (`240.0.x.y`), so it can never collide with a real host a Worker might legitimately connect to. The two random octets identify the binding.
* Connecting to `ip:port` routes to the same place as the hostname — a connect override is registered for both the hostname and the synthetic IP.
* `node:dns` `lookup()` resolves the magic `.hyperdrive.local` hostname to the synthetic IP (via a hostname→IP override on the global scope, queried through `cloudflare-internal:sockets`), so drivers that resolve-then-connect also work. The override is only honoured for IPv4-acceptable lookups (family `0`/`4`).

Both the hostname and IP overrides are registered lazily on first access of `.host`/`.ip` (they require an active `IoContext`), so by the time a driver has a value to use, routing is in place.

Tests cover connecting via the synthetic IP directly and resolving the hostname through `node:dns` before connecting; both assert the connection reaches the Hyperdrive backend. Types snapshot regenerated for the new `ip` field.

_Made with AI assistance under my review_
