### PR TITLE
[build] Use -Wl,--lto-O0 when linking tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@npm//:capnp-es/package_json.bzl", capnp_es_bins = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//:build/wd_cc_embed.bzl", "wd_cc_embed")
 
 # This is used to embed the ICU data file which libicu needs at runtime to do its thing.

--- a/build/config/BUILD.bazel
+++ b/build/config/BUILD.bazel
@@ -20,14 +20,3 @@ config_setting(
     values = {"define": "never_match=true"},  # This will never match
     visibility = ["//visibility:public"],
 )
-
-# Whether rules_rust binaries/tests should link via cc_common.link (see the
-# wd_rust_* macros). Always false standalone; an embedder may override this
-# when it needs these targets to link through the cc toolchain (e.g. to pick
-# up a custom allocator selected via --custom_malloc). Kept off here because
-# standalone workerd builds with non-hermetic system clang.
-config_setting(
-    name = "rust_cc_common_link",
-    values = {"define": "never_match=true"},  # This will never match
-    visibility = ["//visibility:public"],
-)

--- a/build/deps/BUILD
+++ b/build/deps/BUILD
@@ -1,0 +1,56 @@
+# Bazel makes it difficult to define link options so that they can be set to different values for
+# tool/test binaries and across different C++ and Rust binaries – define a common configuration for
+# linker flags for workerd and downstream builds.
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "linkopts_common",
+    # -dead_strip is the macOS equivalent of -ffunction-sections, -Wl,--gc-sections.
+    # -no_exported_symbols is used to not include the exports trie, which significantly reduces
+    # binary sizes. Unfortunately, the flag and the exports trie are poorly documented. Based
+    # on analyzing the binary sections with and without the flag, the information being removed
+    # consists of weak binding info, export binding info and stub bindings as described in
+    # http://www.newosxbook.com/articles/DYLD.html. The flag itself is described in
+    # https://www.wwdcnotes.com/notes/wwdc22/110362/.
+    # The affected sections appear to not be needed for debugging and are only used when
+    # external code needs to look up bindings in a binary, e.g. when loading a plugin
+    # (mac-specific feature). In particular, the symbol table is not affected (the name of the
+    # flag is misleading here).
+    linkopts = select({
+        "@//:use_dead_strip": [
+            "-Wl,-dead_strip",
+            "-Wl,-no_exported_symbols",
+        ],
+        "//conditions:default": [""],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "linkopts_default",
+    # For test binaries, reduce thinLTO optimizations and inlining to speed up linking. This
+    # only has an effect if thinLTO is enabled.
+    # Disabling cross-optimization entirely using -Wl,--lto-O0.
+    linkopts = select({
+        "@platforms//os:linux": ["-Wl,--lto-O0"],
+        "//conditions:default": [""],
+    }),
+    visibility = ["//visibility:public"],
+    # TODO(someday): We previously used turn down thinLTO optimization slightly less – maybe there's
+    # a use case for these settings somewhere still?
+    # linkopts = ["-Wl,--lto-O1", "-Wl,-mllvm,-import-instr-limit=5"],
+    deps = [":linkopts_common"],
+)
+
+# link options to use with tools where we don't want to compromise performance, e.g. workerd.
+cc_library(
+    name = "linkopts_tool",
+    # Increase thinLTO parallelism so tool binaries are less of a bottleneck during builds.
+    linkopts = select({
+        "@platforms//os:linux": ["-Wl,--thinlto-jobs=8"],
+        "//conditions:default": [""],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":linkopts_common"],
+)

--- a/build/kj_test.bzl
+++ b/build/kj_test.bzl
@@ -16,18 +16,11 @@ def kj_test(
         srcs = [src],
         deps = [
             "@capnp-cpp//src/kj:kj-test",
+            "//build/deps:linkopts_default",
         ] + deps,
         linkstatic = select({
             "@platforms//os:linux": 0,
             "//conditions:default": 1,
-        }),
-        # For test binaries, reduce thinLTO optimizations and inlining to speed up linking. This
-        # only has an effect if thinLTO is enabled. Also apply dead_strip on macOS to manage binary
-        # sizes.
-        linkopts = select({
-            "@platforms//os:linux": ["-Wl,--lto-O1", "-Wl,-mllvm,-import-instr-limit=5"],
-            "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
-            "//conditions:default": [""],
         }),
         data = data,
         tags = tags,

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -4,7 +4,6 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 def wd_cc_benchmark(
         name,
-        linkopts = [],
         deps = [],
         tags = [],
         visibility = None,
@@ -21,14 +20,13 @@ def wd_cc_benchmark(
             "@platforms//os:linux": 0,
             "//conditions:default": 1,
         }),
-        linkopts = linkopts + select({
-            "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
-            "//conditions:default": [""],
-        }),
         visibility = visibility,
         deps = deps + [
             "@google_benchmark//:benchmark_main",
             "//src/workerd/tests:bench-tools",
+            # Use same linker flags as with test binaries – wd_cc_benchmark is used with
+            # microbenchmarks, which will produce relatively accurate results without thinLTO.
+            "//build/deps:linkopts_default",
         ],
         # use the same malloc we use for server
         malloc = "//src/workerd/server:malloc",

--- a/build/wd_cc_binary.bzl
+++ b/build/wd_cc_binary.bzl
@@ -4,7 +4,6 @@ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 
 def wd_cc_binary(
         name,
-        linkopts = [],
         visibility = None,
         deps = [],
         target_compatible_with = [],
@@ -13,27 +12,12 @@ def wd_cc_binary(
     """
     cc_binary(
         name = name,
-        # -dead_strip is the macOS equivalent of -ffunction-sections, -Wl,--gc-sections.
-        # -no_exported_symbols is used to not include the exports trie, which significantly reduces
-        # binary sizes. Unfortunately, the flag and the exports trie are poorly documented. Based
-        # on analyzing the binary sections with and without the flag, the information being removed
-        # consists of weak binding info, export binding info and stub bindings as described in
-        # http://www.newosxbook.com/articles/DYLD.html. The flag itself is described in
-        # https://www.wwdcnotes.com/notes/wwdc22/110362/.
-        # The affected sections appear to not be needed for debugging and are only used when
-        # external code needs to look up bindings in a binary, e.g. when loading a plugin
-        # (mac-specific feature). In particular, the symbol table is not affected (the name of the
-        # flag is misleading here).
-        linkopts = linkopts + select({
-            "@//:use_dead_strip": ["-Wl,-dead_strip", "-Wl,-no_exported_symbols"],
-            "//conditions:default": [""],
-        }),
         target_compatible_with = select({
             "@//build/config:no_build": ["@platforms//:incompatible"],
             "//conditions:default": [],
         }) + target_compatible_with,
         visibility = visibility,
-        deps = deps,
+        deps = deps + ["//build/deps:linkopts_tool"],
         **kwargs
     )
 

--- a/build/wd_rust_binary.bzl
+++ b/build/wd_rust_binary.bzl
@@ -53,19 +53,16 @@ def wd_rust_binary(
         srcs = srcs,
         rustc_env = rustc_env,
         deps = deps,
-        link_deps = link_deps,
+        # wd_rust_binary is not used for the workerd production binary so far – apply default
+        # optimization instead of linkopts_tool
+        link_deps = link_deps + ["//build/deps:linkopts_default"],
         visibility = visibility,
         data = data,
+        experimental_use_cc_common_link = 1,
         proc_macro_deps = proc_macro_deps,
         target_compatible_with = select({
             "@//build/config:no_build": ["@platforms//:incompatible"],
             "//conditions:default": [],
-        }),
-        # Optionally link via cc_common.link so embedder-selected cc link settings
-        # (e.g. --custom_malloc) take effect. Off standalone (see //build/config).
-        experimental_use_cc_common_link = select({
-            "@//build/config:rust_cc_common_link": 1,
-            "//conditions:default": -1,
         }),
     )
 
@@ -83,12 +80,8 @@ def wd_rust_binary(
             "@//build/config:no_build": ["@platforms//:incompatible"],
             "//conditions:default": [],
         }),
+        experimental_use_cc_common_link = 1,
+        link_deps = ["//build/deps:linkopts_default"],
         size = test_size,
         tags = ["no-coverage"],
-        # Optionally link via cc_common.link so embedder-selected cc link settings
-        # (e.g. --custom_malloc) take effect. Off standalone (see //build/config).
-        experimental_use_cc_common_link = select({
-            "@//build/config:rust_cc_common_link": 1,
-            "//conditions:default": -1,
-        }),
     )

--- a/build/wd_rust_crate.bzl
+++ b/build/wd_rust_crate.bzl
@@ -163,15 +163,11 @@ def wd_rust_crate(
         } | test_env,
         size = test_size,
         tags = test_tags + ["no-coverage"],
+        experimental_use_cc_common_link = 1,
         crate_features = crate_features,
         deps = test_deps,
+        link_deps = ["//build/deps:linkopts_default"],
         proc_macro_deps = test_proc_macro_deps,
-        # Optionally link via cc_common.link so embedder-selected cc link settings
-        # (e.g. --custom_malloc) take effect. Off standalone (see //build/config).
-        experimental_use_cc_common_link = select({
-            "@//build/config:rust_cc_common_link": 1,
-            "//conditions:default": -1,
-        }),
     )
 
     if len(proc_macro_deps) + len(cxx_bridge_srcs) > 0:

--- a/build/wd_rust_proc_macro.bzl
+++ b/build/wd_rust_proc_macro.bzl
@@ -45,6 +45,8 @@ def wd_rust_proc_macro(
             # our tests are usually very heavy and do not support concurrent invocation
             "RUST_TEST_THREADS": "1",
         } | test_env,
+        experimental_use_cc_common_link = 1,
         tags = test_tags + ["no-coverage"],
         deps = test_deps,
+        link_deps = ["@@//deps:rust_runtime", "//build/deps:linkopts_default"],
     )


### PR DESCRIPTION
As part of keeping linker options in one place to avoid duplication. Also unconditionally enable experimental_use_cc_common_link, which is hopefully supported across platforms now.