### PR TITLE
Fix Buffer *Write methods to default omitted length to remaining space

### DIFF
--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -919,7 +919,10 @@ Buffer.prototype.asciiWrite = function asciiWrite(
   length?: number
 ) {
   offset ??= 0;
-  length ??= this.length;
+  // Default an omitted length to the space remaining after offset, not the full
+  // buffer size, so a two-argument call with a non-zero offset doesn't throw.
+  // Matches Node.js. See https://github.com/cloudflare/workerd/issues/6875
+  length ??= this.length - offset;
   validateOffset(offset as number, 'offset', 0, this.length);
   validateOffset(length as number, 'length', 0, this.length - offset);
   return bufferUtil.write(
@@ -937,7 +940,7 @@ Buffer.prototype.base64Write = function base64Write(
   length?: number
 ) {
   offset ??= 0;
-  length ??= this.length;
+  length ??= this.length - offset;
   validateOffset(offset as number, 'offset', 0, this.length);
   validateOffset(length as number, 'length', 0, this.length - offset);
   return bufferUtil.write(
@@ -955,7 +958,7 @@ Buffer.prototype.base64urlWrite = function base64urlWrite(
   length?: number
 ) {
   offset ??= 0;
-  length ??= this.length;
+  length ??= this.length - offset;
   validateOffset(offset as number, 'offset', 0, this.length);
   validateOffset(length as number, 'length', 0, this.length - offset);
   return bufferUtil.write(
@@ -973,7 +976,7 @@ Buffer.prototype.hexWrite = function hexWrite(
   length: number
 ) {
   offset ??= 0;
-  length ??= this.length;
+  length ??= this.length - offset;
   validateOffset(offset as number, 'offset', 0, this.length);
   validateOffset(length as number, 'length', 0, this.length - offset);
   return bufferUtil.write(
@@ -991,7 +994,7 @@ Buffer.prototype.latin1Write = function latin1Write(
   length: number
 ) {
   offset ??= 0;
-  length ??= this.length;
+  length ??= this.length - offset;
   validateOffset(offset as number, 'offset', 0, this.length);
   validateOffset(length as number, 'length', 0, this.length - offset);
   return bufferUtil.write(
@@ -1009,7 +1012,7 @@ Buffer.prototype.ucs2Write = function ucs2Write(
   length: number
 ) {
   offset ??= 0;
-  length ??= this.length;
+  length ??= this.length - offset;
   validateOffset(offset as number, 'offset', 0, this.length);
   validateOffset(length as number, 'length', 0, this.length - offset);
   return bufferUtil.write(
@@ -1027,7 +1030,7 @@ Buffer.prototype.utf8Write = function utf8Write(
   length: number
 ) {
   offset ??= 0;
-  length ??= this.length;
+  length ??= this.length - offset;
   validateOffset(offset as number, 'offset', 0, this.length);
   validateOffset(length as number, 'length', 0, this.length - offset);
   return bufferUtil.write(

--- a/src/workerd/api/node/tests/buffer-nodejs-test.js
+++ b/src/workerd/api/node/tests/buffer-nodejs-test.js
@@ -6262,3 +6262,50 @@ export const invalidThisTests = {
     ok(new bufferModule.Blob([]));
   },
 };
+
+// Ref: https://github.com/cloudflare/workerd/issues/6875
+// The encoding-specific write methods must default an omitted `length` to the
+// bytes remaining after `offset` (this.length - offset), not the full buffer
+// size. Before the fix, any two-argument call with a non-zero offset threw
+// ERR_OUT_OF_RANGE, which broke callers like protobufjs.
+export const writeMethodsDefaultLength = {
+  test() {
+    // A representative valid input per encoding, all decoding to bytes that fit
+    // in the 5 bytes remaining after offset 5 in a 10-byte buffer.
+    const inputs = {
+      asciiWrite: 'hi',
+      base64Write: 'aGk=', // -> "hi"
+      base64urlWrite: 'aGk', // -> "hi"
+      hexWrite: '4869', // -> "Hi"
+      latin1Write: 'hi',
+      ucs2Write: 'h', // 2 bytes per char
+      utf8Write: 'hi',
+    };
+
+    for (const [method, input] of Object.entries(inputs)) {
+      // Omitting `length` with a non-zero offset must not throw, and must not
+      // write past the space remaining after `offset`.
+      const buf = Buffer.alloc(10);
+      const written = buf[method](input, 5);
+      ok(
+        written > 0,
+        `${method}: expected a non-zero byte count, got ${written}`
+      );
+      ok(
+        written <= buf.length - 5,
+        `${method}: wrote ${written} bytes, past the remaining space`
+      );
+    }
+
+    // Spot-check the actual bytes for utf8Write: "hi" at offset 5.
+    const buf = Buffer.alloc(10);
+    strictEqual(buf.utf8Write('hi', 5), 2);
+    strictEqual(buf[5], 0x68); // 'h'
+    strictEqual(buf[6], 0x69); // 'i'
+
+    // Offset defaults to 0 and length still defaults to the whole buffer.
+    const buf2 = Buffer.alloc(4);
+    strictEqual(buf2.utf8Write('abcd'), 4);
+    strictEqual(buf2.toString(), 'abcd');
+  },
+};


### PR DESCRIPTION
## What

The encoding-specific `Buffer` write methods (`asciiWrite`, `base64Write`,
`base64urlWrite`, `hexWrite`, `latin1Write`, `ucs2Write`, `utf8Write`)
defaulted an omitted `length` to the full buffer size, then validated it
against the space remaining after `offset`. Any two-argument call with a
non-zero offset therefore threw:

RangeError [ERR_OUT_OF_RANGE]: The value of "length" is out of range.
It must be >= 0 && <= 9. Received 10


This breaks real callers - notably protobufjs ≥ 7.6.0, which calls
`buf.utf8Write(val, pos)` during encoding.

## Fix

Default the omitted `length` to `this.length - offset` in all seven
methods, matching Node.js (which itself hit and reverted this exact bug
class between v22.7.0 and v22.8.0, nodejs/node#54523).

## Testing

Adds `writeMethodsDefaultLength` to `buffer-nodejs-test.js`, exercising all
seven methods with a non-zero offset and omitted length, plus a byte-level
spot check for `utf8Write`. The expected results were cross-checked against
Node.js.

Fixes #6875 