### PR TITLE
Improve URL redaction in tail logs

### DIFF
--- a/src/workerd/api/util-test.c++
+++ b/src/workerd/api/util-test.c++
@@ -57,6 +57,31 @@ KJ_TEST("redactUrl can detect base64 ids") {
   expectUnredacted("https://domain/IThinkIShallNeverSee0/x"_kj);
 }
 
+KJ_TEST("redactUrl can detect payment card numbers") {
+  expectRedacted(
+      "https://domain/path?number=4222222222222"_kj, "https://domain/path?number=REDACTED"_kj);
+  expectRedacted(
+      "https://domain/path?number=30569309025904"_kj, "https://domain/path?number=REDACTED"_kj);
+  expectRedacted(
+      "https://domain/path?number=378282246310005"_kj, "https://domain/path?number=REDACTED"_kj);
+  expectRedacted(
+      "https://domain/path?number=4111111111111111"_kj, "https://domain/path?number=REDACTED"_kj);
+  expectRedacted("https://domain/path?number=4000000000000000006"_kj,
+      "https://domain/path?number=REDACTED"_kj);
+
+  // URL-safe separators do not affect the checksum.
+  expectRedacted("https://domain/path?number=4111-1111-1111-1111"_kj,
+      "https://domain/path?number=REDACTED"_kj);
+  expectRedacted("https://domain/path?number=4111+1111+1111+1111"_kj,
+      "https://domain/path?number=REDACTED"_kj);
+
+  // Numeric identifiers which fail Luhn validation are preserved.
+  expectUnredacted("https://domain/path?number=4111111111111112"_kj);
+
+  // Luhn-valid values outside the 13 to 19 digit PAN range are preserved.
+  expectUnredacted("https://domain/path?short=79927398713&long=40000000000000000002"_kj);
+}
+
 KJ_TEST("readContentTypeParameter can fetch boundary parameter") {
 
   // normal

--- a/src/workerd/api/util.c++
+++ b/src/workerd/api/util.c++
@@ -137,6 +137,34 @@ kj::Own<kj::AsyncInputStream> newTeeErrorAdapter(kj::Own<kj::AsyncInputStream> i
   }
 }
 
+namespace {
+
+bool isLuhnPan(kj::ArrayPtr<const char> span) {
+  uint digitCount = 0;
+  uint sum = 0;
+  bool shouldDouble = false;
+
+  for (size_t i = span.size(); i > 0; --i) {
+    char c = span[i - 1];
+    if (c == '+' || c == '-' || c == '_') continue;
+    if (c < '0' || c > '9') return false;
+
+    uint digit = c - '0';
+    if (shouldDouble) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+
+    sum += digit;
+    digitCount++;
+    shouldDouble = !shouldDouble;
+  }
+
+  return digitCount >= 13 && digitCount <= 19 && sum % 10 == 0;
+}
+
+}  // namespace
+
 kj::String redactUrl(kj::StringPtr url) {
   kj::Vector<char> redacted(url.size() + 1);
   const char* spanStart = url.begin();
@@ -151,7 +179,7 @@ kj::String redactUrl(kj::StringPtr url) {
     bool probablyBase64Id =
         (span.size() >= 21 && digitCount >= 2 && upperCount >= 2 && lowerCount >= 2);
 
-    if (isHexId || probablyBase64Id) {
+    if (isHexId || probablyBase64Id || isLuhnPan(span)) {
       redacted.addAll("REDACTED"_kj);
     } else {
       redacted.addAll(span);

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -81,6 +81,7 @@ kj::Own<kj::AsyncInputStream> newTeeErrorAdapter(kj::Own<kj::AsyncInputStream> i
 //   - Any run of hex characters of 32 or more digits, ignoring potential "+-_" separators
 //   - Any run of base64 characters of 21 or more digits, including at least
 //     two each of digits, capital letters, and lowercase letters.
+//   - Any 13 to 19 digit value with a valid Luhn checksum.
 // Such ids are replaced with the text "REDACTED".
 kj::String redactUrl(kj::StringPtr url);
 


### PR DESCRIPTION
Extends URL redaction to cover additional checksum-valid numeric values.

Internal counterpart tracks the same behavior.