### PR TITLE
fix(node:dns): handle CAA/NAPTR presentation format from 1.1.1.1 DoH API

### DIFF
--- a/src/rust/api/dns.rs
+++ b/src/rust/api/dns.rs
@@ -116,6 +116,28 @@ pub fn parse_replacement(input: &[&str]) -> jsg::Result<String, DnsParserError> 
     Ok(output.join("."))
 }
 
+
+/// Splits the first whitespace-delimited token from `s`.
+/// Returns `(token, rest)` where `rest` is trimmed of leading whitespace.
+fn split_first_token(s: &str) -> Option<(&str, &str)> {
+    let s = s.trim_start();
+    if s.is_empty() { return None; }
+    let end = s.find(|c: char| c.is_ascii_whitespace()).unwrap_or(s.len());
+    Some((&s[..end], s[end..].trim_start()))
+}
+
+/// Extracts the next double-quoted token from `s`.
+/// Returns `(content_without_quotes, rest)` trimmed of leading whitespace.
+/// The quoted string may contain internal whitespace.
+fn next_quoted(s: &str) -> Option<(&str, &str)> {
+    let s = s.trim_start();
+    if !s.starts_with('"') { return None; }
+    let close = s[1..].find('"')? + 1;
+    let content = &s[1..close];
+    let rest = s[close + 1..].trim_start();
+    Some((content, rest))
+}
+
 #[jsg_resource]
 pub struct DnsUtil;
 
@@ -149,44 +171,78 @@ impl DnsUtil {
     /// # Errors
     /// `DnsParserError::InvalidHexString`
     /// `DnsParserError::ParseIntError`
+    /// Parses a CAA record. Supports both the RFC 3597 generic hex encoding
+    /// (old format: `\# <length> <hex bytes>`) and the presentation format
+    /// introduced in the 1.1.1.1 DoH JSON API rollout of 2026-07-28
+    /// (new format: `0 issue "pki.goog"`).
+    ///
+    /// CAA values can contain whitespace (e.g. `"digicert.com; params=yes"`),
+    /// so the value is extracted with surrounding quotes stripped rather than
+    /// whitespace-split.
     #[jsg_method]
     pub fn parse_caa_record(&self, record: String) -> Result<CaaRecord, DnsParserError> {
-        // Let's remove "\\#" and the length of data from the beginning of the record
-        let parts: Vec<_> = record.split_ascii_whitespace().collect();
-        if parts.len() < 3 {
-            return Err(DnsParserError::InvalidDnsResponse(
-                "CAA record too short: expected at least 3 fields".to_owned(),
-            ));
-        }
-        let data = parts[2..].to_vec();
-        if data.len() < 2 {
-            return Err(DnsParserError::InvalidDnsResponse(
-                "CAA record data too short: expected critical and prefix length fields".to_owned(),
-            ));
-        }
-        let critical = data[0].parse::<u8>()?;
-        let prefix_length = data[1].parse::<usize>()?;
+        let trimmed = record.trim();
 
-        if data.len() < 2 + prefix_length {
-            return Err(DnsParserError::InvalidDnsResponse(format!(
-                "CAA record data too short for prefix_length {prefix_length}"
-            )));
-        }
-        let field = decode_hex(&data[2..prefix_length + 2])?.join("");
-        let value = decode_hex(&data[(prefix_length + 2)..])?.join("");
+        if trimmed.starts_with("\\#") {
+            // RFC 3597 generic hex: \# <length> <hex bytes...>
+            let parts: Vec<_> = trimmed.split_ascii_whitespace().collect();
+            if parts.len() < 3 {
+                return Err(DnsParserError::InvalidDnsResponse(
+                    "CAA record too short: expected at least 3 fields".to_owned(),
+                ));
+            }
+            let data = parts[2..].to_vec();
+            if data.len() < 2 {
+                return Err(DnsParserError::InvalidDnsResponse(
+                    "CAA record data too short: expected critical and prefix length fields".to_owned(),
+                ));
+            }
+            let critical = data[0].parse::<u8>()?;
+            let prefix_length = data[1].parse::<usize>()?;
+            if data.len() < 2 + prefix_length {
+                return Err(DnsParserError::InvalidDnsResponse(format!(
+                    "CAA record data too short for prefix_length {prefix_length}"
+                )));
+            }
+            let field = decode_hex(&data[2..prefix_length + 2])?.join("");
+            let value = decode_hex(&data[(prefix_length + 2)..])?.join("");
+            if field != "issuewild" && field != "issue" && field != "iodef" {
+                return Err(DnsParserError::InvalidDnsResponse(format!(
+                    "Received unknown field '{field}'"
+                )));
+            }
+            Ok(CaaRecord { critical, field, value })
+        } else {
+            // Presentation format: <critical> <tag> "<value>"
+            // Value may contain whitespace, so parse tokens manually.
+            let (critical_str, rest) = split_first_token(trimmed).ok_or_else(|| {
+                DnsParserError::InvalidDnsResponse(
+                    "CAA presentation format: missing critical field".to_owned(),
+                )
+            })?;
+            let critical = critical_str.parse::<u8>()?;
 
-        // Field can be "issuewild", "issue" or "iodef"
-        if field != "issuewild" && field != "issue" && field != "iodef" {
-            return Err(DnsParserError::InvalidDnsResponse(format!(
-                "Received unknown field '{field}'"
-            )));
-        }
+            let (field, rest) = split_first_token(rest).ok_or_else(|| {
+                DnsParserError::InvalidDnsResponse(
+                    "CAA presentation format: missing tag field".to_owned(),
+                )
+            })?;
+            let field = field.to_owned();
 
-        Ok(CaaRecord {
-            critical,
-            field,
-            value,
-        })
+            let value_raw = rest.trim();
+            let value = if value_raw.len() >= 2 && value_raw.starts_with('"') && value_raw.ends_with('"') {
+                value_raw[1..value_raw.len() - 1].to_owned()
+            } else {
+                value_raw.to_owned()
+            };
+
+            if field != "issuewild" && field != "issue" && field != "iodef" {
+                return Err(DnsParserError::InvalidDnsResponse(format!(
+                    "Received unknown field '{field}'"
+                )));
+            }
+            Ok(CaaRecord { critical, field, value })
+        }
     }
 
     /// Parses an unknown RR format returned from Cloudflare DNS.
@@ -220,65 +276,98 @@ impl DnsUtil {
     /// # Errors
     /// `DnsParserError::InvalidHexString`
     /// `DnsParserError::ParseIntError`
+    /// Parses a NAPTR record. Supports both the RFC 3597 generic hex encoding
+    /// and the presentation format introduced in the 1.1.1.1 DoH JSON API
+    /// rollout of 2026-07-28 (e.g. `100 10 "s" "SIP+D2U" "" _sip._udp.example.com.`).
+    ///
+    /// The replacement trailing dot is stripped to match Node.js behaviour.
     #[jsg_method]
     pub fn parse_naptr_record(&self, record: String) -> jsg::Result<NaptrRecord, DnsParserError> {
-        let parts: Vec<_> = record.split_ascii_whitespace().collect();
-        if parts.len() < 2 {
-            return Err(DnsParserError::InvalidDnsResponse(
-                "NAPTR record too short".to_owned(),
-            ));
+        let trimmed = record.trim();
+
+        if trimmed.starts_with("\\#") {
+            // RFC 3597 generic hex encoding.
+            let parts: Vec<_> = trimmed.split_ascii_whitespace().collect();
+            if parts.len() < 2 {
+                return Err(DnsParserError::InvalidDnsResponse("NAPTR record too short".to_owned()));
+            }
+            let data = parts[1..].to_vec();
+            if data.len() < 6 {
+                return Err(DnsParserError::InvalidDnsResponse(
+                    "NAPTR record data too short: expected at least 6 fields".to_owned(),
+                ));
+            }
+            let order_str = data[1..3].to_vec();
+            let order = u32::from_str_radix(&order_str.join(""), 16)?;
+            let preference_str = data[3..5].to_vec();
+            let preference = u32::from_str_radix(&preference_str.join(""), 16)?;
+            let flag_length = usize::from_str_radix(data[5], 16)?;
+            let flag_offset = 6;
+            if data.len() < flag_offset + flag_length + 1 {
+                return Err(DnsParserError::InvalidDnsResponse(
+                    "NAPTR record too short for flags field".to_owned(),
+                ));
+            }
+            let flags = decode_hex(&data[flag_offset..flag_length + flag_offset])?.join("");
+            let service_length = usize::from_str_radix(data[flag_offset + flag_length], 16)?;
+            let service_offset = flag_offset + flag_length + 1;
+            if data.len() < service_offset + service_length + 1 {
+                return Err(DnsParserError::InvalidDnsResponse(
+                    "NAPTR record too short for service field".to_owned(),
+                ));
+            }
+            let service = decode_hex(&data[service_offset..service_length + service_offset])?.join("");
+            let regexp_length = usize::from_str_radix(data[service_offset + service_length], 16)?;
+            let regexp_offset = service_offset + service_length + 1;
+            if data.len() < regexp_offset + regexp_length {
+                return Err(DnsParserError::InvalidDnsResponse(
+                    "NAPTR record too short for regexp field".to_owned(),
+                ));
+            }
+            let regexp = decode_hex(&data[regexp_offset..regexp_length + regexp_offset])?.join("");
+            let replacement = parse_replacement(&data[regexp_offset + regexp_length..])?;
+            Ok(NaptrRecord { flags, service, regexp, replacement, order, preference })
+        } else {
+            // Presentation format: <order> <preference> "<flags>" "<service>" "<regexp>" <replacement>
+            let (order_str, rest) = split_first_token(trimmed).ok_or_else(|| {
+                DnsParserError::InvalidDnsResponse("NAPTR presentation format: missing order".to_owned())
+            })?;
+            let order = order_str.parse::<u32>()?;
+
+            let (pref_str, rest) = split_first_token(rest).ok_or_else(|| {
+                DnsParserError::InvalidDnsResponse("NAPTR presentation format: missing preference".to_owned())
+            })?;
+            let preference = pref_str.parse::<u32>()?;
+
+            let (flags, rest) = next_quoted(rest).ok_or_else(|| {
+                DnsParserError::InvalidDnsResponse("NAPTR presentation format: missing or malformed flags field".to_owned())
+            })?;
+            let (service, rest) = next_quoted(rest).ok_or_else(|| {
+                DnsParserError::InvalidDnsResponse("NAPTR presentation format: missing or malformed service field".to_owned())
+            })?;
+            let (regexp, rest) = next_quoted(rest).ok_or_else(|| {
+                DnsParserError::InvalidDnsResponse("NAPTR presentation format: missing or malformed regexp field".to_owned())
+            })?;
+
+            // Strip trailing dot from replacement (DNS presentation convention).
+            let replacement_raw = rest.trim();
+            let replacement = if replacement_raw == "." {
+                String::new()
+            } else if replacement_raw.ends_with('.') {
+                replacement_raw[..replacement_raw.len() - 1].to_owned()
+            } else {
+                replacement_raw.to_owned()
+            };
+
+            Ok(NaptrRecord {
+                flags: flags.to_owned(),
+                service: service.to_owned(),
+                regexp: regexp.to_owned(),
+                replacement,
+                order,
+                preference,
+            })
         }
-        let data = parts[1..].to_vec();
-
-        // Need at least: length(1) + order(2) + preference(2) + flag_length(1) = 6 fields
-        if data.len() < 6 {
-            return Err(DnsParserError::InvalidDnsResponse(
-                "NAPTR record data too short: expected at least 6 fields".to_owned(),
-            ));
-        }
-
-        let order_str = data[1..3].to_vec();
-        let order = u32::from_str_radix(&order_str.join(""), 16)?;
-        let preference_str = data[3..5].to_vec();
-        let preference = u32::from_str_radix(&preference_str.join(""), 16)?;
-
-        let flag_length = usize::from_str_radix(data[5], 16)?;
-        let flag_offset = 6;
-        if data.len() < flag_offset + flag_length + 1 {
-            return Err(DnsParserError::InvalidDnsResponse(
-                "NAPTR record too short for flags field".to_owned(),
-            ));
-        }
-        let flags = decode_hex(&data[flag_offset..flag_length + flag_offset])?.join("");
-
-        let service_length = usize::from_str_radix(data[flag_offset + flag_length], 16)?;
-        let service_offset = flag_offset + flag_length + 1;
-        if data.len() < service_offset + service_length + 1 {
-            return Err(DnsParserError::InvalidDnsResponse(
-                "NAPTR record too short for service field".to_owned(),
-            ));
-        }
-        let service = decode_hex(&data[service_offset..service_length + service_offset])?.join("");
-
-        let regexp_length = usize::from_str_radix(data[service_offset + service_length], 16)?;
-        let regexp_offset = service_offset + service_length + 1;
-        if data.len() < regexp_offset + regexp_length {
-            return Err(DnsParserError::InvalidDnsResponse(
-                "NAPTR record too short for regexp field".to_owned(),
-            ));
-        }
-        let regexp = decode_hex(&data[regexp_offset..regexp_length + regexp_offset])?.join("");
-
-        let replacement = parse_replacement(&data[regexp_offset + regexp_length..])?;
-
-        Ok(NaptrRecord {
-            flags,
-            service,
-            regexp,
-            replacement,
-            order,
-            preference,
-        })
     }
 }
 
@@ -439,4 +528,68 @@ mod tests {
                 .is_err()
         );
     }
+    // --- CAA presentation format (post 2026-07-28) ---
+
+    #[test]
+    fn test_parse_caa_record_presentation_simple() {
+        let dns_util = DnsUtil {};
+        let record = dns_util.parse_caa_record(r#"0 issue "pki.goog""#.to_owned()).unwrap();
+        assert_eq!(record.critical, 0);
+        assert_eq!(record.field, "issue");
+        assert_eq!(record.value, "pki.goog");
+    }
+
+    #[test]
+    fn test_parse_caa_record_presentation_value_with_whitespace() {
+        let dns_util = DnsUtil {};
+        let record = dns_util
+            .parse_caa_record(r#"0 issue "digicert.com; cansignhttpexchanges=yes""#.to_owned())
+            .unwrap();
+        assert_eq!(record.critical, 0);
+        assert_eq!(record.field, "issue");
+        assert_eq!(record.value, "digicert.com; cansignhttpexchanges=yes");
+    }
+
+    #[test]
+    fn test_parse_caa_record_presentation_issuewild() {
+        let dns_util = DnsUtil {};
+        let record = dns_util.parse_caa_record(r#"0 issuewild "letsencrypt.org""#.to_owned()).unwrap();
+        assert_eq!(record.critical, 0);
+        assert_eq!(record.field, "issuewild");
+        assert_eq!(record.value, "letsencrypt.org");
+    }
+
+    #[test]
+    fn test_parse_caa_record_presentation_invalid_tag() {
+        assert!(DnsUtil {}.parse_caa_record(r#"0 badtag "example.com""#.to_owned()).is_err());
+    }
+
+    // --- NAPTR presentation format (post 2026-07-28) ---
+
+    #[test]
+    fn test_parse_naptr_record_presentation_basic() {
+        let dns_util = DnsUtil {};
+        let record = dns_util
+            .parse_naptr_record(r#"100 10 "s" "SIP+D2U" "" _sip._udp.example.com."#.to_owned())
+            .unwrap();
+        assert_eq!(record.order, 100);
+        assert_eq!(record.preference, 10);
+        assert_eq!(record.flags, "s");
+        assert_eq!(record.service, "SIP+D2U");
+        assert_eq!(record.regexp, "");
+        assert_eq!(record.replacement, "_sip._udp.example.com");
+    }
+
+    #[test]
+    fn test_parse_naptr_record_presentation_with_regexp() {
+        let dns_util = DnsUtil {};
+        let record = dns_util
+            .parse_naptr_record(r#"100 10 "u" "E2U+sip" "!^.*$!sip:info@example.com!i" ."#.to_owned())
+            .unwrap();
+        assert_eq!(record.order, 100);
+        assert_eq!(record.flags, "u");
+        assert_eq!(record.regexp, "!^.*$!sip:info@example.com!i");
+        assert_eq!(record.replacement, "");
+    }
+
 }


### PR DESCRIPTION
The 1.1.1.1 DoH JSON API is rolling out a new presentation-format encoding (changelog 2026-07-28), replacing RFC 3597 generic hex with standard presentation format:

  CAA:   0 issue "pki.goog"
  NAPTR: 100 10 "s" "SIP+D2U" "" _sip._udp.example.com.

parse_caa_record and parse_naptr_record only understood the old hex encoding, causing dns.resolveCaa() and dns.resolveNaptr() to throw errors on colos already serving the new format.

Fix: branch on whether the record starts with '\#'. Hex path is unchanged; presentation format is parsed with two new helper functions (split_first_token, next_quoted).

Two format-specific traps handled:
- CAA values can contain whitespace (e.g. digicert.com; params=yes)
- NAPTR replacement has a trailing dot that must be stripped

Adds 6 new tests covering both encodings and edge cases.

Fixes: #6912