### PR TITLE
Don't let a failed accept() take the server down

### DIFF
--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -3958,6 +3958,119 @@ KJ_TEST("Server: drain incoming HTTP connections") {
 }
 
 // =======================================================================================
+// Tolerating accept() failures
+
+// A listener whose accept() fails a given number of times before handing out the connections the
+// test has queued on it.
+class FlakyConnectionReceiver final: public kj::ConnectionReceiver {
+ public:
+  explicit FlakyConnectionReceiver(uint failuresRemaining): failuresRemaining(failuresRemaining) {}
+
+  void queueConnection(kj::Own<kj::AsyncIoStream> stream) {
+    pending = kj::mv(stream);
+  }
+
+  kj::Promise<kj::Own<kj::AsyncIoStream>> accept() override {
+    if (failuresRemaining > 0) {
+      --failuresRemaining;
+      return KJ_EXCEPTION(FAILED, "simulated accept() failure");
+    }
+
+    KJ_IF_SOME(stream, pending) {
+      auto result = kj::mv(stream);
+      pending = kj::none;
+      return kj::mv(result);
+    }
+
+    return kj::NEVER_DONE;
+  }
+
+  uint getPort() override {
+    return 0;
+  }
+
+ private:
+  uint failuresRemaining;
+  kj::Maybe<kj::Own<kj::AsyncIoStream>> pending;
+};
+
+// Swallows the warnings logged for each retried accept() and counts them, so that a test can assert
+// on how many retries happened without the messages cluttering the test output.
+class AcceptRetryCounter final: public kj::ExceptionCallback {
+ public:
+  uint count = 0;
+
+  void logMessage(kj::LogSeverity severity,
+      const char* file,
+      int line,
+      int contextDepth,
+      kj::String&& text) override {
+    if (severity == kj::LogSeverity::WARNING && text.contains("accept() failed, retrying"_kj)) {
+      ++count;
+      return;
+    }
+    kj::ExceptionCallback::logMessage(severity, file, line, contextDepth, kj::mv(text));
+  }
+};
+
+constexpr kj::StringPtr HELLO_WORKER = R"((
+  compatibilityDate = "2022-08-17",
+  serviceWorkerScript =
+      `addEventListener("fetch", event => {
+      `  event.respondWith(new Response("hello"));
+      `})
+))"_kj;
+
+KJ_TEST("Server: transient accept() failures are retried") {
+  TestServer test(singleWorker(HELLO_WORKER));
+
+  auto receiver = kj::heap<FlakyConnectionReceiver>(3);
+  auto& receiverRef = *receiver;
+  test.server.overrideSocket(kj::str("main"), kj::mv(receiver));
+
+  // Queue a connection for the listener to hand over once it stops failing.
+  auto pipe = kj::newTwoWayPipe();
+  receiverRef.queueConnection(kj::mv(pipe.ends[0]));
+
+  AcceptRetryCounter retries;
+
+  test.start();
+
+  // Let the retry delays elapse.
+  test.wait(1);
+
+  KJ_EXPECT(retries.count == 3);
+
+  // The listener recovered, so the queued connection is served as usual.
+  TestStream conn(test.getWaitScope(), kj::mv(pipe.ends[1]));
+  conn.httpGet200("/", "hello");
+}
+
+KJ_TEST("Server: an accept() that never succeeds shuts the server down") {
+  TestServer test(singleWorker(HELLO_WORKER));
+
+  test.server.overrideSocket(kj::str("main"), kj::heap<FlakyConnectionReceiver>(kj::maxValue));
+
+  // Drive `run()` directly: TestServer::start() treats its failure as a test failure, which is the
+  // very thing we're asserting on here.
+  auto task = test.server.run(v8System, *test.config);
+
+  {
+    AcceptRetryCounter retries;
+    KJ_EXPECT_LOG(ERROR, "fatal task failure, shutting down");
+
+    // Advance through every retry delay.
+    test.wait(1);
+
+    // Retries are finite, so the failure is eventually reported rather than being retried forever.
+    KJ_EXPECT(retries.count > 0);
+  }
+
+  KJ_EXPECT(task.poll(test.ws));
+  KJ_EXPECT_THROW_MESSAGE("simulated accept() failure", task.wait(test.ws));
+}
+
+// =======================================================================================
 // Test alternate service types
 //
 // We're going to stop using JavaScript here because it's not really helping. We can directly

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -6331,20 +6331,113 @@ class Server::TcpListener final: public kj::Refcounted {
   };
 };
 
+namespace {
+
+// A ConnectionReceiver that retries a failed accept() instead of propagating the failure.
+//
+// A failed accept() usually says nothing about the health of the listening socket. The common case
+// is a client that completes the TCP handshake and then resets the connection before we get around
+// to accepting it; the pending connection is already dead by the time we ask for it. KJ's Unix
+// implementation absorbs the errno values that mean this and accepts the next connection instead,
+// but its Windows implementation reports them as exceptions, which would otherwise escape the
+// accept loop and take down a server that is in fact perfectly healthy.
+//
+// Retries are delayed, with the delay growing after each consecutive failure, and give up after
+// MAX_CONSECUTIVE_FAILURES. A listener that is genuinely broken fails every time, so it exhausts
+// the retries and reports the failure promptly rather than spinning forever.
+class TolerantConnectionReceiver final: public kj::ConnectionReceiver {
+ public:
+  TolerantConnectionReceiver(kj::Timer& timer, kj::Own<kj::ConnectionReceiver> inner)
+      : timer(timer),
+        inner(kj::mv(inner)) {}
+
+  kj::Promise<kj::Own<kj::AsyncIoStream>> accept() override {
+    for (;;) {
+      kj::Maybe<kj::Exception> failure;
+      try {
+        auto result = co_await inner->accept();
+        consecutiveFailures = 0;
+        co_return kj::mv(result);
+      } catch (...) {
+        failure = kj::getCaughtExceptionAsKj();
+      }
+      co_await retryAfterFailure(kj::mv(KJ_ASSERT_NONNULL(failure)));
+    }
+  }
+
+  kj::Promise<kj::AuthenticatedStream> acceptAuthenticated() override {
+    for (;;) {
+      kj::Maybe<kj::Exception> failure;
+      try {
+        auto result = co_await inner->acceptAuthenticated();
+        consecutiveFailures = 0;
+        co_return kj::mv(result);
+      } catch (...) {
+        failure = kj::getCaughtExceptionAsKj();
+      }
+      co_await retryAfterFailure(kj::mv(KJ_ASSERT_NONNULL(failure)));
+    }
+  }
+
+  uint getPort() override {
+    return inner->getPort();
+  }
+  void getsockopt(int level, int option, void* value, uint* length) override {
+    inner->getsockopt(level, option, value, length);
+  }
+  void setsockopt(int level, int option, const void* value, uint length) override {
+    inner->setsockopt(level, option, value, length);
+  }
+  void getsockname(struct sockaddr* addr, uint* length) override {
+    inner->getsockname(addr, length);
+  }
+
+ private:
+  static constexpr uint MAX_CONSECUTIVE_FAILURES = 8;
+
+  kj::Timer& timer;
+  kj::Own<kj::ConnectionReceiver> inner;
+  uint consecutiveFailures = 0;
+
+  // Wait for the current retry delay, or rethrow if we've run out of retries.
+  kj::Promise<void> retryAfterFailure(kj::Exception&& exception) {
+    if (++consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      kj::throwFatalException(kj::mv(exception));
+    }
+
+    KJ_LOG(WARNING, "accept() failed, retrying", consecutiveFailures, exception);
+    co_await timer.afterDelay(retryDelay());
+  }
+
+  // Zero for the first failure, so that a connection lost to the usual race doesn't delay the next
+  // one, then 10ms doubling to 320ms. Seven retries therefore span a little over half a second.
+  kj::Duration retryDelay() const {
+    if (consecutiveFailures <= 1) return 0 * kj::MILLISECONDS;
+    return (1u << (consecutiveFailures - 2)) * 10 * kj::MILLISECONDS;
+  }
+};
+
+}  // namespace
+
+kj::Own<kj::ConnectionReceiver> Server::tolerateTransientAcceptFailures(
+    kj::Own<kj::ConnectionReceiver> listener) {
+  return kj::heap<TolerantConnectionReceiver>(timer, kj::mv(listener));
+}
+
 kj::Promise<void> Server::listenHttp(kj::Own<kj::ConnectionReceiver> listener,
     kj::Own<Service> service,
     kj::StringPtr physicalProtocol,
     kj::Own<HttpRewriter> rewriter) {
-  auto obj =
-      kj::refcounted<HttpListener>(*this, kj::mv(listener), kj::mv(service), physicalProtocol,
-          kj::mv(rewriter), globalContext->headerTable, timer, globalContext->httpOverCapnpFactory);
+  auto obj = kj::refcounted<HttpListener>(*this, tolerateTransientAcceptFailures(kj::mv(listener)),
+      kj::mv(service), physicalProtocol, kj::mv(rewriter), globalContext->headerTable, timer,
+      globalContext->httpOverCapnpFactory);
   co_return co_await obj->run();
 }
 
 kj::Promise<void> Server::listenTcp(
     kj::Own<kj::ConnectionReceiver> listener, kj::Own<Service> service, kj::StringPtr addrStr) {
-  auto obj = kj::refcounted<TcpListener>(
-      *this, kj::mv(listener), kj::mv(service), globalContext->headerTable, addrStr);
+  auto obj = kj::refcounted<TcpListener>(*this, tolerateTransientAcceptFailures(kj::mv(listener)),
+      kj::mv(service), globalContext->headerTable, addrStr);
   co_return co_await obj->run();
 }
 
@@ -6479,7 +6572,8 @@ class Server::DebugPortListener {
 };
 
 kj::Promise<void> Server::listenDebugPort(kj::Own<kj::ConnectionReceiver> listener) {
-  DebugPortListener obj(*this, kj::mv(listener), globalContext->httpOverCapnpFactory);
+  DebugPortListener obj(*this, tolerateTransientAcceptFailures(kj::mv(listener)),
+      globalContext->httpOverCapnpFactory);
   co_return co_await obj.run();
 }
 

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -5778,6 +5778,11 @@ kj::Promise<kj::Own<Server::Service>> Server::makeService(config::Service::Reade
 }
 
 void Server::taskFailed(kj::Exception&& exception) {
+  // Every task in this set is essential to the server's operation, so a failure here shuts the
+  // server down. Log before rejecting: `fatalFulfiller`'s rejection propagates out of `run()` to
+  // the top level, and not every platform's `std::terminate()` implementation is able to report
+  // the in-flight exception, so this log is the only guaranteed record of why we died.
+  KJ_LOG(ERROR, "fatal task failure, shutting down", exception);
   fatalFulfiller->reject(kj::mv(exception));
 }
 

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -296,6 +296,11 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
           kj::StringPtr serviceName, kj::Maybe<kj::StringPtr> entrypoint, Frankenvalue props)>
           callback);
 
+  // Wrap a listener so that a failed accept() is retried rather than bringing down the server. A
+  // dead pending connection is not a reason to stop listening; see the implementation for detail.
+  kj::Own<kj::ConnectionReceiver> tolerateTransientAcceptFailures(
+      kj::Own<kj::ConnectionReceiver> listener);
+
   kj::Promise<void> listenHttp(kj::Own<kj::ConnectionReceiver> listener,
       kj::Own<Service> service,
       kj::StringPtr physicalProtocol,

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -1403,7 +1403,7 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
   }
 
   template <typename Func>
-  void serveImpl(Func&& func) noexcept {
+  void serveImpl(Func&& func) {
     if (hadErrors) {
       // Can't start, stuff is broken.
       KJ_IF_SOME(w, watcher) {
@@ -1438,6 +1438,12 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
       WorkerdPlatform v8Platform(*platform);
       jsg::V8System v8System(v8Platform,
           KJ_MAP(flag, config.getV8Flags()) -> kj::StringPtr { return flag; }, platform.get());
+
+      // Server maintains a reference to the V8 platform, which is a local in this scope, so the
+      // server has to go first. This must hold even when we leave the scope by throwing, e.g.
+      // because a fatal task failed.
+      KJ_DEFER(server = nullptr);
+
       auto promise = func(v8System, config);
       KJ_IF_SOME(w, watcher) {
         promise = promise.exclusiveJoin(waitForChanges(w).then([this]() {
@@ -1456,13 +1462,10 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
       if (getenv("KJ_CLEAN_SHUTDOWN") == nullptr) {
         context.exit();
       }
-
-      // Server maintains a reference to the v8 platform. Clean up before destroying the platform.
-      server = nullptr;
     }
   }
 
-  void serve() noexcept {
+  void serve() {
     serveImpl([&](jsg::V8System& v8System, config::Config::Reader config) {
 #if _WIN32
       return server->run(v8System, config);


### PR DESCRIPTION
Fixes #6913.

## The bug

On Windows, a workerd process would die with no usable diagnostic:

```
*** std::terminate() called with no exception
```

The reproduction in the issue is a worker with a `tailConsumer` pointing at a second workerd. Killing the second process kills the first.

Two separate defects, one per commit.

## 1. The failure was unreportable

`Server::taskFailed()` rejected `fatalFulfiller` and **discarded the exception**. The rejection propagated out of `Server::run()`, was re-thrown by `Promise::wait()` in `CliMain::serveImpl()` — which was `noexcept` — so the process called `std::terminate()`. MSVC reports no in-flight exception for a re-thrown asynchronous one, hence "with no exception", and the stack trace named only the wait, not the task that failed.

The stack trace was structurally incapable of identifying the origin; only the discarded `kj::Exception` knew. So:

- log the exception where we decide to shut down
- drop the `noexcept` so `kj::runMainAndExit()` prints it as an uncaught exception instead of aborting

Dropping `noexcept` newly allows `serveImpl()` to unwind, which would destroy the V8 platform while `server` still referenced it, so the existing cleanup moves into a `KJ_DEFER` to cover that path too.

## 2. A dead pending connection was fatal

A failed `accept()` usually says nothing about the health of the listening socket. The common case is a client that completes the TCP handshake and then resets before the server accepts it, so the pending connection is already dead when we ask for it.

KJ's Unix implementation absorbs the errno values that mean this and accepts the next connection instead ([`async-io-unix.c++`](https://github.com/capnproto/capnproto/blob/v2/c%2B%2B/src/kj/async-io-unix.c%2B%2B) has an explicit retry list); the Windows implementation reports them as exceptions. Those escaped the accept loop, and since the loop runs in `Server::tasks`, one dead connection took down a healthy server.

This is reachable from ordinary use: a `tailConsumer` targeting a second workerd makes the two processes connect to each other's debug port (`ExternalServiceProxy`'s constructor alone opens two connections), so killing one resets connections queued on the other's listener.

Listeners are now wrapped so a failed `accept()` is retried with a delay that grows after each consecutive failure — 0/10/20/40/80/160/320 ms — giving up on the 8th. A genuinely broken listener fails every time, so it exhausts the retries and reports within ~630 ms rather than spinning forever. Bind and listen failures are unaffected: those are raised before any accept, so `EADDRINUSE` still kills the process.

### Why no error classification

Deliberately not conditioned on the error type. `kj::Exception` carries no OS error code, and `typeOfWin32Error()` maps only `WSAE*` values, so `ERROR_NETNAME_DELETED` (64), `ERROR_CONNECTION_ABORTED` (1236) and `ERROR_SEM_TIMEOUT` (121) all arrive as `FAILED`, not `DISCONNECTED` — a narrow filter would miss the most likely site. If KJ later classifies those codes, this can be narrowed to `DISCONNECTED` with the backoff kept purely as spin protection.

## Testing

Two tests in `server-test.c++`, red-green verified. Without the fix, the retry test fails with the exact reported symptom — `fatal task failure, shutting down` from a **single** accept failure.

Full `//...` is green. Each commit builds and passes tests on its own.

Note the fix is verified by unit test rather than on a live Windows box; that's the one gap.