### PR TITLE
fix: three Node.js compat bugs in node:crypto and node:buffer

### DIFF
--- a/src/node/internal/crypto_cipher.ts
+++ b/src/node/internal/crypto_cipher.ts
@@ -209,11 +209,7 @@ Cipheriv.prototype.update = function (
   let ret: ArrayBuffer;
   if (typeof data === 'string') {
     if (inputEncoding === undefined) {
-      throw new ERR_INVALID_ARG_VALUE(
-        'inputEncoding',
-        inputEncoding,
-        'If inputEncoding is not provided then the data must be a Buffer'
-      );
+      inputEncoding = 'utf8';
     }
     ret = this[kHandle].update(Buffer.from(data, inputEncoding));
   } else if (isAnyArrayBuffer(data)) {
@@ -356,11 +352,7 @@ Decipheriv.prototype.update = function (
   let ret: ArrayBuffer;
   if (typeof data === 'string') {
     if (inputEncoding === undefined) {
-      throw new ERR_INVALID_ARG_VALUE(
-        'inputEncoding',
-        inputEncoding,
-        'If inputEncoding is not provided then the data must be a Buffer'
-      );
+      inputEncoding = 'utf8';
     }
     ret = this[kHandle].update(Buffer.from(data, inputEncoding));
   } else if (isAnyArrayBuffer(data)) {

--- a/src/node/internal/crypto_hash.ts
+++ b/src/node/internal/crypto_hash.ts
@@ -277,9 +277,7 @@ Hmac.prototype.digest = function (
 ): Buffer | string {
   const state = this[kState];
   if (state[kFinalized]) {
-    return !outputEncoding || outputEncoding === 'buffer'
-      ? Buffer.from('')
-      : '';
+    throw new ERR_CRYPTO_HASH_FINALIZED();
   }
 
   // Explicit conversion for backward compatibility.

--- a/src/node/internal/internal_buffer.ts
+++ b/src/node/internal/internal_buffer.ts
@@ -447,7 +447,7 @@ function alloc(size: number, fill?: FillValue, encoding?: string): Buffer {
   if (Number.isNaN(size)) {
     throw new ERR_INVALID_ARG_VALUE.RangeError('size', size);
   }
-  if (size >= kMaxLength) {
+  if (size > kMaxLength) {
     throw new ERR_OUT_OF_RANGE('size', `0 to ${kMaxLength}`, size);
   }
 


### PR DESCRIPTION
Fixes three Node.js compatibility bugs found during manual code review.

## Changes

### 1. `node:crypto` — `Cipheriv.prototype.update` default encoding
Fixes #6920

`cipher.update('string')` without `inputEncoding` now defaults to `'utf8'` instead of throwing `ERR_INVALID_ARG_VALUE`, matching Node.js behavior.

### 2. `node:crypto` — `Hmac.prototype.digest` finalization
Fixes #6921

Calling `hmac.digest()` a second time now throws `ERR_CRYPTO_HASH_FINALIZED` instead of silently returning an empty Buffer, matching `Hash.prototype.digest` and Node.js behavior.

### 3. `node:buffer` — `Buffer.alloc` / `allocUnsafe` off-by-one
Fixes #6922

Changed `size >= kMaxLength` to `size > kMaxLength` so that `Buffer.alloc(kMaxLength)` no longer incorrectly throws `ERR_OUT_OF_RANGE`. The internal `createBuffer` function already used `>` — this makes `alloc` consistent.