### PR TITLE
Make ctx.abort() (for stateless workers) non-experimental.

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -398,19 +398,7 @@ class ExecutionContext: public jsg::Object {
     // and enterSpan() is a no-op when called outside a traced request.
     JSG_LAZY_INSTANCE_PROPERTY(tracing, getTracing);
 
-    if (flags.getWorkerdExperimental()) {
-      // TODO(soon): Before making this generally available we need to:
-      // * Consider whether to use TerminateExecution() instead of throwing.
-      // * Make sure it's really not possible for more code to run in the context after abort().
-      //   Currently, abort() triggers in a partially async way so there's an opportunity for some
-      //   other event in the event queue to squeeze in.
-      // * Try to ensure that the provided error is actually the one that propagates out of event
-      //   handlers. Currently this is not consistently true.
-      // * Make sure all event handlers actually honor onAbort().
-      // * Enable the Durable Object version at the same time -- and make sure they're suitably
-      //   consistent with each other.
-      JSG_METHOD(abort);
-    }
+    JSG_METHOD(abort);
 
     // TODO(soon): This is getting unwieldy.
     if (flags.getEnableCtxExports()) {

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -629,3 +629,11 @@ kj_test(
         "//src/workerd/tests:test-fixture",
     ],
 )
+
+kj_test(
+    src = "io-context-abort-test.c++",
+    deps = [
+        ":io",
+        "//src/workerd/tests:test-fixture",
+    ],
+)

--- a/src/workerd/io/io-context-abort-test.c++
+++ b/src/workerd/io/io-context-abort-test.c++
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+//
+// Tests of IoContext::abort() behavior.
+
+#include <workerd/io/io-context.h>
+#include <workerd/tests/test-fixture.h>
+
+#include <kj/test.h>
+
+namespace workerd {
+namespace {
+
+KJ_TEST("JS queued before abort() does not run after it") {
+  TestFixture fixture;
+  auto request = fixture.newIncomingRequest();
+  auto& context = request->getContext();
+  auto& waitScope = fixture.getWaitScope();
+
+  bool firstRan = false;
+  bool secondRan = false;
+
+  // Simulate outstanding I/O, as in a real request that has pending subrequests, streams, etc.
+  // (e.g. awaitIo() attaches a pending event to every promise it awaits). Without this, the
+  // registerPendingEvent() call in runImpl() happens to throw the abort exception as a side
+  // effect of hang detection, masking the gap this test covers. With an existing PendingEvent
+  // alive -- or in an actor context, which doesn't use pending events at all -- it performs no
+  // abort check.
+  auto pendingEvent = context.registerPendingEvent();
+
+  // Make two back-to-back calls to run(). Both pass the abort check at the top of runSingle()
+  // before either has acquired the isolate lock and entered JS. The first run aborts the context,
+  // so the second must be refused rather than executed.
+  auto first = context.run([&firstRan](Worker::Lock&, IoContext& context) {
+    firstRan = true;
+    context.abort(KJ_EXCEPTION(FAILED, "jsg.Error: test abort reason"));
+  });
+  auto second = context.run([&secondRan](Worker::Lock&) { secondRan = true; });
+
+  first.wait(waitScope);
+  KJ_EXPECT(firstRan);
+
+  KJ_EXPECT_THROW_MESSAGE("test abort reason", second.wait(waitScope));
+  KJ_EXPECT(!secondRan);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -1365,6 +1365,11 @@ kj::PromiseForResult<Func, Worker::Lock&> IoContext::runSingle(
 
   return asyncLockPromise.then([this, inputLock = kj::mv(inputLock), func = kj::fwd<Func>(func)](
                                    Worker::AsyncLock lock) mutable {
+    // Re-check if context was aborted while we waited for the lock.
+    KJ_IF_SOME(ex, abortException) {
+      kj::throwFatalException(ex.clone());
+    }
+
     using Result = decltype(func(kj::instance<Worker::Lock&>()));
 
     if constexpr (kj::isSameType<Result, void>()) {

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -505,6 +505,7 @@ interface ExecutionContext<Props = unknown> {
   cache?: CacheContext;
   readonly access?: CloudflareAccessContext;
   tracing: Tracing;
+  abort(reason?: any): void;
 }
 type ExportedHandlerFetchHandler<
   Env = unknown,

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -507,6 +507,7 @@ export interface ExecutionContext<Props = unknown> {
   cache?: CacheContext;
   readonly access?: CloudflareAccessContext;
   tracing: Tracing;
+  abort(reason?: any): void;
 }
 export type ExportedHandlerFetchHandler<
   Env = unknown,


### PR DESCRIPTION
All of the concerns in the TODO bullet points had already been addressed:

* We already use TerminateExecution().
* Abort handling has been significantly refactored (some time ago!) closing most ways that code could keep running after abort. One remaining, minor issue is fixed in the first commit in this PR.
* The refactoring of abort handling also ensured that the correct exception propagates.
* All event handler paths were verified as respecting abort.
* The Durable Object version was un-gated a long time ago.