### PR TITLE
Use jsg::JsArrayBufferView and remove cached length/offset in byob options

### DIFF
--- a/src/workerd/api/streams-test.c++
+++ b/src/workerd/api/streams-test.c++
@@ -95,8 +95,7 @@ KJ_TEST("Reading from byob reader") {
       KJ_REQUIRE(reader.is<jsg::Ref<ReadableStreamBYOBReader>>());
       auto& byobReader = reader.get<jsg::Ref<ReadableStreamBYOBReader>>();
 
-      auto buffer = v8::Uint8Array::New(
-          v8::ArrayBuffer::New(js.v8Isolate, test.bufferSize), 0, test.bufferSize);
+      auto buffer = jsg::JsArrayBufferView(jsg::JsUint8Array::create(js, test.bufferSize));
 
       return env.context.awaitJs(js, byobReader->read(js, buffer, {}).then(js,
                   JSG_VISITABLE_LAMBDA(

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -398,9 +398,7 @@ class ReadableStreamController {
   struct ByobOptions {
     static constexpr size_t DEFAULT_AT_LEAST = 1;
 
-    jsg::V8Ref<v8::ArrayBufferView> bufferView;
-    size_t byteOffset = 0;
-    size_t byteLength;
+    jsg::JsRef<jsg::JsArrayBufferView> bufferView;
 
     // The minimum number of elements that should be read. When not specified, the default
     // is DEFAULT_AT_LEAST. This is a non-standard, Workers-specific extension to

--- a/src/workerd/api/streams/internal-test.c++
+++ b/src/workerd/api/streams/internal-test.c++
@@ -754,8 +754,7 @@ KJ_TEST("ReadableStreamBYOBReader rejects read with zero-sized buffer") {
     auto rs = makeByteStream(env.js);
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 0);
-    auto view = v8::Uint8Array::New(buffer, 0, 0);
+    auto view = jsg::JsArrayBufferView(jsg::JsUint8Array::create(env.js, 0));
 
     bool rejected = false;
     reader->read(env.js, view, kj::none)
@@ -778,8 +777,7 @@ KJ_TEST("ReadableStreamBYOBReader rejects read with atLeast=0") {
     auto rs = makeByteStream(env.js);
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 10);
-    auto view = v8::Uint8Array::New(buffer, 0, 10);
+    auto view = jsg::JsArrayBufferView(jsg::JsUint8Array::create(env.js, 10));
 
     bool rejected = false;
     reader->readAtLeast(env.js, 0, view)
@@ -802,8 +800,7 @@ KJ_TEST("ReadableStreamBYOBReader rejects read when atLeast exceeds buffer size"
     auto rs = makeByteStream(env.js);
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 10);
-    auto view = v8::Uint8Array::New(buffer, 0, 10);
+    auto view = jsg::JsArrayBufferView(jsg::JsUint8Array::create(env.js, 10));
 
     bool rejected = false;
     reader->readAtLeast(env.js, 20, view)
@@ -830,7 +827,7 @@ KJ_TEST("ReadableStreamBYOBReader readAtLeast with element count within capacity
 
     // Uint32Array: element size 4, byteLength 40, length 10
     auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 40);
-    auto view = v8::Uint32Array::New(buffer, 0, 10);
+    auto view = jsg::JsArrayBufferView(v8::Uint32Array::New(buffer, 0, 10));
 
     bool rejected = false;
     reader->readAtLeast(env.js, 10, view)
@@ -857,7 +854,7 @@ KJ_TEST("ReadableStreamBYOBReader readAtLeast rejects when element count exceeds
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
     auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 40);
-    auto view = v8::Uint32Array::New(buffer, 0, 10);
+    auto view = jsg::JsArrayBufferView(v8::Uint32Array::New(buffer, 0, 10));
 
     bool rejected = false;
     reader->readAtLeast(env.js, 11, view)
@@ -881,7 +878,7 @@ KJ_TEST("ReadableStreamBYOBReader readAtLeast rejects byteLength as element coun
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
     auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 4096);
-    auto view = v8::Uint32Array::New(buffer, 0, 1024);
+    auto view = jsg::JsArrayBufferView(v8::Uint32Array::New(buffer, 0, 1024));
 
     bool rejected = false;
     reader->readAtLeast(env.js, 4096, view)
@@ -907,7 +904,7 @@ KJ_TEST("ReadableStreamBYOBReader read() with min exceeding element capacity rej
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
 
     auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 40);
-    auto view = v8::Uint32Array::New(buffer, 0, 10);
+    auto view = jsg::JsArrayBufferView(v8::Uint32Array::New(buffer, 0, 10));
 
     ReadableStreamBYOBReader::ReadableStreamBYOBReaderReadOptions opts;
     opts.min = 11;
@@ -931,8 +928,7 @@ KJ_TEST("ReadableStreamBYOBReader rejects read after releaseLock") {
     auto reader = ReadableStreamBYOBReader::constructor(env.js, rs.addRef());
     reader->releaseLock(env.js);
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, 10);
-    auto view = v8::Uint8Array::New(buffer, 0, 10);
+    auto view = jsg::JsArrayBufferView(jsg::JsUint8Array::create(env.js, 10));
 
     bool rejected = false;
     reader->read(env.js, view, kj::none)
@@ -948,77 +944,78 @@ KJ_TEST("ReadableStreamBYOBReader rejects read after releaseLock") {
 }
 
 // ======================================================================================
-// BYOB read destination bounds validation
+// BYOB read destination placement
 //
 // ReadableStreamInternalController::read() derives the tryRead() destination from the
-// byteOffset/byteLength in ByobOptions, which are copied out of the in-cage
-// v8::ArrayBufferView metadata. If those values disagree with the backing store's real
-// extent, the destination lands outside the allocation and tryRead() writes there. The
-// controller must reject the read rather than issue it.
-//
-// ReadableStreamBYOBReader always derives the pair from a live view, so these
-// combinations cannot be produced through it. The tests drive the controller directly.
+// live view's byteOffset/byteLength at the time the read is issued; there is no separately
+// cached copy of those values that could disagree with the view. Out-of-bounds destinations
+// therefore cannot be produced through any API; the controller's check against the
+// BackingStore's out-of-cage length exists purely as sandbox hardening against corrupted
+// in-cage view metadata, and jsg::JsArrayBufferView::asArrayPtr() independently validates
+// the same bounds when the destination pointer is derived.
 
-// Records the destination it is handed without writing to it, so that an unvalidated read
-// is observable without performing the out-of-bounds write it would otherwise do.
-class RecordingSource final: public ReadableStreamSource {
+// Fills the entire destination it is handed with a recognizable pattern, so a test can
+// verify exactly where read data lands in the caller's buffer.
+class PatternSource final: public ReadableStreamSource {
  public:
   kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    called = true;
-    return static_cast<size_t>(0);
+    auto bytes = kj::arrayPtr(static_cast<kj::byte*>(buffer), maxBytes);
+    for (auto i: kj::indices(bytes)) {
+      bytes[i] = static_cast<kj::byte>('A' + (i % 26));
+    }
+    return maxBytes;
   }
-
-  bool called = false;
 };
 
-void expectByobReadOutOfBoundsRejected(size_t byteOffset, size_t byteLength) {
+KJ_TEST("BYOB read into an offset view fills only the view's region, returns a Uint8Array") {
   static constexpr size_t kBufferSize = 64;
+  static constexpr size_t kViewOffset = 16;
+  static constexpr size_t kViewLength = 32;
 
   auto fixture = makeStreamTestFixture();
-  fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    auto source = kj::heap<RecordingSource>();
-    auto& sourceRef = *source;
-    auto rs = env.js.alloc<ReadableStream>(env.context, kj::mv(source));
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto& js = env.js;
+    auto rs = js.alloc<ReadableStream>(env.context, kj::heap<PatternSource>());
 
-    auto buffer = v8::ArrayBuffer::New(env.js.v8Isolate, kBufferSize);
-    auto view = v8::Uint8Array::New(buffer, 0, kBufferSize);
+    auto buffer = jsg::JsArrayBuffer::create(js, kBufferSize);
+    // A non-Uint8Array view type verifies that the result type does not depend on the
+    // view type passed in.
+    auto view =
+        jsg::JsArrayBufferView(buffer.newUint32View(kViewOffset, kViewLength / sizeof(uint32_t)));
 
     auto options = ReadableStreamController::ByobOptions{
-      .bufferView = env.js.v8Ref(view.As<v8::ArrayBufferView>()),
-      .byteOffset = byteOffset,
-      .byteLength = byteLength,
+      .bufferView = view.addRef(js),
       .atLeast = 1,
       .detachBuffer = false,
     };
 
-    auto maybePromise = rs->getController().read(env.js, kj::mv(options));
+    auto maybePromise = rs->getController().read(js, kj::mv(options));
     auto promise = kj::mv(KJ_ASSERT_NONNULL(maybePromise));
 
-    bool rejected = false;
-    kj::mv(promise).catch_(env.js, [&](jsg::Lock& js, jsg::Value reason) -> ReadResult {
-      rejected = true;
-      auto ex = js.exceptionToKj(kj::mv(reason));
-      KJ_ASSERT(ex.getDescription().contains("exceeds backing buffer bounds"), ex);
-      return {.done = true};
-    });
-    env.js.runMicrotasks();
+    return env.context.awaitJs(js, kj::mv(promise).then(js, JSG_VISITABLE_LAMBDA((bufferRef = buffer.addRef(js), rs = rs.addRef()), (bufferRef, rs), (jsg::Lock& js, ReadResult result) {
+      KJ_ASSERT(!result.done);
+      auto& value = KJ_REQUIRE_NONNULL(result.value);
+      auto handle = value.getHandle(js);
 
-    KJ_ASSERT(!sourceRef.called, "read was issued with a destination outside the backing store",
-        byteOffset, byteLength, kBufferSize);
-    KJ_ASSERT(rejected, "expected out-of-bounds BYOB read to be rejected", byteOffset, byteLength);
+      // The result is a Uint8Array over the same buffer, covering the view's region.
+      v8::Local<v8::Uint8Array> u8 = KJ_ASSERT_NONNULL(handle.tryCast<jsg::JsUint8Array>());
+      auto buffer = bufferRef.getHandle(js);
+      KJ_ASSERT(u8->Buffer() == static_cast<v8::Local<v8::ArrayBuffer>>(buffer));
+      KJ_ASSERT(u8->ByteOffset() == kViewOffset);
+      KJ_ASSERT(u8->ByteLength() == kViewLength);
+
+      // The data landed exactly in [kViewOffset, kViewOffset + kViewLength); the rest of
+      // the buffer is untouched (v8::ArrayBuffer allocations are zero-initialized).
+      auto data = buffer.asArrayPtr();
+      for (size_t i: kj::zeroTo(kBufferSize)) {
+      if (i >= kViewOffset && i < kViewOffset + kViewLength) {
+      KJ_ASSERT(data[i] == static_cast<kj::byte>('A' + ((i - kViewOffset) % 26)), i);
+      } else {
+      KJ_ASSERT(data[i] == 0, i);
+      }
+      }
+    })));
   });
-}
-
-KJ_TEST("BYOB read rejects byteOffset past the end of the backing store") {
-  expectByobReadOutOfBoundsRejected(64, 64);
-}
-
-KJ_TEST("BYOB read rejects byteLength extending past the backing store") {
-  expectByobReadOutOfBoundsRejected(0, 4096);
-}
-
-KJ_TEST("BYOB read rejects byteOffset plus byteLength overflowing size_t") {
-  expectByobReadOutOfBoundsRejected(kj::maxValue, 64);
 }
 
 KJ_TEST("Writing strings works") {

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -516,8 +516,7 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
         // them against the BackingStore's length, which lives outside the V8 sandbox and so is not
         // reachable from an in-cage write. Testing byteOffset first keeps the subtraction from
         // underflowing and avoids summing two untrusted lengths; that stays correct no matter how
-        // large the sandbox, and hence the maximum buffer size, becomes. For a resizable buffer this
-        // length is the maximum reservation rather than the live size; the branch below narrows it.
+        // large the sandbox, and hence the maximum buffer size, becomes.
         size_t byteLength = store.size();
         size_t byteOffset = store.getOffset();
         auto backingSize = store.getBuffer().backingStoreSize();

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -436,42 +436,43 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
         js.typeError("This ReadableStream belongs to an object that is closing."_kj));
   }
 
-  v8::Local<v8::ArrayBuffer> store;
-  size_t byteLength = 0;
-  size_t byteOffset = 0;
+  // It's worth mentioning the fact that the implementation here has always
+  // been non-standard. The spec requires that the read() return the same
+  // kind of TypedArray as was passed in, but this implementation has always
+  // instead returned a Uint8Array over the same backing memory. This is
+  // non-conformant but cannot be changed without a compat flag and there's
+  // never been a strong motivation to do so.
+
+  kj::Maybe<jsg::JsArrayBufferView> maybeBufferView;
   size_t atLeast = 1;
 
   KJ_IF_SOME(byobOptions, maybeByobOptions) {
-    store = byobOptions.bufferView.getHandle(js)->Buffer();
-    byteOffset = byobOptions.byteOffset;
-    byteLength = byobOptions.byteLength;
+    auto view = byobOptions.bufferView.getHandle(js);
     atLeast = byobOptions.atLeast.orDefault(atLeast);
     if (byobOptions.detachBuffer) {
-      if (!store->IsDetachable()) {
+      if (!view.isDetachable()) {
         return js.rejectedPromise<ReadResult>(
             js.typeError("Unable to use non-detachable ArrayBuffer"_kj));
       }
-      auto backing = store->GetBackingStore();
-      jsg::check(store->Detach(v8::Local<v8::Value>()));
-      store = v8::ArrayBuffer::New(js.v8Isolate, kj::mv(backing));
+      view = view.detachAndTake(js);
     }
+    maybeBufferView = view;
   }
 
-  auto getOrInitStore = [&](bool errorCase = false) {
-    if (store.IsEmpty()) {
-      if (errorCase) {
-        byteLength = 0;
-      } else if (util::Autogate::isEnabled(util::AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE)) {
-        byteLength = UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE_2;
-      } else {
-        byteLength = UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE;
-      }
-
-      if (!v8::ArrayBuffer::MaybeNew(js.v8Isolate, byteLength).ToLocal(&store)) {
-        return v8::Local<v8::ArrayBuffer>();
-      }
+  auto getOrInitStore = [&](bool errorCase = false) -> kj::Maybe<jsg::JsArrayBufferView> {
+    KJ_IF_SOME(byobView, maybeBufferView) {
+      return byobView;
     }
-    return store;
+
+    if (errorCase) {
+      return jsg::JsUint8Array::tryCreate(js, 0).map(
+          [](auto& u8) { return jsg::JsArrayBufferView(u8); });
+    } else if (util::Autogate::isEnabled(util::AutogateKey::UPDATED_AUTO_ALLOCATE_CHUNK_SIZE)) {
+      return jsg::JsUint8Array::tryCreate(js, UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE_2)
+          .map([](auto& u8) { return jsg::JsArrayBufferView(u8); });
+    }
+    return jsg::JsUint8Array::tryCreate(js, UnderlyingSource::DEFAULT_AUTO_ALLOCATE_CHUNK_SIZE)
+        .map([](auto& u8) { return jsg::JsArrayBufferView(u8); });
   };
 
   disturbed = true;
@@ -481,16 +482,15 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
       if (maybeByobOptions != kj::none && FeatureFlags::get(js).getInternalStreamByobReturn()) {
         // When using the BYOB reader, we must return a sized-0 Uint8Array that is backed
         // by the ArrayBuffer passed in the options.
-        auto theStore = getOrInitStore(true);
-        if (theStore.IsEmpty()) {
+        KJ_IF_SOME(store, getOrInitStore(true)) {
+          return js.resolvedPromise(ReadResult{
+            .value = jsg::JsValue(store.getBuffer().newUint8View(0, 0)).addRef(js),
+            .done = true,
+          });
+        } else {
           return js.rejectedPromise<ReadResult>(
               js.typeError("Unable to allocate memory for read"_kj));
         }
-        auto u8 = v8::Uint8Array::New(theStore, 0, 0);
-        return js.resolvedPromise(ReadResult{
-          .value = jsg::JsValue(u8).addRef(js),
-          .done = true,
-        });
       }
       return js.resolvedPromise(ReadResult{.done = true});
     }
@@ -510,175 +510,183 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamInternalController::read(
       }
       readPending = true;
 
-      auto theStore = getOrInitStore();
-      if (theStore.IsEmpty()) {
-        return js.rejectedPromise<ReadResult>(
-            js.typeError("Unable to allocate memory for read"_kj));
-      }
-
-      // byteOffset/byteLength are copied out of the in-cage v8::ArrayBufferView metadata on the
-      // BYOB path, so a corrupted view could place the destination outside the allocation. Bound
-      // them against the BackingStore's length, which lives outside the V8 sandbox and so is not
-      // reachable from an in-cage write. Testing byteOffset first keeps the subtraction from
-      // underflowing and avoids summing two untrusted lengths; that stays correct no matter how
-      // large the sandbox, and hence the maximum buffer size, becomes. For a resizable buffer this
-      // length is the maximum reservation rather than the live size; the branch below narrows it.
-      auto backingSize = theStore->GetBackingStore()->ByteLength();
-      if (byteOffset > backingSize || byteLength > backingSize - byteOffset) {
-        readPending = false;
-        return js.rejectedPromise<ReadResult>(
-            js.typeError("BYOB read destination view exceeds backing buffer bounds."_kj));
-      }
-
-      // A resizable ArrayBuffer may shrink while the read is pending, so narrow the request to the
-      // live size now. The continuation below re-validates against the size at completion time.
-      if (theStore->IsResizableByUserJavaScript()) {
-        auto currentByteLength = theStore->ByteLength();
-        if (byteOffset >= currentByteLength) {
+      KJ_IF_SOME(store, getOrInitStore()) {
+        // byteOffset/byteLength are copied out of the in-cage v8::ArrayBufferView metadata on the
+        // BYOB path, so a corrupted view could place the destination outside the allocation. Bound
+        // them against the BackingStore's length, which lives outside the V8 sandbox and so is not
+        // reachable from an in-cage write. Testing byteOffset first keeps the subtraction from
+        // underflowing and avoids summing two untrusted lengths; that stays correct no matter how
+        // large the sandbox, and hence the maximum buffer size, becomes. For a resizable buffer this
+        // length is the maximum reservation rather than the live size; the branch below narrows it.
+        size_t byteLength = store.size();
+        size_t byteOffset = store.getOffset();
+        auto backingSize = store.getBuffer().backingStoreSize();
+        if (byteOffset > backingSize || byteLength > backingSize - byteOffset) {
           readPending = false;
-          auto u8 = v8::Uint8Array::New(theStore, 0, 0);
-          return js.resolvedPromise(ReadResult{
-            .value = jsg::JsValue(u8).addRef(js),
-            .done = false,
-          });
+          return js.rejectedPromise<ReadResult>(
+              js.typeError("BYOB read destination view exceeds backing buffer bounds."_kj));
         }
-        if (byteOffset + byteLength > currentByteLength) {
-          byteLength = currentByteLength - byteOffset;
-          if (atLeast > byteLength) {
-            atLeast = byteLength > 0 ? byteLength : 1;
-          }
-        }
-      }
 
-      // Reads land in a kj-heap buffer outside the V8 sandbox rather than directly in the
-      // BackingStore. tryRead() completes on the kj event loop without the isolate lock, and when
-      // MPK protects isolate memory the sandbox pages carry the isolate's protection key, so a
-      // write from that context faults: SIGSEGV for a memcpy, or EFAULT for a write the kernel
-      // performs on our behalf. The continuation below copies into the BackingStore under the lock,
-      // after re-validating that it is still attached and large enough. Routing through a temporary
-      // also means a buffer detached mid-read never receives a late write, which would otherwise
-      // corrupt whatever now owns the transferred BackingStore.
-      auto tempBuffer = kj::heapArray<kj::byte>(byteLength);
-      auto bytes = tempBuffer.asPtr();
-
-      KJ_ASSERT(atLeast <= bytes.size(), "minBytes must not exceed maxBytes in tryRead");
-
-      auto promise =
-          kj::evalNow([&] { return readable->tryRead(bytes.begin(), atLeast, bytes.size()); });
-      KJ_IF_SOME(readerLock, readState.tryGetUnsafe<ReaderLocked>()) {
-        promise = KJ_ASSERT_NONNULL(readerLock.getCanceler())->wrap(kj::mv(promise));
-      }
-
-      // TODO(soon): We use awaitIoLegacy() here because if the stream terminates in JavaScript in
-      // this same isolate, then the promise may actually be waiting on JavaScript to do something,
-      // and so should not be considered waiting on external I/O. We will need to use
-      // registerPendingEvent() manually when reading from an external stream. Ideally, we would
-      // refactor the implementation so that when waiting on a JavaScript stream, we strictly use
-      // jsg::Promises and not kj::Promises, so that it doesn't look like I/O at all, and there's
-      // no need to drop the isolate lock and take it again every time some data is read/written.
-      // That's a larger refactor, though.
-      auto& ioContext = IoContext::current();
-      return ioContext.awaitIoLegacy(js, kj::mv(promise))
-          .then(js,
-              ioContext.addFunctor(
-                  [ref = addRef(), store = js.v8Ref(store), byteOffset, byteLength,
-                      isByob = maybeByobOptions != kj::none, tempBuffer = kj::mv(tempBuffer)](
-                      jsg::Lock& js, size_t amount) mutable -> jsg::Promise<ReadResult> {
-        auto& controller = static_cast<ReadableStreamInternalController&>(ref->getController());
-        controller.readPending = false;
-        KJ_ASSERT(amount <= byteLength);
-        if (amount == 0) {
-          if (!controller.state.is<StreamStates::Errored>()) {
-            controller.doClose(js);
-          }
-          KJ_IF_SOME(o, controller.owner) {
-            o->signalEof(js);
-          }
-          if (isByob && FeatureFlags::get(js).getInternalStreamByobReturn()) {
-            // When using the BYOB reader, we must return a sized-0 Uint8Array that is backed
-            // by the ArrayBuffer passed in the options.
-            auto u8 = v8::Uint8Array::New(store.getHandle(js), 0, 0);
+        // A resizable ArrayBuffer may shrink while the read is pending, so narrow the request to
+        // the live size now. The continuation below re-validates against the size at completion
+        // time.
+        if (store.isResizable()) {
+          // Note that we measure against the buffer's live size, not the view's: a
+          // fixed-length view over a shrunken buffer reports itself fully out-of-bounds
+          // (size 0) even when part of its range is still backed by live buffer memory.
+          auto currentByteLength = store.getBuffer().size();
+          if (byteOffset >= currentByteLength) {
+            readPending = false;
+            // The view's own offset may extend beyond the shrunken buffer, so the
+            // zero-length result view is created at offset 0 instead.
             return js.resolvedPromise(ReadResult{
-              .value = jsg::JsValue(u8).addRef(js),
-              .done = true,
-            });
-          }
-          return js.resolvedPromise(ReadResult{.done = true});
-        }
-        // Return a slice so the script can see how many bytes were read.
-
-        // We have to check to see if the store was detached or resized while we were waiting
-        // for the read to complete.
-        auto handle = store.getHandle(js);
-        if (handle->WasDetached()) {
-          // If the buffer was detached, we resolve with a new zero-length ArrayBuffer.
-          // The bytes that were read are lost, but this is a valid result.
-
-          // Silly user, trix are for kids.
-          IoContext::current().logWarningOnce(
-              "A buffer that was being used for a read operation on a ReadableStream was detached "
-              "while the read was pending. The read completed with a zero-length buffer and the data "
-              "that was read is lost. Avoid detaching buffers that are being used for active read "
-              "operations on streams, or use the streams_byob_reader_detaches_buffer compatibility "
-              "flag, to prevent this from happening."_kj);
-
-          auto buffer = v8::ArrayBuffer::New(js.v8Isolate, 0);
-          auto u8 = v8::Uint8Array::New(buffer, 0, 0);
-          return js.resolvedPromise(ReadResult{
-            .value = jsg::JsValue(u8).addRef(js),
-            .done = false,
-          });
-        }
-
-        // Re-derive the deliverable length from the size the buffer has now. byteOffset and amount
-        // are compared against it without being summed, for the same reason as the bounds check at
-        // read time.
-        auto liveLength = handle->ByteLength();
-        if (byteOffset > liveLength || amount > liveLength - byteOffset) {
-          // If the buffer was resized smaller, we return a truncated result.
-
-          IoContext::current().logWarningOnce(
-              "A buffer that was being used for a read operation on a ReadableStream was resized "
-              "smaller while the read was pending. The read completed with a truncated buffer "
-              "containing only the bytes that fit within the new size. Avoid resizing buffers that "
-              "are being used for active read operations on streams, or use the "
-              "streams_byob_reader_detaches_buffer compatibility flag, to prevent this from "
-              "happening."_kj);
-
-          if (byteOffset >= liveLength) {
-            auto u8 = v8::Uint8Array::New(store.getHandle(js), 0, 0);
-            return js.resolvedPromise(ReadResult{
-              .value = jsg::JsValue(u8).addRef(js),
+              .value = jsg::JsValue(store.getBuffer().newUint8View(0, 0)).addRef(js),
               .done = false,
             });
           }
-          amount = liveLength - byteOffset;
+          if (byteOffset + byteLength > currentByteLength) {
+            byteLength = currentByteLength - byteOffset;
+            if (atLeast > byteLength) {
+              atLeast = byteLength > 0 ? byteLength : 1;
+            }
+          }
         }
 
-        // Deliver the bytes from the temporary into the caller's BackingStore. The checks above
-        // guarantee the buffer is still attached and that [byteOffset, byteOffset + amount) lies
-        // within its live length, and `amount <= byteLength == tempBuffer.size()`.
-        KJ_ASSERT(byteOffset <= liveLength && amount <= liveLength - byteOffset);
-        auto destPtr = static_cast<kj::byte*>(handle->GetBackingStore()->Data());
-        memcpy(destPtr + byteOffset, tempBuffer.begin(), amount);
+        // Reads land in a kj-heap buffer outside the V8 sandbox rather than directly in the
+        // BackingStore. tryRead() completes on the kj event loop without the isolate lock, and when
+        // MPK protects isolate memory the sandbox pages carry the isolate's protection key, so a
+        // write from that context faults: SIGSEGV for a memcpy, or EFAULT for a write the kernel
+        // performs on our behalf. The continuation below copies into the BackingStore under the lock,
+        // after re-validating that it is still attached and large enough. Routing through a temporary
+        // also means a buffer detached mid-read never receives a late write, which would otherwise
+        // corrupt whatever now owns the transferred BackingStore.
+        auto tempBuffer = kj::heapArray<kj::byte>(byteLength);
+        auto bytes = tempBuffer.asPtr();
 
-        auto u8 = v8::Uint8Array::New(store.getHandle(js), byteOffset, amount);
-        return js.resolvedPromise(ReadResult{
-          .value = jsg::JsValue(u8).addRef(js),
-          .done = false,
-        });
-      }),
-              ioContext.addFunctor([ref = addRef()](jsg::Lock& js,
-                                       jsg::Value reason) mutable -> jsg::Promise<ReadResult> {
-        auto& controller = static_cast<ReadableStreamInternalController&>(ref->getController());
-        controller.readPending = false;
-        auto error = jsg::JsValue(reason.getHandle(js));
-        if (!controller.state.is<StreamStates::Errored>()) {
-          controller.doError(js, error);
+        KJ_ASSERT(atLeast <= bytes.size(), "minBytes must not exceed maxBytes in tryRead");
+
+        auto promise =
+            kj::evalNow([&] { return readable->tryRead(bytes.begin(), atLeast, bytes.size()); });
+        KJ_IF_SOME(readerLock, readState.tryGetUnsafe<ReaderLocked>()) {
+          promise = KJ_ASSERT_NONNULL(readerLock.getCanceler())->wrap(kj::mv(promise));
         }
 
-        return js.rejectedPromise<ReadResult>(error);
-      }));
+        // TODO(soon): We use awaitIoLegacy() here because if the stream terminates in JavaScript
+        // in this same isolate, then the promise may actually be waiting on JavaScript to do
+        // something, and so should not be considered waiting on external I/O. We will need to use
+        // registerPendingEvent() manually when reading from an external stream. Ideally, we would
+        // refactor the implementation so that when waiting on a JavaScript stream, we strictly use
+        // jsg::Promises and not kj::Promises, so that it doesn't look like I/O at all, and there's
+        // no need to drop the isolate lock and take it again every time some data is read/written.
+        // That's a larger refactor, though.
+        auto& ioContext = IoContext::current();
+        return ioContext.awaitIoLegacy(js, kj::mv(promise))
+            .then(js,
+                ioContext.addFunctor(
+                    [ref = addRef(), store = store.addRef(js), byteOffset, byteLength,
+                        isByob = maybeByobOptions != kj::none, tempBuffer = kj::mv(tempBuffer)](
+                        jsg::Lock& js, size_t amount) mutable -> jsg::Promise<ReadResult> {
+          auto& controller = static_cast<ReadableStreamInternalController&>(ref->getController());
+          auto view = store.getHandle(js);
+          controller.readPending = false;
+          KJ_ASSERT(amount <= byteLength);
+          if (amount == 0) {
+            if (!controller.state.is<StreamStates::Errored>()) {
+              controller.doClose(js);
+            }
+            KJ_IF_SOME(o, controller.owner) {
+              o->signalEof(js);
+            }
+            if (isByob && FeatureFlags::get(js).getInternalStreamByobReturn()) {
+              // When using the BYOB reader, we must return a sized-0 Uint8Array that is backed
+              // by the ArrayBuffer passed in the options.
+              return js.resolvedPromise(ReadResult{
+                .value = jsg::JsValue(view.getBuffer().newUint8View(0, 0)).addRef(js),
+                .done = true,
+              });
+            }
+            return js.resolvedPromise(ReadResult{.done = true});
+          }
+
+          // We have to check to see if the store was detached or resized while we were waiting
+          // for the read to complete.
+          if (view.isDetached()) {
+            // If the buffer was detached, we resolve with a new zero-length ArrayBuffer.
+            // The bytes that were read are lost, but this is a valid result.
+
+            // Silly user, trix are for kids.
+            IoContext::current().logWarningOnce(
+                "A buffer that was being used for a read operation on a ReadableStream was detached "
+                "while the read was pending. The read completed with a zero-length buffer and the "
+                "data that was read is lost. Avoid detaching buffers that are being used for active "
+                "read operations on streams, or use the streams_byob_reader_detaches_buffer "
+                "compatibility flag, to prevent this from happening."_kj);
+
+            return js.resolvedPromise(ReadResult{
+              .value = jsg::JsValue(jsg::JsUint8Array::create(js, 0)).addRef(js),
+              .done = false,
+            });
+          }
+
+          // Re-derive the deliverable length from the size the buffer has now. byteOffset and
+          // amount are compared against it without being summed, for the same reason as the bounds
+          // check at read time.
+          auto liveLength = view.getBuffer().size();
+          if (byteOffset > liveLength || amount > liveLength - byteOffset) {
+            // If the buffer was resized smaller, we return a truncated result.
+
+            IoContext::current().logWarningOnce(
+                "A buffer that was being used for a read operation on a ReadableStream was resized "
+                "smaller while the read was pending. The read completed with a truncated buffer "
+                "containing only the bytes that fit within the new size. Avoid resizing buffers "
+                "that are being used for active read operations on streams, or use the "
+                "streams_byob_reader_detaches_buffer compatibility flag, to prevent this from "
+                "happening."_kj);
+
+            if (byteOffset >= liveLength) {
+              // The view's own offset extends beyond the shrunken buffer, so the
+              // zero-length result view is created at offset 0 instead.
+              return js.resolvedPromise(ReadResult{
+                .value = jsg::JsValue(view.getBuffer().newUint8View(0, 0)).addRef(js),
+                .done = false,
+              });
+            }
+            amount = liveLength - byteOffset;
+          }
+
+          // Deliver the bytes from the temporary into the caller's BackingStore. The checks above
+          // guarantee the buffer is still attached and that [byteOffset, byteOffset + amount) lies
+          // within its live length, and `amount <= byteLength == tempBuffer.size()`.
+          KJ_ASSERT(byteOffset <= liveLength && amount <= liveLength - byteOffset);
+          view.getBuffer()
+              .asArrayPtr()
+              .slice(byteOffset, byteOffset + amount)
+              .copyFrom(tempBuffer.first(amount));
+
+          // Return a Uint8Array over the bytes that were read so the script can see how
+          // many bytes were read. Reads always resolve with a Uint8Array over the same
+          // buffer that backed the read, regardless of the view type provided in the
+          // read options.
+          return js.resolvedPromise(ReadResult{
+            .value = jsg::JsValue(view.getBuffer().newUint8View(byteOffset, amount)).addRef(js),
+            .done = false,
+          });
+        }),
+                ioContext.addFunctor([ref = addRef()](jsg::Lock& js,
+                                         jsg::Value reason) mutable -> jsg::Promise<ReadResult> {
+          auto& controller = static_cast<ReadableStreamInternalController&>(ref->getController());
+          controller.readPending = false;
+          auto error = jsg::JsValue(reason.getHandle(js));
+          if (!controller.state.is<StreamStates::Errored>()) {
+            controller.doError(js, error);
+          }
+
+          return js.rejectedPromise<ReadResult>(error);
+        }));
+      } else {
+        return js.rejectedPromise<ReadResult>(
+            js.typeError("Unable to allocate memory for read"_kj));
+      }
     }
   }
   KJ_UNREACHABLE;

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -82,8 +82,17 @@ jsg::Promise<ReadResult> ReaderImpl::read(
   KJ_IF_SOME(options, byobOptions) {
     // Per the spec, we must perform these checks before disturbing the stream.
     size_t atLeast = options.atLeast.orDefault(1);
+    auto byobView = options.bufferView.getHandle(js);
 
-    if (options.byteLength == 0) {
+    if (byobView.isImmutable()) {
+      return js.rejectedPromise<ReadResult>(
+          js.typeError("Cannot call read() with an immutable ArrayBuffer."_kj));
+    }
+
+    size_t byteLength = byobView.size();
+    auto elementSize = byobView.getElementSize();
+
+    if (byteLength == 0) {
       return js.rejectedPromise<ReadResult>(
           js.typeError("You must call read() on a \"byob\" reader with a positive-sized "
                        "TypedArray object."_kj));
@@ -101,18 +110,16 @@ jsg::Promise<ReadResult> ReaderImpl::read(
     // the buffer size. That keeps the multiplication below from overflowing however large buffers
     // are allowed to get, and it catches a negative minElements, which reaches this point
     // sign-extended to a huge size_t.
-    if (atLeast > options.byteLength) {
-      return js.rejectedPromise<ReadResult>(js.typeError(kj::str("Minimum bytes to read (", atLeast,
-          ") exceeds size of buffer (", options.byteLength, ").")));
+    if (atLeast > byteLength) {
+      return js.rejectedPromise<ReadResult>(js.typeError(kj::str(
+          "Minimum bytes to read (", atLeast, ") exceeds size of buffer (", byteLength, ").")));
     }
 
-    jsg::JsArrayBufferView source(options.bufferView.getHandle(js));
-    auto elementSize = source.getElementSize();
     atLeast = atLeast * elementSize;
 
-    if (atLeast > options.byteLength) {
-      return js.rejectedPromise<ReadResult>(js.typeError(kj::str("Minimum bytes to read (", atLeast,
-          ") exceeds size of buffer (", options.byteLength, ").")));
+    if (atLeast > byteLength) {
+      return js.rejectedPromise<ReadResult>(js.typeError(kj::str(
+          "Minimum bytes to read (", atLeast, ") exceeds size of buffer (", byteLength, ").")));
     }
 
     options.atLeast = atLeast;
@@ -239,13 +246,11 @@ void ReadableStreamBYOBReader::lockToStream(jsg::Lock& js, ReadableStream& strea
 }
 
 jsg::Promise<ReadResult> ReadableStreamBYOBReader::read(jsg::Lock& js,
-    v8::Local<v8::ArrayBufferView> byobBuffer,
+    jsg::JsArrayBufferView byobBuffer,
     jsg::Optional<ReadableStreamBYOBReaderReadOptions> maybeOptions) {
   static const ReadableStreamBYOBReaderReadOptions defaultOptions{};
   auto options = ReadableStreamController::ByobOptions{
-    .bufferView = js.v8Ref(byobBuffer),
-    .byteOffset = byobBuffer->ByteOffset(),
-    .byteLength = byobBuffer->ByteLength(),
+    .bufferView = byobBuffer.addRef(js),
     .atLeast = maybeOptions.orDefault(defaultOptions).min.orDefault(1),
     .detachBuffer = FeatureFlags::get(js).getStreamsByobReaderDetachesBuffer(),
   };
@@ -253,11 +258,9 @@ jsg::Promise<ReadResult> ReadableStreamBYOBReader::read(jsg::Lock& js,
 }
 
 jsg::Promise<ReadResult> ReadableStreamBYOBReader::readAtLeast(
-    jsg::Lock& js, int minElements, v8::Local<v8::ArrayBufferView> byobBuffer) {
+    jsg::Lock& js, int minElements, jsg::JsArrayBufferView byobBuffer) {
   auto options = ReadableStreamController::ByobOptions{
-    .bufferView = js.v8Ref(byobBuffer),
-    .byteOffset = byobBuffer->ByteOffset(),
-    .byteLength = byobBuffer->ByteLength(),
+    .bufferView = byobBuffer.addRef(js),
     .atLeast = minElements,
     .detachBuffer = true,
   };

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -163,7 +163,7 @@ public:
     JSG_STRUCT(min);
   };
 
-  jsg::Promise<ReadResult> read(jsg::Lock& js, v8::Local<v8::ArrayBufferView> byobBuffer,
+  jsg::Promise<ReadResult> read(jsg::Lock& js, jsg::JsArrayBufferView byobBuffer,
       jsg::Optional<ReadableStreamBYOBReaderReadOptions> options = kj::none);
 
   // Non-standard extension so that reads can specify a minimum number of elements to read. It's a
@@ -175,7 +175,7 @@ public:
   // TODO(soon): Like fetch() and Cache.match(), readAtLeast() returns a promise for a V8 object.
   jsg::Promise<ReadResult> readAtLeast(jsg::Lock& js,
                                         int minElements,
-                                        v8::Local<v8::ArrayBufferView> byobBuffer);
+                                        jsg::JsArrayBufferView byobBuffer);
 
   void releaseLock(jsg::Lock& js);
 

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -2091,7 +2091,7 @@ struct ByteReadable final: public kj::PtrTarget,
       reading = true;
       KJ_DEFER(reading = false);
       KJ_IF_SOME(byob, byobOptions) {
-        jsg::JsArrayBufferView view = jsg::JsArrayBufferView(byob.bufferView.getHandle(js));
+        auto view = byob.bufferView.getHandle(js);
         view = view.detachAndTake(js);
         size_t elementSize = view.getElementSize();
         // If atLeast is not given, then by default it is the element size of the view
@@ -2874,12 +2874,12 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamJsController::read(
   KJ_IF_SOME(byobOptions, maybeByobOptions) {
     byobOptions.detachBuffer = true;
     auto view = byobOptions.bufferView.getHandle(js);
-    if (!view->Buffer()->IsDetachable()) {
+    if (!view.isDetachable()) {
       return js.rejectedPromise<ReadResult>(
           js.typeError("Unabled to use non-detachable ArrayBuffer."_kj));
     }
 
-    if (view->ByteLength() == 0 || view->Buffer()->ByteLength() == 0) {
+    if (view.size() == 0) {
       return js.rejectedPromise<ReadResult>(
           js.typeError("Unable to use a zero-length ArrayBuffer."_kj));
     }
@@ -2893,10 +2893,9 @@ kj::Maybe<jsg::Promise<ReadResult>> ReadableStreamJsController::read(
       // If it is a BYOB read, then the spec requires that we return an empty
       // view of the same type provided, that uses the same backing memory
       // as that provided, but with zero-length.
-      auto source = jsg::JsArrayBufferView(byobOptions.bufferView.getHandle(js));
-      source = source.detachAndTake(js).slice(js, 0, 0);
+      view = view.detachAndTake(js).slice(js, 0, 0);
       return js.resolvedPromise(ReadResult{
-        .value = jsg::JsValue(source).addRef(js),
+        .value = jsg::JsValue(view).addRef(js),
         .done = true,
       });
     }

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -752,6 +752,11 @@ size_t JsArrayBuffer::size() const {
   return inner->ByteLength();
 }
 
+size_t JsArrayBuffer::backingStoreSize() const {
+  v8::Local<v8::ArrayBuffer> inner = *this;
+  return inner->GetBackingStore()->ByteLength();
+}
+
 kj::Array<kj::byte> JsArrayBuffer::copy() {
   auto ptr = asArrayPtr();
   return kj::heapArray(ptr);

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -255,6 +255,9 @@ class JsArrayBuffer final: public JsBase<v8::ArrayBuffer, JsArrayBuffer> {
 
   size_t size() const;
 
+  // Used for safety checks
+  size_t backingStoreSize() const;
+
   // Return a copy of this buffer's data as a kj::Array.
   kj::Array<kj::byte> copy();
 

--- a/src/wpt/fetch/api-test.ts
+++ b/src/wpt/fetch/api-test.ts
@@ -19,6 +19,8 @@ export default {
       'Stream errors once aborted, after reading. Underlying connection closed.',
       // Flaky since 2025-07-25. To be investigated.
       'Stream errors once aborted. Underlying connection closed.',
+      // Flaky since 2026-08-07. To be investigated.
+      'Underlying connection is closed when aborting after receiving response',
     ],
     expectedFailures: [
       // The fetch promise still resolves for some reason


### PR DESCRIPTION
…tions

The `ByobOptions` were using a cache length/offset making it risky when resizable/transfered ArrayBuffers were used. Harden it more by not caching the length/offset and switching to JsArrayBufferView