### PR TITLE
Add support for request-time WebAssembly compilation

### DIFF
--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -1125,7 +1125,12 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
           module: string;
           name: string;
         }
-        abstract class Module {
+        interface CompileOptions {
+          builtins?: string[];
+          importedStringConstants?: string;
+        }
+        class Module {
+          constructor(bytes: BufferSource, options?: CompileOptions);
           static customSections(module: Module, sectionName: string): ArrayBuffer[];
           static exports(module: Module): ModuleExportDescriptor[];
           static imports(module: Module): ModuleImportDescriptor[];
@@ -1145,13 +1150,25 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
           set(index: number, value?: any): void;
         }
 
-        function instantiate(module: Module, imports?: Imports): Promise<Instance>;
+        interface WebAssemblyInstantiatedSource {
+          instance: Instance;
+          module: Module;
+        }
+        function compile(bytes: BufferSource, options?: CompileOptions): Promise<Module>;
+        function instantiate(
+          bytes: BufferSource,
+          imports?: Imports,
+          options?: CompileOptions
+        ): Promise<WebAssemblyInstantiatedSource>;
+        function instantiate(
+          module: Module,
+          imports?: Imports
+        ): Promise<Instance>;
         function validate(bytes: BufferSource): boolean;
       }
     )");
-    // workerd disables dynamic WebAssembly compilation, so `compile()`, `compileStreaming()`, the
-    // `instantiate()` override taking a `BufferSource` and `instantiateStreaming()` are omitted.
-    // `Module` is also declared `abstract` to disable its `BufferSource` constructor.
+    // Streaming compilation remains unavailable because it cannot pass through request-time byte
+    // recording before compilation.
 
     JSG_TS_OVERRIDE({
       setTimeout(callback: (...args: any[]) => void, msDelay?: number): number;

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -1077,7 +1077,10 @@ wd_test(
 wd_test(
     src = "worker-test.wd-test",
     args = ["--experimental"],
-    data = ["worker-test.js"],
+    data = [
+        "worker-test.js",
+        "worker-wasm-disabled-test.js",
+    ],
 )
 
 wd_test(

--- a/src/workerd/api/tests/worker-test.js
+++ b/src/workerd/api/tests/worker-test.js
@@ -14,6 +14,9 @@ const StartupFunction2 = new Function('return 2+2');
 strictEqual(StartupFunction2(), 4); // should still work
 strictEqual((await import('module-does-eval')).default, 2); // should work
 
+const startupWasmBytes = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+const startupWasmModule = new WebAssembly.Module(startupWasmBytes);
+
 export const testStartupEval = {
   async test() {
     throws(() => eval('console.log("This should not work")'), {
@@ -53,6 +56,41 @@ export const testStartupEval = {
     class Foo extends Function {}
     const foo = new Foo();
     strictEqual(typeof foo, 'function');
+
+    strictEqual(startupWasmModule instanceof WebAssembly.Module, true);
+
+    const wasmBytes = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+    const module = new WebAssembly.Module(wasmBytes);
+    strictEqual(module instanceof WebAssembly.Module, true);
+    strictEqual(module.constructor, WebAssembly.Module);
+    strictEqual(WebAssembly.Module.length, 1);
+    strictEqual(WebAssembly.compile.length, 1);
+    strictEqual(WebAssembly.instantiate.length, 1);
+    throws(() => WebAssembly.Module(wasmBytes), TypeError);
+    throws(() => new WebAssembly.compile(wasmBytes), TypeError);
+    strictEqual(
+      Object.getOwnPropertyDescriptor(WebAssembly.Module, 'prototype').writable,
+      false
+    );
+
+    let optionsRead = false;
+    const compilePromise = WebAssembly.compile(wasmBytes, {
+      get builtins() {
+        optionsRead = true;
+        return [];
+      },
+    });
+    strictEqual(optionsRead, true);
+    const compiled = await compilePromise;
+    strictEqual(compiled instanceof WebAssembly.Module, true);
+    const instantiatedBytes = await WebAssembly.instantiate(wasmBytes);
+    strictEqual(instantiatedBytes.module instanceof WebAssembly.Module, true);
+    strictEqual(
+      instantiatedBytes.instance instanceof WebAssembly.Instance,
+      true
+    );
+    const instantiatedModule = await WebAssembly.instantiate(module);
+    strictEqual(instantiatedModule instanceof WebAssembly.Instance, true);
   },
 };
 

--- a/src/workerd/api/tests/worker-test.wd-test
+++ b/src/workerd/api/tests/worker-test.wd-test
@@ -12,7 +12,14 @@ const unitTests :Workerd.Config = (
         compatibilityFlags = [
           "nodejs_compat",
           "allow_eval_during_startup",
+          "experimental",
+          "request_time_webassembly_compilation",
         ]
+      )
+    ),
+    ( name = "worker-wasm-disabled-test",
+      worker = (
+        modules = [(name = "worker", esModule = embed "worker-wasm-disabled-test.js")],
       )
     ),
   ],

--- a/src/workerd/api/tests/worker-wasm-disabled-test.js
+++ b/src/workerd/api/tests/worker-wasm-disabled-test.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export default {
+  async test() {
+    const bytes = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+    try {
+      await WebAssembly.compile(bytes);
+    } catch (error) {
+      if (error.message.includes('Wasm code generation disallowed by embedder'))
+        return;
+      throw error;
+    }
+    throw new Error(
+      'Request-time WebAssembly compilation was enabled without its compatibility flag'
+    );
+  },
+};

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -98,6 +98,7 @@ wd_cc_library(
         ":observer",
         ":release-version",
         ":trace",
+        ":wasm-codegen-shim",
         ":wasm-instantiate-shim",
         ":worker-interface",
         ":worker-source",
@@ -417,6 +418,12 @@ wd_cc_embed(
     name = "maximum-compatibility-date",
     src = ":trimmed-maximum-compatibility-date.txt",
     base_name = "maximum-compatibility-date",
+)
+
+wd_cc_embed(
+    name = "wasm-codegen-shim",
+    src = "wasm-codegen-shim.js",
+    base_name = "wasm-codegen-shim",
 )
 
 wd_cc_embed(

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1642,4 +1642,9 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
       $compatEnableDate("2026-08-11");
   # Enables fast Workflow engine creation by generating instance IDs with the Durable Object
   # namespace's `newUniqueId()` method instead of UUIDs.
+
+  requestTimeWebAssemblyCompilation @186 :Bool
+      $compatEnableFlag("request_time_webassembly_compilation")
+      $experimental;
+  # Enables request-time WebAssembly compilation after retaining the exact input bytes.
 }

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -188,6 +188,15 @@ class IoChannelFactory: public virtual kj::Refcounted {
   // may implement Spectre mitigations.
   virtual TimerChannel& getTimer() = 0;
 
+  // Records WebAssembly bytes before request-time compilation. Production embedders can override
+  // this to durably retain the bytes; the standalone runtime permits compilation without upload.
+  virtual kj::Promise<void> uploadWasmForCodeGeneration(
+      kj::Array<kj::byte> module, SpanParent parentSpan) = 0;
+
+  // Retains an upload for a synchronous WebAssembly.Module constructor.
+  virtual void queueWasmUploadForCodeGeneration(
+      kj::Array<kj::byte> module, SpanParent parentSpan) = 0;
+
   // Write a log message to a logfwdr channel. Each log binding has its own channel number.
   //
   // The IoChannelFactory already knows which member of the overall message union is expected to

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -152,6 +152,11 @@ class RequestObserver: public kj::Refcounted {
   // Used to record when a worker has used a dynamic dispatch binding.
   virtual void setHasDispatched() {};
 
+  // Called before request-time WebAssembly bytes are uploaded or compiled.
+  virtual bool recordLoadedWasmModule(kj::ArrayPtr<const kj::byte> module) {
+    return true;
+  }
+
   virtual SpanParent getSpan() {
     return nullptr;
   }

--- a/src/workerd/io/wasm-codegen-shim.js
+++ b/src/workerd/io/wasm-codegen-shim.js
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+// This file contains shims for request-time WebAssembly compilation. Streaming compilation remains
+// unavailable because it cannot pass through byte retention before compilation.
+
+(function (prepareWasm, prepareWasmInBackground) {
+  const {
+    compile: originalCompile,
+    Instance,
+    instantiate: originalInstantiate,
+    Module,
+  } = WebAssembly;
+  // Capture trusted intrinsics once so Worker code cannot alter upload ordering or conversions.
+  const reflectApply = Reflect.apply;
+  const reflectConstruct = Reflect.construct;
+  const arrayFrom = Array.from;
+  const stringConstructor = String;
+  const promiseThen = Promise.prototype.then;
+  const rejectPromise = Promise.reject.bind(Promise);
+
+  function then(promise, onFulfilled) {
+    return reflectApply(promiseThen, promise, [onFulfilled]);
+  }
+
+  function copyCompileOptions(options) {
+    if (options === undefined) return undefined;
+    const result = {};
+    const builtins = options.builtins;
+    if (builtins !== undefined) {
+      result.builtins = reflectApply(arrayFrom, undefined, [
+        builtins,
+        stringConstructor,
+      ]);
+    }
+    const importedStringConstants = options.importedStringConstants;
+    if (importedStringConstants !== undefined) {
+      result.importedStringConstants = stringConstructor(
+        importedStringConstants
+      );
+    }
+    return result;
+  }
+
+  WebAssembly.compile = new Proxy(originalCompile, {
+    apply(_, receiver, args) {
+      try {
+        const [snapshot, upload] = prepareWasm(args[0]);
+        args[0] = snapshot;
+        if (args.length > 1) args[1] = copyCompileOptions(args[1]);
+        return then(upload, () => reflectConstruct(Module, args));
+      } catch (error) {
+        return rejectPromise(error);
+      }
+    },
+  });
+
+  WebAssembly.instantiate = new Proxy(originalInstantiate, {
+    apply(_, receiver, args) {
+      const moduleOrBytes = args[0];
+      if (moduleOrBytes instanceof Module) {
+        return reflectApply(originalInstantiate, receiver, args);
+      }
+
+      let start;
+      try {
+        const [snapshot, upload] = prepareWasm(moduleOrBytes);
+        if (args.length > 2) args[2] = copyCompileOptions(args[2]);
+        start = then(upload, () => {
+          const moduleArgs = args.length > 2 ? [snapshot, args[2]] : [snapshot];
+          const module = reflectConstruct(Module, moduleArgs);
+          const instance = reflectConstruct(Instance, [module, args[1]]);
+          return { module, instance };
+        });
+      } catch (error) {
+        return rejectPromise(error);
+      }
+      return start;
+    },
+  });
+
+  // WebAssembly.Module is synchronous, so its upload is retained as a background task.
+  const ModuleWrapper = new Proxy(Module, {
+    construct(target, args, newTarget) {
+      args[0] = prepareWasmInBackground(args[0]);
+      return reflectConstruct(target, args, newTarget);
+    },
+  });
+  Object.defineProperty(ModuleWrapper.prototype, 'constructor', {
+    value: ModuleWrapper,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(WebAssembly, 'Module', {
+    value: ModuleWrapper,
+    writable: true,
+    configurable: true,
+  });
+});

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -16,6 +16,7 @@
 #include <workerd/io/frankenvalue.h>
 #include <workerd/io/per-isolate-bootstrap.h>
 #include <workerd/io/tracer.h>
+#include <workerd/io/wasm-codegen-shim.embed.h>
 #include <workerd/io/wasm-instantiate-shim.embed.h>
 #include <workerd/io/worker.h>
 #include <workerd/jsg/async-context.h>
@@ -1764,6 +1765,78 @@ void shimWebAssemblyInstantiate(jsg::Lock& lock, v8::Local<v8::Context> context)
   shimFn.call(lock, lock.global(), jsg::JsFunction(registerFn));
 }
 
+// Installs wrappers that retain request-time WebAssembly bytes before compilation.
+void shimWebAssemblyCodeGeneration(jsg::Lock& lock, v8::Local<v8::Context> context) {
+  lock.allowWasmCodeGeneration();
+
+  static constexpr size_t MAX_REQUEST_TIME_WASM_SIZE = 64 * 1024 * 1024;
+  v8::Context::Scope contextScope(context);
+
+  // Snapshot a BufferSource and start recording it before V8 sees the bytes. Promise-based APIs
+  // receive [snapshot, uploadPromise]. WebAssembly.Module receives the snapshot after the embedder
+  // has retained the upload as a background task.
+  auto prepareCb = [](const v8::FunctionCallbackInfo<v8::Value>& info) {
+    auto& js = jsg::Lock::from(info.GetIsolate());
+    js.withinHandleScope([&] {
+      KJ_IF_SOME(e, kj::runCatchingExceptions([&] {
+        auto maybeIoContext = IoContext::tryCurrent();
+        if (maybeIoContext == kj::none) {
+          JSG_REQUIRE(js.isEvalAllowed(), Error,
+              "WebAssembly compilation only allowed during startup or while handling a request.");
+        }
+
+        JSG_REQUIRE(info.Length() >= 1, TypeError, "WebAssembly source must be a BufferSource");
+        auto source = JSG_REQUIRE_NONNULL(jsg::JsValue(info[0]).tryCast<jsg::JsBufferSource>(),
+            TypeError, "WebAssembly source must be a BufferSource");
+        KJ_IF_SOME(_, maybeIoContext) {
+          JSG_REQUIRE(source.size() <= MAX_REQUEST_TIME_WASM_SIZE, RangeError,
+              "WebAssembly source exceeds the maximum request-time compilation size");
+        }
+        auto bytes = source.copy();
+        auto snapshot = jsg::JsArrayBuffer::create(js, bytes);
+
+        auto returnAsyncResult = [&](jsg::Promise<void> upload) {
+          auto result = v8::Array::New(js.v8Isolate, 2);
+          jsg::check(result->Set(js.v8Context(), 0, snapshot));
+          jsg::check(result->Set(js.v8Context(), 1, upload.consumeHandle(js)));
+          info.GetReturnValue().Set(result);
+        };
+
+        KJ_IF_SOME(ioContext, maybeIoContext) {
+          JSG_REQUIRE(ioContext.getMetrics().recordLoadedWasmModule(bytes), Error,
+              "Too many unique WebAssembly modules loaded in a single request");
+          if (info.Data()->IsTrue()) {
+            ioContext.getIoChannelFactory().queueWasmUploadForCodeGeneration(
+                kj::mv(bytes), ioContext.getCurrentTraceSpan());
+            info.GetReturnValue().Set(static_cast<v8::Local<v8::ArrayBuffer>>(snapshot));
+          } else {
+            returnAsyncResult(ioContext.awaitIo(js,
+                ioContext.getIoChannelFactory().uploadWasmForCodeGeneration(
+                    kj::mv(bytes), ioContext.getCurrentTraceSpan())));
+          }
+        } else {
+          if (info.Data()->IsTrue()) {
+            info.GetReturnValue().Set(static_cast<v8::Local<v8::ArrayBuffer>>(snapshot));
+          } else {
+            returnAsyncResult(js.resolvedPromise());
+          }
+        }
+      })) {
+        js.v8Isolate->ThrowException(js.exceptionToJs(kj::mv(e)).getHandle(js));
+      }
+    });
+  };
+  auto prepareFn = jsg::check(v8::Function::New(context, prepareCb, v8::False(lock.v8Isolate)));
+  auto prepareBackgroundFn =
+      jsg::check(v8::Function::New(context, prepareCb, v8::True(lock.v8Isolate)));
+
+  auto shimScript =
+      jsg::NonModuleScript::compile(lock, WASM_CODEGEN_SHIM, "wasm-codegen-shim.js"_kj);
+  auto shimFn = KJ_ASSERT_NONNULL(shimScript.runAndReturn(lock).tryCast<jsg::JsFunction>());
+  shimFn.call(
+      lock, lock.global(), jsg::JsFunction(prepareFn), jsg::JsFunction(prepareBackgroundFn));
+}
+
 void Worker::setupContext(
     jsg::Lock& lock, v8::Local<v8::Context> context, const LoggingOptions& loggingOptions) {
   // We replace the default V8 console.log(), etc. methods, to give the worker access to
@@ -1798,6 +1871,14 @@ void Worker::setupContextInternalScripts(jsg::Lock& lock, v8::Local<v8::Context>
 
   // Shim WebAssembly.instantiate to detect modules exporting "__instance_signal".
   shimWebAssemblyInstantiate(lock, context);
+
+  // Retain request-time WebAssembly bytes before compiling them.
+  if (Worker::Isolate::from(lock)
+          .getApi()
+          .getFeatureFlags()
+          .getRequestTimeWebAssemblyCompilation()) {
+    shimWebAssemblyCodeGeneration(lock, context);
+  }
 }
 // =======================================================================================
 

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -381,6 +381,10 @@ bool Lock::isEvaluatingModule() {
   return IsolateBase::from(v8Isolate).isEvaluatingModule();
 }
 
+void Lock::allowWasmCodeGeneration() {
+  IsolateBase::from(v8Isolate).allowWasmCodeGeneration({});
+}
+
 Lock::ModuleEvaluationScope::ModuleEvaluationScope(Lock& js): js(js) {
   IsolateBase::from(js.v8Isolate).enterModuleEvaluation({});
 }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -3201,6 +3201,10 @@ class Lock {
 
   bool isEvaluatingModule();
 
+  // Permanently enables WebAssembly code generation for this isolate without enabling string
+  // code generation.
+  void allowWasmCodeGeneration();
+
   class ModuleEvaluationScope {
    public:
     explicit ModuleEvaluationScope(Lock& js);

--- a/src/workerd/jsg/setup-test.c++
+++ b/src/workerd/jsg/setup-test.c++
@@ -35,6 +35,10 @@ KJ_TEST("eval() is blocked") {
   e.expectEval("new Function('a', 'b', undefined)", "throws",
       "EvalError: Code generation from strings disallowed for this context");
 
+  e.expectEval("new WebAssembly.Module(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0])) instanceof "
+               "WebAssembly.Module",
+      "throws", "CompileError: WebAssembly.Module(): Wasm code generation disallowed by embedder");
+
   // Extending Function with super() and no arguments is also allowed.
   e.expectEval("class Foo extends Function { constructor() { super(); } }; typeof new Foo()",
       "string", "function");
@@ -43,6 +47,9 @@ KJ_TEST("eval() is blocked") {
 
   e.expectEval("eval('123')", "number", "123");
   e.expectEval("new Function('a', 'b', 'return a + b;')(123, 321)", "number", "444");
+  e.expectEval("new WebAssembly.Module(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0])) instanceof "
+               "WebAssembly.Module",
+      "boolean", "true");
 
   e.getIsolate().runInLockScope([&](EvalIsolate::Lock& lock) { lock.setAllowEval(false); });
 
@@ -50,10 +57,6 @@ KJ_TEST("eval() is blocked") {
       "EvalError: Code generation from strings disallowed for this context");
   e.expectEval("new Function('a', 'b', 'return a + b;')(123, 321)", "throws",
       "EvalError: Code generation from strings disallowed for this context");
-
-  // Note: It would be nice to test as well that WebAssembly is blocked, but that requires
-  //   setting up an event loop since the WebAssembly calls are all async. We'll test this
-  //   elsewhere.
 }
 
 // ========================================================================================

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -595,10 +595,9 @@ v8::ModifyCodeGenerationFromStringsResult IsolateBase::modifyCodeGenCallback(
 }
 
 bool IsolateBase::allowWasmCallback(v8::Local<v8::Context> context, v8::Local<v8::String> source) {
-  // Don't allow WASM unless arbitrary eval() is allowed.
   IsolateBase* self =
       static_cast<IsolateBase*>(v8::Isolate::GetCurrent()->GetData(SET_DATA_ISOLATE_BASE));
-  return self->evalAllowed;
+  return self->evalAllowed || self->wasmCodeGenerationAllowed;
 }
 
 void IsolateBase::jitCodeEvent(const v8::JitCodeEvent* event) noexcept {

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -196,6 +196,10 @@ class IsolateBase {
     return evalAllowed;
   }
 
+  inline void allowWasmCodeGeneration(kj::Badge<Lock>) {
+    wasmCodeGenerationAllowed = true;
+  }
+
   inline void setDisallowJavascriptExecution(kj::Badge<Lock>, bool allow) {
     if (allow) {
       javascriptExecutionDisallowed++;
@@ -435,6 +439,7 @@ class IsolateBase {
   // When true, evalAllowed is true and switching it to false is a no-op.
   bool alwaysAllowEval = false;
   bool evalAllowed = false;
+  bool wasmCodeGenerationAllowed = false;
 
   // When > 0, we take the "safe" path in unwrap() to avoid calling Get() which can invoke
   // user-defined getters, triggering the `DisallowJavascriptExecution` scope constructed

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -4285,6 +4285,12 @@ class Server::WorkerService final: public Service,
     return *this;
   }
 
+  kj::Promise<void> uploadWasmForCodeGeneration(kj::Array<kj::byte>, SpanParent) override {
+    return kj::READY_NOW;
+  }
+
+  void queueWasmUploadForCodeGeneration(kj::Array<kj::byte>, SpanParent) override {}
+
   kj::Promise<void> writeLogfwdr(
       uint channel, kj::FunctionParam<void(capnp::AnyPointer::Builder)> buildMessage) override {
     auto& context = IoContext::current();

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -304,6 +304,10 @@ struct TestFixture {
     TimerChannel& getTimer() override {
       return timer;
     }
+    kj::Promise<void> uploadWasmForCodeGeneration(kj::Array<kj::byte>, SpanParent) override {
+      return kj::READY_NOW;
+    }
+    void queueWasmUploadForCodeGeneration(kj::Array<kj::byte>, SpanParent) override {}
     kj::Promise<void> writeLogfwdr(
         uint channel, kj::FunctionParam<void(capnp::AnyPointer::Builder)> buildMessage) override {
       KJ_FAIL_ASSERT("no log channels");

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -263,7 +263,12 @@ declare namespace WebAssembly {
     module: string;
     name: string;
   }
-  abstract class Module {
+  interface CompileOptions {
+    builtins?: string[];
+    importedStringConstants?: string;
+  }
+  class Module {
+    constructor(bytes: BufferSource, options?: CompileOptions);
     static customSections(module: Module, sectionName: string): ArrayBuffer[];
     static exports(module: Module): ModuleExportDescriptor[];
     static imports(module: Module): ModuleImportDescriptor[];
@@ -281,6 +286,19 @@ declare namespace WebAssembly {
     grow(delta: number, value?: any): number;
     set(index: number, value?: any): void;
   }
+  interface WebAssemblyInstantiatedSource {
+    instance: Instance;
+    module: Module;
+  }
+  function compile(
+    bytes: BufferSource,
+    options?: CompileOptions,
+  ): Promise<Module>;
+  function instantiate(
+    bytes: BufferSource,
+    imports?: Imports,
+    options?: CompileOptions,
+  ): Promise<WebAssemblyInstantiatedSource>;
   function instantiate(module: Module, imports?: Imports): Promise<Instance>;
   function validate(bytes: BufferSource): boolean;
 }

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -263,7 +263,12 @@ export declare namespace WebAssembly {
     module: string;
     name: string;
   }
-  abstract class Module {
+  interface CompileOptions {
+    builtins?: string[];
+    importedStringConstants?: string;
+  }
+  class Module {
+    constructor(bytes: BufferSource, options?: CompileOptions);
     static customSections(module: Module, sectionName: string): ArrayBuffer[];
     static exports(module: Module): ModuleExportDescriptor[];
     static imports(module: Module): ModuleImportDescriptor[];
@@ -281,6 +286,19 @@ export declare namespace WebAssembly {
     grow(delta: number, value?: any): number;
     set(index: number, value?: any): void;
   }
+  interface WebAssemblyInstantiatedSource {
+    instance: Instance;
+    module: Module;
+  }
+  function compile(
+    bytes: BufferSource,
+    options?: CompileOptions,
+  ): Promise<Module>;
+  function instantiate(
+    bytes: BufferSource,
+    imports?: Imports,
+    options?: CompileOptions,
+  ): Promise<WebAssemblyInstantiatedSource>;
   function instantiate(module: Module, imports?: Imports): Promise<Instance>;
   function validate(bytes: BufferSource): boolean;
 }


### PR DESCRIPTION
Add the request_time_webassembly_compilation compatibility flag and keep the feature disabled by default.

Wrap WebAssembly.compile(), byte-based instantiate(), and Module() to snapshot exact input bytes before compilation.
Await retention for promise APIs and queue best-effort retention for the synchronous constructor.

Expose embedder upload hooks and per-request admission accounting while keeping eval() and Function() disabled. Preserve startup compilation and existing WebAssembly API behavior.