### PR TITLE
Fix error messages on types to avoid Js* names

### DIFF
--- a/src/workerd/api/tests/reporterror-test.js
+++ b/src/workerd/api/tests/reporterror-test.js
@@ -37,7 +37,7 @@ reportError('boom');
 throws(() => reportError(), {
   message:
     "Failed to execute 'reportError' on 'ServiceWorkerGlobalScope': " +
-    "parameter 1 is not of type 'JsValue'.",
+    "parameter 1 is not of type 'Value'.",
 });
 
 export const reportErrorTest = {

--- a/src/workerd/jsg/jsvalue-test.c++
+++ b/src/workerd/jsg/jsvalue-test.c++
@@ -139,7 +139,7 @@ KJ_TEST("simple") {
   e.expectEval("setRef('foo'); getRef('foo')", "string", "foo");
   e.expectEval("takeJsObject(undefined)", "throws",
       "TypeError: Failed to execute 'takeJsObject' on 'JsValueContext': parameter 1 "
-      "is not of type 'JsObject'.");
+      "is not of type 'Object'.");
   e.expectEval("getDate() instanceof Date", "boolean", "true");
   e.expectEval(
       "checkProxyPrototype(new Proxy(class extends Foo{}, {})) === Foo", "boolean", "true");

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -1159,12 +1159,12 @@ struct JsValueWrapper {
 
   // `BufferSource` is a Web IDL type with no V8 equivalent, so name it explicitly rather than
   // falling through to the templates above, which would name the C++ class.
-  static constexpr kj::LiteralStringConst getName(JsBufferSource*) {
-    return "BufferSource"_kjc;
+  static constexpr const char* getName(JsBufferSource*) {
+    return "BufferSource";
   }
 
-  static constexpr kj::LiteralStringConst getName(JsRef<JsBufferSource>*) {
-    return "BufferSource"_kjc;
+  static constexpr const char* getName(JsRef<JsBufferSource>*) {
+    return "BufferSource";
   }
 
   // `getName()` supplies the type name that appears in the TypeError thrown when unwrapping a

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -1144,6 +1144,9 @@ struct JsValueWrapper {
   V(Value)                                                                                         \
   JS_TYPE_CLASSES(V)
 
+  // Fallback for JsValueType types that have no corresponding V8 type, and so can only name
+  // themselves. The `TYPES_TO_WRAP` overloads below take precedence for the types they cover,
+  // being non-templates.
   template <JsValueType T>
   static constexpr const std::type_info& getName(T*) {
     return typeid(T);
@@ -1154,7 +1157,28 @@ struct JsValueWrapper {
     return typeid(T);
   }
 
+  // `BufferSource` is a Web IDL type with no V8 equivalent, so name it explicitly rather than
+  // falling through to the templates above, which would name the C++ class.
+  static constexpr kj::LiteralStringConst getName(JsBufferSource*) {
+    return "BufferSource"_kjc;
+  }
+
+  static constexpr kj::LiteralStringConst getName(JsRef<JsBufferSource>*) {
+    return "BufferSource"_kjc;
+  }
+
+  // `getName()` supplies the type name that appears in the TypeError thrown when unwrapping a
+  // parameter fails. Name the V8 type rather than the C++ wrapper class, so that a `JsArrayBuffer`
+  // parameter is reported as 'ArrayBuffer' -- the name the script author wrote -- and not as
+  // 'JsArrayBuffer', which means nothing outside this codebase. `typeName()` strips the `v8::`
+  // namespace qualifier.
 #define V(Name)                                                                                    \
+  static constexpr const std::type_info& getName(Js##Name*) {                                      \
+    return typeid(v8::Name);                                                                       \
+  }                                                                                                \
+  static constexpr const std::type_info& getName(JsRef<Js##Name>*) {                               \
+    return typeid(v8::Name);                                                                       \
+  }                                                                                                \
   v8::Local<v8::Name> wrap(jsg::Lock& js, v8::Local<v8::Context> context,                          \
       kj::Maybe<v8::Local<v8::Object>> creator, Js##Name value) {                                  \
     return value;                                                                                  \


### PR DESCRIPTION
James' recent change at
https://github.com/cloudflare/workerd/pull/6932/changes#diff-cf3ef99febc9f6094b40af5937078c19d6e7789bb89178e4a2c817dffb043d14R166 changed the type of a method in readable.h.  Because of the way JSG works, this also changes the error message from
     read: parameter 2 is not of type 'ArrayBufferView'
to
     read: parameter 2 is not of type 'JsArrayBufferView'

This type makes no sense to our users, so we should make sure it is not visible in error messages.

This change fixes several cases of this sort of thing and updates some test expectations to match.