### PR TITLE
Add HandleScope in logWarning

### DIFF
--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -165,6 +165,15 @@ wd_test(
     tags = ["resources:socket:1"],
 )
 
+wd_test(
+    src = "rpc-stub-gc-warning-test.wd-test",
+    args = ["--experimental"],
+    data = [
+        "rpc-stub-gc-warning-test.js",
+        "tail-worker-test-no-op.js",
+    ],
+)
+
 # Test to validate timing semantics for JSRPC streaming responses.
 # This test verifies that Return events occur when the handler returns,
 # NOT when the stream is fully consumed.

--- a/src/workerd/api/tests/rpc-stub-gc-warning-test.js
+++ b/src/workerd/api/tests/rpc-stub-gc-warning-test.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+import assert from 'node:assert';
+import { WorkerEntrypoint } from 'cloudflare:workers';
+
+export class MyService extends WorkerEntrypoint {
+  // Returns a transient object rather than a plain value, so the caller receives a stub that it
+  // is responsible for disposing.
+  getCounter() {
+    let value = 0;
+    return {
+      increment() {
+        return ++value;
+      },
+    };
+  }
+}
+
+// Obtains a stub and drops it without disposing. Kept in its own function so the stub is not
+// still referenced by the caller's frame when the collection runs.
+async function leakStub(env) {
+  let counter = await env.MyService.getCounter();
+  assert.strictEqual(await counter.increment(), 1);
+}
+
+export default {
+  async test(ctrl, env, ctx) {
+    // A leaked RPC stub makes ~JsRpcStub log a warning from a GC finalizer. Reaching that
+    // warning requires the collection to happen while this request is still live, so that
+    // IoContext::tryCurrent() and its tracer are both still available -- hence the explicit
+    // gc() below rather than waiting for a collection to occur on its own.
+    //
+    // Logging the warning reads the current async context to attribute it to a span, which
+    // creates V8 handles. Handle creation during a collection requires a fresh HandleScope,
+    // because V8 seals the enclosing one for the duration of the collection. Without one this
+    // aborts the process with "Cannot create a handle without a HandleScope".
+    //
+    // A streaming tail worker must be configured for this to bite: the tracer is what pulls the
+    // warning down the path that touches the async context.
+    await leakStub(env);
+
+    // Unwind to a fresh task so the stub is not kept alive by a stack slot, which conservative
+    // stack scanning would otherwise treat as a root.
+    await scheduler.wait(0);
+
+    // Reaching the end of this test at all is the assertion: the process must not abort.
+    //
+    // Whether the abort actually fires depends on the V8 build. V8 only refuses handle creation
+    // while its seal is in force, which lasts for the duration of a collection; if sweeping is
+    // deferred past the end of the collection then the finalizer runs outside the seal and the
+    // handle is created silently. Builds with V8 checks enabled sweep within the collection and
+    // do abort. The warning is emitted either way, so this test still drives the code path
+    // everywhere -- it just cannot fail everywhere.
+    gc();
+    gc();
+  },
+};

--- a/src/workerd/api/tests/rpc-stub-gc-warning-test.wd-test
+++ b/src/workerd/api/tests/rpc-stub-gc-warning-test.wd-test
@@ -1,0 +1,29 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "rpc-stub-gc-warning-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "rpc-stub-gc-warning-test.js")
+        ],
+        compatibilityFlags = ["nodejs_compat", "experimental"],
+        bindings = [
+          (name = "MyService", service = (
+            name = "rpc-stub-gc-warning-test",
+            entrypoint = "MyService")),
+        ],
+        # The tracer is what routes the GC-time warning through the async-context lookup that
+        # creates handles, so a streaming tail worker is required to exercise the bug.
+        streamingTails = ["no-op-tail"],
+      )
+    ),
+    ( name = "no-op-tail",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "tail-worker-test-no-op.js")
+        ],
+      ),
+    ),
+  ],
+);

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3567,9 +3567,17 @@ void Worker::Isolate::logWarning(kj::StringPtr description, Lock& lock) {
       capnp::JsonCodec json;
       auto jsonDescription = kj::str("[", json.encode(capnp::Text::Reader(description)), "]");
 
-      auto timestamp = ioContext.now();
-      tracer.addLog(
-          ioContext.getInvocationSpanContext(), timestamp, LogLevel::WARN, kj::mv(jsonDescription));
+      // The wrapped call needs a HandleScope on the stack, because
+      // `getInvocationSpanContext()` probes the current async context for the
+      // active user span, which creates V8 handles. Our callers are not
+      // required to have a HandleScope and eg. the GC destructors in
+      // worker-rpc.c++ reach here without one.  We establish one here.
+      jsg::Lock& js = lock;
+      js.withinHandleScope([&] {
+        auto timestamp = ioContext.now();
+        tracer.addLog(ioContext.getInvocationSpanContext(), timestamp, LogLevel::WARN,
+            kj::mv(jsonDescription));
+      });
     }
   }
 }


### PR DESCRIPTION
This was a missing handle scope during GC callbacks.