### PR TITLE
Ensure hibernated websockets handle code updates gracefully

### DIFF
--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -25,47 +25,20 @@ void markHibernatableWebSocketReceive(IoContext& context) {
 
 HibernatableWebSocketEvent::HibernatableWebSocketEvent(): ExtendableEvent("webSocketMessage") {};
 
-Worker::Actor::HibernationManager& HibernatableWebSocketEvent::getHibernationManager(
-    jsg::Lock& lock) {
-  auto& actor = KJ_REQUIRE_NONNULL(IoContext::current().getActor());
-  return KJ_REQUIRE_NONNULL(actor.getHibernationManager());
-}
-
 HibernatableWebSocketEvent::ItemsForRelease HibernatableWebSocketEvent::prepareForRelease(
     jsg::Lock& lock, kj::StringPtr websocketId) {
-  auto& manager = kj::downcast<LegacyHibernationManagerImpl>(getHibernationManager(lock));
-  auto& hibernatableWebSocket =
-      KJ_REQUIRE_NONNULL(manager.webSocketsForEventHandler.findEntry(websocketId));
-
-  // Note that we don't call `claimWebSocket()` to get this, since we would lose our reference to
-  // the HibernatableWebSocket (it removes it from `webSocketsForEventHandler`).
-  auto websocketRef = hibernatableWebSocket.value->getActiveOrUnhibernate(lock);
-  auto tags = hibernatableWebSocket.value->getTags();
-
-  // Now that we've obtained the websocket for the event, let's free up the slots we had allocated.
-  manager.webSocketsForEventHandler.erase(hibernatableWebSocket);
+  auto& hibernatableWebSocket = LegacyHibernationManagerImpl::takeWebSocketForEvent(websocketId);
+  auto websocketRef = hibernatableWebSocket.getActiveOrUnhibernate(lock);
+  auto tags = hibernatableWebSocket.getTags();
 
   return ItemsForRelease(kj::mv(websocketRef), kj::mv(tags));
 }
 
 jsg::Ref<WebSocket> HibernatableWebSocketEvent::claimWebSocket(
     jsg::Lock& lock, kj::StringPtr websocketId) {
-  // Should only be called once per event since it removes the HibernatableWebSocket from the
-  // webSocketsForEventHandler collection.
-  auto& manager = kj::downcast<LegacyHibernationManagerImpl>(getHibernationManager(lock));
-
-  // Grab it from our collection.
-  auto& hibernatableWebSocket =
-      KJ_REQUIRE_NONNULL(manager.webSocketsForEventHandler.findEntry(websocketId));
-
-  // Get the reference.
-  auto websocket = hibernatableWebSocket.value->getActiveOrUnhibernate(lock);
-
-  // Now that we've obtained the websocket, we need to remove the entry from the map and make the
-  // key available again.
-  manager.webSocketsForEventHandler.erase(hibernatableWebSocket);
-
-  return kj::mv(websocket);
+  // Should only be called once per event since it deregisters the event's HibernatableWebSocket.
+  auto& hibernatableWebSocket = LegacyHibernationManagerImpl::takeWebSocketForEvent(websocketId);
+  return hibernatableWebSocket.getActiveOrUnhibernate(lock);
 }
 
 kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEvent::run(
@@ -83,14 +56,12 @@ kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEve
 
   EventOutcome outcome = EventOutcome::OK;
 
-  // We definitely have an actor by this point. Let's set the hibernation manager on the actor
-  // before we start running any events that might need to access it.
-  auto& a = KJ_REQUIRE_NONNULL(context.getActor());
-  if (a.getHibernationManager() == kj::none) {
-    a.setHibernationManager(kj::addRef(KJ_REQUIRE_NONNULL(manager)));
-  }
-
   auto eventParameters = consumeParams();
+
+  // Deliberately outside the try below: failing to route the event is not the application's
+  // failure, and the catch block would report it as the handler having thrown.
+  ensureHibernationManagerForEvent(
+      KJ_REQUIRE_NONNULL(context.getActor()), eventParameters.websocketId);
 
   try {
     co_await context.run(
@@ -144,6 +115,46 @@ kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEve
   };
 }
 
+void HibernatableWebSocketCustomEvent::ensureHibernationManagerForEvent(
+    Worker::Actor& actor, kj::StringPtr websocketId) {
+  // Resolved before any JS runs, so an event that cannot be routed fails here rather than from
+  // inside a handler that has already observed it.
+  auto& manager = KJ_REQUIRE_NONNULL(LegacyHibernationManagerImpl::findManagerForEvent(websocketId),
+      "hibernatable WebSocket event manager was not found for this event ID");
+
+  // The adopt branch below has no manager of its own to compare against, so these checks are what
+  // stop an actor adopting a manager another actor is still using. Both are needed, for the reasons
+  // given on LegacyHibernationManagerImpl::takeWebSocketForEvent().
+  KJ_IF_SOME(ownerId, manager.getOwningActorId()) {
+    KJ_REQUIRE(Worker::Actor::idsEqual(ownerId, actor.getId()),
+        "hibernatable WebSocket event names a hibernation manager owned by a different actor");
+  }
+  KJ_IF_SOME(owner, manager.getOwningActor()) {
+    KJ_REQUIRE(&owner == &actor,
+        "hibernatable WebSocket event names a hibernation manager owned by a different live actor");
+  }
+
+  KJ_IF_SOME(existing, actor.getHibernationManager()) {
+    // The event ID is resolved in a registry shared by every manager on the event loop, so it can
+    // name a manager this actor does not use. That means the event was misrouted, and delivering it
+    // would strand the socket in a manager this actor's own getWebSockets() cannot see.
+    KJ_REQUIRE(&existing == &manager,
+        "hibernatable WebSocket event ID names a different hibernation manager than the receiving "
+        "actor's");
+  } else {
+    // A fresh actor, including the one a code-update wake creates, adopts the manager holding the
+    // socket rather than building a second one on its first acceptWebSocket() call.
+    //
+    // The ID checked above is shared by every facet of a Durable Object, so it does not by itself
+    // say that this actor is a later generation of the holder the sockets belong to rather than a
+    // sibling facet. Adopting stamps the manager with this actor, erasing who it belonged to, so
+    // this is the last point at which the distinction can be made.
+    KJ_REQUIRE(actor.ownsHibernatedSockets(manager),
+        "hibernatable WebSocket event names a hibernation manager owned by a different holder");
+    actor.setHibernationManager(manager.addRef());
+  }
+}
+
 kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEvent::sendRpc(
     capnp::HttpOverCapnpFactory& httpOverCapnpFactory,
     capnp::ByteStreamFactory& byteStreamFactory,
@@ -182,6 +193,8 @@ kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEve
     }
   }
 
+  // The registration this event relies on is owned by the task that is delivering it, which
+  // deregisters the event once this promise settles either way.
   return req.send().then([](auto resp) {
     auto respResult = resp.getResult();
     return WorkerInterface::CustomEvent::Result{
@@ -195,16 +208,14 @@ HibernatableWebSocketEvent::ItemsForRelease::ItemsForRelease(
     : webSocketRef(kj::mv(ref)),
       tags(kj::mv(tags)) {}
 
-HibernatableWebSocketCustomEvent::HibernatableWebSocketCustomEvent(uint16_t typeId,
-    kj::Own<HibernationReader> params,
-    kj::Maybe<Worker::Actor::HibernationManager&> manager)
+HibernatableWebSocketCustomEvent::HibernatableWebSocketCustomEvent(
+    uint16_t typeId, kj::Own<HibernationReader> params)
     : typeId(typeId),
       params(kj::mv(params)) {}
 HibernatableWebSocketCustomEvent::HibernatableWebSocketCustomEvent(
-    uint16_t typeId, HibernatableSocketParams params, Worker::Actor::HibernationManager& manager)
+    uint16_t typeId, HibernatableSocketParams params)
     : typeId(typeId),
-      params(kj::mv(params)),
-      manager(manager) {}
+      params(kj::mv(params)) {}
 
 // Try to extract event type from params if available
 tracing::HibernatableWebSocketEventInfo::Type HibernatableWebSocketCustomEvent::getEventType()

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -18,6 +18,7 @@ namespace workerd::api {
 
 using HibernationReader =
     rpc::HibernatableWebSocketEventDispatcher::HibernatableWebSocketEventParams::Reader;
+struct HibernatableWebSocketCustomEventTestAccess;
 class HibernatableWebSocketEvent final: public ExtendableEvent {
  public:
   explicit HibernatableWebSocketEvent();
@@ -76,6 +77,8 @@ class HibernatableWebSocketCustomEvent final: public WorkerInterface::CustomEven
   }
 
  private:
+  friend struct HibernatableWebSocketCustomEventTestAccess;
+
   // Returns `params`, but if we have a HibernationReader we convert it to a
   // HibernatableSocketParams first.
   HibernatableSocketParams consumeParams();

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -42,19 +42,16 @@ class HibernatableWebSocketEvent final: public ExtendableEvent {
   JSG_RESOURCE_TYPE(HibernatableWebSocketEvent) {
     JSG_INHERIT(ExtendableEvent);
   }
-
- private:
-  Worker::Actor::HibernationManager& getHibernationManager(jsg::Lock& lock);
 };
 
 class HibernatableWebSocketCustomEvent final: public WorkerInterface::CustomEvent,
                                               public kj::Refcounted {
  public:
-  HibernatableWebSocketCustomEvent(uint16_t typeId,
-      kj::Own<HibernationReader> params,
-      kj::Maybe<Worker::Actor::HibernationManager&> manager = kj::none);
-  HibernatableWebSocketCustomEvent(
-      uint16_t typeId, HibernatableSocketParams params, Worker::Actor::HibernationManager& manager);
+  // The event carries no manager reference: the manager owning the socket is found from the event's
+  // WebSocket ID when the event runs. An RPC-delivered event could not carry a C++ reference, and a
+  // local one cannot know whether the actor it reaches still uses the same manager.
+  HibernatableWebSocketCustomEvent(uint16_t typeId, kj::Own<HibernationReader> params);
+  HibernatableWebSocketCustomEvent(uint16_t typeId, HibernatableSocketParams params);
 
   kj::Promise<Result> run(kj::Own<IoContext_IncomingRequest> incomingRequest,
       kj::Maybe<kj::StringPtr> entrypointName,
@@ -83,13 +80,17 @@ class HibernatableWebSocketCustomEvent final: public WorkerInterface::CustomEven
   // HibernatableSocketParams first.
   HibernatableSocketParams consumeParams();
 
+  // Resolves the manager owning `websocketId` and installs it on the actor if the actor has none,
+  // as the actor created by a code-update wake has not. Throws if the actor already holds a
+  // different manager, which means the event reached an actor that does not own the socket.
+  void ensureHibernationManagerForEvent(Worker::Actor& actor, kj::StringPtr websocketId);
+
   // Peeks at params to extract the event type for tracing, without consuming them.
   tracing::HibernatableWebSocketEventInfo::Type getEventType() const;
 
   uint16_t typeId;
   kj::OneOf<HibernatableSocketParams, kj::Own<HibernationReader>> params;
   kj::Maybe<uint32_t> timeoutMs;
-  kj::Maybe<Worker::Actor::HibernationManager&> manager;
 };
 
 #define EW_WEB_SOCKET_MESSAGE_ISOLATE_TYPES                                                        \

--- a/src/workerd/io/hibernation-manager-test.c++
+++ b/src/workerd/io/hibernation-manager-test.c++
@@ -12,7 +12,9 @@
 // implementation as that work lands. The tests themselves are the source of
 // truth for the contract; comments are best-effort context.
 
+#include <workerd/api/hibernatable-web-socket.h>
 #include <workerd/api/web-socket.h>
+#include <workerd/io/frankenvalue.h>
 #include <workerd/io/legacy-hibernation-manager.h>
 #include <workerd/io/worker-interface.h>
 #include <workerd/io/worker.h>
@@ -27,6 +29,88 @@
 
 namespace workerd {
 
+struct LegacyHibernationManagerTestAccess {
+  static void registerOnlyWebSocketForEvent(
+      LegacyHibernationManagerImpl& manager, kj::String websocketId) {
+    manager.registerEventWebSocket(kj::mv(websocketId), getOnlyWebSocket(manager));
+  }
+
+  static void registerWebSocketForEvent(
+      LegacyHibernationManagerImpl& manager, kj::String websocketId, size_t acceptIndex) {
+    manager.registerEventWebSocket(
+        kj::mv(websocketId), getWebSocketByAcceptOrder(manager, acceptIndex));
+  }
+
+  static bool findManagerForEventMatches(
+      kj::StringPtr websocketId, LegacyHibernationManagerImpl& expectedManager) {
+    KJ_IF_SOME(manager, LegacyHibernationManagerImpl::findManagerForEvent(websocketId)) {
+      return &kj::downcast<LegacyHibernationManagerImpl>(manager) == &expectedManager;
+    }
+    return false;
+  }
+
+  static void cancelEvent(LegacyHibernationManagerImpl& manager, kj::StringPtr websocketId) {
+    manager.cancelEvent(websocketId);
+  }
+
+  static kj::Own<WorkerInterface> getWorkerForOnlyWebSocket(LegacyHibernationManagerImpl& manager) {
+    return manager.getWorkerForEvent(getOnlyWebSocket(manager));
+  }
+
+  static size_t registeredEventCount(LegacyHibernationManagerImpl& manager) {
+    return manager.registeredEventCount;
+  }
+
+  static size_t loopbackWaiterCount(LegacyHibernationManagerImpl& manager) {
+    return manager.loopbackWaiters.size();
+  }
+
+  static bool takeWebSocketForEventMatches(
+      kj::StringPtr websocketId, LegacyHibernationManagerImpl& expectedManager) {
+    auto& webSocket = LegacyHibernationManagerImpl::takeWebSocketForEvent(websocketId);
+    return &webSocket == &getOnlyWebSocket(expectedManager);
+  }
+
+  static bool takeWebSocketForEventMatches(kj::StringPtr websocketId,
+      LegacyHibernationManagerImpl& expectedManager,
+      size_t acceptIndex) {
+    auto& webSocket = LegacyHibernationManagerImpl::takeWebSocketForEvent(websocketId);
+    return &webSocket == &getWebSocketByAcceptOrder(expectedManager, acceptIndex);
+  }
+
+  // Whether the event is registered at all, without naming a manager. Lets a test outlive the
+  // manager it registered and still observe the registry.
+  static bool hasEventRegistration(kj::StringPtr websocketId) {
+    return LegacyHibernationManagerImpl::findManagerForEvent(websocketId) != kj::none;
+  }
+
+ private:
+  static LegacyHibernationManagerImpl::HibernatableWebSocket& getOnlyWebSocket(
+      LegacyHibernationManagerImpl& manager) {
+    KJ_ASSERT(manager.allWs.size() == 1);
+    return getWebSocketByAcceptOrder(manager, 0);
+  }
+
+  // `acceptIndex` counts in the order the WebSockets were accepted. `allWs` is push_front-ordered,
+  // so the first one accepted sits at the back.
+  static LegacyHibernationManagerImpl::HibernatableWebSocket& getWebSocketByAcceptOrder(
+      LegacyHibernationManagerImpl& manager, size_t acceptIndex) {
+    KJ_ASSERT(acceptIndex < manager.allWs.size());
+    auto it = manager.allWs.rbegin();
+    for (size_t i = 0; i < acceptIndex; ++i) ++it;
+    return **it;
+  }
+};
+
+namespace api {
+struct HibernatableWebSocketCustomEventTestAccess {
+  static void ensureHibernationManagerForEvent(
+      HibernatableWebSocketCustomEvent& event, Worker::Actor& actor, kj::StringPtr websocketId) {
+    event.ensureHibernationManagerForEvent(actor, websocketId);
+  }
+};
+}  // namespace api
+
 namespace {
 
 // ============================================================================
@@ -39,6 +123,13 @@ struct DispatchStats {
   uint getWorkerCalls = 0;
   uint customEventCalls = 0;
   bool rejectCustomEvents = false;
+
+  // When set, customEvent() holds the event and never settles, standing in for a peer that stops
+  // responding mid-dispatch.
+  bool hangCustomEvents = false;
+
+  // What the most recent getWorker() call asked for. Null until the first call.
+  kj::Maybe<ReresolveActorPipeline> lastReresolveActorPipeline;
 };
 
 // Minimal WorkerInterface for tests. Returns success on customEvent (so the HM's
@@ -52,6 +143,10 @@ class StubWorkerInterface final: public WorkerInterface {
   kj::Promise<WorkerInterface::CustomEvent::Result> customEvent(
       kj::Own<WorkerInterface::CustomEvent> event) override {
     ++stats.customEventCalls;
+    if (stats.hangCustomEvents) {
+      return kj::Promise<WorkerInterface::CustomEvent::Result>(kj::NEVER_DONE)
+          .attach(kj::mv(event));
+    }
     if (stats.rejectCustomEvents) {
       return kj::Promise<WorkerInterface::CustomEvent::Result>(KJ_EXCEPTION(
           OVERLOADED, "jsg.Error: Durable Object is overloaded. Too many requests queued."));
@@ -92,8 +187,9 @@ class StubLoopback final: public Worker::Actor::Loopback, public kj::Refcounted 
  public:
   explicit StubLoopback(DispatchStats& stats): stats(stats) {}
 
-  kj::Own<WorkerInterface> getWorker(IoChannelFactory::SubrequestMetadata) override {
+  kj::Own<WorkerInterface> getWorker(IoChannelFactory::SubrequestMetadata metadata) override {
     ++stats.getWorkerCalls;
+    stats.lastReresolveActorPipeline = metadata.reresolveActorPipeline;
     return kj::heap<StubWorkerInterface>(stats);
   }
 
@@ -105,20 +201,72 @@ class StubLoopback final: public Worker::Actor::Loopback, public kj::Refcounted 
   DispatchStats& stats;
 };
 
+class ControlledHibernatableEventDispatcher final
+    : public rpc::HibernatableWebSocketEventDispatcher::Server {
+ public:
+  ControlledHibernatableEventDispatcher(
+      kj::Promise<void> completion, kj::String& receivedWebsocketId, bool& called)
+      : completion(kj::mv(completion)),
+        receivedWebsocketId(receivedWebsocketId),
+        called(called) {}
+
+  kj::Promise<void> hibernatableWebSocketEvent(HibernatableWebSocketEventContext context) override {
+    called = true;
+    receivedWebsocketId = kj::str(context.getParams().getMessage().getWebsocketId());
+    return kj::mv(completion);
+  }
+
+ private:
+  kj::Promise<void> completion;
+  kj::String& receivedWebsocketId;
+  bool& called;
+};
+
 // Helpers below are intentionally split so the HibernationManager can outlive any single
 // IncomingRequest, which matters for tests that span multiple IRs. makeTestHm() needs no
 // IoContext; acceptNewWebSocket() and sendFromDo() do (the api::WebSocket constructor stores
 // IoOwn members, and ws.send() is delivered through the IoContext's pump).
 
+// A TimerChannel whose afterLimitTimeout() fires only when the test asks it to, so a test can reach
+// a timeout measured in seconds without spending them. Install with setTimerChannel().
+struct ManualTimerChannel final: public TimerChannel {
+  void syncTime() override {}
+
+  kj::Date now(kj::Maybe<kj::Date>) override {
+    return kj::systemPreciseCalendarClock().now();
+  }
+
+  kj::Promise<void> atTime(kj::Date when) override {
+    return kj::NEVER_DONE;
+  }
+
+  kj::Promise<void> afterLimitTimeout(kj::Duration t) override {
+    auto paf = kj::newPromiseAndFulfiller<void>();
+    fulfillers.add(kj::mv(paf.fulfiller));
+    return kj::mv(paf.promise);
+  }
+
+  void fireAll() {
+    for (auto& fulfiller: fulfillers) {
+      fulfiller->fulfill();
+    }
+    fulfillers.clear();
+  }
+
+  kj::Vector<kj::Own<kj::PromiseFulfiller<void>>> fulfillers;
+};
+
 // SetupParams builder that installs a StubLoopback on the actor referencing `stats`. The
 // caller MUST keep `stats` alive for the lifetime of the resulting TestFixture (declare it
 // before the fixture). The same StubLoopback is later retrieved via actor.getLoopback() and
 // handed to the HM, so actor and HM share a single Loopback (mirroring production).
-TestFixture::SetupParams stubLoopbackParams(DispatchStats& stats, kj::String actorId) {
+TestFixture::SetupParams stubLoopbackParams(
+    DispatchStats& stats, kj::String actorId, kj::Maybe<uint64_t> holderToken = kj::none) {
   return {
     .actorId = Worker::Actor::Id(kj::mv(actorId)),
     .useRealTimers = true,
     .actorLoopback = kj::refcounted<StubLoopback>(stats),
+    .holderToken = holderToken,
   };
 }
 
@@ -187,6 +335,862 @@ void sendFromDo(TestFixture& fixture,
         websockets.size() == 1, "expected exactly one WebSocket for tag", tag, websockets.size());
     websockets[0]->send(js, kj::OneOf<kj::Array<kj::byte>, kj::String>(kj::str(msg)));
   });
+}
+
+KJ_TEST("HibernationManager: event delivery resolves the manager that registered the event") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-local")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  constexpr kj::StringPtr websocketId = "local-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::findManagerForEventMatches(websocketId, legacyHm));
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment&) {
+    KJ_ASSERT(
+        LegacyHibernationManagerTestAccess::takeWebSocketForEventMatches(websocketId, legacyHm));
+  });
+
+  // Claiming deregisters the event, and every delivery path claims unconditionally.
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::registeredEventCount(legacyHm) == 0);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: a dispatch that never settles does not keep the manager alive") {
+  DispatchStats stats;
+  stats.hangCustomEvents = true;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("never-settling-dispatch")));
+  auto request = fixture.newIncomingRequest();
+
+  {
+    auto hm = makeTestHm(fixture);
+    auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+    // Start a dispatch and leave it pending. The manager owns the task waiting on it, so anything
+    // the dispatch holds that leads back to the manager would make it immortal.
+    end1->send("hello"_kj).wait(fixture.getWaitScope());
+    fixture.pollEventLoop();
+    KJ_ASSERT(stats.customEventCalls == 1, stats.customEventCalls);
+
+    // `hm` is deliberately never handed to the actor, so it holds the manager's only reference, and
+    // a dispatch that led back to the manager would show up here as a second one. The native
+    // WebSocket outlives the manager while a dispatch is in flight, so whether the eyeball end
+    // closes says nothing about the manager's lifetime.
+    KJ_ASSERT(!hm->isShared(), "a pending dispatch holds a reference back to the manager");
+  }
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: events wait for the replacement loopback during handoff") {
+  DispatchStats oldStats;
+  DispatchStats replacementStats;
+  TestFixture fixture(stubLoopbackParams(oldStats, kj::str("loopback-handoff")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  auto handoff = hm->beginLoopbackHandoff();
+  end1->send("during handoff"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+
+  // The message found no loopback to dispatch through. Only `oldStats` is worth asserting on:
+  // nothing references `replacementStats` until its StubLoopback exists, below.
+  KJ_ASSERT(oldStats.getWorkerCalls == 0, oldStats.getWorkerCalls);
+
+  hm->setLoopback(kj::refcounted<StubLoopback>(replacementStats));
+  fixture.pollEventLoop();
+
+  KJ_ASSERT(replacementStats.getWorkerCalls == 1, replacementStats.getWorkerCalls);
+  KJ_ASSERT(replacementStats.customEventCalls == 1, replacementStats.customEventCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: dropping the handoff handle restores the previous loopback") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("loopback-handoff-drop")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  {
+    auto handoff = hm->beginLoopbackHandoff();
+    end1->send("during handoff"_kj).wait(fixture.getWaitScope());
+    fixture.pollEventLoop();
+
+    // No replacement actor has attached, so the event has nothing to dispatch through.
+    KJ_ASSERT(stats.getWorkerCalls == 0, stats.getWorkerCalls);
+  }
+
+  // Dropping the handle puts the outgoing generation's loopback back, so the event that was
+  // waiting is served by the actor that supplied it.
+  fixture.pollEventLoop();
+  KJ_ASSERT(stats.getWorkerCalls == 1, stats.getWorkerCalls);
+  KJ_ASSERT(stats.customEventCalls == 1, stats.customEventCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: a stale handoff handle leaves a later handoff alone") {
+  DispatchStats firstStats;
+  DispatchStats secondStats;
+  DispatchStats thirdStats;
+  TestFixture fixture(stubLoopbackParams(firstStats, kj::str("loopback-handoff-stale")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // One code update completes, so the handle it began no longer owns the handoff in progress.
+  auto staleHandoff = hm->beginLoopbackHandoff();
+  hm->setLoopback(kj::refcounted<StubLoopback>(secondStats));
+
+  // A second code update parks the loopback the first one installed.
+  auto liveHandoff = hm->beginLoopbackHandoff();
+  { auto drop = kj::mv(staleHandoff); }
+
+  end1->send("during second handoff"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+
+  // Dropping the stale handle did not end the second handoff, so the event is still waiting rather
+  // than dispatched through the loopback that handoff parked.
+  KJ_ASSERT(secondStats.getWorkerCalls == 0, secondStats.getWorkerCalls);
+  KJ_ASSERT(firstStats.getWorkerCalls == 0, firstStats.getWorkerCalls);
+
+  hm->setLoopback(kj::refcounted<StubLoopback>(thirdStats));
+  fixture.pollEventLoop();
+
+  KJ_ASSERT(thirdStats.getWorkerCalls == 1, thirdStats.getWorkerCalls);
+  KJ_ASSERT(thirdStats.customEventCalls == 1, thirdStats.customEventCalls);
+  KJ_ASSERT(secondStats.getWorkerCalls == 0, secondStats.getWorkerCalls);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: waiting for a replacement loopback is bounded") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("loopback-handoff-timeout")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  ManualTimerChannel manualTimer;
+  hm->setTimerChannel(manualTimer);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Once the loopback has been handed off, an event has nothing to dispatch through, so it is given
+  // a WorkerInterface that waits for the replacement to arrive.
+  auto handoff = hm->beginLoopbackHandoff();
+  auto worker = LegacyHibernationManagerTestAccess::getWorkerForOnlyWebSocket(legacyHm);
+  auto promise = worker->prewarm(""_kj);
+  KJ_ASSERT(!promise.poll(fixture.getWaitScope()));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::loopbackWaiterCount(legacyHm) == 1);
+
+  // Nothing supplies a replacement loopback and nothing cancels the handoff. The wait must still
+  // end: an unbounded one parks this event, and the read loop behind it, for the manager's
+  // lifetime.
+  manualTimer.fireAll();
+  KJ_ASSERT(promise.poll(fixture.getWaitScope()));
+  KJ_EXPECT_THROW_MESSAGE(
+      "gave up waiting for the replacement actor's loopback", promise.wait(fixture.getWaitScope()));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::loopbackWaiterCount(legacyHm) == 0);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: event naming another actor's manager is rejected") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-other-manager")));
+  auto actorHm = makeTestHm(fixture);
+  auto eventHm = makeTestHm(fixture);
+  auto& eventLegacyHm = kj::downcast<LegacyHibernationManagerImpl>(*eventHm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *eventHm);
+
+  // The event ID resolves to a manager, but not the one this actor is using. The ID is the only
+  // part of an event not derived from the receiving actor, so this is the shape a misrouted event
+  // takes.
+  fixture.getActor().setHibernationManager(actorHm->addRef());
+
+  constexpr kj::StringPtr websocketId = "other-manager-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(
+      eventLegacyHm, kj::str(websocketId));
+  KJ_ASSERT(
+      LegacyHibernationManagerTestAccess::findManagerForEventMatches(websocketId, eventLegacyHm));
+
+  capnp::MallocMessageBuilder message;
+  auto params =
+      message
+          .initRoot<rpc::HibernatableWebSocketEventDispatcher::HibernatableWebSocketEventParams>();
+  auto eventMessage = params.initMessage();
+  eventMessage.initPayload().setText("hello"_kj);
+  eventMessage.setWebsocketId(websocketId);
+  auto event = kj::refcounted<api::HibernatableWebSocketCustomEvent>(
+      0, kj::heap<api::HibernationReader>(params.asReader()));
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    api::HibernatableWebSocketCustomEventTestAccess::ensureHibernationManagerForEvent(
+        *event, fixture.getActor(), websocketId);
+  });
+  auto& e = KJ_ASSERT_NONNULL(exception, "expected a foreign manager's event ID to be rejected");
+  KJ_ASSERT(e.getDescription().endsWith(
+                "hibernatable WebSocket event ID names a different hibernation manager than the "
+                "receiving actor's"_kj),
+      e);
+
+  // The rejected event leaves the registration alone: it belongs to the manager that made it, which
+  // is still holding the socket for whoever legitimately claims it.
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::registeredEventCount(eventLegacyHm) == 1);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: claiming a socket owned by another live actor is rejected") {
+  // Two actors sharing one event loop, and so one event registry, in which a claim resolves by ID
+  // alone.
+  DispatchStats ownerStats;
+  TestFixture ownerFixture(stubLoopbackParams(ownerStats, kj::str("claim-owner")));
+
+  DispatchStats otherStats;
+  TestFixture otherFixture({
+    .waitScope = ownerFixture.getWaitScope(),
+    .actorId = Worker::Actor::Id(kj::str("claim-other")),
+    .actorLoopback = kj::refcounted<StubLoopback>(otherStats),
+  });
+
+  auto hm = makeTestHm(ownerFixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto ownerRequest = ownerFixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(ownerFixture, *ownerRequest, *hm);
+  ownerFixture.getActor().setHibernationManager(hm->addRef());
+
+  constexpr kj::StringPtr websocketId = "cross-actor-claim"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+
+  // Nothing in an ID says whose socket it names, so the other actor can reach the registration.
+  // Claiming it would hand this actor a jsg::Ref belonging to the owner's isolate.
+  auto otherRequest = otherFixture.newIncomingRequest();
+  kj::Maybe<kj::Exception> exception;
+  otherFixture.enterContext(*otherRequest, [&](const TestFixture::Environment&) {
+    exception = kj::runCatchingExceptions([&]() {
+      LegacyHibernationManagerTestAccess::takeWebSocketForEventMatches(websocketId, legacyHm);
+    });
+  });
+  auto& e = KJ_ASSERT_NONNULL(exception, "expected a cross-actor claim to be rejected");
+  KJ_ASSERT(e.getDescription().endsWith(
+                "hibernatable WebSocket event ID names a socket owned by a different actor"_kj),
+      e);
+
+  // The rejected claim leaves the registration for the actor that does own it.
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+
+  otherFixture.drainAndDestroy(kj::mv(otherRequest));
+  ownerFixture.drainAndDestroy(kj::mv(ownerRequest));
+}
+
+KJ_TEST("HibernationManager: claiming a socket owned by a live actor sharing its ID is rejected") {
+  // Both actors carry the same ID, so the ID comparison admits the claim and only the instance
+  // check stands between the claimant and a jsg::Ref minted in the owner's isolate.
+  constexpr kj::StringPtr sharedId = "claim-shared-id"_kj;
+  DispatchStats ownerStats;
+  TestFixture ownerFixture(stubLoopbackParams(ownerStats, kj::str(sharedId)));
+
+  DispatchStats otherStats;
+  TestFixture otherFixture({
+    .waitScope = ownerFixture.getWaitScope(),
+    .actorId = Worker::Actor::Id(kj::str(sharedId)),
+    .actorLoopback = kj::refcounted<StubLoopback>(otherStats),
+  });
+
+  auto hm = makeTestHm(ownerFixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto ownerRequest = ownerFixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(ownerFixture, *ownerRequest, *hm);
+  ownerFixture.getActor().setHibernationManager(hm->addRef());
+
+  constexpr kj::StringPtr websocketId = "same-id-claim"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+
+  auto otherRequest = otherFixture.newIncomingRequest();
+  kj::Maybe<kj::Exception> exception;
+  otherFixture.enterContext(*otherRequest, [&](const TestFixture::Environment&) {
+    exception = kj::runCatchingExceptions([&]() {
+      LegacyHibernationManagerTestAccess::takeWebSocketForEventMatches(websocketId, legacyHm);
+    });
+  });
+  auto& e = KJ_ASSERT_NONNULL(exception, "expected a same-ID claim to be rejected");
+  KJ_ASSERT(
+      e.getDescription().endsWith(
+          "hibernatable WebSocket event ID names a socket owned by a different live actor"_kj),
+      e);
+
+  // The rejected claim leaves the registration for the actor that does own it.
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+
+  otherFixture.drainAndDestroy(kj::mv(otherRequest));
+  ownerFixture.drainAndDestroy(kj::mv(ownerRequest));
+}
+
+KJ_TEST("HibernationManager: an actor handed a running actor's manager does not take it") {
+  // Whatever holds a manager across generations does not necessarily hold one per actor, so a
+  // manager can be supplied to an actor the sockets do not belong to: a facet constructed while
+  // the actor that accepted them is still running, for instance.
+  DispatchStats ownerStats;
+  TestFixture ownerFixture(stubLoopbackParams(ownerStats, kj::str("adopt-owner")));
+  auto hm = makeTestHm(ownerFixture);
+  auto ownerRequest = ownerFixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(ownerFixture, *ownerRequest, *hm);
+  ownerFixture.getActor().setHibernationManager(hm->addRef());
+
+  DispatchStats otherStats;
+  TestFixture otherFixture({
+    .waitScope = ownerFixture.getWaitScope(),
+    .actorId = Worker::Actor::Id(kj::str("adopt-other")),
+    .actorLoopback = kj::refcounted<StubLoopback>(otherStats),
+    .hibernationManager = hm->addRef(),
+  });
+
+  // The manager stayed with the actor it belongs to, and the other actor kept nothing.
+  KJ_ASSERT(otherFixture.getActor().getHibernationManager() == kj::none);
+  KJ_ASSERT(&KJ_ASSERT_NONNULL(hm->getOwningActor()) == &ownerFixture.getActor());
+
+  // So a message on the socket still reaches the actor that accepted it.
+  end1->send("still the owner's"_kj).wait(ownerFixture.getWaitScope());
+  ownerFixture.pollEventLoop();
+  KJ_ASSERT(ownerStats.getWorkerCalls == 1, ownerStats.getWorkerCalls);
+  KJ_ASSERT(otherStats.getWorkerCalls == 0, otherStats.getWorkerCalls);
+
+  ownerFixture.drainAndDestroy(kj::mv(ownerRequest));
+}
+
+KJ_TEST("HibernationManager: a manager-less actor adopts the event's manager") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-adopt-manager")));
+  auto eventHm = makeTestHm(fixture);
+  auto& eventLegacyHm = kj::downcast<LegacyHibernationManagerImpl>(*eventHm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *eventHm);
+
+  // The actor a code-update wake creates has no manager of its own yet, and must take on the one
+  // that has been holding its sockets rather than building a second one.
+  KJ_ASSERT(fixture.getActor().getHibernationManager() == kj::none);
+
+  constexpr kj::StringPtr websocketId = "adopt-manager-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(
+      eventLegacyHm, kj::str(websocketId));
+
+  capnp::MallocMessageBuilder message;
+  auto params =
+      message
+          .initRoot<rpc::HibernatableWebSocketEventDispatcher::HibernatableWebSocketEventParams>();
+  auto eventMessage = params.initMessage();
+  eventMessage.initPayload().setText("hello"_kj);
+  eventMessage.setWebsocketId(websocketId);
+  auto event = kj::refcounted<api::HibernatableWebSocketCustomEvent>(
+      0, kj::heap<api::HibernationReader>(params.asReader()));
+
+  api::HibernatableWebSocketCustomEventTestAccess::ensureHibernationManagerForEvent(
+      *event, fixture.getActor(), websocketId);
+
+  auto& adopted = KJ_ASSERT_NONNULL(fixture.getActor().getHibernationManager());
+  KJ_ASSERT(&adopted == eventHm.get());
+
+  // Having adopted it, the actor now passes the same check the delivery path applies, so the event
+  // that follows can claim its socket.
+  api::HibernatableWebSocketCustomEventTestAccess::ensureHibernationManagerForEvent(
+      *event, fixture.getActor(), websocketId);
+  fixture.enterContext(*request, [&](const TestFixture::Environment&) {
+    KJ_ASSERT(LegacyHibernationManagerTestAccess::takeWebSocketForEventMatches(
+        websocketId, eventLegacyHm));
+  });
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+
+  // Adoption is what gives the manager an owner: afterwards it names this actor, and an event
+  // reaching a different actor is rejected rather than handing it these sockets.
+  auto& owner = KJ_ASSERT_NONNULL(eventHm->getOwningActor());
+  KJ_ASSERT(&owner == &fixture.getActor());
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: a sibling holder sharing the actor ID does not take an orphan") {
+  // Facets use their parent's actor ID by default, so an ID match does not mean the claimant is a
+  // later actor of the holder the sockets belong to.
+  DispatchStats ownerStats;
+  TestFixture ownerFixture(stubLoopbackParams(ownerStats, kj::str("sibling-shared-id"), 1));
+  auto hm = makeTestHm(ownerFixture);
+  auto ownerRequest = ownerFixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(ownerFixture, *ownerRequest, *hm);
+  ownerFixture.getActor().setHibernationManager(hm->addRef());
+
+  // Orphan the manager, as hibernating the owning actor does.
+  ownerFixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+  ownerFixture.drainAndDestroy(kj::mv(ownerRequest));
+  ownerFixture.resetActor();
+  KJ_ASSERT(hm->getOwningActor() == kj::none);
+  KJ_ASSERT(hm->getOwningActorId() != kj::none);
+
+  DispatchStats siblingStats;
+  TestFixture siblingFixture({
+    .waitScope = ownerFixture.getWaitScope(),
+    .actorId = Worker::Actor::Id(kj::str("sibling-shared-id")),
+    .actorLoopback = kj::refcounted<StubLoopback>(siblingStats),
+    .hibernationManager = hm->addRef(),
+    .holderToken = 2,
+  });
+
+  // The IDs match, so only the differing holder token stands between the sibling and the sockets.
+  KJ_ASSERT(siblingFixture.getActor().getHibernationManager() == kj::none);
+  KJ_ASSERT(hm->getOwningActor() == kj::none);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(hm->getOwningHolderToken()) == 1);
+}
+
+KJ_TEST("HibernationManager: an event does not hand a sibling holder an orphan") {
+  // An event resolves its manager from a registry shared by the whole event loop, so it reaches an
+  // actor that was never offered the manager at construction. The holder token has to be checked
+  // here too, and it is the last chance to check it: adopting stamps the manager with the adopting
+  // actor, which is what every check downstream reads.
+  DispatchStats ownerStats;
+  TestFixture ownerFixture(stubLoopbackParams(ownerStats, kj::str("sibling-event-shared-id"), 1));
+  auto hm = makeTestHm(ownerFixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto ownerRequest = ownerFixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(ownerFixture, *ownerRequest, *hm);
+  ownerFixture.getActor().setHibernationManager(hm->addRef());
+
+  // Orphan the manager, as hibernating the owning actor does.
+  ownerFixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+  ownerFixture.drainAndDestroy(kj::mv(ownerRequest));
+  ownerFixture.resetActor();
+  KJ_ASSERT(hm->getOwningActor() == kj::none);
+
+  constexpr kj::StringPtr websocketId = "sibling-holder-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+
+  // A sibling facet, which shares the owner's ID and so passes every check the ID supports. It is
+  // built without the manager, so it reaches the adopt path with nothing of its own to compare.
+  DispatchStats siblingStats;
+  TestFixture siblingFixture({
+    .waitScope = ownerFixture.getWaitScope(),
+    .actorId = Worker::Actor::Id(kj::str("sibling-event-shared-id")),
+    .actorLoopback = kj::refcounted<StubLoopback>(siblingStats),
+    .holderToken = 2,
+  });
+  KJ_ASSERT(siblingFixture.getActor().getHibernationManager() == kj::none);
+
+  capnp::MallocMessageBuilder message;
+  auto params =
+      message
+          .initRoot<rpc::HibernatableWebSocketEventDispatcher::HibernatableWebSocketEventParams>();
+  auto eventMessage = params.initMessage();
+  eventMessage.initPayload().setText("hello"_kj);
+  eventMessage.setWebsocketId(websocketId);
+  auto event = kj::refcounted<api::HibernatableWebSocketCustomEvent>(
+      0, kj::heap<api::HibernationReader>(params.asReader()));
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    api::HibernatableWebSocketCustomEventTestAccess::ensureHibernationManagerForEvent(
+        *event, siblingFixture.getActor(), websocketId);
+  });
+  auto& e = KJ_ASSERT_NONNULL(exception, "expected a sibling holder's event to be rejected");
+  KJ_ASSERT(e.getDescription().endsWith(
+                "hibernatable WebSocket event names a hibernation manager owned by a different "
+                "holder"_kj),
+      e);
+
+  // Refusing leaves the manager named by the holder it belongs to, so that holder's own next
+  // generation still adopts it, and leaves the registration for that generation to claim.
+  KJ_ASSERT(siblingFixture.getActor().getHibernationManager() == kj::none);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(hm->getOwningHolderToken()) == 1);
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+}
+
+KJ_TEST("HibernationManager: a manager that forgot its holder is adopted by another") {
+  // Handing a manager to a replacement generation cannot name the holder that will adopt it, since
+  // that holder does not exist yet. Forgetting the token leaves the ID as the identity to check.
+  DispatchStats ownerStats;
+  TestFixture ownerFixture(stubLoopbackParams(ownerStats, kj::str("forgotten-holder"), 1));
+  auto hm = makeTestHm(ownerFixture);
+  auto ownerRequest = ownerFixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(ownerFixture, *ownerRequest, *hm);
+  ownerFixture.getActor().setHibernationManager(hm->addRef());
+
+  // Orphan the manager, as hibernating the owning actor does.
+  ownerFixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+  ownerFixture.drainAndDestroy(kj::mv(ownerRequest));
+  ownerFixture.resetActor();
+  KJ_ASSERT(KJ_ASSERT_NONNULL(hm->getOwningHolderToken()) == 1);
+
+  hm->forgetOwningHolder();
+  KJ_ASSERT(hm->getOwningHolderToken() == kj::none);
+
+  DispatchStats replacementStats;
+  TestFixture replacementFixture({
+    .waitScope = ownerFixture.getWaitScope(),
+    .actorId = Worker::Actor::Id(kj::str("forgotten-holder")),
+    .actorLoopback = kj::refcounted<StubLoopback>(replacementStats),
+    .hibernationManager = hm->addRef(),
+    .holderToken = 2,
+  });
+
+  // The token a sibling was refused for is gone, so this holder takes the sockets.
+  auto& adopted = KJ_ASSERT_NONNULL(replacementFixture.getActor().getHibernationManager());
+  KJ_ASSERT(&adopted == hm.get());
+
+  // Adopting names the holder now running, so the next sibling is refused again.
+  auto& newOwner = KJ_ASSERT_NONNULL(hm->getOwningActor());
+  KJ_ASSERT(&newOwner == &replacementFixture.getActor());
+  KJ_ASSERT(KJ_ASSERT_NONNULL(hm->getOwningHolderToken()) == 2);
+}
+
+KJ_TEST("HibernationManager: a new generation of the owning actor adopts its manager") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("adopt-same-actor-id")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request1 = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request1, *hm);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  // Hibernate and replace the actor, as a code update does. The manager outlives the actor that
+  // owned it, leaving the copied ID as the only identity it can still be checked against.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+  fixture.drainAndDestroy(kj::mv(request1));
+  fixture.resetActor();
+  KJ_ASSERT(hm->getOwningActor() == kj::none);
+  KJ_ASSERT(hm->getOwningActorId() != kj::none);
+
+  constexpr kj::StringPtr websocketId = "adopt-same-actor-id-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+
+  capnp::MallocMessageBuilder message;
+  auto params =
+      message
+          .initRoot<rpc::HibernatableWebSocketEventDispatcher::HibernatableWebSocketEventParams>();
+  auto eventMessage = params.initMessage();
+  eventMessage.initPayload().setText("hello"_kj);
+  eventMessage.setWebsocketId(websocketId);
+  auto event = kj::refcounted<api::HibernatableWebSocketCustomEvent>(
+      0, kj::heap<api::HibernationReader>(params.asReader()));
+
+  // Same Durable Object, so this generation is entitled to the sockets the last one left behind.
+  api::HibernatableWebSocketCustomEventTestAccess::ensureHibernationManagerForEvent(
+      *event, fixture.getActor(), websocketId);
+
+  auto& adopted = KJ_ASSERT_NONNULL(fixture.getActor().getHibernationManager());
+  KJ_ASSERT(&adopted == hm.get());
+
+  // Adopting re-points the manager at the generation now running.
+  auto& newOwner = KJ_ASSERT_NONNULL(hm->getOwningActor());
+  KJ_ASSERT(&newOwner == &fixture.getActor());
+}
+
+KJ_TEST("HibernationManager: a different Durable Object cannot adopt an orphaned manager") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("adopt-owner-id")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request1 = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request1, *hm);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+  fixture.drainAndDestroy(kj::mv(request1));
+
+  // A different Durable Object, not a new generation of the same one. The owner is gone, so the
+  // instance check has nothing to compare and the copied ID is all that stands in the way.
+  fixture.resetActor(Worker::Actor::Id(kj::str("adopt-interloper-id")));
+  KJ_ASSERT(hm->getOwningActor() == kj::none);
+
+  constexpr kj::StringPtr websocketId = "adopt-different-actor-id-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+
+  capnp::MallocMessageBuilder message;
+  auto params =
+      message
+          .initRoot<rpc::HibernatableWebSocketEventDispatcher::HibernatableWebSocketEventParams>();
+  auto eventMessage = params.initMessage();
+  eventMessage.initPayload().setText("hello"_kj);
+  eventMessage.setWebsocketId(websocketId);
+  auto event = kj::refcounted<api::HibernatableWebSocketCustomEvent>(
+      0, kj::heap<api::HibernationReader>(params.asReader()));
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    api::HibernatableWebSocketCustomEventTestAccess::ensureHibernationManagerForEvent(
+        *event, fixture.getActor(), websocketId);
+  });
+  auto& e =
+      KJ_ASSERT_NONNULL(exception, "expected an adoption by a different Durable Object to fail");
+  KJ_ASSERT(e.getDescription().endsWith(
+                "hibernatable WebSocket event names a hibernation manager owned by a "
+                "different actor"_kj),
+      e);
+
+  // The rejected actor is left with no manager at all, rather than holding the owner's sockets.
+  KJ_ASSERT(fixture.getActor().getHibernationManager() == kj::none);
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+}
+
+KJ_TEST("HibernationManager: an event re-resolves the pipeline only when no actor owns it") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("force-fresh-unowned")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+
+  // No actor has claimed this manager, as when the actor holding it goes away. The loopback it
+  // holds can name a version that is no longer current, so the pipeline is re-resolved from its
+  // script ID.
+  KJ_ASSERT(hm->getOwningActor() == kj::none);
+  auto worker1 KJ_UNUSED = LegacyHibernationManagerTestAccess::getWorkerForOnlyWebSocket(legacyHm);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(stats.lastReresolveActorPipeline) == ReresolveActorPipeline::YES);
+
+  // A live owning actor holds a current pipeline, so reusing its loopback's is correct.
+  fixture.getActor().setHibernationManager(hm->addRef());
+  auto worker2 KJ_UNUSED = LegacyHibernationManagerTestAccess::getWorkerForOnlyWebSocket(legacyHm);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(stats.lastReresolveActorPipeline) == ReresolveActorPipeline::NO);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: a hibernated socket on a running actor reuses the pipeline") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("force-fresh-packaged")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  // Package the sockets away, as an idle actor does. Packaging is not the signal: un-packaging is
+  // per-socket, so keying on it would re-resolve the pipeline for every socket a woken actor has
+  // not yet un-packaged.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  auto worker KJ_UNUSED = LegacyHibernationManagerTestAccess::getWorkerForOnlyWebSocket(legacyHm);
+  KJ_ASSERT(KJ_ASSERT_NONNULL(stats.lastReresolveActorPipeline) == ReresolveActorPipeline::NO);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: delivering one event leaves other hibernated WebSockets registered") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-multi-socket")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm, "first"_kj);
+  auto end2 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm, "second"_kj);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  constexpr kj::StringPtr firstId = "multi-socket-event-first"_kj;
+  constexpr kj::StringPtr secondId = "multi-socket-event-second"_kj;
+  LegacyHibernationManagerTestAccess::registerWebSocketForEvent(legacyHm, kj::str(firstId), 0);
+  LegacyHibernationManagerTestAccess::registerWebSocketForEvent(legacyHm, kj::str(secondId), 1);
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::registeredEventCount(legacyHm) == 2);
+
+  // Deliver only the first event. An actor holds many hibernated WebSockets at once, so waking one
+  // of them must leave the rest routable.
+  fixture.enterContext(*request, [&](const TestFixture::Environment&) {
+    KJ_ASSERT(
+        LegacyHibernationManagerTestAccess::takeWebSocketForEventMatches(firstId, legacyHm, 0));
+  });
+
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(firstId));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::findManagerForEventMatches(secondId, legacyHm));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::registeredEventCount(legacyHm) == 1);
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment&) {
+    KJ_ASSERT(
+        LegacyHibernationManagerTestAccess::takeWebSocketForEventMatches(secondId, legacyHm, 1));
+  });
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(secondId));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::registeredEventCount(legacyHm) == 0);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: destroying a manager removes its event registrations") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-destroyed-manager")));
+  auto request = fixture.newIncomingRequest();
+
+  constexpr kj::StringPtr websocketId = "destroyed-manager-event"_kj;
+  kj::Own<kj::WebSocket> end1;
+  {
+    auto hm = makeTestHm(fixture);
+    auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+    end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+    LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(
+        legacyHm, kj::str(websocketId));
+    KJ_ASSERT(LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+
+    // Deliberately not handed to the actor, so `hm` holds the only reference and the manager is
+    // destroyed with the event still registered.
+  }
+
+  // The registry doesn't own the manager, so the manager can go away while an event is registered.
+  // Its destructor must take the registration with it, or the next event with this ID would be
+  // routed into freed memory.
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: cancelling an event deregisters it") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-cancel")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  constexpr kj::StringPtr websocketId = "cancel-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+
+  LegacyHibernationManagerTestAccess::cancelEvent(legacyHm, websocketId);
+
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::registeredEventCount(legacyHm) == 0);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: cancelling an already-claimed event is a no-op") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-cancel-claimed")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  constexpr kj::StringPtr websocketId = "cancel-claimed-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+
+  // Cleanup after a dispatch runs unconditionally, and normally has nothing left to do because the
+  // handler already claimed the WebSocket.
+  fixture.enterContext(*request, [&](const TestFixture::Environment&) {
+    KJ_ASSERT(
+        LegacyHibernationManagerTestAccess::takeWebSocketForEventMatches(websocketId, legacyHm));
+  });
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+
+  LegacyHibernationManagerTestAccess::cancelEvent(legacyHm, websocketId);
+
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::registeredEventCount(legacyHm) == 0);
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: unresolvable event ID fails to claim a WebSocket") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-unresolvable")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  constexpr kj::StringPtr websocketId = "unresolvable-event"_kj;
+
+  kj::Maybe<kj::Exception> exception;
+  fixture.enterContext(*request, [&](const TestFixture::Environment&) {
+    exception = kj::runCatchingExceptions([&]() {
+      LegacyHibernationManagerTestAccess::takeWebSocketForEventMatches(websocketId, legacyHm);
+    });
+  });
+  KJ_ASSERT(exception != kj::none, "expected the unresolvable event ID to fail");
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: rejected RPC dispatch leaves the event registration to its owner") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-rpc-rejected")));
+  auto hm = makeTestHm(fixture);
+  auto& legacyHm = kj::downcast<LegacyHibernationManagerImpl>(*hm);
+  auto request = fixture.newIncomingRequest();
+  auto end1 KJ_UNUSED = acceptNewWebSocket(fixture, *request, *hm);
+  fixture.getActor().setHibernationManager(hm->addRef());
+
+  constexpr kj::StringPtr websocketId = "rejected-rpc-event"_kj;
+  LegacyHibernationManagerTestAccess::registerOnlyWebSocketForEvent(legacyHm, kj::str(websocketId));
+
+  capnp::ByteStreamFactory byteStreamFactory;
+  kj::HttpHeaderTable::Builder headerTableBuilder;
+  capnp::HttpOverCapnpFactory httpOverCapnpFactory(byteStreamFactory,
+      capnp::HttpOverCapnpFactory::HeaderIdBundle(headerTableBuilder),
+      capnp::HttpOverCapnpFactory::LEVEL_2);
+
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  kj::String receivedWebsocketId;
+  bool dispatcherCalled = false;
+  auto dispatcher = rpc::HibernatableWebSocketEventDispatcher::Client(
+      kj::heap<ControlledHibernatableEventDispatcher>(
+          kj::mv(paf.promise), receivedWebsocketId, dispatcherCalled))
+                        .castAs<rpc::EventDispatcher>();
+
+  auto event = kj::refcounted<api::HibernatableWebSocketCustomEvent>(
+      0, api::HibernatableSocketParams(kj::str("hello"), kj::str(websocketId)));
+  auto rpcPromise = event->sendRpc(httpOverCapnpFactory, byteStreamFactory,
+      getUnsupportedFrankenvalueHandler(), kj::mv(dispatcher));
+
+  fixture.pollEventLoop();
+  KJ_ASSERT(dispatcherCalled);
+  KJ_ASSERT(receivedWebsocketId == websocketId);
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::findManagerForEventMatches(websocketId, legacyHm));
+
+  paf.fulfiller->reject(KJ_EXCEPTION(FAILED, "test RPC rejection before claim"));
+  auto exception = kj::runCatchingExceptions([&]() { rpcPromise.wait(fixture.getWaitScope()); });
+  KJ_ASSERT(exception != kj::none, "expected RPC rejection");
+
+  // The dispatch attempt does not own the registration, so a rejection leaves it for the task that
+  // registered it to clean up. Deregistering here would race that task's cleanup.
+  KJ_ASSERT(LegacyHibernationManagerTestAccess::findManagerForEventMatches(websocketId, legacyHm));
+
+  LegacyHibernationManagerTestAccess::cancelEvent(legacyHm, websocketId);
+  KJ_ASSERT(!LegacyHibernationManagerTestAccess::hasEventRegistration(websocketId));
+
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: event without a registered manager returns exception") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("event-routing-missing-manager")));
+
+  capnp::MallocMessageBuilder message;
+  auto params =
+      message
+          .initRoot<rpc::HibernatableWebSocketEventDispatcher::HibernatableWebSocketEventParams>();
+  auto eventMessage = params.initMessage();
+  auto payload = eventMessage.initPayload();
+  payload.setText("hello"_kj);
+  eventMessage.setWebsocketId("missing-manager-event"_kj);
+
+  auto event = kj::refcounted<api::HibernatableWebSocketCustomEvent>(
+      0, kj::heap<api::HibernationReader>(params.asReader()));
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    api::HibernatableWebSocketCustomEventTestAccess::ensureHibernationManagerForEvent(
+        *event, fixture.getActor(), "missing-manager-event"_kj);
+  });
+  auto& e = KJ_ASSERT_NONNULL(exception, "expected missing manager to throw");
+  KJ_ASSERT(e.getType() == kj::Exception::Type::FAILED, e);
+  KJ_ASSERT(e.getDescription().endsWith(
+                "hibernatable WebSocket event manager was not found for this event ID"_kj),
+      e);
 }
 
 KJ_TEST("HibernationManager: smoke (create, accept, query)") {

--- a/src/workerd/io/hibernation-manager.c++
+++ b/src/workerd/io/hibernation-manager.c++
@@ -42,8 +42,36 @@ kj::Maybe<jsg::Ref<api::WebSocketRequestResponsePair>> HibernationManagerImpl::
       "HibernationManagerImpl::getWebSocketAutoResponse not yet implemented (EW-10817)");
 }
 
+void HibernationManagerImpl::setLoopback(kj::Own<Worker::Actor::Loopback> loopback) {
+  KJ_UNIMPLEMENTED("HibernationManagerImpl::setLoopback not yet implemented (EW-10817)");
+}
+
+kj::Own<void> HibernationManagerImpl::beginLoopbackHandoff() {
+  KJ_UNIMPLEMENTED("HibernationManagerImpl::beginLoopbackHandoff not yet implemented (EW-10817)");
+}
+
 void HibernationManagerImpl::setTimerChannel(TimerChannel& timerChannel) {
   KJ_UNIMPLEMENTED("HibernationManagerImpl::setTimerChannel not yet implemented (EW-10817)");
+}
+
+void HibernationManagerImpl::setOwningActor(Worker::Actor& actor) {
+  KJ_UNIMPLEMENTED("HibernationManagerImpl::setOwningActor not yet implemented (EW-10817)");
+}
+
+kj::Maybe<Worker::Actor&> HibernationManagerImpl::getOwningActor() {
+  KJ_UNIMPLEMENTED("HibernationManagerImpl::getOwningActor not yet implemented (EW-10817)");
+}
+
+kj::Maybe<const Worker::Actor::Id&> HibernationManagerImpl::getOwningActorId() {
+  KJ_UNIMPLEMENTED("HibernationManagerImpl::getOwningActorId not yet implemented (EW-10817)");
+}
+
+kj::Maybe<uint64_t> HibernationManagerImpl::getOwningHolderToken() {
+  KJ_UNIMPLEMENTED("HibernationManagerImpl::getOwningHolderToken not yet implemented (EW-10817)");
+}
+
+void HibernationManagerImpl::forgetOwningHolder() {
+  KJ_UNIMPLEMENTED("HibernationManagerImpl::forgetOwningHolder not yet implemented (EW-10817)");
 }
 
 kj::Own<Worker::Actor::HibernationManager> HibernationManagerImpl::addRef() {

--- a/src/workerd/io/hibernation-manager.h
+++ b/src/workerd/io/hibernation-manager.h
@@ -27,7 +27,14 @@ class HibernationManagerImpl final: public Worker::Actor::HibernationManager {
       kj::Maybe<kj::StringPtr> request, kj::Maybe<kj::StringPtr> response) override;
   kj::Maybe<jsg::Ref<api::WebSocketRequestResponsePair>> getWebSocketAutoResponse(
       jsg::Lock& js) override;
+  kj::Own<void> beginLoopbackHandoff() override KJ_WARN_UNUSED_RESULT;
+  void setLoopback(kj::Own<Worker::Actor::Loopback> loopback) override;
   void setTimerChannel(TimerChannel& timerChannel) override;
+  void setOwningActor(Worker::Actor& actor) override;
+  kj::Maybe<Worker::Actor&> getOwningActor() override;
+  kj::Maybe<const Worker::Actor::Id&> getOwningActorId() override;
+  kj::Maybe<uint64_t> getOwningHolderToken() override;
+  void forgetOwningHolder() override;
   kj::Own<HibernationManager> addRef() override;
   void setEventTimeout(kj::Maybe<uint32_t> timeoutMs) override;
   kj::Maybe<uint32_t> getEventTimeout() override;

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -31,6 +31,7 @@ class WorkerInterface;
 // bindings of a flag-enabled worker are `Persistent::YES`; everything else is `Persistent::NO`.
 // A `Persistent::YES` channel/token may be stored in long-term storage; `Persistent::NO` may not.
 WD_STRONG_BOOL(Persistent);
+WD_STRONG_BOOL(ReresolveActorPipeline);
 
 // Whether an actor request is a retry of an earlier attempt.
 WD_STRONG_BOOL(IsActorRetry);
@@ -175,6 +176,11 @@ class IoChannelFactory: public virtual kj::Refcounted {
     // Present when the caller classified this as a retry-eligible actor request and selected its
     // logical-call token.
     kj::Maybe<ActorRetryRequestMetadata> actorRetryRequestMetadata;
+
+    // A hibernatable WebSocket event wakes an actor over a loopback that outlives it. With no live
+    // actor owning the manager, the pipeline that loopback holds can name a version that is no
+    // longer current, so runtimes with mutable actor code should re-resolve it from its script ID.
+    ReresolveActorPipeline reresolveActorPipeline = ReresolveActorPipeline::NO;
 
     // True if this request was started on a channel that was reconstructed from a stored
     // ("persistent") stub. The target worker re-verifies that it still has the

--- a/src/workerd/io/legacy-hibernation-manager.c++
+++ b/src/workerd/io/legacy-hibernation-manager.c++
@@ -9,7 +9,14 @@
 
 #include <workerd/util/uuid.h>
 
+#include <kj/common.h>
+
 namespace workerd {
+
+LegacyHibernationManagerImpl::EventRegistry& LegacyHibernationManagerImpl::getEventRegistry() {
+  static const kj::EventLoopLocal<EventRegistry> registry;
+  return *registry;
+}
 
 LegacyHibernationManagerImpl::HibernatableWebSocket::HibernatableWebSocket(
     jsg::Ref<api::WebSocket> websocket,
@@ -43,6 +50,37 @@ LegacyHibernationManagerImpl::HibernatableWebSocket::~HibernatableWebSocket() no
     item.list = kj::none;
   }
 }
+
+class LegacyHibernationManagerImpl::LoopbackWaiterAdapter final: public LoopbackWaiter {
+ public:
+  LoopbackWaiterAdapter(kj::PromiseFulfiller<kj::Own<WorkerInterface>>& fulfiller,
+      LoopbackWaiterList& waiters,
+      IoChannelFactory::SubrequestMetadata metadata)
+      : LoopbackWaiter{fulfiller, kj::mv(metadata)},
+        waiters(waiters) {
+    waiters.add(*this);
+  }
+
+  ~LoopbackWaiterAdapter() noexcept(false) {
+    unlink();
+  }
+
+  void moveTo(LoopbackWaiterList& destination) {
+    unlink();
+    waiters = destination;
+    destination.add(*this);
+  }
+
+  void unlink() {
+    KJ_IF_SOME(w, waiters) {
+      if (link.isLinked()) w.remove(*this);
+    }
+    waiters = kj::none;
+  }
+
+ private:
+  kj::Maybe<LoopbackWaiterList&> waiters;
+};
 
 kj::Array<kj::String> LegacyHibernationManagerImpl::HibernatableWebSocket::getTags() {
   auto tags = kj::heapArray<kj::String>(tagItems.size());
@@ -86,7 +124,25 @@ LegacyHibernationManagerImpl::~LegacyHibernationManagerImpl() noexcept(false) {
   // Drop our outstanding tasks, the `readLoopTasks` have weak references to the
   // `HibernatableWebSockets` in `allWs`, and since we're about to drop all of those WebSockets,
   // we can't allow any more events to be delivered.
+  //
+  // Cancelling those tasks also deregisters the events they were delivering, which is why
+  // `registeredEventCount` is normally zero below.
   readLoopTasks.clear();
+
+  while (!loopbackWaiters.empty()) {
+    auto& waiter = static_cast<LoopbackWaiterAdapter&>(loopbackWaiters.front());
+    waiter.fulfiller.reject(KJ_EXCEPTION(
+        DISCONNECTED, "hibernation manager destroyed while waiting for its replacement loopback"));
+    waiter.unlink();
+  }
+
+  if (registeredEventCount > 0) {
+    // The registry holds non-owning pointers, so anything still naming this manager has to go: a
+    // surviving entry would route the next event with that ID into freed memory.
+    getEventRegistry().eraseAll(
+        [this](kj::StringPtr, RegisteredEvent& registered) { return registered.manager == this; });
+    registeredEventCount = 0;
+  }
 
   // Note that the HibernatableWebSocket destructor handles removing any references to itself in
   // `tagToWs`, and even removes the hashmap entry if there are no more entries in the bucket.
@@ -217,8 +273,96 @@ kj::Maybe<jsg::Ref<api::WebSocketRequestResponsePair>> LegacyHibernationManagerI
   return kj::none;
 }
 
+void LegacyHibernationManagerImpl::setLoopback(kj::Own<Worker::Actor::Loopback> loopback) {
+  // A loopback arriving completes any handoff in progress: the parked one belongs to a generation
+  // that is gone. Clearing the generation makes dropping that handoff's handle a no-op.
+  handoffLoopback = kj::none;
+  loopbackHandoffGeneration = 0;
+  this->loopback = loopback->addRef();
+
+  // Isolate this batch because fulfilling it can re-enter the manager and add more waiters.
+  LoopbackWaiterList waiters;
+  while (!loopbackWaiters.empty()) {
+    static_cast<LoopbackWaiterAdapter&>(loopbackWaiters.front()).moveTo(waiters);
+  }
+  while (!waiters.empty()) {
+    auto& waiter = static_cast<LoopbackWaiterAdapter&>(waiters.front());
+    // Hand a failure to the waiter it belongs to rather than letting it escape: we run from the
+    // actor's constructor, where a throw would fail the construction and abandon the remaining
+    // waiters with only a "fulfiller destroyed" exception to show for it.
+    KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
+      waiter.fulfiller.fulfill(loopback->getWorker(kj::mv(waiter.metadata)));
+    })) {
+      waiter.fulfiller.reject(kj::mv(exception));
+    }
+    waiter.unlink();
+  }
+}
+
+// Ends a loopback handoff when dropped. Holds a reference to the manager, which a code update moves
+// between actor generations, so the end of the handoff reaches it wherever it ended up.
+class LoopbackHandoff {
+ public:
+  LoopbackHandoff(kj::Own<LegacyHibernationManagerImpl> manager, uint64_t generation)
+      : manager(kj::mv(manager)),
+        generation(generation) {}
+  ~LoopbackHandoff() noexcept(false) {
+    manager->cancelLoopbackHandoff(generation);
+  }
+  KJ_DISALLOW_COPY_AND_MOVE(LoopbackHandoff);
+
+ private:
+  kj::Own<LegacyHibernationManagerImpl> manager;
+  uint64_t generation;
+};
+
+kj::Own<void> LegacyHibernationManagerImpl::beginLoopbackHandoff() {
+  KJ_REQUIRE(loopbackHandoffGeneration == 0, "a loopback handoff is already in progress");
+  loopbackHandoffGeneration = nextLoopbackHandoffGeneration++;
+  handoffLoopback = kj::mv(loopback);
+  return kj::heap<LoopbackHandoff>(kj::addRef(*this), loopbackHandoffGeneration);
+}
+
+void LegacyHibernationManagerImpl::cancelLoopbackHandoff(uint64_t generation) {
+  if (generation != loopbackHandoffGeneration) {
+    // This handle's handoff already ended, either because a replacement attached or because a
+    // later handoff superseded it. Restoring now would strand whatever is parked for the handoff
+    // currently in progress.
+    return;
+  }
+  loopbackHandoffGeneration = 0;
+  KJ_IF_SOME(previous, handoffLoopback) {
+    setLoopback(kj::mv(previous));
+  }
+}
+
 void LegacyHibernationManagerImpl::setTimerChannel(TimerChannel& timerChannel) {
   timer = timerChannel;
+}
+
+void LegacyHibernationManagerImpl::setOwningActor(Worker::Actor& actor) {
+  owningActor = actor.getWeakRef();
+  owningActorId = actor.cloneId();
+  owningHolderToken = actor.getHolderToken();
+}
+
+kj::Maybe<Worker::Actor&> LegacyHibernationManagerImpl::getOwningActor() {
+  KJ_IF_SOME(weak, owningActor) {
+    return weak->tryGet();
+  }
+  return kj::none;
+}
+
+kj::Maybe<const Worker::Actor::Id&> LegacyHibernationManagerImpl::getOwningActorId() {
+  return owningActorId;
+}
+
+kj::Maybe<uint64_t> LegacyHibernationManagerImpl::getOwningHolderToken() {
+  return owningHolderToken;
+}
+
+void LegacyHibernationManagerImpl::forgetOwningHolder() {
+  owningHolderToken = kj::none;
 }
 
 void LegacyHibernationManagerImpl::hibernateWebSockets(Worker::Lock& lock) {
@@ -248,6 +392,64 @@ kj::Maybe<uint32_t> LegacyHibernationManagerImpl::getEventTimeout() {
   return eventTimeoutMs;
 }
 
+kj::Maybe<Worker::Actor::HibernationManager&> LegacyHibernationManagerImpl::findManagerForEvent(
+    kj::StringPtr websocketId) {
+  KJ_IF_SOME(registered, getEventRegistry().find(websocketId)) {
+    return *registered.manager;
+  }
+  return kj::none;
+}
+
+LegacyHibernationManagerImpl::HibernatableWebSocket& LegacyHibernationManagerImpl::
+    takeWebSocketForEvent(kj::StringPtr websocketId) {
+  auto& registry = getEventRegistry();
+  auto& entry = KJ_REQUIRE_NONNULL(registry.findEntry(websocketId),
+      "hibernatable WebSocket event is not registered", websocketId);
+  auto& registered = entry.value;
+
+  // Nothing about the ID comes from the actor claiming the socket, so the manager holding it has
+  // to be this actor's own. Generations on different script versions are different isolates, so a
+  // stray claim would hand an actor a jsg::Ref minted in another one.
+  //
+  // Both checks are needed. The ID outlives the owning actor, so it still rejects an unrelated
+  // actor once a code update has destroyed the owner. The instance check rejects an actor that is
+  // live alongside the owner and shares its ID, which the ID alone would admit.
+  KJ_IF_SOME(claimant, IoContext::current().getActor()) {
+    KJ_IF_SOME(ownerId, registered.manager->getOwningActorId()) {
+      KJ_REQUIRE(Worker::Actor::idsEqual(ownerId, claimant.getId()),
+          "hibernatable WebSocket event ID names a socket owned by a different actor");
+    }
+    KJ_IF_SOME(owner, registered.manager->getOwningActor()) {
+      KJ_REQUIRE(&owner == &claimant,
+          "hibernatable WebSocket event ID names a socket owned by a different live actor");
+    }
+  }
+
+  --registered.manager->registeredEventCount;
+  auto& webSocket = *registered.webSocket;
+  registry.erase(entry);
+  return webSocket;
+}
+
+void LegacyHibernationManagerImpl::registerEventWebSocket(
+    kj::String websocketId, HibernatableWebSocket& hib) {
+  auto& registry = getEventRegistry();
+  KJ_ASSERT(registry.find(websocketId) == kj::none, "duplicate hibernatable WebSocket event ID",
+      websocketId);
+  registry.insert(kj::mv(websocketId), RegisteredEvent{this, &hib});
+  ++registeredEventCount;
+}
+
+void LegacyHibernationManagerImpl::cancelEvent(kj::StringPtr websocketId) {
+  auto& registry = getEventRegistry();
+  KJ_IF_SOME(entry, registry.findEntry(websocketId)) {
+    KJ_ASSERT(entry.value.manager == this,
+        "hibernatable WebSocket event registered to a different manager", websocketId);
+    --registeredEventCount;
+    registry.erase(entry);
+  }
+}
+
 void LegacyHibernationManagerImpl::dropHibernatableWebSocket(HibernatableWebSocket& hib) {
   removeFromAllWs(hib);
 }
@@ -259,11 +461,11 @@ inline void LegacyHibernationManagerImpl::removeFromAllWs(HibernatableWebSocket&
 
 kj::Promise<void> LegacyHibernationManagerImpl::handleSocketTermination(
     HibernatableWebSocket& hib, kj::Maybe<kj::Exception>& maybeError) {
-  // A failed termination event must not leave a disconnected socket in either registry.
+  // A failed termination event must not leave a disconnected socket registered.
   kj::String eventWebSocketId;
   KJ_DEFER({
     if (eventWebSocketId.size() > 0) {
-      webSocketsForEventHandler.erase(eventWebSocketId);
+      cancelEvent(eventWebSocketId);
     }
     dropHibernatableWebSocket(hib);
   });
@@ -272,7 +474,7 @@ kj::Promise<void> LegacyHibernationManagerImpl::handleSocketTermination(
   KJ_IF_SOME(error, maybeError) {
     auto websocketId = randomUUID(kj::none);
     eventWebSocketId = kj::str(websocketId);
-    webSocketsForEventHandler.insert(kj::str(websocketId), &hib);
+    registerEventWebSocket(kj::str(websocketId), hib);
     kj::Maybe<api::HibernatableSocketParams> params;
     if (!hib.hasDispatchedClose && (error.getType() == kj::Exception::Type::DISCONNECTED)) {
       // If premature disconnect/cancel, dispatch a close event if we haven't already.
@@ -286,17 +488,10 @@ kj::Promise<void> LegacyHibernationManagerImpl::handleSocketTermination(
     }
 
     KJ_REQUIRE_NONNULL(params).setTimeout(eventTimeoutMs);
-    // Dispatch the event, restoring the trace context captured at acceptWebSocket time.
-    SpanParent userSpanParent = SpanParent(nullptr);
-    KJ_IF_SOME(ctx, hib.userSpanContext) {
-      userSpanParent = SpanParent::fromSpanContext(tracing::SpanContext::clone(ctx));
-    }
-    auto workerInterface = loopback->getWorker({
-      .userSpanParent = kj::mv(userSpanParent),
-    });
+    auto workerInterface = getWorkerForEvent(hib);
     event = workerInterface
                 ->customEvent(kj::rc<api::HibernatableWebSocketCustomEvent>(
-                    hibernationEventType, kj::mv(KJ_REQUIRE_NONNULL(params)), *this)
+                    hibernationEventType, kj::mv(KJ_REQUIRE_NONNULL(params)))
                                   .toOwn())
                 .ignoreResult()
                 .attach(kj::mv(workerInterface));
@@ -307,6 +502,40 @@ kj::Promise<void> LegacyHibernationManagerImpl::handleSocketTermination(
   KJ_IF_SOME(promise, event) {
     co_await promise;
   }
+}
+
+kj::Own<WorkerInterface> LegacyHibernationManagerImpl::getWorkerForEvent(
+    HibernatableWebSocket& hib) {
+  SpanParent userSpanParent = SpanParent(nullptr);
+  KJ_IF_SOME(ctx, hib.userSpanContext) {
+    userSpanParent = SpanParent::fromSpanContext(tracing::SpanContext::clone(ctx));
+  }
+  auto metadata = IoChannelFactory::SubrequestMetadata{
+    .userSpanParent = kj::mv(userSpanParent),
+    .reresolveActorPipeline =
+        getOwningActor() == kj::none ? ReresolveActorPipeline::YES : ReresolveActorPipeline::NO,
+  };
+  KJ_IF_SOME(l, loopback) {
+    // Hold a reference across the call: getWorker() can construct the actor, which hands this
+    // manager its own loopback, destroying the one whose getWorker() is still on the stack.
+    auto owned = l->addRef();
+    return owned->getWorker(kj::mv(metadata));
+  }
+
+  kj::Promise<kj::Own<WorkerInterface>> worker =
+      kj::newAdaptedPromise<kj::Own<WorkerInterface>, LoopbackWaiterAdapter>(
+          loopbackWaiters, kj::mv(metadata));
+
+  // Don't wait for the replacement loopback indefinitely.
+  KJ_IF_SOME(t, timer) {
+    worker = worker.exclusiveJoin(
+        t.afterLimitTimeout(LOOPBACK_HANDOFF_TIMEOUT).then([]() -> kj::Own<WorkerInterface> {
+      KJ_FAIL_REQUIRE("hibernatable WebSocket event gave up waiting for the replacement actor's "
+                      "loopback during a code-update handoff");
+    }));
+  }
+
+  return newPromisedWorkerInterface(kj::mv(worker));
 }
 
 kj::Promise<void> LegacyHibernationManagerImpl::readLoop(HibernatableWebSocket& hib) {
@@ -389,8 +618,8 @@ kj::Promise<void> LegacyHibernationManagerImpl::readLoop(HibernatableWebSocket& 
 
     auto websocketId = randomUUID(kj::none);
     auto eventWebSocketId = kj::str(websocketId);
-    webSocketsForEventHandler.insert(kj::str(websocketId), &hib);
-    KJ_DEFER(webSocketsForEventHandler.erase(eventWebSocketId));
+    registerEventWebSocket(kj::str(websocketId), hib);
+    KJ_DEFER(cancelEvent(eventWebSocketId));
 
     // Build the event params depending on what type of message we got.
     kj::Maybe<api::HibernatableSocketParams> maybeParams;
@@ -412,16 +641,9 @@ kj::Promise<void> LegacyHibernationManagerImpl::readLoop(HibernatableWebSocket& 
     auto params = kj::mv(KJ_REQUIRE_NONNULL(maybeParams));
     params.setTimeout(eventTimeoutMs);
     auto isClose = params.isCloseEvent();
-    // Dispatch the event, restoring the trace context captured at acceptWebSocket time.
-    SpanParent userSpanParent = SpanParent(nullptr);
-    KJ_IF_SOME(ctx, hib.userSpanContext) {
-      userSpanParent = SpanParent::fromSpanContext(tracing::SpanContext::clone(ctx));
-    }
-    auto workerInterface = loopback->getWorker({
-      .userSpanParent = kj::mv(userSpanParent),
-    });
+    auto workerInterface = getWorkerForEvent(hib);
     co_await workerInterface->customEvent(
-        kj::rc<api::HibernatableWebSocketCustomEvent>(hibernationEventType, kj::mv(params), *this)
+        kj::rc<api::HibernatableWebSocketCustomEvent>(hibernationEventType, kj::mv(params))
             .toOwn());
     if (isClose) {
       co_return;

--- a/src/workerd/io/legacy-hibernation-manager.h
+++ b/src/workerd/io/legacy-hibernation-manager.h
@@ -11,6 +11,7 @@
 #include <workerd/jsg/jsg.h>
 
 #include <kj/exception.h>
+#include <kj/list.h>
 
 #include <list>
 
@@ -41,11 +42,19 @@ class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManag
       kj::Maybe<kj::StringPtr> request, kj::Maybe<kj::StringPtr> response) override;
   kj::Maybe<jsg::Ref<api::WebSocketRequestResponsePair>> getWebSocketAutoResponse(
       jsg::Lock& js) override;
+  kj::Own<void> beginLoopbackHandoff() override KJ_WARN_UNUSED_RESULT;
+  void setLoopback(kj::Own<Worker::Actor::Loopback> loopback) override;
   void setTimerChannel(TimerChannel& timerChannel) override;
+  void setOwningActor(Worker::Actor& actor) override;
+  kj::Maybe<Worker::Actor&> getOwningActor() override;
+  kj::Maybe<const Worker::Actor::Id&> getOwningActorId() override;
+  kj::Maybe<uint64_t> getOwningHolderToken() override;
+  void forgetOwningHolder() override;
 
   kj::Own<HibernationManager> addRef() override;
 
   friend class api::HibernatableWebSocketEvent;
+  friend class api::HibernatableWebSocketCustomEvent;
 
   // Sets/Unset the maximum time in milliseconds that an hibernatable websocket event can run for.
   // If the timeout is reached, event is canceled.
@@ -54,8 +63,23 @@ class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManag
   // Gets the event timeout if set.
   kj::Maybe<uint32_t> getEventTimeout() override;
 
+  // Returns the manager that registered `websocketId`, or kj::none if no manager on this event loop
+  // registered that ID.
+  //
+  // The result is a bare reference on purpose: an owning one would keep the manager alive until the
+  // event settles, and since the manager owns the task delivering the event, an event that never
+  // settles would keep both alive forever.
+  static kj::Maybe<Worker::Actor::HibernationManager&> findManagerForEvent(
+      kj::StringPtr websocketId);
+
  private:
   class HibernatableWebSocket;
+
+  // Ends the handoff identified by `generation`, putting the parked loopback back if no replacement
+  // supplied one. Does nothing if that handoff already ended, so a handle dropped afterwards cannot
+  // disturb a later one. Reachable only by dropping the handle that began the handoff.
+  void cancelLoopbackHandoff(uint64_t generation);
+  friend class LoopbackHandoff;
 
   kj::Promise<void> handleReadLoop(HibernatableWebSocket& refToHibernatable);
 
@@ -150,6 +174,44 @@ class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManag
   // Removes the HibernatableWebSocket from `allWs`.
   inline void removeFromAllWs(HibernatableWebSocket& hib);
 
+  struct RegisteredEvent {
+    // Neither pointer is owning: a registration lives only as long as the task delivering the
+    // event, and ~LegacyHibernationManagerImpl drops any that remain, so an entry always names a
+    // live manager and WebSocket. The manager also carries the event's identity, naming the owning
+    // actor.
+    //
+    // Pointers rather than references because erasing a kj::HashMap row move-assigns the last row
+    // over it, which requires an assignable type; see KJ's style guide.
+    LegacyHibernationManagerImpl* manager;
+    HibernatableWebSocket* webSocket;
+  };
+
+  // Maps each event ID currently being delivered to the manager and socket it belongs to. Delivery
+  // can take an RPC round trip that cannot carry a C++ reference, and can arrive at an actor whose
+  // manager is not the one holding the socket, so the ID is the only dependable route back.
+  //
+  // Per-event-loop: a manager, its WebSockets and its JavaScript state all belong to one event
+  // loop, and delivery always returns to it. An event loop is not an OS thread, so a thread local
+  // would not be sound.
+  using EventRegistry = kj::HashMap<kj::String, RegisteredEvent>;
+  static EventRegistry& getEventRegistry();
+
+  // Removes and returns the WebSocket for the event currently being delivered. Fails if no manager
+  // on this event loop holds that event ID.
+  static HibernatableWebSocket& takeWebSocketForEvent(kj::StringPtr websocketId);
+
+  // Records `hib` against an event ID, so that the handler that runs next can claim the WebSocket
+  // and so that delivery can find this manager again. The registry owns its copy of the ID.
+  void registerEventWebSocket(kj::String websocketId, HibernatableWebSocket& hib);
+
+  // Removes an event registration. Safe to call after the receiver already claimed the event.
+  void cancelEvent(kj::StringPtr websocketId);
+
+  // Returns a worker to dispatch an event for `hib` on, carrying the trace context captured when
+  // the WebSocket was accepted. Asks for pipeline re-resolution when no live actor owns this
+  // manager, since the pipeline the loopback holds may name a version that is no longer current.
+  kj::Own<WorkerInterface> getWorkerForEvent(HibernatableWebSocket& hib);
+
   // Handles the termination of the websocket. If termination was not clean, we might try to
   // dispatch a close event (if we haven't already), or an error event.
   // We will also remove the HibernatableWebSocket from the HibernationManager's collections.
@@ -187,24 +249,62 @@ class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManag
   // We store all of our HibernatableWebSockets in a doubly linked-list.
   std::list<kj::Own<HibernatableWebSocket>> allWs;
 
-  // Used to obtain the worker so we can dispatch Hibernatable websocket events.
-  kj::Own<Worker::Actor::Loopback> loopback;
+  struct LoopbackWaiter {
+    kj::PromiseFulfiller<kj::Own<WorkerInterface>>& fulfiller;
+    IoChannelFactory::SubrequestMetadata metadata;
+    kj::ListLink<LoopbackWaiter> link;
+  };
+  using LoopbackWaiterList = kj::List<LoopbackWaiter, &LoopbackWaiter::link>;
+  class LoopbackWaiterAdapter;
+
+  // The loopback events are delivered through. Null only while this manager is moving between actor
+  // generations; events arriving in that window wait for the replacement actor's loopback.
+  kj::Maybe<kj::Own<Worker::Actor::Loopback>> loopback;
+
+  // The outgoing generation's loopback, parked here by beginLoopbackHandoff() so that dropping the
+  // handle it returned can put it back if no replacement arrives.
+  kj::Maybe<kj::Own<Worker::Actor::Loopback>> handoffLoopback;
+
+  // Identifies the handoff in progress, or zero when there is none. Values are never reused, so a
+  // handle that outlives its own handoff can tell it no longer owns the one in progress.
+  uint64_t loopbackHandoffGeneration = 0;
+
+  // Source of the next value for `loopbackHandoffGeneration`.
+  uint64_t nextLoopbackHandoffGeneration = 1;
+
+  // Events waiting out a handoff, served in order once a loopback is available again.
+  LoopbackWaiterList loopbackWaiters;
+
+  // The actor that owns this manager, invalid once that actor is destroyed. Not inferrable from
+  // `loopback`, which outlives the actor that supplied it.
+  kj::Maybe<kj::Own<Worker::Actor::WeakRef>> owningActor;
+
+  // The ID of the actor named by `owningActor`, copied so that it outlives that actor. A code
+  // update destroys the owner before its replacement adopts the manager, leaving this the only
+  // identity still available to check.
+  kj::Maybe<Worker::Actor::Id> owningActorId;
+
+  // The holder token of the actor named by `owningActor`, held as a copy for the same reason as
+  // `owningActorId`.
+  kj::Maybe<uint64_t> owningHolderToken;
 
   // Passed to HibernatableWebSocket custom event as the typeId.
   uint16_t hibernationEventType;
 
-  // A map of { ID -> HibernatableWebSocket } that allows the event handler that is currently
-  // running to access the HibernatableWebSocket that it needs to execute.
-  //
-  // Dispatching events tends to result in races when events are received on different websockets
-  // around the same time. Suppose there are two websockets that disconnect at the same time.
-  // It is possible that both of them will be added to the map (i.e. their `receive()`
-  // will throw) before the first event is dispatched and manages to obtain its associated websocket.
-  kj::HashMap<kj::String, HibernatableWebSocket*> webSocketsForEventHandler;
+  // How many of this manager's events are registered in the event loop's registry. Lets the
+  // destructor skip the registry when nothing is registered, which is the only case reachable
+  // without a current event loop.
+  size_t registeredEventCount = 0;
 
   // The maximum number of Hibernatable WebSocket connections a single LegacyHibernationManagerImpl
   // instance can manage.
   const size_t ACTIVE_CONNECTION_LIMIT = 1024 * 32;
+
+  // How long an event waits for a replacement loopback before giving up. A handoff ends when the
+  // replacement supplies its loopback or when the handle is dropped, so this bound is reached only
+  // if some path does neither. Deliberately far longer than a handoff needs, so that such a bug
+  // costs one failed event rather than a read loop parked forever.
+  static constexpr kj::Duration LOOPBACK_HANDOFF_TIMEOUT = 30 * kj::SECONDS;
 
   class DisconnectHandler: public kj::TaskSet::ErrorHandler {
    public:

--- a/src/workerd/io/legacy-hibernation-manager.h
+++ b/src/workerd/io/legacy-hibernation-manager.h
@@ -17,6 +17,8 @@
 
 namespace workerd {
 
+struct LegacyHibernationManagerTestAccess;
+
 // Implements the HibernationManager class.
 class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManager {
  public:
@@ -55,6 +57,7 @@ class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManag
 
   friend class api::HibernatableWebSocketEvent;
   friend class api::HibernatableWebSocketCustomEvent;
+  friend struct LegacyHibernationManagerTestAccess;
 
   // Sets/Unset the maximum time in milliseconds that an hibernatable websocket event can run for.
   // If the timeout is reached, event is canceled.

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3673,6 +3673,10 @@ struct Worker::Actor::Impl {
   kj::Maybe<FacetManager&> facetManager;
   kj::Maybe<ActorVersion> version;
 
+  // Names the holder this actor belongs to, where the embedder supplies one. Actors of one holder
+  // share it; sibling facets do not.
+  kj::Maybe<uint64_t> holderToken;
+
   struct NoClass {};
   struct Initializing {};
 
@@ -3898,13 +3902,15 @@ Worker::Actor::Actor(const Worker& worker,
     kj::Maybe<uint16_t> hibernationEventType,
     kj::Maybe<rpc::Container::Client> container,
     kj::Maybe<FacetManager&> facetManager,
-    kj::Maybe<ActorVersion> version)
+    kj::Maybe<ActorVersion> version,
+    kj::Maybe<uint64_t> holderToken)
     : worker(kj::atomicAddRef(worker)),
       tracker(tracker.map([](RequestTracker& tracker) { return tracker.addRef(); })) {
   impl = kj::heap<Impl>(*this, kj::mv(actorId), hasTransient, kj::mv(makeActorCache), kj::mv(props),
       kj::mv(makeStorage), kj::mv(loopback), timerChannel, kj::mv(metrics), kj::mv(manager),
       hibernationEventType, kj::mv(container), facetManager);
   impl->version = kj::mv(version);
+  impl->holderToken = holderToken;
 
   KJ_IF_SOME(c, className) {
     KJ_IF_SOME(cls, worker.impl->actorClasses.find(c)) {
@@ -3917,6 +3923,18 @@ Worker::Actor::Actor(const Worker& worker,
     }
   } else {
     impl->classInstance = Impl::NoClass();
+  }
+
+  // Attach only once this actor is fully built: attaching releases events queued while the previous
+  // generation went away, and delivering one reaches straight back into `impl`.
+  KJ_IF_SOME(m, impl->hibernationManager) {
+    if (ownsHibernatedSockets(*m)) {
+      attachHibernationManager(*m);
+    } else {
+      // Another actor's sockets. Letting go leaves them with the actor they belong to, and lets
+      // this actor build its own manager if it accepts a hibernatable WebSocket.
+      impl->hibernationManager = kj::none;
+    }
   }
 }
 
@@ -4018,6 +4036,8 @@ kj::Promise<void> Worker::Actor::ensureConstructedImpl(IoContext& context, Actor
 Worker::Actor::~Actor() noexcept(false) {
   // Note: We do not need an isolate lock to destroy the actor impl. Everything in it is specific
   // to our thread, or is a handle that can be dropped outside of the lock.
+
+  selfRef->invalidate();
 }
 
 void Worker::Actor::shutdown(uint16_t reasonCode, kj::Maybe<const kj::Exception&> error) {
@@ -4397,16 +4417,65 @@ kj::Maybe<Worker::Actor::HibernationManager&> Worker::Actor::getHibernationManag
       [](kj::Own<HibernationManager>& hib) -> HibernationManager& { return *hib; });
 }
 
-void Worker::Actor::setHibernationManager(kj::Own<HibernationManager> hib) {
-  KJ_REQUIRE(impl->hibernationManager == kj::none);
-  hib->setTimerChannel(impl->timerChannel);
+kj::Maybe<uint64_t> Worker::Actor::getHolderToken() {
+  return impl->holderToken;
+}
+
+bool Worker::Actor::ownsHibernatedSockets(HibernationManager& manager) {
+  KJ_IF_SOME(owner, manager.getOwningActor()) {
+    // The owner is still running, so nothing was handed over. Another actor taking the manager
+    // would redirect the owner's events to itself.
+    return &owner == this;
+  }
+
+  // The owner is gone, which is what a code update or an eviction leaves behind. Its sockets pass
+  // to the next actor of the same holder, and to nothing else.
+  KJ_IF_SOME(ownerToken, manager.getOwningHolderToken()) {
+    KJ_IF_SOME(token, getHolderToken()) {
+      return token == ownerToken;
+    }
+    return false;
+  }
+
+  // No token to compare, so fall back to the ID. That admits a sibling facet, which uses its
+  // parent's ID by default, so embedders running facets are expected to supply a token.
+  KJ_IF_SOME(ownerId, manager.getOwningActorId()) {
+    return idsEqual(ownerId, getId());
+  }
+
+  // Never owned, so there is nothing to inherit and nothing to disturb.
+  return true;
+}
+
+void Worker::Actor::attachHibernationManager(HibernationManager& manager) {
   // Not the cleanest way to provide hibernation manager with a timer channel reference, but
   // where HibernationManager is constructed (actor-state), we don't have a timer channel ref.
+  manager.setTimerChannel(impl->timerChannel);
+
+  manager.setOwningActor(*this);
+
+  // The loopback goes last: supplying it releases events the manager queued while it had no actor,
+  // and those dispatch against the owning actor set just above.
+  manager.setLoopback(impl->loopback->addRef());
+}
+
+void Worker::Actor::setHibernationManager(kj::Own<HibernationManager> hib) {
+  KJ_REQUIRE(impl->hibernationManager == kj::none);
+
+  // A manager built by acceptWebSocket() already points here, but an adopted one still carries the
+  // loopback and owning actor of the outgoing generation. Leaving those in place would send its
+  // events to a dead generation, or queue them for a loopback nothing will supply.
+  attachHibernationManager(*hib);
+
   impl->hibernationManager = kj::mv(hib);
 }
 
 kj::Maybe<uint16_t> Worker::Actor::getHibernationEventType() {
   return impl->hibernationEventType;
+}
+
+kj::Own<Worker::Actor::WeakRef> Worker::Actor::getWeakRef() {
+  return kj::addRef(*selfRef);
 }
 
 kj::Own<Worker::Actor> Worker::Actor::addRef() {

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -892,7 +892,35 @@ class Worker::Actor final: public kj::Refcounted {
         kj::Maybe<kj::StringPtr> request, kj::Maybe<kj::StringPtr> response) = 0;
     virtual kj::Maybe<jsg::Ref<api::WebSocketRequestResponsePair>> getWebSocketAutoResponse(
         jsg::Lock& js) = 0;
+    // A loopback is how the manager reaches its actor to deliver an event. A code update replaces
+    // the actor that supplied one, so this parks it and events arriving meanwhile wait for a
+    // loopback rather than reaching the outgoing generation. The handoff ends when the replacement
+    // actor calls setLoopback(), or when the returned handle is dropped, which puts the parked
+    // loopback back.
+    virtual kj::Own<void> beginLoopbackHandoff() KJ_WARN_UNUSED_RESULT = 0;
+    virtual void setLoopback(kj::Own<Loopback> loopback) = 0;
     virtual void setTimerChannel(TimerChannel& timerChannel) = 0;
+
+    // Points the manager at the actor that owns it. The manager holds only a weak reference, so it
+    // can tell whether that actor is still alive.
+    virtual void setOwningActor(Actor& actor) = 0;
+
+    // The actor that owns this manager, or kj::none if no live actor does.
+    virtual kj::Maybe<Actor&> getOwningActor() = 0;
+
+    // The ID of the actor that owns this manager, or kj::none if none ever has. Kept as the
+    // manager's own copy, so unlike getOwningActor() it still names the owner after a code update
+    // destroyed it, which is exactly when a replacement adopts the manager.
+    virtual kj::Maybe<const Id&> getOwningActorId() = 0;
+
+    // The holder token of the owning actor, or kj::none if it had none. Unlike the ID, this
+    // distinguishes sibling facets, which share their parent's ID by default.
+    virtual kj::Maybe<uint64_t> getOwningHolderToken() = 0;
+
+    // Drops the owning holder token, leaving the actor ID as the manager's identity. Called when
+    // the manager leaves its holder for a holder that cannot be named yet, which is what handing it
+    // to a replacement generation in another cart does. The adopting actor sets a new token.
+    virtual void forgetOwningHolder() = 0;
     virtual kj::Own<HibernationManager> addRef() = 0;
     virtual void setEventTimeout(kj::Maybe<uint32_t> timeoutMs) = 0;
     virtual kj::Maybe<uint32_t> getEventTimeout() = 0;
@@ -947,7 +975,8 @@ class Worker::Actor final: public kj::Refcounted {
       kj::Maybe<uint16_t> hibernationEventType,
       kj::Maybe<rpc::Container::Client> container = kj::none,
       kj::Maybe<FacetManager&> facetManager = kj::none,
-      kj::Maybe<ActorVersion> version = kj::none);
+      kj::Maybe<ActorVersion> version = kj::none,
+      kj::Maybe<uint64_t> holderToken = kj::none);
 
   ~Actor() noexcept(false);
 
@@ -1035,6 +1064,14 @@ class Worker::Actor final: public kj::Refcounted {
   // setHibernationManager() hasn't been called yet.
   kj::Maybe<HibernationManager&> getHibernationManager();
 
+  // Names the holder this actor belongs to, or null if the embedder supplies no such name.
+  kj::Maybe<uint64_t> getHolderToken();
+
+  // Whether the sockets `manager` holds belong to this actor. Whatever holds a manager across
+  // generations does not necessarily hold one per actor, so a manager offered to this actor can
+  // still be in use by a live actor, or belong to a sibling facet that shares this actor's ID.
+  bool ownsHibernatedSockets(HibernationManager& manager);
+
   // Set the HibernationManager for this actor. This is called once, on the first call to
   // `acceptWebSocket`.
   void setHibernationManager(kj::Own<HibernationManager> manager);
@@ -1063,13 +1100,24 @@ class Worker::Actor final: public kj::Refcounted {
 
   kj::Own<Worker::Actor> addRef();
 
+  using WeakRef = workerd::WeakRef<Actor>;
+
+  // A reference that goes invalid when this actor is destroyed.
+  kj::Own<WeakRef> getWeakRef();
+
  private:
   kj::Promise<WorkerInterface::ScheduleAlarmResult> handleAlarm(kj::Date scheduledTime);
+
+  // Points a manager at this actor. Both the constructor and setHibernationManager() go through
+  // here, so an adopted manager ends up in the same state as one supplied at construction.
+  void attachHibernationManager(HibernationManager& manager);
 
   kj::Own<const Worker> worker;
   kj::Maybe<kj::Own<RequestTracker>> tracker;
   struct Impl;
   kj::Own<Impl> impl;
+
+  kj::Own<WeakRef> selfRef = kj::refcounted<WeakRef>(kj::Badge<Actor>(), *this);
 
   kj::Maybe<api::ExportedHandler&> getHandler();
   friend class Worker;

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -407,6 +407,8 @@ TestFixture::TestFixture(SetupParams&& params)
     } else {
       savedActorLoopback = kj::refcounted<MockActorLoopback>();
     }
+    savedHibernationManager = kj::mv(params.hibernationManager);
+    savedHolderToken = params.holderToken;
     actor = makeActor(kj::mv(id));
   }
 }
@@ -435,11 +437,18 @@ kj::Own<Worker::Actor> TestFixture::makeActor(Worker::Actor::Id id) {
   return kj::refcounted<Worker::Actor>(*worker, /*tracker=*/kj::none, kj::mv(id),
       /*hasTransient=*/false, actorCacheFactory, /*classname=*/kj::none,
       /*props=*/Frankenvalue(), storageFactory, loopback->addRef(), *timerChannel,
-      kj::refcounted<ActorObserver>(), kj::none, kj::none);
+      kj::refcounted<ActorObserver>(),
+      savedHibernationManager.map(
+          [](kj::Own<Worker::Actor::HibernationManager>& m) { return m->addRef(); }),
+      /*hibernationEventType=*/kj::none, /*container=*/kj::none, /*facetManager=*/kj::none,
+      /*version=*/kj::none, savedHolderToken);
 }
 
 void TestFixture::resetActor() {
-  auto id = KJ_ASSERT_NONNULL(actor)->cloneId();
+  resetActor(KJ_ASSERT_NONNULL(actor)->cloneId());
+}
+
+void TestFixture::resetActor(Worker::Actor::Id id) {
   actor = kj::none;  // Drop the old Actor (and its OutputGate / InputGate / ActorCache).
   actor = makeActor(kj::mv(id));
 }

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -51,6 +51,13 @@ struct TestFixture {
     // to it) via actor.getLoopback(). This way the actor and the HibernationManager share a
     // single Loopback, mirroring production.
     kj::Maybe<kj::Own<Worker::Actor::Loopback>> actorLoopback;
+    // If set, supplied to the actor's constructor, as whatever holds a manager across generations
+    // does in production. What an actor does with a manager it is handed differs from what
+    // setHibernationManager() does with one it adopts.
+    kj::Maybe<kj::Own<Worker::Actor::HibernationManager>> hibernationManager;
+    // If set, supplied to the actor's constructor as its holder token. Actors of one holder share a
+    // token; sibling facets do not.
+    kj::Maybe<uint64_t> holderToken;
     // If set, called to create the RequestObserver for each IncomingRequest instead of the default
     // no-op base RequestObserver. Lets tests observe metrics hooks (e.g. recording the values
     // passed to setNextSubrequestBodyRewindable()).
@@ -239,6 +246,10 @@ struct TestFixture {
   // outlives the actor by virtue of the test holding it.
   void resetActor();
 
+  // Same, but the replacement actor answers to `id`, so a test can stand up a different Durable
+  // Object rather than a new generation of the same one.
+  void resetActor(Worker::Actor::Id id);
+
  private:
   kj::Maybe<kj::WaitScope&> waitScope;
   capnp::MallocMessageBuilder configArena;
@@ -253,6 +264,10 @@ struct TestFixture {
   // where the namespace's Loopback outlives any single actor instance). Held via addRef so we
   // can hand fresh refs to actors as we reconstruct them.
   kj::Maybe<kj::Own<Worker::Actor::Loopback>> savedActorLoopback;
+  // Saved for the same reason as savedActorLoopback: resetActor() hands a fresh ref to each actor
+  // it constructs.
+  kj::Maybe<kj::Own<Worker::Actor::HibernationManager>> savedHibernationManager;
+  kj::Maybe<uint64_t> savedHolderToken;
   capnp::ByteStreamFactory byteStreamFactory;
   kj::HttpHeaderTable::Builder headerTableBuilder;
   ThreadContext::HeaderIdBundle threadContextHeaderBundle;


### PR DESCRIPTION
This PR adds the necessary methods to ensure hibernated websockets can survive code updates while hibernated.