### PR TITLE
Rebase perfetto patches onto v54.0

### DIFF
--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -127,10 +127,10 @@ archive_override(
         "//:patches/perfetto/0001-Don-t-attempt-to-use-rules_android.patch",
         "//:patches/perfetto/0002-disable-info-level-logging-re2.patch",
     ],
-    sha256 = "60dd39e5f21800c4f61032ca9f9f73973cfc7d93db9f0d39e63ad3d8fb3740e9",
-    strip_prefix = "google-perfetto-25e635e",
+    sha256 = "90aea67f5ac88ae7bb56bc24574beb5cd924a5ae9d861826a6fd151c13b4767b",
+    strip_prefix = "google-perfetto-b34c975",
     type = "tgz",
-    url = "https://api.github.com/repos/google/perfetto/tarball/v56.1",
+    url = "https://api.github.com/repos/google/perfetto/tarball/v54.0",
 )
 
 # simdutf

--- a/patches/perfetto/0001-Don-t-attempt-to-use-rules_android.patch
+++ b/patches/perfetto/0001-Don-t-attempt-to-use-rules_android.patch
@@ -5,10 +5,10 @@ Subject: Don't attempt to use rules_android
 
 
 diff --git a/MODULE.bazel b/MODULE.bazel
-index f94686dcb5d94d0bc7c9e5113203450086e8fb36..87eb246bfe8502d5a6c667b395a26c218b81e6f5 100644
+index 47f7f25cfdb0bd0b0879cbb24adda7330645157a..dc006ebba8d85af30f3a129a41c1164b4c4bc5c0 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -14,10 +14,8 @@
+@@ -14,102 +14,10 @@
  
  """Perfetto Bazel module configuration for bzlmod."""
  
@@ -19,11 +19,6 @@ index f94686dcb5d94d0bc7c9e5113203450086e8fb36..87eb246bfe8502d5a6c667b395a26c21
 +module(name = "perfetto")
 +bazel_dep(name = "perfetto_cfg", version = "0.0.0")
  
- bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
- git_override(
-@@ -28,97 +26,6 @@ git_override(
- 
- bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
  bazel_dep(name = "bazel_skylib", version = "1.7.1")
 -bazel_dep(name = "platforms", version = "0.0.10")
 -bazel_dep(name = "protobuf", version = "31.1", repo_name = "com_google_protobuf")
@@ -105,24 +100,23 @@ index f94686dcb5d94d0bc7c9e5113203450086e8fb36..87eb246bfe8502d5a6c667b395a26c21
 -)
 -maven.install(
 -    name = "perfetto_maven",
--    # Use rules_android's aar_import to avoid toolchain type mismatch.
--    aar_import_bzl_label = "@rules_android//rules:rules.bzl",
 -    artifacts = [
 -        "androidx.test:runner:1.6.2",
 -        "androidx.test:monitor:1.7.2",
 -        "com.google.truth:truth:1.4.4",
 -        "junit:junit:4.13.2",
 -        "androidx.test.ext:junit:1.2.1",
--        "com.google.errorprone:error_prone_annotations:2.36.0",
 -    ],
 -    repositories = [
 -        "https://maven.google.com",
 -        "https://repo1.maven.org/maven2",
 -    ],
+-    # Use rules_android's aar_import to avoid toolchain type mismatch.
+-    aar_import_bzl_label = "@rules_android//rules:rules.bzl",
 -)
 -use_repo(maven, "perfetto_maven")
 diff --git a/bazel/rules.bzl b/bazel/rules.bzl
-index 958e9bc0aabb47a4039f67e39e4868ea2676d36d..2e11ef26b27597679241b5577d4fff7a7e2331e3 100644
+index 563382a18bfde2506f613f274304387dace9f2dd..d7e77cf21416588a3a55e0bb6d67099a148d1de1 100644
 --- a/bazel/rules.bzl
 +++ b/bazel/rules.bzl
 @@ -13,9 +13,7 @@

--- a/patches/perfetto/0002-disable-info-level-logging-re2.patch
+++ b/patches/perfetto/0002-disable-info-level-logging-re2.patch
@@ -5,7 +5,7 @@ Subject: disable info level logging, re2
 
 
 diff --git a/include/perfetto/base/build_configs/bazel/perfetto_build_flags.h b/include/perfetto/base/build_configs/bazel/perfetto_build_flags.h
-index 8fb2bc7cab11ccc7a669ba023bca62569c0b151c..149c2b18c4e8c553dea7f8ab90dd12ea661d3534 100644
+index a9bfdbc2aa9e1ea83830e4b094ad2cd12aae0936..278785fb7b509957af6a8fa48f0207686ad077d2 100644
 --- a/include/perfetto/base/build_configs/bazel/perfetto_build_flags.h
 +++ b/include/perfetto/base/build_configs/bazel/perfetto_build_flags.h
 @@ -36,7 +36,7 @@
@@ -17,12 +17,3 @@ index 8fb2bc7cab11ccc7a669ba023bca62569c0b151c..149c2b18c4e8c553dea7f8ab90dd12ea
  #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_VERSION_GEN() (1)
  #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_TP_PERCENTILE() (1)
  #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_TP_LINENOISE() (1)
-@@ -55,7 +55,7 @@
- #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ENABLE_RT_MUTEX() (1)
- #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ENABLE_LOCKFREE_TASKRUNNER() (1)
- #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_ENABLE_SOCK_INOTIFY() (1)
--#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_RE2() (1)
-+#define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_RE2() (0)
- #define PERFETTO_BUILDFLAG_DEFINE_PERFETTO_PCRE2() (0)
- 
- struct PerfettoBuildFlag {


### PR DESCRIPTION
Neither patch applied after the freeze to v54.0 in #6945. Re-anchor 0001's MODULE.bazel hunks against v54.0, whose bazel_dep set and ordering differ from the context the patch carried. Drop 0002's PERFETTO_RE2 hunk, since that build flag appears nowhere in v54.0.