### PR TITLE
Add regression tests for vuln-88 and harden checkSignal()

### DIFF
--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -217,6 +217,11 @@ class WritableLockImpl {
     };
     Flags flags{};
 
+    // Completes a signal-aborted pipe.  Deliberately static: releasing the
+    // pipe lock destroys the PipeLocked, so there is no longer a `this`.
+    static jsg::Promise<void> finishAbortedPipe(
+        jsg::Lock& js, Controller& self, jsg::JsValue reason, Flags flags);
+
     JSG_MEMORY_INFO(PipeLocked) {
       tracker.trackField("readableStreamRef", readableStreamRef);
       tracker.trackField("signal", maybeSignal);
@@ -550,33 +555,36 @@ void WritableLockImpl<Controller>::visitForGc(jsg::GcVisitor& visitor) {
 }
 
 template <typename Controller>
+jsg::Promise<void> WritableLockImpl<Controller>::PipeLocked::finishAbortedPipe(
+    jsg::Lock& js, Controller& self, jsg::JsValue reason, Flags flags) {
+  if (!flags.preventAbort) {
+    return self.abort(js, reason)
+        .then(js, [reason = reason.addRef(js), flags, ref = self.addRef()](jsg::Lock& js) {
+      return rejectedMaybeHandledPromise<void>(js, reason.getHandle(js), flags.pipeThrough);
+    });
+  }
+  return rejectedMaybeHandledPromise<void>(js, reason, flags.pipeThrough);
+}
+
+template <typename Controller>
 kj::Maybe<jsg::Promise<void>> WritableLockImpl<Controller>::PipeLocked::checkSignal(
     jsg::Lock& js, Controller& self) {
   KJ_IF_SOME(signal, maybeSignal) {
     if (signal->getAborted(js)) {
       auto reason = signal->getReason(js);
-      // Copy the flags needed below before calling releaseSource(): with a cancel
-      // reason it runs the source's cancel algorithm (arbitrary user JS)
-      // synchronously, and that JS may re-enter the controller and release the
-      // write-side pipe lock, destroying *this. For the same reason the abort
-      // continuation must not capture `this`: it runs after the caller has already
-      // released the pipe lock.
-      auto preventCancel = flags.preventCancel;
-      auto preventAbort = flags.preventAbort;
-      auto pipeThrough = flags.pipeThrough;
-      if (!preventCancel) {
+      // Copy the flags before calling releaseSource(): with a cancel reason it runs the
+      // source's cancel algorithm (arbitrary user JS) synchronously, and that JS may
+      // re-enter the controller and release the write-side pipe lock, destroying *this.
+      auto flagsCopy = flags;
+      if (!flagsCopy.preventCancel) {
         releaseSource(js, reason);
       } else {
         releaseSource(js);
       }
-      if (!preventAbort) {
-        return self.abort(js, reason)
-            .then(
-                js, [pipeThrough, reason = reason.addRef(js), ref = self.addRef()](jsg::Lock& js) {
-          return rejectedMaybeHandledPromise<void>(js, reason.getHandle(js), pipeThrough);
-        });
-      }
-      return rejectedMaybeHandledPromise<void>(js, reason, pipeThrough);
+      // *this may already have been destroyed by user JS run from releaseSource(). The rest
+      // of the work is done by a static method so the compiler enforces that we do not
+      // touch it.
+      return finishAbortedPipe(js, self, reason, flagsCopy);
     }
   }
   return kj::none;

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -721,6 +721,12 @@ wd_test(
 )
 
 wd_test(
+    src = "autovuln-88-test.wd-test",
+    args = ["--experimental"],
+    data = ["autovuln-88-test.js"],
+)
+
+wd_test(
     src = "streams-respond-test.wd-test",
     args = ["--experimental"],
     data = ["streams-respond-test.js"],

--- a/src/workerd/api/tests/autovuln-88-test.js
+++ b/src/workerd/api/tests/autovuln-88-test.js
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Regression test for AUTOVULN-CLOUDFLARE-WORKERD-88.
+//
+// The destination's pipe lock (WritableLockImpl::PipeLocked) holds a raw
+// reference `source` to the readable controller's PipeController. That object
+// lives inline in a kj::OneOf inside the readable controller, so destroying it
+// never frees heap memory -- the reference is left pointing at live storage
+// holding some other state. ASAN therefore cannot see this; only the production
+// cfi-vcall check can. See pipe-source-error-uaf-test.js for a sibling bug.
+//
+// The bug: checkSignal() releases the source (destroying that PipeController),
+// then calls self.abort() *before* its caller in pipeLoop() gets a chance to run
+// lock.releasePipeLock(). Everything abort() reaches -- including the JS abort
+// event listener and, synchronously after it, doError() -- therefore observes a
+// destination still in the PipeLocked state whose `source` already dangles.
+// doError() then calls source.release() on it.
+//
+// Every other release site in pipeLoop() pairs source.release() with
+// lock.releasePipeLock(); the fix closes this one remaining window by doing the
+// same inside checkSignal(), before any JS runs.
+
+import { rejects, strictEqual } from 'node:assert';
+
+// Observes the dangling reference deterministically, without relying on a crash.
+//
+// The abort listener re-pipes the (now unlocked) readable to a second
+// destination. That constructs a fresh PipeController in the exact same inline
+// storage the stale `source` still points at, so the stale reference silently
+// aliases the *second* pipe. Pre-fix, doError() then calls release() through it
+// and unlocks a pipe it has nothing to do with. Post-fix, doError() finds no pipe
+// lock and leaves it alone.
+//
+// preventCancel matters here: without it the first release() also *cancels* the
+// readable, so the second pipe would immediately run to completion on a closed
+// stream and release the lock on its own -- making rs.locked false either way and
+// the assertion useless. preventCancel keeps the readable open, so the only thing
+// that can unlock it is the stale reference.
+export const abortedSignalPipeMustNotReleaseUnrelatedPipe = {
+  async test() {
+    let wsCtrl;
+    const ws = new WritableStream({
+      start(c) {
+        wsCtrl = c;
+      },
+    });
+    await Promise.resolve();
+
+    const rs = new ReadableStream({});
+    const ws2 = new WritableStream({});
+
+    wsCtrl.signal.addEventListener('abort', () => {
+      // checkSignal() has already released the source, so rs is unlocked here.
+      // It is still open, so this pipe parks on a read that never completes.
+      rs.pipeTo(ws2).catch(() => {});
+    });
+
+    const ac = new AbortController();
+    ac.abort(new Error('pipe-abort'));
+    await rejects(rs.pipeTo(ws, { signal: ac.signal, preventCancel: true }), {
+      message: 'pipe-abort',
+    });
+
+    // The second pipe is still in progress and owns the readable. Pre-fix,
+    // doError() released it through the stale reference and this is false.
+    strictEqual(rs.locked, true);
+  },
+};
+
+// The same window, observed the way it actually crashes in production: the
+// listener re-locks the readable with a reader, so the stale `source` ends up
+// pointing at a ReaderLocked -- a non-polymorphic type. doError()'s virtual
+// release() call then reads a garbage vptr and jumps through it.
+export const abortedSignalPipeSourceReleaseThenRelock = {
+  async test() {
+    let wsCtrl;
+    const ws = new WritableStream({
+      start(c) {
+        wsCtrl = c;
+      },
+    });
+    await Promise.resolve();
+
+    const rs = new ReadableStream({});
+
+    wsCtrl.signal.addEventListener('abort', () => {
+      rs.getReader();
+    });
+
+    const ac = new AbortController();
+    ac.abort(new Error('pipe-abort'));
+    await rejects(rs.pipeTo(ws, { signal: ac.signal }), {
+      message: 'pipe-abort',
+    });
+  },
+};

--- a/src/workerd/api/tests/autovuln-88-test.wd-test
+++ b/src/workerd/api/tests/autovuln-88-test.wd-test
@@ -1,0 +1,14 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "autovuln-88-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "autovuln-88-test.js")
+        ],
+        compatibilityFlags = ["nodejs_compat", "streams_enable_constructors"],
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
vuln-88 itself is already fixed: PipeLocked::releaseSource() nulls `source` before releasing and is idempotent, so doError()'s second release is a no-op. These tests pin that behaviour down.

The deterministic test re-pipes the readable from the destination's abort listener, so a stale source reference would tear down an unrelated pipe; it asserts rs.locked instead of relying on a crash, because PipeLocked lives inline in a kj::OneOf and is never heap freed, so ASAN cannot see the corruption. The second test is the raw crash repro: it re-locks the readable with a reader, leaving a non-polymorphic ReaderLocked where the stale reference points.

checkSignal() must not touch *this after releaseSource(), which can run the source's cancel algorithm and let user JS destroy it. That was upheld by copying three flags into locals. Copy the Flags struct once instead, and move the tail into a static finishAbortedPipe() so the compiler enforces the rule rather than a comment.