### PR TITLE
Implement import.meta.dirname/filename in NMR

### DIFF
--- a/src/workerd/api/tests/new-module-registry-test.js
+++ b/src/workerd/api/tests/new-module-registry-test.js
@@ -43,6 +43,11 @@ strictEqual(import.meta.url, 'file:///bundle/worker');
 // Verify that import.meta.main is true here.
 ok(import.meta.main);
 
+// Verify that import.meta.filename and import.meta.dirname are correct
+// for file: URLs (WinterCG import.meta path helpers).
+strictEqual(import.meta.filename, '/bundle/worker');
+strictEqual(import.meta.dirname, '/bundle');
+
 // When running in nodejs_compat_v2 mode, the globalThis.Buffer
 // and globalThis.process properties are resolved from the module
 // registry. Let's make sure we get good values here.
@@ -602,6 +607,23 @@ export const complexModuleTest = {
 
     const { default: abc2 } = await import('abc');
     strictEqual(abc2, 'file:///bundle/abc');
+  },
+};
+
+// Verify import.meta.filename and import.meta.dirname (WinterCG path helpers)
+// work correctly for modules in subdirectories and are absent for non-file URLs.
+export const importMetaPathHelpers = {
+  async test() {
+    // Module in a subdirectory should have correct dirname/filename.
+    const { filename, dirname } = await import('sub/dir/meta-test');
+    strictEqual(filename, '/bundle/sub/dir/meta-test');
+    strictEqual(dirname, '/bundle/sub/dir');
+
+    // Non-file URL modules should not have filename/dirname.
+    const mod = await import('https://example.com/mod');
+    strictEqual(mod.default, 'example');
+    strictEqual(mod.filename, undefined);
+    strictEqual(mod.dirname, undefined);
   },
 };
 

--- a/src/workerd/api/tests/new-module-registry-test.wd-test
+++ b/src/workerd/api/tests/new-module-registry-test.wd-test
@@ -76,6 +76,9 @@ const unitTests :Workerd.Config = (
           (name = "complex/complex2", esModule = "import * as def from '/bundle/complex/complex3'; export { def }; export const foo = 1;"),
           (name = "complex/complex3", esModule = "export const bar = 2;"),
 
+          # Module in a subdirectory to test import.meta.filename/dirname
+          (name = "sub/dir/meta-test", esModule = "export const filename = import.meta.filename; export const dirname = import.meta.dirname;"),
+
           # When the user bundle name begins with a slash, it is stripped before
           # processing, ensuring that the module is still processed relative to
           # the bundle base URL. Query strings and fragments are ignored.
@@ -89,7 +92,7 @@ const unitTests :Workerd.Config = (
           (name = "/foo/../bar/../../../../////abc123", esModule = "export default 1;"),
 
           # It should be possible to have a module whose name is a valid URL.
-          (name = "https://example.com/mod", esModule = "export default 'example';"),
+          (name = "https://example.com/mod", esModule = "export default 'example'; export const filename = import.meta.filename; export const dirname = import.meta.dirname;"),
 
           # Percent-encoded characters in the path should be normalized, and absolute
           # file URLs are accepted as long as they are under the bundle base URL.

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -1225,6 +1225,16 @@ KJ_TEST("import.meta works as expected") {
 
       KJ_ASSERT(url.toString(js) == "file:///foo"_kj);
 
+      // import.meta.filename is the pathname of the file: URL.
+      JsValue filename = obj.get(js, "filename");
+      KJ_ASSERT(filename.isString());
+      KJ_ASSERT(filename.toString(js) == "/foo"_kj);
+
+      // import.meta.dirname is the parent directory of the pathname.
+      JsValue dirname = obj.get(js, "dirname");
+      KJ_ASSERT(dirname.isString());
+      KJ_ASSERT(dirname.toString(js) == "/"_kj);
+
       auto mainVal = KJ_ASSERT_NONNULL(main.tryCast<JsBoolean>());
       KJ_ASSERT(!mainVal.value(js));
 
@@ -1250,6 +1260,16 @@ KJ_TEST("import.meta works as expected") {
       KJ_ASSERT(res.isFunction());
 
       KJ_ASSERT(url.toString(js) == "file:///foo/bar"_kj);
+
+      // import.meta.filename for file:///foo/bar should be /foo/bar.
+      JsValue filename = obj.get(js, "filename");
+      KJ_ASSERT(filename.isString());
+      KJ_ASSERT(filename.toString(js) == "/foo/bar"_kj);
+
+      // import.meta.dirname for file:///foo/bar should be /foo.
+      JsValue dirname = obj.get(js, "dirname");
+      KJ_ASSERT(dirname.isString());
+      KJ_ASSERT(dirname.toString(js) == "/foo"_kj);
 
       auto mainVal = KJ_ASSERT_NONNULL(main.tryCast<JsBoolean>());
       KJ_ASSERT(mainVal.value(js));
@@ -1297,6 +1317,16 @@ KJ_TEST("import specifiers with query params and hash fragments work") {
       KJ_ASSERT(url.isString());
       // The import.meta.url should include the query param and hash fragment
       KJ_ASSERT(url.toString(js) == "file:///foo?1"_kj);
+
+      // import.meta.filename and dirname should reflect the pathname without
+      // query params or hash fragments.
+      auto filename = obj.get(js, "filename");
+      KJ_ASSERT(filename.isString());
+      KJ_ASSERT(filename.toString(js) == "/foo"_kj);
+
+      auto dirname = obj.get(js, "dirname");
+      KJ_ASSERT(dirname.isString());
+      KJ_ASSERT(dirname.toString(js) == "/"_kj);
     }, [&](Value exception) { js.throwException(kj::mv(exception)); });
   });
 }

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -1273,6 +1273,33 @@ void importMeta(
           return;
         }
 
+        // import.meta.filename and import.meta.dirname are only available for
+        // modules loaded from the vfs (file: URLs)
+        if (found.id.getSchemeType() == Url::SchemeType::FILE) {
+          auto pathname = found.id.getPathname();
+
+          // import.meta.filename is the full absolute filesystem path to the
+          // current module, equivalent to fileURLToPath(import.meta.url).
+          if (meta->CreateDataProperty(js.v8Context(),
+                      v8::Local<v8::String>(js.strIntern("filename"_kj)), js.str(pathname))
+                  .IsNothing()) {
+            return;
+          }
+
+          // import.meta.dirname is the directory containing the current module,
+          // without a trailing slash (unless it is the root "/").
+          // File URL pathnames always start with '/', so findLast is guaranteed
+          // to succeed (same reasoning as url.c++:374).
+          auto lastSlash = KJ_ASSERT_NONNULL(pathname.findLast('/'));
+          auto dirname = lastSlash > 0 ? pathname.first(lastSlash) : pathname.first(1);
+
+          if (meta->CreateDataProperty(js.v8Context(),
+                      v8::Local<v8::String>(js.strIntern("dirname"_kj)), js.str(dirname))
+                  .IsNothing()) {
+            return;
+          }
+        }
+
         // The import.meta.resolve(...) function is effectively a shortcut for
         // new URL(specifier, import.meta.url).href. The idea is that it allows
         // resolving import specifiers relative to the current modules base URL.


### PR DESCRIPTION
Add `import.meta.dirname` and `import.meta.filename` to new module registry `import.meta` support