### PR TITLE
IMAGES-2229: Add tracing spans for hosted images RPC operations

### DIFF
--- a/src/cloudflare/internal/images-api.ts
+++ b/src/cloudflare/internal/images-api.ts
@@ -254,6 +254,57 @@ interface ServiceEntrypointStub {
   list(options?: ImageListOptions): Promise<ImageList>;
 }
 
+async function annotateErrorOnSpan<T>(
+  span: Span,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (e) {
+    span.setAttribute('error.type', e instanceof Error ? e.message : String(e));
+    throw e;
+  }
+}
+
+// `handle` is a JS RPC stub, not a `fetch()`-based object.
+class ImageHandleImpl implements ImageHandle {
+  readonly #handle: ImageHandle;
+
+  constructor(handle: ImageHandle) {
+    this.#handle = handle;
+  }
+
+  async details(): Promise<ImageMetadata | null> {
+    return await withSpan('images_details', async (span) => {
+      span.setAttribute('cloudflare.binding.type', 'Images');
+      return await annotateErrorOnSpan(span, () => this.#handle.details());
+    });
+  }
+
+  async bytes(): Promise<ReadableStream<Uint8Array> | null> {
+    return await withSpan('images_fetch', async (span) => {
+      span.setAttribute('cloudflare.binding.type', 'Images');
+      return await annotateErrorOnSpan(span, () => this.#handle.bytes());
+    });
+  }
+
+  async update(options: ImageUpdateOptions): Promise<ImageMetadata> {
+    return await withSpan('images_update', async (span) => {
+      span.setAttribute('cloudflare.binding.type', 'Images');
+      return await annotateErrorOnSpan(span, () =>
+        this.#handle.update(options)
+      );
+    });
+  }
+
+  async delete(): Promise<boolean> {
+    return await withSpan('images_delete', async (span) => {
+      span.setAttribute('cloudflare.binding.type', 'Images');
+      return await annotateErrorOnSpan(span, () => this.#handle.delete());
+    });
+  }
+}
+
 class HostedImagesBindingImpl implements HostedImagesBinding {
   readonly #fetcher: ServiceEntrypointStub;
 
@@ -262,18 +313,26 @@ class HostedImagesBindingImpl implements HostedImagesBinding {
   }
 
   image(imageId: string): ImageHandle {
-    return this.#fetcher.image(imageId);
+    return new ImageHandleImpl(this.#fetcher.image(imageId));
   }
 
   async upload(
     image: ReadableStream<Uint8Array> | ArrayBuffer,
     options?: ImageUploadOptions
   ): Promise<ImageMetadata> {
-    return this.#fetcher.upload(image, options);
+    return await withSpan('images_upload', async (span) => {
+      span.setAttribute('cloudflare.binding.type', 'Images');
+      return await annotateErrorOnSpan(span, () =>
+        this.#fetcher.upload(image, options)
+      );
+    });
   }
 
   async list(options?: ImageListOptions): Promise<ImageList> {
-    return this.#fetcher.list(options);
+    return await withSpan('images_list', async (span) => {
+      span.setAttribute('cloudflare.binding.type', 'Images');
+      return await annotateErrorOnSpan(span, () => this.#fetcher.list(options));
+    });
   }
 }
 

--- a/src/cloudflare/internal/test/images/images-api-instrumentation-test.js
+++ b/src/cloudflare/internal/test/images/images-api-instrumentation-test.js
@@ -498,4 +498,76 @@ const expectedSpans = [
     'cloudflare.binding.type': 'Images',
     closed: true,
   },
+  // hosted images spans (JS RPC, no paired 'fetch' span)
+  {
+    name: 'images_details',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_details',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_fetch',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_fetch',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_upload',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_upload',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_update',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_update',
+    'cloudflare.binding.type': 'Images',
+    'error.type': 'Image not found',
+    closed: true,
+  },
+  {
+    name: 'images_delete',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_delete',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_list',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_list',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_upload',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
+  {
+    name: 'images_upload',
+    'cloudflare.binding.type': 'Images',
+    closed: true,
+  },
 ];


### PR DESCRIPTION
Adds user tracing spans to env.IMAGES.hosted.* (images_fetch, images_details, images_update, images_delete, images_upload, images_list). These calls go over JS RPC rather than fetch(), which is why they had no spans until now.

[withSpan](https://github.com/cloudflare/workerd/blob/bbbc142c46cc8a3f2ba4d657cb976c9431b9680f/src/cloudflare/internal/tracing-helpers.ts#L38) can now wrap a direct RPC method call and still close correctly, so the same instrumentation already used for the fetch()-based images_output and images_info spans now applies here too.
