### PR TITLE
STOR-5489: Plumb actor retry request metadata through Fetcher

### DIFF
--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -93,6 +93,12 @@ IoChannelFactory::ActorChannel& GlobalActorOutgoingFactory::getOrCreateActorChan
 
 kj::Own<WorkerInterface> GlobalActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr) {
+  return newSingleUseClientWithActorRetryMetadata(kj::mv(cfStr), kj::none);
+}
+
+kj::Own<WorkerInterface> GlobalActorOutgoingFactory::newSingleUseClientWithActorRetryMetadata(
+    kj::Maybe<kj::String> cfStr,
+    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) {
   auto& context = IoContext::current();
 
   return context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
@@ -102,7 +108,8 @@ kj::Own<WorkerInterface> GlobalActorOutgoingFactory::newSingleUseClient(
     return getOrCreateActorChannel(context, tracing.getInternalSpanParent())
         .startRequest({.cfBlobJson = kj::mv(cfStr),
           .parentSpan = tracing.getInternalSpanParent(),
-          .userSpanParent = tracing.getUserSpanParent()});
+          .userSpanParent = tracing.getUserSpanParent(),
+          .actorRetryRequestMetadata = kj::mv(actorRetryRequestMetadata)});
   },
       {.inHouse = true,
         .wrapMetrics = true,

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -347,6 +347,8 @@ class GlobalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
         persistent(persistent) {}
 
   kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
+  kj::Own<WorkerInterface> newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
+      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) override;
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() override;
 
  private:

--- a/src/workerd/api/fetch-body-rewindable-test.c++
+++ b/src/workerd/api/fetch-body-rewindable-test.c++
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+#include "actor.h"
 #include "global-scope.h"
 
 #include <workerd/io/io-context.h>
@@ -65,12 +66,112 @@ class MockFetchTarget final: public WorkerInterface {
   }
 };
 
+class RetryMetadataOutgoingFactory final: public Fetcher::OutgoingFactory {
+ public:
+  RetryMetadataOutgoingFactory(
+      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata>& capturedMetadata)
+      : capturedMetadata(capturedMetadata) {}
+
+  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String>) override {
+    return kj::heap<MockFetchTarget>();
+  }
+
+  kj::Own<WorkerInterface> newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String>,
+      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) override {
+    capturedMetadata = kj::mv(actorRetryRequestMetadata);
+    return kj::heap<MockFetchTarget>();
+  }
+
+ private:
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata>& capturedMetadata;
+};
+
+class UnsupportedOutgoingFactory final: public Fetcher::OutgoingFactory {
+ public:
+  UnsupportedOutgoingFactory(bool& called): called(called) {}
+
+  kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String>) override {
+    called = true;
+    return kj::heap<MockFetchTarget>();
+  }
+
+ private:
+  bool& called;
+};
+
+class MockActorId final: public ActorIdFactory::ActorId {
+ public:
+  kj::String toString() const override {
+    return kj::str("actor-id");
+  }
+
+  kj::Maybe<kj::StringPtr> getName() const override {
+    return kj::none;
+  }
+
+  kj::Maybe<kj::StringPtr> getJurisdiction() const override {
+    return kj::none;
+  }
+
+  bool equals(const ActorId& other) const override {
+    return other.toString() == "actor-id";
+  }
+
+  kj::Own<ActorId> clone() const override {
+    return kj::heap<MockActorId>();
+  }
+};
+
+class RecordingActorChannel final: public IoChannelFactory::ActorChannel {
+ public:
+  RecordingActorChannel(kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata>& capturedMetadata)
+      : capturedMetadata(capturedMetadata) {}
+
+  kj::Own<WorkerInterface> startRequest(IoChannelFactory::SubrequestMetadata metadata) override {
+    capturedMetadata = kj::mv(metadata.actorRetryRequestMetadata);
+    return kj::heap<MockFetchTarget>();
+  }
+
+  void requireAllowsTransfer() override {
+    KJ_UNIMPLEMENTED("not used in this test");
+  }
+
+  kj::OneOf<kj::Array<byte>, kj::Promise<kj::Array<byte>>> getTokenMaybeSync(
+      IoChannelFactory::ChannelTokenUsage) override {
+    KJ_UNIMPLEMENTED("not used in this test");
+  }
+
+ private:
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata>& capturedMetadata;
+};
+
 struct FetchTargetIoChannelFactory final: public TestFixture::DummyIoChannelFactory {
   FetchTargetIoChannelFactory(TimerChannel& timer): DummyIoChannelFactory(timer) {}
 
   kj::Own<WorkerInterface> startSubrequest(uint channel, SubrequestMetadata metadata) override {
     return kj::heap<MockFetchTarget>();
   }
+};
+
+struct ActorIoChannelFactory final: public TestFixture::DummyIoChannelFactory {
+  ActorIoChannelFactory(
+      TimerChannel& timer, kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata>& capturedMetadata)
+      : DummyIoChannelFactory(timer),
+        capturedMetadata(capturedMetadata) {}
+
+  kj::Own<ActorChannel> getGlobalActor(uint,
+      const ActorIdFactory::ActorId&,
+      kj::Maybe<kj::String>,
+      ActorGetMode,
+      bool,
+      ActorRoutingMode,
+      SpanParent,
+      kj::Maybe<ActorVersion>,
+      Persistent) override {
+    return kj::refcounted<RecordingActorChannel>(capturedMetadata);
+  }
+
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata>& capturedMetadata;
 };
 
 // fetchImplNoOutputLock forwards Request::canRewindBody() to RequestObserver so that, downstream,
@@ -119,6 +220,109 @@ KJ_TEST("fetch reports each outgoing body's rewindability per-call without stale
   KJ_EXPECT(bodyRewindableCalls[0] == true, "buffered request body should be rewindable");
   KJ_EXPECT(bodyRewindableCalls[1] == false,
       "streamed request body should not be rewindable (no carryover)");
+}
+
+// Isolate Fetcher's dispatch decision from actor routing: a metadata-aware factory must receive the
+// caller's logical-call metadata unchanged.
+KJ_TEST("Fetcher dispatches actor retry metadata through the metadata-aware factory hook") {
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> capturedMetadata;
+  TestFixture fixture;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    Fetcher fetcher(env.context.addObject<Fetcher::OutgoingFactory>(
+                        kj::heap<RetryMetadataOutgoingFactory>(capturedMetadata)),
+        Fetcher::RequiresHostAndProtocol::YES);
+
+    auto client = fetcher.getClientWithTracing(env.context, kj::none, "fetch"_kjc,
+        IoChannelFactory::ActorRetryRequestMetadata{
+          .nonce = 0x123456789abcdef0,
+          .createdAt = kj::UNIX_EPOCH + 123 * kj::MILLISECONDS,
+          .isRetry = IsActorRetry::YES,
+        });
+
+    KJ_IF_SOME(metadata, capturedMetadata) {
+      KJ_EXPECT(metadata.nonce == 0x123456789abcdef0);
+      KJ_EXPECT(metadata.createdAt == kj::UNIX_EPOCH + 123 * kj::MILLISECONDS);
+      KJ_EXPECT(metadata.isRetry == IsActorRetry::YES);
+    } else {
+      KJ_FAIL_EXPECT("actor retry metadata was not forwarded");
+    }
+  });
+}
+
+// Never fall back to ordinary dispatch when a factory cannot carry retry metadata. Doing so would
+// silently replace the caller's logical-call token at a later seam.
+KJ_TEST("Fetcher rejects actor retry metadata instead of using ordinary factory dispatch") {
+  bool called = false;
+  TestFixture fixture;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    Fetcher fetcher(env.context.addObject<Fetcher::OutgoingFactory>(
+                        kj::heap<UnsupportedOutgoingFactory>(called)),
+        Fetcher::RequiresHostAndProtocol::YES);
+
+    KJ_EXPECT_THROW_MESSAGE("actor retry metadata supplied to an unsupported Fetcher",
+        fetcher.getClientWithTracing(env.context, kj::none, "fetch"_kjc,
+            IoChannelFactory::ActorRetryRequestMetadata{
+              .nonce = 1,
+              .createdAt = kj::UNIX_EPOCH,
+              .isRetry = IsActorRetry::NO,
+            }));
+    KJ_EXPECT(!called);
+  });
+}
+
+// A numeric subrequest channel has no metadata-aware factory hook, so reject before dispatch rather
+// than silently dropping the logical-call metadata.
+KJ_TEST("Fetcher rejects actor retry metadata before numeric subrequest-channel dispatch") {
+  TestFixture fixture;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    Fetcher fetcher(static_cast<uint>(1), Fetcher::RequiresHostAndProtocol::YES);
+
+    KJ_EXPECT_THROW_MESSAGE("actor retry metadata supplied to an unsupported Fetcher",
+        fetcher.getClientWithTracing(env.context, kj::none, "fetch"_kjc,
+            IoChannelFactory::ActorRetryRequestMetadata{
+              .nonce = 1,
+              .createdAt = kj::UNIX_EPOCH,
+              .isRetry = IsActorRetry::NO,
+            }));
+  });
+}
+
+// Exercise the real implementation of the hook tested above: global actor factories must place the
+// caller's metadata on the subrequest sent through the actor channel.
+KJ_TEST("GlobalActorOutgoingFactory places actor retry metadata on the actor subrequest") {
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> capturedMetadata;
+  TestFixture fixture(TestFixture::SetupParams{
+    .useRealTimers = false,
+    .ioChannelFactory = kj::Function<kj::Rc<IoChannelFactory>(TimerChannel&)>(
+        [&](TimerChannel& timer) -> kj::Rc<IoChannelFactory> {
+    return kj::rc<ActorIoChannelFactory>(timer, capturedMetadata);
+  }),
+  });
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    GlobalActorOutgoingFactory factory(
+        GlobalActorOutgoingFactory::ChannelIdOrFactory(static_cast<uint>(1)),
+        env.js.alloc<DurableObjectId>(kj::heap<MockActorId>()), kj::none,
+        ActorGetMode::GET_OR_CREATE, false, ActorRoutingMode::DEFAULT, kj::none, Persistent::NO);
+
+    auto client = factory.newSingleUseClientWithActorRetryMetadata(kj::none,
+        IoChannelFactory::ActorRetryRequestMetadata{
+          .nonce = 0x123456789abcdef0,
+          .createdAt = kj::UNIX_EPOCH + 123 * kj::MILLISECONDS,
+          .isRetry = IsActorRetry::YES,
+        });
+
+    KJ_IF_SOME(metadata, capturedMetadata) {
+      KJ_EXPECT(metadata.nonce == 0x123456789abcdef0);
+      KJ_EXPECT(metadata.createdAt == kj::UNIX_EPOCH + 123 * kj::MILLISECONDS);
+      KJ_EXPECT(metadata.isRetry == IsActorRetry::YES);
+    } else {
+      KJ_FAIL_EXPECT("actor retry metadata was not forwarded to the actor channel");
+    }
+  });
 }
 
 }  // namespace

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1506,7 +1506,8 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
       SubrequestBodyRewindable(jsRequest->canRewindBody()));
 
   // Get client and trace context (if needed) in one clean call
-  auto clientWithTracing = fetcher->getClientWithTracing(ioContext, jsRequest->serializeCfBlobJson(js), "fetch"_kjc);
+  auto clientWithTracing = fetcher->getClientWithTracing(ioContext,
+      jsRequest->serializeCfBlobJson(js), "fetch"_kjc, kj::none /* actorRetryRequestMetadata */);
   auto traceContext = kj::mv(clientWithTracing.traceContext);
 
   // TODO(cleanup): Don't convert to HttpClient. Use the HttpService interface instead. This
@@ -2460,12 +2461,25 @@ jsg::Promise<Fetcher::ScheduledResult> Fetcher::scheduled(
 
 kj::Own<WorkerInterface> Fetcher::getClient(
     IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
-  auto clientWithTracing = getClientWithTracing(ioContext, kj::mv(cfStr), kj::mv(operationName));
+  auto clientWithTracing = getClientWithTracing(
+      ioContext, kj::mv(cfStr), kj::mv(operationName), kj::none /* actorRetryRequestMetadata */);
   return clientWithTracing.client.attach(kj::mv(clientWithTracing.traceContext));
 }
 
 Fetcher::ClientWithTracing Fetcher::getClientWithTracing(
-    IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
+    IoContext& ioContext,
+    kj::Maybe<kj::String> cfStr,
+    kj::ConstString operationName,
+    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) {
+  KJ_IF_SOME(metadata, actorRetryRequestMetadata) {
+    auto& outgoingFactory = KJ_REQUIRE_NONNULL(
+        channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>(),
+        "actor retry metadata supplied to an unsupported Fetcher");
+    auto client = outgoingFactory->newSingleUseClientWithActorRetryMetadata(
+        kj::mv(cfStr), kj::mv(metadata));
+    return ClientWithTracing{kj::mv(client), kj::none};
+  }
+
   KJ_SWITCH_ONEOF(channelOrClientFactory) {
     KJ_CASE_ONEOF(channel, uint) {
       // For channels, create trace context

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -234,6 +234,14 @@ class Fetcher: public JsRpcClientProvider {
    public:
     virtual kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) = 0;
 
+    // Factories that can carry actor retry metadata override this method. The default rejects the
+    // metadata rather than silently starting a new logical call.
+    virtual kj::Own<WorkerInterface> newSingleUseClientWithActorRetryMetadata(
+        kj::Maybe<kj::String> cfStr,
+        kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) {
+      KJ_FAIL_REQUIRE("actor retry metadata supplied to an unsupported Fetcher");
+    }
+
     // Get a `SubrequestChannel` representing this Fetcher. This is used especially when the
     // Fetcher is being passed to another isolate.
     virtual kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() {
@@ -289,8 +297,10 @@ class Fetcher: public JsRpcClientProvider {
   };
 
   // Get client and optionally create trace context, all in one call
-  ClientWithTracing getClientWithTracing(
-      IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName);
+  ClientWithTracing getClientWithTracing(IoContext& ioContext,
+      kj::Maybe<kj::String> cfStr,
+      kj::ConstString operationName,
+      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata);
 
   // Get a SubrequestChannel representing this Fetcher.
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel(IoContext& ioContext);

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -32,6 +32,9 @@ class WorkerInterface;
 // A `Persistent::YES` channel/token may be stored in long-term storage; `Persistent::NO` may not.
 WD_STRONG_BOOL(Persistent);
 
+// Whether an actor request is a retry of an earlier attempt.
+WD_STRONG_BOOL(IsActorRetry);
+
 // Interface for talking to the Cache API. Needs to be declared here so that IoContext can
 // contain it.
 class CacheClient {
@@ -125,6 +128,13 @@ class IoChannelFactory: public virtual kj::Refcounted {
   // surface only when the token is genuinely required.
   class SelfTokenFactory: public kj::Refcounted {};
 
+  // The sender-selected retry token and retry flag for one logical actor call attempt.
+  struct ActorRetryRequestMetadata {
+    uint64_t nonce;
+    kj::Date createdAt;
+    IsActorRetry isRetry;
+  };
+
   // Contains metadata attached to an outgoing subrequest from a worker, independent of the type
   // of request.
   struct SubrequestMetadata {
@@ -152,6 +162,10 @@ class IoChannelFactory: public virtual kj::Refcounted {
     // appropriate to pass down to the IoContext as the `selfTokenFactory`, for use by the
     // implementation of `ctx.restore()`, so that it can determine its own base token.
     kj::Maybe<kj::Own<SelfTokenFactory>> restoredSelfTokenFactory;
+
+    // Present when a global actor request belongs to a logical call whose retry token was selected
+    // by the caller. Actor channels generate a fresh first-attempt token when this is absent.
+    kj::Maybe<ActorRetryRequestMetadata> actorRetryRequestMetadata;
 
     // True if this request was started on a channel that was reconstructed from a stored
     // ("persistent") stub. The target worker re-verifies that it still has the


### PR DESCRIPTION
Add optional actor retry request metadata containing a nonce, creation time, and retry flag. This lets a future caller replay a logical actor call with a stable token.

Those call sites are not implemented yet, that will be the next MR that will make use of this plumbing.