### PR TITLE
queue.c++: Copy data out of sandbox for MPK

### DIFF
--- a/src/workerd/api/queue.c++
+++ b/src/workerd/api/queue.c++
@@ -103,17 +103,25 @@ Serialized serializeV8(jsg::Lock& js, const jsg::JsValue& body) {
   return kj::mv(result);
 }
 
-// Control whether serialize() detaches/copies the ArrayBuffer or holds a shallow reference.
+// Control whether serialize() copies the ArrayBuffer or holds a shallow reference.
 //
-// send() uses DEEP_COPY, which detaches the buffer when possible (transferring ownership
-// without copying).  sendBatch() uses SHALLOW_REFERENCE, which avoids detaching so the
-// caller can reuse the buffer after the call.  Do not change sendBatch() to DEEP_COPY
-// without a compat flag — users may depend on the buffer remaining usable.
+// send() uses DEEP_COPY, which memcpys into a kj-heap allocation.  sendBatch() uses
+// SHALLOW_REFERENCE, which avoids the copy so the caller can reuse the buffer after the
+// call.  Do not change sendBatch() to DEEP_COPY without a compat flag — users may depend
+// on the buffer remaining usable.
 //
 // SHALLOW_REFERENCE holds a raw pointer into the BackingStore.  This is safe for
 // non-resizable buffers (the BackingStore shared_ptr prevents deallocation), but
 // resizable buffers can have pages decommitted by resize(0) while the pointer is held.
 // The SHALLOW_REFERENCE path deep-copies resizable buffers to prevent this.
+//
+// SHALLOW_REFERENCE for non-resizable buffers additionally aliases pkey-protected V8
+// sandbox memory when MPK is enabled.  Callers MUST consume the bytes synchronously under
+// the isolate lock and not hand the ArrayPtr to async I/O that runs after the lock is
+// released; the I/O thread would not have the sender's pkey and the access would fault.
+// sendBatch() relies on this: it base64-encodes the bytes into a fresh kj-heap buffer
+// before any co_await.  New SHALLOW_REFERENCE callers must preserve this invariant or
+// switch to DEEP_COPY.
 enum class SerializeArrayBufferBehavior {
   DEEP_COPY,
   SHALLOW_REFERENCE,
@@ -153,15 +161,18 @@ Serialized serialize(jsg::Lock& js,
       result.data = source.asArrayPtr();
       result.own = source.addRef(js);
       return kj::mv(result);
-    } else if (source.isDetachable()) {
-      // Prefer detaching the input ArrayBuffer whenever possible to avoid needing to copy it.
-      auto backingSource = source.detachAndTake(js);
-      Serialized result;
-      result.data = backingSource.asArrayPtr();
-      result.own = backingSource.addRef(js);
-      return kj::mv(result);
     } else {
-      kj::Array<kj::byte> bytes = jsg::JsBufferSource(source).copy();
+      // DEEP_COPY: the data is held across an async boundary and read by I/O code that runs
+      // without the isolate lock.  When MPK protects isolate memory, the V8 sandbox backing
+      // store pages are tagged with the isolate's pkey and are inaccessible from other
+      // threads, so we memcpy into an unprotected kj-heap allocation.
+      //
+      // Detach first when the buffer is detachable.  The copy makes detaching unnecessary
+      // for our own purposes, but send() detaching its argument is observable from JS and
+      // applications may depend on it.
+      jsg::JsBufferSource taken(
+          source.isDetachable() ? source.detachAndTake(js) : jsg::JsArrayBufferView(source));
+      kj::Array<kj::byte> bytes = taken.copy();
       Serialized result;
       result.data = bytes;
       result.own = kj::mv(bytes);


### PR DESCRIPTION
This is a reland of a change to copy data out of array buffers
that are MPK protected.  The data needs to be accessible to
kj code that does not hold the isolate lock and thus the key.

Since we now take a copy, the user can no longer make a
late write into the buffer, so detaching is unnecessary.
Unlike the original land we detach anyway: send() detaching
its argument is observable from JS and applications may rely
on it.  Also there's a minor GC benefit to making the array
buffer backing collectible.