### PR TITLE
Copy writable sink adapter data for MPK

### DIFF
--- a/src/workerd/api/streams/writable-sink-adapter.c++
+++ b/src/workerd/api/streams/writable-sink-adapter.c++
@@ -217,7 +217,15 @@ jsg::Promise<void> WritableStreamSinkJsAdapter::write(jsg::Lock& js, const jsg::
       return js.resolvedPromise();
     }
 
-    active.bytesInFlight += source.size();
+    // Copy the bytes into a kj-heap allocation while we hold the isolate lock.  The kj
+    // sink->write below runs from the kj event loop after the lock has been released.  When
+    // MPK protects isolate memory, the V8 sandbox pages are tagged with the isolate's pkey
+    // and the sink would fault.  Per Fetch-like semantics the caller is free to mutate the
+    // buffer once write() returns its promise.
+    kj::Array<kj::byte> bytes = kj::heapArray(source.asArrayPtr());
+    size_t byteSize = bytes.size();
+
+    active.bytesInFlight += byteSize;
     maybeSignalBackpressure(js);
     // Enqueue the actual write operation into the write queue. We pass in
     // two lambdas, one that does the actual write, and one that handles
@@ -239,15 +247,14 @@ jsg::Promise<void> WritableStreamSinkJsAdapter::write(jsg::Lock& js, const jsg::
     // Capturing active by reference here is safe because the lambda is
     // held by the write queue, which is itself held by Active. If active
     // is destroyed, the write queue is destroyed along with the lambda.
-    auto promise =
-        active.enqueue(kj::coCapture([&active, ptr = source.asArrayPtr()]() -> kj::Promise<void> {
-      co_await active.sink->write(ptr);
-      active.bytesInFlight -= ptr.size();
+    auto promise = active.enqueue(
+        kj::coCapture([&active, bytes = kj::mv(bytes), byteSize]() -> kj::Promise<void> {
+      co_await active.sink->write(bytes);
+      active.bytesInFlight -= byteSize;
     }));
 
     return ioContext
-        .awaitIo(js, kj::mv(promise),
-            [self = selfRef.addRef(), source = source.addRef(js)](jsg::Lock& js) {
+        .awaitIo(js, kj::mv(promise), [self = selfRef.addRef()](jsg::Lock& js) {
       // Why do we need a weak ref here? Well, because this is a JavaScript
       // promise continuation. It is possible that the kj::Own holding our
       // adapter can be dropped while we are waiting for the continuation

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -654,6 +654,19 @@ static kj::Array<kj::byte> getEmptyArray() {
   return kj::Array<kj::byte>(&DUMMY, 0, kj::NullArrayDisposer::instance);
 }
 
+// The returned kj::Array<kj::byte> aliases the V8 BackingStore (kept alive via the attached
+// shared_ptr).  Two consequences:
+//
+//   * When MPK protects isolate memory, the bytes live in V8 sandbox pages tagged with the
+//     isolate's pkey.  Access is then only valid while the isolate lock is held.  Handing this
+//     Array to async I/O that runs without the lock will fault.  Callers that cross a lock
+//     boundary must make their own kj-heap copy (e.g. via `kj::heapArray(result.asPtr())`)
+//     before the await.
+//
+//   * Writes through the Array land in the JS BackingStore.  This is the contract Pyodide's
+//     ReadOnlyBuffer::read and similar "destination buffer" APIs rely on.  An always-copy
+//     implementation would silently break those callers: their data would land in a temporary
+//     that is dropped on return.
 kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBuffer> arrayBuffer) {
   if (arrayBuffer->IsResizableByUserJavaScript() || arrayBuffer->IsImmutable()) {
     // For resizable ArrayBuffers, resize(0) decommits pages (PROT_NONE) even while the
@@ -679,6 +692,8 @@ kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBuffer> arrayBuffer) {
   }
   return bytes.attach(kj::mv(backing));
 }
+
+// See the ArrayBuffer overload above for the aliasing contract (MPK + write-through).
 kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBufferView> arrayBufferView) {
   auto buffer = arrayBufferView->Buffer();
   if (buffer->IsResizableByUserJavaScript() || buffer->IsImmutable()) {
@@ -704,9 +719,7 @@ kj::Array<kj::byte> asBytes(v8::Local<v8::ArrayBufferView> arrayBufferView) {
   return bytes.attach(kj::mv(backing));
 }
 
-// TODO(soon): If the returned kj::Array<kj::byte> is used outside of the isolate lock,
-// we'll need to ensure it works correctly once MPK (Memory Protection Keys) enforcement
-// is fully in place.
+// See the ArrayBuffer overload above for the aliasing contract (MPK + write-through).
 kj::Array<kj::byte> asBytes(v8::Local<v8::SharedArrayBuffer> sharedArrayBuffer) {
   auto backing = sharedArrayBuffer->GetBackingStore();
   kj::ArrayPtr bytes(static_cast<kj::byte*>(backing->Data()), backing->ByteLength());


### PR DESCRIPTION
This copies data out of the V8 sandbox so it can be read by code not holding the V8 isolate lock and any MPK keys associated with the sandbox.