### PR TITLE
Copy readable stream data for MPK

### DIFF
--- a/src/workerd/api/blob.c++
+++ b/src/workerd/api/blob.c++
@@ -277,8 +277,10 @@ jsg::Promise<jsg::JsRef<jsg::JsString>> Blob::text(jsg::Lock& js) {
 
 JsReadableStream Blob::stream(jsg::Lock& js) {
   FeatureObserver::maybeRecordUse(FeatureObserver::Feature::BLOB_AS_STREAM);
-  return JsReadableStream::create(
-      js, IoContext::current(), streams::newMemorySource(data, kj::heap(JSG_THIS)));
+  // Pass no backing so that newMemorySource copies: our data is a V8 ArrayBuffer, and the
+  // stream is read from the kj event loop where the isolate's MPK-protected sandbox pages
+  // are unreadable.
+  return JsReadableStream::create(js, IoContext::current(), streams::newMemorySource(data));
 }
 
 // =======================================================================================

--- a/src/workerd/api/js-readable-stream.c++
+++ b/src/workerd/api/js-readable-stream.c++
@@ -453,14 +453,18 @@ kj::Promise<DeferredProxy<void>> pumpQueuedTsStream(jsg::Lock& js,
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdangling-field"
 JsReadableStream::Buffer::Buffer(kj::Array<const kj::byte> data): view(data), owned(kj::mv(data)) {}
-
-JsReadableStream::Buffer::Buffer(jsg::Ref<Blob> data): view(data->getData()), owned(kj::mv(data)) {}
 #pragma clang diagnostic pop
+
+// Blob contents live in a V8 ArrayBuffer.  The streams built from this Buffer are read on the
+// kj event loop, where the isolate's MPK-protected sandbox pages are unreadable, so take a
+// kj-heap copy.  It is shared by every stream derived from this Buffer -- rewinds and tee
+// branches alike.
+JsReadableStream::Buffer::Buffer(jsg::Ref<Blob> data): Buffer(kj::heapArray(data->getData())) {}
 
 JsReadableStream::Impl JsReadableStream::bufferBackedImpl(jsg::Lock& js, kj::Rc<Buffer> buffer) {
   // Use streams::newMemorySource() rather than newSystemStream() wrapping a memory input stream:
-  // buffer-backed bodies may have V8 heap provenance and therefore must NOT be deferred-proxied.
-  // The data must be consumed and destroyed while under the isolate lock.
+  // it reads the Buffer's bytes in place, so every stream derived from this Buffer -- rewinds
+  // and tee branches alike -- shares the one allocation.
   //
   // TODO(streams-ts): Like create(), the stream construction here must dispatch on the
   // worker's configuration once the TypeScript implementation lands.

--- a/src/workerd/api/js-readable-stream.h
+++ b/src/workerd/api/js-readable-stream.h
@@ -45,10 +45,12 @@ class JsReadableStream final {
   // The underlying stream.
   using StreamImpl = kj::OneOf<jsg::Ref<ReadableStream>, jsg::JsRef<jsg::JsObject>>;
 
-  // Holds the in-memory data backing a buffer-backed (rewindable) JsReadableStream.
+  // Holds the in-memory data backing a buffer-backed (rewindable) JsReadableStream.  `owned`
+  // is always kj-heap memory: the streams built from it are read on the kj event loop without
+  // the isolate lock, so the bytes must not sit in the V8 sandbox.
   struct Buffer {
     kj::ArrayPtr<const kj::byte> view;
-    kj::OneOf<kj::Array<const kj::byte>, jsg::Ref<Blob>> owned;
+    kj::Array<const kj::byte> owned;
 
     explicit Buffer(kj::Array<const kj::byte> data);
     explicit Buffer(jsg::Ref<Blob> data);

--- a/src/workerd/api/streams/readable-source.h
+++ b/src/workerd/api/streams/readable-source.h
@@ -216,13 +216,17 @@ kj::Own<ReadableSource> newEncodedReadableSource(
 kj::Own<kj::AsyncInputStream> wrapTeeBranch(kj::Own<kj::AsyncInputStream> branch);
 
 // A ReadableStreamSource backed by in-memory data. Unlike newSystemStream() wrapping a
-// newMemoryInputStream(), this implementation does NOT support deferred proxying. This is
-// important when the backing memory has V8 heap provenance (e.g., ArrayBuffer, Blob data,
-// kj::Array<kj::byte> with a v8::BackingStore attached, etc)
-// since the memory could be freed by GC after the IoContext completes.
+// newMemoryInputStream(), this implementation does NOT support deferred proxying, so the data
+// is always consumed before the IoContext goes away and `backing` can be something whose
+// lifetime is tied to the IoContext.
 //
 // The `backing` parameter keeps the underlying memory alive for the lifetime of the stream.
 // If not provided, the bytes are copied.
+//
+// Reads and pumps run on the kj event loop without the isolate lock, so `bytes` MUST be
+// readable there.  When MPK protects isolate memory, that rules out anything inside the V8
+// sandbox -- ArrayBuffer and Blob contents in particular.  Callers holding such data must
+// omit `backing` and let this function copy, or copy it themselves beforehand.
 //
 // TODO(soon): Update to implement ReadableSource instead of ReadableStreamSource.
 // For now this is a ReadableStreamSource for compat with existing code. Once internal.h/c++


### PR DESCRIPTION
This copies data out of the V8 sandbox so it can be read by code not holding the V8 isolate lock and any MPK keys associated with the sandbox.