### PR TITLE
containers: Always run monitor in the background after container.start()

### DIFF
--- a/src/workerd/api/container-test.c++
+++ b/src/workerd/api/container-test.c++
@@ -72,6 +72,10 @@ class MockContainerServer final: public rpc::Container::Server {
     return kj::READY_NOW;
   }
 
+  kj::Promise<void> monitor(MonitorContext context) override {
+    return kj::NEVER_DONE;
+  }
+
   kj::Promise<void> snapshotDirectory(SnapshotDirectoryContext context) override {
     auto params = context.getParams();
     KJ_EXPECT(params.hasSpanContext());
@@ -162,6 +166,10 @@ class MockExecContainerServer final: public rpc::Container::Server {
       : byteStreamFactory(byteStreamFactory),
         observations(observations),
         resizeFulfiller(kj::mv(resizeFulfiller)) {}
+
+  kj::Promise<void> monitor(MonitorContext context) override {
+    return kj::NEVER_DONE;
+  }
 
   kj::Promise<void> exec(ExecContext context) override {
     observations.execCalled = true;
@@ -420,6 +428,10 @@ class TestContainerServer final: public rpc::Container::Server {
     return kj::READY_NOW;
   }
 
+  kj::Promise<void> monitor(MonitorContext context) override {
+    return kj::NEVER_DONE;
+  }
+
   kj::Promise<void> getTcpPort(GetTcpPortContext context) override {
     context.getResults().setPort(kj::heap<TestPort>(
         byteStreamFactory, mode, connectCount, closeFulfiller, upEndedUncleanly, deferConnect));
@@ -528,6 +540,39 @@ TestFixture makeFixture() {
     .useRealTimers = false,
     .requestObserverFactory = kj::Function<kj::Own<RequestObserver>()>(
         []() -> kj::Own<RequestObserver> { return kj::refcounted<TracingRequestObserver>(); }),
+  });
+}
+
+KJ_TEST("Container::start monitors a container that exits immediately") {
+  class ImmediateExitContainerServer final: public rpc::Container::Server {
+   public:
+    kj::Promise<void> start(StartContext context) override {
+      started = true;
+      return kj::READY_NOW;
+    }
+
+    kj::Promise<void> monitor(MonitorContext context) override {
+      KJ_EXPECT(started);
+      context.getResults().setExitCode(0);
+      return kj::READY_NOW;
+    }
+
+    bool started = false;
+  };
+
+  auto fixture = makeFixture();
+  fixture.runInIoContext([](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = kj::heap<Container>(
+        rpc::Container::Client(kj::heap<ImmediateExitContainerServer>()), false);
+
+    container->start(env.js, kj::none);
+    KJ_EXPECT(container->getRunning());
+
+    for (auto i = 0; i < 10 && container->getRunning(); ++i) {
+      co_await kj::evalLater([]() {});
+    }
+
+    KJ_EXPECT(!container->getRunning());
   });
 }
 

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -306,11 +306,14 @@ void ExecProcess::resize(jsg::Lock& js, int cols, int rows) {
 
 Container::Container(rpc::Container::Client rpcClient, bool running)
     : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))),
-      running(running) {}
+      monitorState(kj::rc<MonitorState>(running)) {
+  if (running) startMonitor();
+}
 
 void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions) {
   auto flags = FeatureFlags::get(js);
-  JSG_REQUIRE(!running, Error, "start() cannot be called on a container that is already running.");
+  JSG_REQUIRE(
+      !getRunning(), Error, "start() cannot be called on a container that is already running.");
   invalidateTcpPortStates();
 
   StartupOptions options = kj::mv(maybeOptions).orDefault({});
@@ -414,11 +417,34 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
 
   IoContext::current().addTask(req.sendIgnoringResult());
 
-  running = true;
+  backgroundMonitor = kj::none;
+  monitorPromise = kj::none;
+  monitorState = kj::rc<MonitorState>(true);
+  startMonitor();
+}
+
+void Container::startMonitor() {
+  KJ_ASSERT(getRunning());
+  KJ_ASSERT(monitorPromise == kj::none);
+
+  auto monitor = rpcClient->monitorRequest(capnp::MessageSize{4, 0})
+                     .send()
+                     .then([](capnp::Response<rpc::Container::MonitorResults> results) {
+    return results.getExitCode();
+  }).fork();
+
+  auto background = monitor.addBranch().then([state = monitorState.addRef()](int32_t) {
+    state->running = false;
+  }, [state = monitorState.addRef()](kj::Exception&&) { state->running = false; });
+
+  auto& ioContext = IoContext::current();
+  monitorPromise = ioContext.addObject(kj::heap(kj::mv(monitor)));
+  backgroundMonitor = ioContext.addObject(kj::heap(kj::mv(background).eagerlyEvaluate(nullptr)));
 }
 
 jsg::Promise<void> Container::setLabels(jsg::Lock& js, jsg::Dict<kj::String> labels) {
-  JSG_REQUIRE(running, Error, "setLabels() cannot be called on a container that is not running.");
+  JSG_REQUIRE(
+      getRunning(), Error, "setLabels() cannot be called on a container that is not running.");
 
   auto& ioContext = IoContext::current();
 
@@ -461,8 +487,8 @@ jsg::Promise<kj::Maybe<Container::Info>> Container::inspect(jsg::Lock& js) {
 
 jsg::Promise<Container::DirectorySnapshot> Container::snapshotDirectory(
     jsg::Lock& js, DirectorySnapshotOptions options) {
-  JSG_REQUIRE(
-      running, Error, "snapshotDirectory() cannot be called on a container that is not running.");
+  JSG_REQUIRE(getRunning(), Error,
+      "snapshotDirectory() cannot be called on a container that is not running.");
   JSG_REQUIRE(options.dir.size() > 0 && options.dir.startsWith("/"), TypeError,
       "snapshotDirectory() requires an absolute directory path (starting with '/').");
 
@@ -496,8 +522,8 @@ jsg::Promise<Container::DirectorySnapshot> Container::snapshotDirectory(
 
 jsg::Promise<Container::Snapshot> Container::snapshotContainer(
     jsg::Lock& js, SnapshotOptions options) {
-  JSG_REQUIRE(
-      running, Error, "snapshotContainer() cannot be called on a container that is not running.");
+  JSG_REQUIRE(getRunning(), Error,
+      "snapshotContainer() cannot be called on a container that is not running.");
 
   auto req = rpcClient->snapshotContainerRequest();
   KJ_IF_SOME(spanContext, IoContext::current().getCurrentTraceSpan().toSpanContext()) {
@@ -603,7 +629,7 @@ kj::Promise<void> Container::interceptOutboundHttpsImpl(rpc::Container::Client r
 
 jsg::Promise<jsg::Ref<ExecProcess>> Container::exec(
     jsg::Lock& js, kj::Array<kj::String> cmd, jsg::Optional<ExecOptions> maybeOptions) {
-  JSG_REQUIRE(running, Error, "exec() cannot be called on a container that is not running.");
+  JSG_REQUIRE(getRunning(), Error, "exec() cannot be called on a container that is not running.");
   JSG_REQUIRE(cmd.size() > 0, TypeError, "exec() requires a non-empty command array.");
 
   auto options = kj::mv(maybeOptions).orDefault({});
@@ -808,18 +834,16 @@ kj::Promise<void> Container::interceptOutboundTcpImpl(rpc::Container::Client rpc
 }
 
 jsg::Promise<void> Container::monitor(jsg::Lock& js) {
-  JSG_REQUIRE(running, Error, "monitor() cannot be called on a container that is not running.");
+  JSG_REQUIRE(monitorPromise != kj::none, Error,
+      "monitor() cannot be called on a container that is not running.");
 
   return IoContext::current()
-      .awaitIo(js, rpcClient->monitorRequest(capnp::MessageSize{4, 0}).send())
+      .awaitIo(js, KJ_ASSERT_NONNULL(monitorPromise)->addBranch())
       // Note: `self` (jsg::Ref) is captured to prevent GC from collecting this object while
       // the promise continuation is pending. Without it, the bare `this` pointer dangles.
-      .then(js,
-          [self = JSG_THIS](
-              jsg::Lock& js, capnp::Response<rpc::Container::MonitorResults> results) mutable {
-    self->running = false;
+      .then(js, [self = JSG_THIS](jsg::Lock& js, int32_t exitCode) mutable {
+    self->monitorState->running = false;
     self->invalidateTcpPortStates();
-    auto exitCode = results.getExitCode();
     KJ_IF_SOME(d, self->destroyReason) {
       jsg::Value error = kj::mv(d);
       self->destroyReason = kj::none;
@@ -831,9 +855,8 @@ jsg::Promise<void> Container::monitor(jsg::Lock& js) {
       KJ_ASSERT_NONNULL(err.tryCast<jsg::JsObject>()).set(js, "exitCode", js.num(exitCode));
       js.throwException(err);
     }
-  },
-          [self = JSG_THIS](jsg::Lock& js, jsg::Value&& error) mutable {
-    self->running = false;
+  }, [self = JSG_THIS](jsg::Lock& js, jsg::Value&& error) mutable {
+    self->monitorState->running = false;
     self->invalidateTcpPortStates();
     self->destroyReason = kj::none;
     js.throwException(kj::mv(error));
@@ -841,7 +864,7 @@ jsg::Promise<void> Container::monitor(jsg::Lock& js) {
 }
 
 jsg::Promise<void> Container::destroy(jsg::Lock& js, jsg::Optional<jsg::Value> error) {
-  if (!running) return js.resolvedPromise();
+  if (!getRunning()) return js.resolvedPromise();
   invalidateTcpPortStates();
 
   if (destroyReason == kj::none) {
@@ -854,7 +877,7 @@ jsg::Promise<void> Container::destroy(jsg::Lock& js, jsg::Optional<jsg::Value> e
 
 void Container::signal(jsg::Lock& js, int signo) {
   JSG_REQUIRE(signo > 0 && signo <= 64, RangeError, "Invalid signal number.");
-  JSG_REQUIRE(running, Error, "signal() cannot be called on a container that is not running.");
+  JSG_REQUIRE(getRunning(), Error, "signal() cannot be called on a container that is not running.");
 
   auto req = rpcClient->signalRequest(capnp::MessageSize{4, 0});
   req.setSigno(signo);

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -311,7 +311,7 @@ class Container: public jsg::Object {
   };
 
   bool getRunning() const {
-    return running;
+    return monitorState->running;
   }
 
   // Methods correspond closely to the RPC interface in `container.capnp`.
@@ -367,8 +367,19 @@ class Container: public jsg::Object {
   }
 
  private:
+  struct MonitorState final: public kj::Refcounted {
+    explicit MonitorState(bool running): running(running) {}
+
+    bool running;
+  };
+
   IoOwn<rpc::Container::Client> rpcClient;
-  bool running;
+  kj::Rc<MonitorState> monitorState;
+
+  // A single monitor RPC is shared by the background state update and any explicit monitor()
+  // calls. The eager branch lets the Durable Object hibernate while the RPC remains pending.
+  kj::Maybe<IoOwn<kj::ForkedPromise<int32_t>>> monitorPromise;
+  kj::Maybe<IoOwn<kj::Promise<void>>> backgroundMonitor;
 
   kj::Maybe<jsg::Value> destroyReason;
 
@@ -386,6 +397,7 @@ class Container: public jsg::Object {
   kj::Maybe<IoOwn<kj::HashMap<int, kj::Rc<TcpPortState>>>> tcpPortStates;
 
   void invalidateTcpPortStates();
+  void startMonitor();
 
   // These helpers are static since they will leave the IoContext on the first co_await, so we
   // don't want them trying to access `rpcClient` via the `IoOwn`.

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -21,11 +21,6 @@ function getRandomDurableObjectName(name) {
 // When writing a test, don't forget to call waitUntilContainerIsHealthy
 // before testing the behaviour with your container.
 //
-// Don't forget to call monitor() after calling start(), as there
-// is an issue with not calling monitor() in Durable Objects where
-// we might lose track of the container lifetime.
-//
-
 export class DurableObjectExample extends DurableObject {
   async testExitCode() {
     const container = this.ctx.container;
@@ -67,6 +62,23 @@ export class DurableObjectExample extends DurableObject {
       assert.strictEqual(typeof exitCode, 'number');
       assert.equal(137, exitCode);
     }
+  }
+
+  async testRunningAfterImmediateExit() {
+    const container = this.ctx.container;
+    if (container.running) {
+      const monitor = container.monitor().catch((_err) => {});
+      await container.destroy();
+      await monitor;
+    }
+
+    container.start({ entrypoint: ['/bin/sh', '-c', 'exit 0'] });
+
+    for (let i = 0; i < 100 && container.running; ++i) {
+      await scheduler.wait(100);
+    }
+
+    assert.strictEqual(container.running, false);
   }
 
   async testBasics() {
@@ -2850,6 +2862,16 @@ export const testExitCode = {
     );
     const stub = env.MY_CONTAINER.get(id);
     await stub.testExitCode();
+  },
+};
+
+export const testRunningAfterImmediateExit = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testRunningAfterImmediateExit')
+    );
+    const stub = env.MY_CONTAINER.get(id);
+    await stub.testRunningAfterImmediateExit();
   },
 };
 


### PR DESCRIPTION
or if container is already running

Users had to run container.monitor() for their running property to change to false if their container exited.

That is really annoying for simple
DO scripts that just want to start their container, run a series of commands and forget.

Taking over https://github.com/cloudflare/workerd/pull/4371