### PR TITLE
containers: Always run monitor in the background after container.start()

### DIFF
--- a/src/workerd/api/container-test.c++
+++ b/src/workerd/api/container-test.c++
@@ -72,6 +72,10 @@ class MockContainerServer final: public rpc::Container::Server {
     return kj::READY_NOW;
   }
 
+  kj::Promise<void> monitor(MonitorContext context) override {
+    return kj::NEVER_DONE;
+  }
+
   kj::Promise<void> snapshotDirectory(SnapshotDirectoryContext context) override {
     auto params = context.getParams();
     KJ_EXPECT(params.hasSpanContext());
@@ -106,6 +110,38 @@ class MockContainerServer final: public rpc::Container::Server {
   kj::Maybe<kj::Own<kj::PromiseFulfiller<CapturedInstance>>> startFulfiller;
   kj::Maybe<bool&> directoryCalled;
   kj::Maybe<bool&> containerCalled;
+};
+
+class RestartContainerServer final: public rpc::Container::Server {
+ public:
+  kj::Promise<void> start(StartContext context) override {
+    ++startCount;
+    return kj::READY_NOW;
+  }
+
+  kj::Promise<void> monitor(MonitorContext context) override {
+    if (startCount > 1) {
+      context.getResults().setExitCode(0);
+      return kj::READY_NOW;
+    }
+
+    auto paf = kj::newPromiseAndFulfiller<void>();
+    pendingMonitor = kj::mv(context);
+    monitorFulfiller = kj::mv(paf.fulfiller);
+    return kj::mv(paf.promise);
+  }
+
+  kj::Promise<void> destroy(DestroyContext context) override {
+    KJ_REQUIRE(startCount == 1);
+    KJ_REQUIRE_NONNULL(pendingMonitor).getResults().setExitCode(0);
+    KJ_REQUIRE_NONNULL(monitorFulfiller)->fulfill();
+    return kj::READY_NOW;
+  }
+
+ private:
+  uint startCount = 0;
+  kj::Maybe<MonitorContext> pendingMonitor;
+  kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> monitorFulfiller;
 };
 
 // Records the arguments passed to exec()/resize() so tests can assert the pty option is piped
@@ -162,6 +198,10 @@ class MockExecContainerServer final: public rpc::Container::Server {
       : byteStreamFactory(byteStreamFactory),
         observations(observations),
         resizeFulfiller(kj::mv(resizeFulfiller)) {}
+
+  kj::Promise<void> monitor(MonitorContext context) override {
+    return kj::NEVER_DONE;
+  }
 
   kj::Promise<void> exec(ExecContext context) override {
     observations.execCalled = true;
@@ -420,6 +460,10 @@ class TestContainerServer final: public rpc::Container::Server {
     return kj::READY_NOW;
   }
 
+  kj::Promise<void> monitor(MonitorContext context) override {
+    return kj::NEVER_DONE;
+  }
+
   kj::Promise<void> getTcpPort(GetTcpPortContext context) override {
     context.getResults().setPort(kj::heap<TestPort>(
         byteStreamFactory, mode, connectCount, closeFulfiller, upEndedUncleanly, deferConnect));
@@ -528,6 +572,63 @@ TestFixture makeFixture() {
     .useRealTimers = false,
     .requestObserverFactory = kj::Function<kj::Own<RequestObserver>()>(
         []() -> kj::Own<RequestObserver> { return kj::refcounted<TracingRequestObserver>(); }),
+  });
+}
+
+KJ_TEST("Container::start monitors a container that exits immediately") {
+  class ImmediateExitContainerServer final: public rpc::Container::Server {
+   public:
+    kj::Promise<void> start(StartContext context) override {
+      started = true;
+      return kj::READY_NOW;
+    }
+
+    kj::Promise<void> monitor(MonitorContext context) override {
+      KJ_EXPECT(started);
+      context.getResults().setExitCode(0);
+      return kj::READY_NOW;
+    }
+
+    bool started = false;
+  };
+
+  auto fixture = makeFixture();
+  fixture.runInIoContext([](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto weakContext = env.context.getWeakRef();
+    auto container = kj::heap<Container>(
+        rpc::Container::Client(kj::heap<ImmediateExitContainerServer>()), false);
+
+    container->start(env.js, kj::none);
+    KJ_EXPECT(container->getRunning());
+
+    // Give the queued start and monitor RPCs bounded time to run.
+    for (auto i = 0; i < 10; ++i) {
+      co_await kj::evalLater([]() {});
+    }
+
+    auto& context = KJ_ASSERT_NONNULL(weakContext->tryGet());
+    co_await context.run([container = kj::mv(container)](
+                             Worker::Lock&) mutable { KJ_EXPECT(!container->getRunning()); });
+  });
+}
+
+KJ_TEST("Container::destroy updates running before restart and clears the old reason") {
+  auto fixture = makeFixture();
+  fixture.runInIoContext([](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container =
+        env.js.alloc<Container>(rpc::Container::Client(kj::heap<RestartContainerServer>()), false);
+    container->start(env.js, kj::none);
+
+    auto lifecycle =
+        container->destroy(env.js, jsg::Value(env.js.v8Isolate, env.js.error("first lifecycle")))
+            .then(env.js, [container = container.addRef()](jsg::Lock& js) mutable {
+      KJ_EXPECT(!container->getRunning());
+      container->start(js, kj::none);
+      KJ_EXPECT(container->getRunning());
+      return container->monitor(js);
+    });
+
+    return env.context.awaitJs(env.js, kj::mv(lifecycle));
   });
 }
 

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -305,12 +305,40 @@ void ExecProcess::resize(jsg::Lock& js, int cols, int rows) {
 // Basic lifecycle methods
 
 Container::Container(rpc::Container::Client rpcClient, bool running)
-    : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))),
-      running(running) {}
+    : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))) {
+  if (running) startMonitor();
+}
+
+kj::Promise<void> Container::Monitor::observe(kj::ForkedPromise<int32_t>& promise, bool& running) {
+  auto markStopped = kj::defer([&running]() { running = false; });
+  return promise.addBranch().then([](int32_t) {}, [](kj::Exception&&) {
+  }).attach(kj::mv(markStopped));
+}
+
+Container::Monitor::Monitor(kj::ForkedPromise<int32_t> promise, uint64_t generation)
+    : generation(generation),
+      promise(kj::mv(promise)),
+      stopped(observe(this->promise, running).fork()),
+      background(stopped.addBranch().eagerlyEvaluate(nullptr)) {}
+
+bool Container::getRunning() {
+  KJ_IF_SOME(monitor, currentMonitor) {
+    return monitor->running;
+  }
+  return false;
+}
+
+bool Container::isCurrentMonitor(uint64_t generation) {
+  KJ_IF_SOME(monitor, currentMonitor) {
+    return monitor->generation == generation;
+  }
+  return false;
+}
 
 void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions) {
   auto flags = FeatureFlags::get(js);
-  JSG_REQUIRE(!running, Error, "start() cannot be called on a container that is already running.");
+  JSG_REQUIRE(
+      !getRunning(), Error, "start() cannot be called on a container that is already running.");
   invalidateTcpPortStates();
 
   StartupOptions options = kj::mv(maybeOptions).orDefault({});
@@ -414,11 +442,28 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
 
   IoContext::current().addTask(req.sendIgnoringResult());
 
-  running = true;
+  // We reset the monitor state as we are re-creating the container here.
+  destroyReason = kj::none;
+  currentMonitor = kj::none;
+  startMonitor();
+}
+
+void Container::startMonitor() {
+  KJ_ASSERT(currentMonitor == kj::none);
+
+  auto monitor = rpcClient->monitorRequest(capnp::MessageSize{4, 0})
+                     .send()
+                     .then([](capnp::Response<rpc::Container::MonitorResults> results) {
+    return results.getExitCode();
+  }).fork();
+
+  currentMonitor =
+      IoContext::current().addObject(kj::heap<Monitor>(kj::mv(monitor), ++nextMonitorGeneration));
 }
 
 jsg::Promise<void> Container::setLabels(jsg::Lock& js, jsg::Dict<kj::String> labels) {
-  JSG_REQUIRE(running, Error, "setLabels() cannot be called on a container that is not running.");
+  JSG_REQUIRE(
+      getRunning(), Error, "setLabels() cannot be called on a container that is not running.");
 
   auto& ioContext = IoContext::current();
 
@@ -461,8 +506,8 @@ jsg::Promise<kj::Maybe<Container::Info>> Container::inspect(jsg::Lock& js) {
 
 jsg::Promise<Container::DirectorySnapshot> Container::snapshotDirectory(
     jsg::Lock& js, DirectorySnapshotOptions options) {
-  JSG_REQUIRE(
-      running, Error, "snapshotDirectory() cannot be called on a container that is not running.");
+  JSG_REQUIRE(getRunning(), Error,
+      "snapshotDirectory() cannot be called on a container that is not running.");
   JSG_REQUIRE(options.dir.size() > 0 && options.dir.startsWith("/"), TypeError,
       "snapshotDirectory() requires an absolute directory path (starting with '/').");
 
@@ -496,8 +541,8 @@ jsg::Promise<Container::DirectorySnapshot> Container::snapshotDirectory(
 
 jsg::Promise<Container::Snapshot> Container::snapshotContainer(
     jsg::Lock& js, SnapshotOptions options) {
-  JSG_REQUIRE(
-      running, Error, "snapshotContainer() cannot be called on a container that is not running.");
+  JSG_REQUIRE(getRunning(), Error,
+      "snapshotContainer() cannot be called on a container that is not running.");
 
   auto req = rpcClient->snapshotContainerRequest();
   KJ_IF_SOME(spanContext, IoContext::current().getCurrentTraceSpan().toSpanContext()) {
@@ -603,7 +648,7 @@ kj::Promise<void> Container::interceptOutboundHttpsImpl(rpc::Container::Client r
 
 jsg::Promise<jsg::Ref<ExecProcess>> Container::exec(
     jsg::Lock& js, kj::Array<kj::String> cmd, jsg::Optional<ExecOptions> maybeOptions) {
-  JSG_REQUIRE(running, Error, "exec() cannot be called on a container that is not running.");
+  JSG_REQUIRE(getRunning(), Error, "exec() cannot be called on a container that is not running.");
   JSG_REQUIRE(cmd.size() > 0, TypeError, "exec() requires a non-empty command array.");
 
   auto options = kj::mv(maybeOptions).orDefault({});
@@ -808,22 +853,25 @@ kj::Promise<void> Container::interceptOutboundTcpImpl(rpc::Container::Client rpc
 }
 
 jsg::Promise<void> Container::monitor(jsg::Lock& js) {
-  JSG_REQUIRE(running, Error, "monitor() cannot be called on a container that is not running.");
+  // The background monitor may have already set running to false, but callers can still observe
+  // that lifecycle's result through the retained promise.
+  JSG_REQUIRE(currentMonitor != kj::none, Error,
+      "monitor() cannot be called on a container that is not running.");
 
+  auto generation = KJ_ASSERT_NONNULL(currentMonitor)->generation;
   return IoContext::current()
-      .awaitIo(js, rpcClient->monitorRequest(capnp::MessageSize{4, 0}).send())
+      .awaitIo(js, KJ_ASSERT_NONNULL(currentMonitor)->promise.addBranch())
       // Note: `self` (jsg::Ref) is captured to prevent GC from collecting this object while
       // the promise continuation is pending. Without it, the bare `this` pointer dangles.
-      .then(js,
-          [self = JSG_THIS](
-              jsg::Lock& js, capnp::Response<rpc::Container::MonitorResults> results) mutable {
-    self->running = false;
-    self->invalidateTcpPortStates();
-    auto exitCode = results.getExitCode();
-    KJ_IF_SOME(d, self->destroyReason) {
-      jsg::Value error = kj::mv(d);
-      self->destroyReason = kj::none;
-      js.throwException(kj::mv(error));
+      .then(js, [self = JSG_THIS, generation](jsg::Lock& js, int32_t exitCode) mutable {
+    // An old monitor can settle after restart, so only mutate the current lifecycle.
+    if (self->isCurrentMonitor(generation)) {
+      self->invalidateTcpPortStates();
+      KJ_IF_SOME(d, self->destroyReason) {
+        jsg::Value error = kj::mv(d);
+        self->destroyReason = kj::none;
+        js.throwException(kj::mv(error));
+      }
     }
 
     if (exitCode != 0) {
@@ -831,30 +879,32 @@ jsg::Promise<void> Container::monitor(jsg::Lock& js) {
       KJ_ASSERT_NONNULL(err.tryCast<jsg::JsObject>()).set(js, "exitCode", js.num(exitCode));
       js.throwException(err);
     }
-  },
-          [self = JSG_THIS](jsg::Lock& js, jsg::Value&& error) mutable {
-    self->running = false;
-    self->invalidateTcpPortStates();
-    self->destroyReason = kj::none;
+  }, [self = JSG_THIS, generation](jsg::Lock& js, jsg::Value&& error) mutable {
+    if (self->isCurrentMonitor(generation)) {
+      self->invalidateTcpPortStates();
+      self->destroyReason = kj::none;
+    }
     js.throwException(kj::mv(error));
   });
 }
 
 jsg::Promise<void> Container::destroy(jsg::Lock& js, jsg::Optional<jsg::Value> error) {
-  if (!running) return js.resolvedPromise();
+  if (!getRunning()) return js.resolvedPromise();
   invalidateTcpPortStates();
 
   if (destroyReason == kj::none) {
     destroyReason = kj::mv(error);
   }
 
+  auto stopped = KJ_ASSERT_NONNULL(currentMonitor)->stopped.addBranch();
+  auto destroyed = rpcClient->destroyRequest(capnp::MessageSize{4, 0}).sendIgnoringResult();
   return IoContext::current().awaitIo(
-      js, rpcClient->destroyRequest(capnp::MessageSize{4, 0}).sendIgnoringResult());
+      js, kj::joinPromisesFailFast(kj::arr(kj::mv(destroyed), kj::mv(stopped))));
 }
 
 void Container::signal(jsg::Lock& js, int signo) {
   JSG_REQUIRE(signo > 0 && signo <= 64, RangeError, "Invalid signal number.");
-  JSG_REQUIRE(running, Error, "signal() cannot be called on a container that is not running.");
+  JSG_REQUIRE(getRunning(), Error, "signal() cannot be called on a container that is not running.");
 
   auto req = rpcClient->signalRequest(capnp::MessageSize{4, 0});
   req.setSigno(signo);

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -310,9 +310,7 @@ class Container: public jsg::Object {
     }
   };
 
-  bool getRunning() const {
-    return running;
-  }
+  bool getRunning();
 
   // Methods correspond closely to the RPC interface in `container.capnp`.
   void start(jsg::Lock& js, jsg::Optional<StartupOptions> options);
@@ -368,7 +366,35 @@ class Container: public jsg::Object {
 
  private:
   IoOwn<rpc::Container::Client> rpcClient;
-  bool running;
+
+  struct Monitor final {
+    Monitor(kj::ForkedPromise<int32_t> promise, uint64_t generation);
+
+    bool running = true;
+
+    // Identifies callbacks belonging to this lifecycle.
+    // Callers can use this to compare with the current generation.
+    uint64_t generation;
+
+    // Shares the container exit result with explicit monitor() calls.
+    kj::ForkedPromise<int32_t> promise;
+
+    // Resolves after running has been set to false.
+    // It is useful for things like destroy() needing to await on
+    // running becoming false.
+    kj::ForkedPromise<void> stopped;
+
+    // Drives stopped even when nothing is explicitly waiting on it.
+    // Eagerly evaluated from `stopped`.
+    kj::Promise<void> background;
+
+   private:
+    static kj::Promise<void> observe(kj::ForkedPromise<int32_t>& promise, bool& running);
+  };
+
+  // Shares one monitor RPC between the background state update and explicit monitor() calls.
+  kj::Maybe<IoOwn<Monitor>> currentMonitor;
+  uint64_t nextMonitorGeneration = 0;
 
   kj::Maybe<jsg::Value> destroyReason;
 
@@ -386,6 +412,8 @@ class Container: public jsg::Object {
   kj::Maybe<IoOwn<kj::HashMap<int, kj::Rc<TcpPortState>>>> tcpPortStates;
 
   void invalidateTcpPortStates();
+  void startMonitor();
+  bool isCurrentMonitor(uint64_t generation);
 
   // These helpers are static since they will leave the IoContext on the first co_await, so we
   // don't want them trying to access `rpcClient` via the `IoOwn`.

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -21,11 +21,6 @@ function getRandomDurableObjectName(name) {
 // When writing a test, don't forget to call waitUntilContainerIsHealthy
 // before testing the behaviour with your container.
 //
-// Don't forget to call monitor() after calling start(), as there
-// is an issue with not calling monitor() in Durable Objects where
-// we might lose track of the container lifetime.
-//
-
 export class DurableObjectExample extends DurableObject {
   async testExitCode() {
     const container = this.ctx.container;
@@ -67,6 +62,39 @@ export class DurableObjectExample extends DurableObject {
       assert.strictEqual(typeof exitCode, 'number');
       assert.equal(137, exitCode);
     }
+  }
+
+  async testRunningAfterImmediateExit() {
+    const container = this.ctx.container;
+    if (container.running) {
+      const monitor = container.monitor().catch((_err) => {});
+      await container.destroy();
+      await monitor;
+    }
+
+    container.start({ entrypoint: ['/bin/sh', '-c', 'exit 0'] });
+
+    for (let i = 0; i < 100 && container.running; ++i) {
+      await scheduler.wait(100);
+    }
+
+    assert.strictEqual(container.running, false);
+  }
+
+  async testRestartAfterDestroy() {
+    const container = this.ctx.container;
+    if (container.running) {
+      await container.destroy();
+    }
+
+    container.start();
+    await this.waitUntilContainerIsHealthy();
+    await container.destroy(new Error('first lifecycle'));
+    assert.strictEqual(container.running, false);
+
+    container.start({ entrypoint: ['/bin/sh', '-c', 'exit 0'] });
+    await container.monitor();
+    assert.strictEqual(container.running, false);
   }
 
   async testBasics() {
@@ -969,13 +997,13 @@ export class DurableObjectExample extends DurableObject {
     await this.waitUntilContainerIsHealthy();
 
     await container.destroy();
-    await assert.rejects(() => container.setLabels({ k: 'v' }), {
-      message: /setLabels\(\) requires a running container/,
-    });
-
-    // Clear the JS wrapper's running state after intentionally skipping monitor()
-    // before the setLabels() assertion above.
-    await container.monitor().catch((_err) => {});
+    await assert.rejects(
+      Promise.try(() => container.setLabels({ k: 'v' })),
+      {
+        message:
+          /setLabels\(\) cannot be called on a container that is not running/,
+      }
+    );
     assert.strictEqual(container.running, false);
   }
 
@@ -2877,6 +2905,26 @@ export const testExitCode = {
     );
     const stub = env.MY_CONTAINER.get(id);
     await stub.testExitCode();
+  },
+};
+
+export const testRunningAfterImmediateExit = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testRunningAfterImmediateExit')
+    );
+    const stub = env.MY_CONTAINER.get(id);
+    await stub.testRunningAfterImmediateExit();
+  },
+};
+
+export const testRestartAfterDestroy = {
+  async test(_ctrl, env) {
+    const id = env.MY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testRestartAfterDestroy')
+    );
+    const stub = env.MY_CONTAINER.get(id);
+    await stub.testRestartAfterDestroy();
   },
 };
 


### PR DESCRIPTION
or if container is already running

Users had to run container.monitor() for their running property to change to false if their container exited.

That is really annoying for simple
DO scripts that just want to start their container, run a series of commands and forget.


Taking over https://github.com/cloudflare/workerd/pull/4371