### PR TITLE
Warn instead of failing when a compat flag is already on by date

### DIFF
--- a/src/workerd/api/worker-loader.c++
+++ b/src/workerd/api/worker-loader.c++
@@ -404,12 +404,6 @@ kj::Own<CompatibilityFlags::Reader> WorkerLoader::extractCompatFlags(
     JSG_FAIL_REQUIRE(Error, errorReporter.errors.front());
   }
 
-  // A dynamically-loaded Worker has no configuration file to point the developer at, so the
-  // process log is the only place left to say anything.
-  for (auto& warning: errorReporter.warnings) {
-    KJ_LOG(WARNING, warning);
-  }
-
   return capnp::clone(compatFlagsBuilder.asReader());
 }
 

--- a/src/workerd/api/worker-loader.c++
+++ b/src/workerd/api/worker-loader.c++
@@ -404,6 +404,12 @@ kj::Own<CompatibilityFlags::Reader> WorkerLoader::extractCompatFlags(
     JSG_FAIL_REQUIRE(Error, errorReporter.errors.front());
   }
 
+  // A dynamically-loaded Worker has no configuration file to point the developer at, so the
+  // process log is the only place left to say anything.
+  for (auto& warning: errorReporter.warnings) {
+    KJ_LOG(WARNING, warning);
+  }
+
   return capnp::clone(compatFlagsBuilder.asReader());
 }
 

--- a/src/workerd/io/compatibility-date-test.c++
+++ b/src/workerd/io/compatibility-date-test.c++
@@ -75,7 +75,8 @@ KJ_TEST("compatibility flag parsing") {
           kj::StringPtr expectedOutput, kj::ArrayPtr<const kj::StringPtr> expectedErrors = nullptr,
           CompatibilityDateValidation dateValidation = CompatibilityDateValidation::FUTURE_FOR_TEST,
           bool r2InternalBetaApiSet = false, bool experimental = false,
-          kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags = nullptr) {
+          kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags = nullptr,
+          kj::ArrayPtr<const kj::StringPtr> expectedWarnings = nullptr) {
     capnp::MallocMessageBuilder message;
     auto orphanage = message.getOrphanage();
 
@@ -106,6 +107,7 @@ KJ_TEST("compatibility flag parsing") {
       KJ_EXPECT(kj::str(output) == kj::str(parsedExpectedOutput.getReader()));
     }
     KJ_EXPECT(kj::strArray(errorReporter.errors, "\n") == kj::strArray(expectedErrors, "\n"));
+    KJ_EXPECT(kj::strArray(errorReporter.warnings, "\n") == kj::strArray(expectedWarnings, "\n"));
   };
 
   expectCompileCompatibilityFlags("2021-05-17", {}, "()");
@@ -138,13 +140,33 @@ KJ_TEST("compatibility flag parsing") {
       "(formDataParserSupportsFiles = true)",
       {"Compatibility flags are mutually contradictory: "
        "formdata_parser_supports_files vs formdata_parser_converts_files_to_strings"});
-  expectCompileCompatibilityFlags("2021-11-04", {"formdata_parser_supports_files"_kj},
-      "(formDataParserSupportsFiles = true)",
-      {"The compatibility flag formdata_parser_supports_files became the default as of "
-       "2021-11-03 so does not need to be specified anymore."},
-      CompatibilityDateValidation::CURRENT_DATE_FOR_CLOUDFLARE);
   expectCompileCompatibilityFlags(
       "2021-05-17", {"unknown_feature"_kj}, "()", {"No such compatibility flag: unknown_feature"});
+
+  // Naming a flag the compatibility date already enables is only a warning, and the flag set is
+  // compiled as if the flag had not been named at all.
+  expectCompileCompatibilityFlags("2021-11-04", {"formdata_parser_supports_files"_kj},
+      "(formDataParserSupportsFiles = true)", {},
+      CompatibilityDateValidation::CURRENT_DATE_FOR_CLOUDFLARE, false, false, {},
+      {"The compatibility flag formdata_parser_supports_files became the default as of "
+       "2021-11-03 so does not need to be specified anymore."});
+  expectCompileCompatibilityFlags("2021-11-04", {"formdata_parser_supports_files"_kj},
+      "(formDataParserSupportsFiles = true)", {}, CompatibilityDateValidation::CODE_VERSION, false,
+      false, {},
+      {"The compatibility flag formdata_parser_supports_files became the default as of "
+       "2021-11-03 so does not need to be specified anymore."});
+
+  // A flag enabled for all dates has no date to name in the warning.
+  expectCompileCompatibilityFlags("2021-05-17", {"r2_public_beta_bindings"_kj}, "()", {},
+      CompatibilityDateValidation::CODE_VERSION, false, false, {},
+      {"The compatibility flag r2_public_beta_bindings is the default, so does not need to be "
+       "specified anymore."});
+
+  // FUTURE_FOR_TEST stays silent about redundant flags. Tests name flags explicitly so that they
+  // run against the oldest compatibility date, and the same test also runs against the newest
+  // date, where every flag is on by default.
+  expectCompileCompatibilityFlags("2021-11-04", {"formdata_parser_supports_files"_kj},
+      "(formDataParserSupportsFiles = true)", {}, CompatibilityDateValidation::FUTURE_FOR_TEST);
 
   expectCompileCompatibilityFlags("2252-04-01", {}, "()",
       {"Can't set compatibility date in the future: 2252-04-01"},

--- a/src/workerd/io/compatibility-date-test.c++
+++ b/src/workerd/io/compatibility-date-test.c++
@@ -360,6 +360,43 @@ KJ_TEST("compatibility flag parsing") {
       {}, CompatibilityDateValidation::FUTURE_FOR_TEST, false, false);
 }
 
+KJ_TEST("a reporter that ignores warnings accepts a redundant compatibility flag") {
+  // A reporter that leaves `addWarning()` at its default -- as deploy-time validation does, since
+  // it distinguishes only valid configurations from invalid ones -- must not see a redundant flag
+  // as an error. The configuration compiles to exactly the same flag set either way.
+  struct ErrorOnlyReporter final: public ValidationErrorReporter {
+    kj::Vector<kj::String> errors;
+
+    void addError(kj::String error) override {
+      errors.add(kj::mv(error));
+    }
+    void addEntrypoint(
+        kj::Maybe<kj::StringPtr> exportName, kj::Array<kj::String> methods) override {
+      KJ_UNREACHABLE;
+    }
+    void addActorClass(kj::StringPtr exportName) override {
+      KJ_UNREACHABLE;
+    }
+    void addWorkflowClass(kj::StringPtr exportName, kj::Array<kj::String> methods) override {
+      KJ_UNREACHABLE;
+    }
+  };
+
+  auto flags = kj::heapArrayBuilder<kj::String>(1);
+  flags.add(kj::str("formdata_parser_supports_files"));
+  auto flagArray = flags.finish();
+
+  capnp::MallocMessageBuilder message;
+  auto output = message.initRoot<CompatibilityFlags>();
+
+  ErrorOnlyReporter errorReporter;
+  compileCompatibilityFlags("2021-11-04", flagArray.asPtr(), output, errorReporter, false,
+      CompatibilityDateValidation::CODE_VERSION, nullptr);
+
+  KJ_EXPECT(errorReporter.errors.empty(), kj::strArray(errorReporter.errors, "\n"));
+  KJ_EXPECT(output.getFormDataParserSupportsFiles());
+}
+
 KJ_TEST("encode to flag list for FL") {
   capnp::MallocMessageBuilder message;
   auto orphanage = message.getOrphanage();

--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -217,16 +217,18 @@ static void compileCompatibilityFlags(kj::StringPtr compatDate,
       errorReporter.addError(kj::str("Compatibility flags are mutually contradictory: ",
           enableFlagName, " vs ", disableFlagName));
     }
+    // Naming a flag that the compatibility date already enables is redundant but harmless, so it
+    // is only worth a warning: the compiled flag set is the same either way.
     if (enableByFlag && enableByDate &&
         dateValidation != CompatibilityDateValidation::FUTURE_FOR_TEST) {
-      // Skip this error for FUTURE_FOR_TEST since tests may need to explicitly specify flags
-      // for the default variant (which uses an old compat date) while the all-compat-flags
-      // variant enables all flags by date.
+      // Stay quiet under FUTURE_FOR_TEST, since tests may need to explicitly specify flags for
+      // the default variant (which uses an old compat date) while the all-compat-flags variant
+      // enables all flags by date. Warning there would fire for nearly every test.
       KJ_IF_SOME(d, enableDate) {
-        errorReporter.addError(kj::str("The compatibility flag ", enableFlagName,
+        errorReporter.addWarning(kj::str("The compatibility flag ", enableFlagName,
             " became the default as of ", d, " so does not need to be specified anymore."));
       } else {
-        errorReporter.addError(kj::str("The compatibility flag ", enableFlagName,
+        errorReporter.addWarning(kj::str("The compatibility flag ", enableFlagName,
             " is the default, so does not need to be specified anymore."));
       }
     }

--- a/src/workerd/io/validation.h
+++ b/src/workerd/io/validation.h
@@ -16,15 +16,15 @@ class ValidationErrorReporter {
  public:
   virtual void addError(kj::String error) = 0;
 
-  // Report a non-fatal problem with the Worker's configuration: something the developer ought to
-  // clean up, but which does not prevent the Worker from running.
+  // Report a problem with the Worker's configuration that the developer ought to clean up but
+  // which does not prevent the Worker from running.
   //
-  // The default implementation forwards to `addError()`. An implementation that has not decided
-  // how to surface warnings therefore keeps rejecting the configuration rather than silently
-  // accepting it; treating a warning as non-fatal is an explicit opt-in.
-  virtual void addWarning(kj::String warning) {
-    addError(kj::mv(warning));
-  }
+  // The default implementation ignores the warning, so only report a problem here if it is
+  // acceptable for nobody to hear about it. Reporters override this when they have somewhere useful
+  // to put the message, such as a developer's terminal. Deploy-time validation deliberately does
+  // not: it distinguishes only valid configurations from invalid ones, and a warning must not fail
+  // a deployment.
+  virtual void addWarning(kj::String warning) {}
 
   // Report that the Worker implements a stateless entrypoint (e.g. WorkerEntrypoint or plain
   // object export) with the given export name and methods.

--- a/src/workerd/io/validation.h
+++ b/src/workerd/io/validation.h
@@ -16,6 +16,16 @@ class ValidationErrorReporter {
  public:
   virtual void addError(kj::String error) = 0;
 
+  // Report a non-fatal problem with the Worker's configuration: something the developer ought to
+  // clean up, but which does not prevent the Worker from running.
+  //
+  // The default implementation forwards to `addError()`. An implementation that has not decided
+  // how to surface warnings therefore keeps rejecting the configuration rather than silently
+  // accepting it; treating a warning as non-fatal is an explicit opt-in.
+  virtual void addWarning(kj::String warning) {
+    addError(kj::mv(warning));
+  }
+
   // Report that the Worker implements a stateless entrypoint (e.g. WorkerEntrypoint or plain
   // object export) with the given export name and methods.
   virtual void addEntrypoint(

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -1125,11 +1125,14 @@ inline const Worker::Isolate& Worker::getIsolate() const {
   return *script->isolate;
 }
 
-// An implementation of Worker::ValidationErrorReporter that collects errors into
-// a kj::Vector<kj::String>.
+// An implementation of Worker::ValidationErrorReporter that collects errors and warnings into
+// kj::Vector<kj::String>s.
 struct SimpleWorkerErrorReporter final: public Worker::ValidationErrorReporter {
   void addError(kj::String error) override {
     errors.add(kj::mv(error));
+  }
+  void addWarning(kj::String warning) override {
+    warnings.add(kj::mv(warning));
   }
   void addEntrypoint(kj::Maybe<kj::StringPtr> exportName, kj::Array<kj::String> methods) override {
     KJ_UNREACHABLE;
@@ -1145,6 +1148,7 @@ struct SimpleWorkerErrorReporter final: public Worker::ValidationErrorReporter {
   SimpleWorkerErrorReporter() = default;
   KJ_DISALLOW_COPY_AND_MOVE(SimpleWorkerErrorReporter);
   kj::Vector<kj::String> errors;
+  kj::Vector<kj::String> warnings;
 };
 
 }  // namespace workerd

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -343,6 +343,14 @@ class TestServer final: private kj::Filesystem, private kj::EntropySource, priva
               } else {
                 KJ_FAIL_EXPECT(error, expectedErrors);
               }
+            },
+            [this](kj::String warning) {
+              if (expectedWarnings.startsWith(warning) &&
+                  expectedWarnings[warning.size()] == '\n') {
+                expectedWarnings = expectedWarnings.slice(warning.size() + 1);
+              } else {
+                KJ_FAIL_EXPECT(warning, expectedWarnings);
+              }
             }),
         fakeDate(kj::UNIX_EPOCH),
         mockNetwork(*this, {}, {}) {}
@@ -360,6 +368,13 @@ class TestServer final: private kj::Filesystem, private kj::EntropySource, priva
     }
   }
 
+  // Declare the warnings the config is expected to produce, one per line. Unlike errors, warnings
+  // don't stop the server, so call this before `start()` or `expectErrors()`, which check that
+  // every declared warning was actually reported.
+  void expectWarnings(kj::StringPtr expected) {
+    expectedWarnings = expected;
+  }
+
   // Start the server. Call before connect().
   void start(kj::Promise<void> drainWhen = kj::NEVER_DONE) {
     KJ_REQUIRE(runTask == kj::none);
@@ -368,6 +383,7 @@ class TestServer final: private kj::Filesystem, private kj::EntropySource, priva
       KJ_FAIL_EXPECT(e);
     });
     KJ_EXPECT(!task.poll(ws));
+    KJ_EXPECT(expectedWarnings == nullptr, "some expected warnings weren't seen");
     runTask = kj::mv(task);
   }
 
@@ -377,6 +393,7 @@ class TestServer final: private kj::Filesystem, private kj::EntropySource, priva
     expectedErrors = expected;
     server.run(v8System, *config).poll(ws);
     KJ_EXPECT(expectedErrors == nullptr, "some expected errors weren't seen");
+    KJ_EXPECT(expectedWarnings == nullptr, "some expected warnings weren't seen");
   }
 
   // Connect to the server on the given address. The string just has to match what is in the
@@ -442,6 +459,7 @@ class TestServer final: private kj::Filesystem, private kj::EntropySource, priva
 
   kj::Maybe<kj::Promise<void>> runTask;
   kj::StringPtr expectedErrors;
+  kj::StringPtr expectedWarnings;
 
   kj::Date fakeDate;
 
@@ -986,6 +1004,32 @@ KJ_TEST("Server: compatibility dates are required") {
   test.expectErrors(R"(
     service hello: Worker must specify compatibilityDate.
   )"_blockquote);
+}
+
+KJ_TEST("Server: naming a flag the compatibility date already enables only warns") {
+  TestServer test(singleWorker(R"((
+    compatibilityDate = "2022-08-17",
+    compatibilityFlags = ["global_navigator"],
+    modules = [
+      ( name = "main.js",
+        esModule =
+            `export default {
+            `  async fetch(request) {
+            `    return new Response(!!self.navigator);
+            `  }
+            `}
+      )
+    ]
+  ))"_kj));
+
+  test.expectWarnings(
+      "service hello: The compatibility flag global_navigator became the default as of "
+      "2022-03-21 so does not need to be specified anymore.\n"_kj);
+
+  // The Worker starts anyway, and the flag is on either way.
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.httpGet200("/", "true");
 }
 
 KJ_TEST("Server: value bindings") {

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3368,12 +3368,6 @@ struct Server::DynamicErrorReporter final: public ErrorReporter {
     errors.add(kj::mv(error));
   }
 
-  void addWarning(kj::String warning) override {
-    // A dynamically-loaded Worker has no configuration file to point the developer at, and the
-    // Worker still starts, so the process log is the only place left to say anything.
-    KJ_LOG(WARNING, warning);
-  }
-
   void throwIfErrors() {
     if (!errors.empty()) {
       JSG_FAIL_REQUIRE(Error, "Failed to start Worker:\n", kj::strArray(errors, "\n"));

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -227,13 +227,15 @@ Server::Server(kj::Filesystem& fs,
     kj::Network& network,
     kj::EntropySource& entropySource,
     Worker::LoggingOptions loggingOptions,
-    kj::Function<void(kj::String)> reportConfigError)
+    kj::Function<void(kj::String)> reportConfigError,
+    kj::Function<void(kj::String)> reportConfigWarning)
     : fs(fs),
       timer(timer),
       monotonicClock(monotonicClock),
       network(network),
       entropySource(entropySource),
       reportConfigError(kj::mv(reportConfigError)),
+      reportConfigWarning(kj::mv(reportConfigWarning)),
       loggingOptions(loggingOptions),
       memoryCacheProvider(kj::heap<api::MemoryCacheProvider>(timer)),
       channelTokenHandler(*this),
@@ -3351,6 +3353,10 @@ struct Server::ConfigErrorReporter final: public ErrorReporter {
   void addError(kj::String error) override {
     server.handleReportConfigError(kj::str("service ", name, ": ", error));
   }
+
+  void addWarning(kj::String warning) override {
+    server.handleReportConfigWarning(kj::str("service ", name, ": ", warning));
+  }
 };
 
 // Implementation of ErrorReporter for dynamically-loaded Workers. We'll collect the errors and
@@ -3360,6 +3366,12 @@ struct Server::DynamicErrorReporter final: public ErrorReporter {
 
   void addError(kj::String error) override {
     errors.add(kj::mv(error));
+  }
+
+  void addWarning(kj::String warning) override {
+    // A dynamically-loaded Worker has no configuration file to point the developer at, and the
+    // Worker still starts, so the process log is the only place left to say anything.
+    KJ_LOG(WARNING, warning);
   }
 
   void throwIfErrors() {

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -41,7 +41,8 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
       kj::Network& network,
       kj::EntropySource& entropySource,
       Worker::LoggingOptions loggingOptions,
-      kj::Function<void(kj::String)> reportConfigError);
+      kj::Function<void(kj::String)> reportConfigError,
+      kj::Function<void(kj::String)> reportConfigWarning);
   ~Server() noexcept;
 
   // Permit experimental features to be used. These features may break backwards compatibility
@@ -131,6 +132,10 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
     reportConfigError(kj::mv(error));
   }
 
+  void handleReportConfigWarning(kj::String warning) {
+    reportConfigWarning(kj::mv(warning));
+  }
+
  private:
   kj::Filesystem& fs;
   kj::Timer& timer;
@@ -140,6 +145,7 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
   kj::Network& network;
   kj::EntropySource& entropySource;
   kj::Function<void(kj::String)> reportConfigError;
+  kj::Function<void(kj::String)> reportConfigWarning;
   PythonConfig pythonConfig = PythonConfig{.packageDiskCacheRoot = kj::none,
     .pyodideDiskCacheRoot = kj::none,
     .createSnapshot = false,

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -701,7 +701,8 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
                 hadErrors = true;
                 context.error(error);
               }
-            })) {
+            },
+            [&](kj::String warning) { context.warning(warning); })) {
     KJ_IF_SOME(e, exeInfo) {
       auto& exe = *e.file;
       auto size = exe.stat().size;


### PR DESCRIPTION
## Problem

Naming a compatibility flag that the Worker's compatibility date already enables was a fatal
configuration error, so `workerd serve` exited instead of starting:

```
workerd: service main: The compatibility flag nodejs_compat became the default as of
2026-08-04 so does not need to be specified anymore.
```

The compiled flag set is identical whether or not the flag is listed, so the redundancy is worth
pointing out but is not a reason to refuse to run. This became a common papercut once
`nodejs_compat` gained a default-on date of 2026-08-04: configs that had always listed the flag
explicitly stopped loading as soon as their compatibility date advanced past it.

## Change

`ValidationErrorReporter` gains `addWarning()` for configuration problems that don't prevent the
Worker from running, and the redundant-flag diagnostic moves onto it.

`addWarning()`'s default implementation **ignores** the warning, so a reporter only hears about one
if it has somewhere useful to put it. Deploy-time validation does not: it distinguishes only valid
configurations from invalid ones, so a warning routed there would refuse to deploy a configuration
that compiles to exactly the same flag set. Surfacing it properly would mean adding warnings to the
validation report on both sides of that interface, which is more than this diagnostic is worth.

That leaves `Server::ConfigErrorReporter` as the only reporter that acts on a warning: it forwards
to a new warning sink on `Server`, which the CLI prints via `context.warning()` so it honours
`--structured-logging`. Everything else — deploy-time validation, Worker startup, and
dynamically-loaded Workers — inherits the default and drops it. Dynamic Workers have no
configuration file to point the developer at, and their flags are compiled in the API layer, which
also runs in the production runtime where a warning logged once per isolate load is noise about a
config the reader cannot edit.

The `Server` constructor gains a parameter, but nothing outside this repo constructs it, so that
signature change is contained here.

The check stays suppressed under `FUTURE_FOR_TEST`, where it would fire for nearly every test:
`wd_test` runs each test at both the oldest and the newest compatibility date.

## Testing

- `compatibility-date-test`: the existing redundant-flag case moves from `expectedErrors` to a new
  `expectedWarnings` (which also newly asserts the resulting flag set, confirming the flag is still
  applied). Adds coverage for the `CODE_VERSION` path, the `$compatEnableAllDates` message variant,
  and `FUTURE_FOR_TEST` staying silent. A separate case pins the contract that matters to
  deploy-time validation: a reporter that leaves `addWarning()` at its default sees no error for a
  redundant flag, and the flag is still compiled on.
- `server-test`: new end-to-end case asserting the Worker actually starts, serves, and emits the
  warning.
- All new assertions were confirmed red before green.
- Full suite: 1621 pass. 14 targets reported TIMEOUT in a single wall-clock window with no test
  output and pass in under a second each when re-run with `--local_test_jobs=2`; that's local
  machine saturation, not breakage.
