### PR TITLE
STOR-5489: Generate retry metadata at actor fetch call sites

### DIFF
--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -123,6 +123,12 @@ kj::Own<IoChannelFactory::SubrequestChannel> GlobalActorOutgoingFactory::getSubr
 
 kj::Own<WorkerInterface> ReplicaActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr) {
+  return newSingleUseClientWithActorRetryMetadata(kj::mv(cfStr), kj::none);
+}
+
+kj::Own<WorkerInterface> ReplicaActorOutgoingFactory::newSingleUseClientWithActorRetryMetadata(
+    kj::Maybe<kj::String> cfStr,
+    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) {
   auto& context = IoContext::current();
 
   return context.getMetrics().wrapActorSubrequestClient(context.getSubrequest(
@@ -133,7 +139,8 @@ kj::Own<WorkerInterface> ReplicaActorOutgoingFactory::newSingleUseClient(
     // already open prior to this DO starting up.
     return actorChannel->startRequest({.cfBlobJson = kj::mv(cfStr),
       .parentSpan = tracing.getInternalSpanParent(),
-      .userSpanParent = tracing.getUserSpanParent()});
+      .userSpanParent = tracing.getUserSpanParent(),
+      .actorRetryRequestMetadata = kj::mv(actorRetryRequestMetadata)});
   },
       {.inHouse = true,
         .wrapMetrics = true,

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -347,6 +347,9 @@ class GlobalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
         persistent(persistent) {}
 
   kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
+  bool supportsActorRetryMetadata() const override {
+    return true;
+  }
   kj::Own<WorkerInterface> newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
       kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) override;
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() override;
@@ -408,6 +411,11 @@ class ReplicaActorOutgoingFactory final: public Fetcher::OutgoingFactory {
         actorId(kj::mv(actorId)) {}
 
   kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) override;
+  bool supportsActorRetryMetadata() const override {
+    return true;
+  }
+  kj::Own<WorkerInterface> newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
+      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) override;
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() override;
 
  private:

--- a/src/workerd/api/fetch-body-rewindable-test.c++
+++ b/src/workerd/api/fetch-body-rewindable-test.c++
@@ -66,14 +66,27 @@ class MockFetchTarget final: public WorkerInterface {
   }
 };
 
+class TestStreamSource final: public ReadableStreamSource {
+ public:
+  kj::Promise<size_t> tryRead(void*, size_t, size_t) override {
+    return static_cast<size_t>(0);
+  }
+};
+
 class RetryMetadataOutgoingFactory final: public Fetcher::OutgoingFactory {
  public:
-  RetryMetadataOutgoingFactory(
+  RetryMetadataOutgoingFactory(bool& ordinaryDispatchCalled,
       kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata>& capturedMetadata)
-      : capturedMetadata(capturedMetadata) {}
+      : ordinaryDispatchCalled(ordinaryDispatchCalled),
+        capturedMetadata(capturedMetadata) {}
 
   kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String>) override {
+    ordinaryDispatchCalled = true;
     return kj::heap<MockFetchTarget>();
+  }
+
+  bool supportsActorRetryMetadata() const override {
+    return true;
   }
 
   kj::Own<WorkerInterface> newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String>,
@@ -83,6 +96,7 @@ class RetryMetadataOutgoingFactory final: public Fetcher::OutgoingFactory {
   }
 
  private:
+  bool& ordinaryDispatchCalled;
   kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata>& capturedMetadata;
 };
 
@@ -222,15 +236,83 @@ KJ_TEST("fetch reports each outgoing body's rewindability per-call without stale
       "streamed request body should not be rewindable (no carryover)");
 }
 
-// Isolate Fetcher's dispatch decision from actor routing: a metadata-aware factory must receive the
-// caller's logical-call metadata unchanged.
-KJ_TEST("Fetcher dispatches actor retry metadata through the metadata-aware factory hook") {
+KJ_TEST("fetch generates actor retry metadata for a supported outgoing factory") {
+  bool ordinaryDispatchCalled = false;
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> capturedMetadata;
+  kj::Date beforeFetch = kj::UNIX_EPOCH;
+  kj::Date afterFetch = kj::UNIX_EPOCH;
+  TestFixture fixture;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    auto fetcher = env.js.alloc<Fetcher>(
+        env.context.addObject<Fetcher::OutgoingFactory>(
+            kj::heap<RetryMetadataOutgoingFactory>(ordinaryDispatchCalled, capturedMetadata)),
+        Fetcher::RequiresHostAndProtocol::YES);
+    beforeFetch = kj::systemCoarseCalendarClock().now();
+    auto promise = fetcher->fetch(env.js, kj::str("http://example.com"), kj::none);
+    afterFetch = kj::systemCoarseCalendarClock().now();
+    return env.context.awaitJs(env.js, kj::mv(promise)).ignoreResult().attach(kj::mv(fetcher));
+  });
+
+  KJ_EXPECT(!ordinaryDispatchCalled);
+  KJ_IF_SOME(metadata, capturedMetadata) {
+    KJ_EXPECT(metadata.createdAt >= beforeFetch);
+    KJ_EXPECT(metadata.createdAt <= afterFetch);
+    KJ_EXPECT(metadata.isRetry == IsActorRetry::NO);
+  } else {
+    KJ_FAIL_EXPECT("supported fetch did not generate actor retry metadata");
+  }
+}
+
+KJ_TEST("fetch omits actor retry metadata for a supported factory with a streaming body") {
+  bool ordinaryDispatchCalled = false;
   kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> capturedMetadata;
   TestFixture fixture;
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    Fetcher fetcher(env.context.addObject<Fetcher::OutgoingFactory>(
-                        kj::heap<RetryMetadataOutgoingFactory>(capturedMetadata)),
+    auto fetcher = env.js.alloc<Fetcher>(
+        env.context.addObject<Fetcher::OutgoingFactory>(
+            kj::heap<RetryMetadataOutgoingFactory>(ordinaryDispatchCalled, capturedMetadata)),
+        Fetcher::RequiresHostAndProtocol::YES);
+    RequestInitializerDict init;
+    init.method = kj::str("POST");
+    init.body = kj::Maybe<Body::Initializer>(
+        JsReadableStream::create(env.js, env.context, kj::heap<TestStreamSource>()));
+    auto promise = fetcher->fetch(env.js, kj::str("http://example.com"), kj::mv(init));
+    return env.context.awaitJs(env.js, kj::mv(promise)).ignoreResult().attach(kj::mv(fetcher));
+  });
+
+  KJ_EXPECT(ordinaryDispatchCalled);
+  KJ_EXPECT(capturedMetadata == kj::none);
+}
+
+KJ_TEST("fetch omits actor retry metadata for an unsupported outgoing factory") {
+  bool ordinaryDispatchCalled = false;
+  TestFixture fixture;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    auto fetcher =
+        env.js.alloc<Fetcher>(env.context.addObject<Fetcher::OutgoingFactory>(
+                                  kj::heap<UnsupportedOutgoingFactory>(ordinaryDispatchCalled)),
+            Fetcher::RequiresHostAndProtocol::YES);
+    auto promise = fetcher->fetch(env.js, kj::str("http://example.com"), kj::none);
+    return env.context.awaitJs(env.js, kj::mv(promise)).ignoreResult().attach(kj::mv(fetcher));
+  });
+
+  KJ_EXPECT(ordinaryDispatchCalled);
+}
+
+// Isolate Fetcher's dispatch decision from actor routing: a metadata-aware factory must receive the
+// caller's logical-call metadata unchanged.
+KJ_TEST("Fetcher dispatches actor retry metadata through the metadata-aware factory hook") {
+  bool ordinaryDispatchCalled = false;
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> capturedMetadata;
+  TestFixture fixture;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    Fetcher fetcher(
+        env.context.addObject<Fetcher::OutgoingFactory>(
+            kj::heap<RetryMetadataOutgoingFactory>(ordinaryDispatchCalled, capturedMetadata)),
         Fetcher::RequiresHostAndProtocol::YES);
 
     auto client = fetcher.getClientWithTracing(env.context, kj::none, "fetch"_kjc,
@@ -307,6 +389,33 @@ KJ_TEST("GlobalActorOutgoingFactory places actor retry metadata on the actor sub
         GlobalActorOutgoingFactory::ChannelIdOrFactory(static_cast<uint>(1)),
         env.js.alloc<DurableObjectId>(kj::heap<MockActorId>()), kj::none,
         ActorGetMode::GET_OR_CREATE, false, ActorRoutingMode::DEFAULT, kj::none, Persistent::NO);
+    KJ_EXPECT(factory.supportsActorRetryMetadata());
+
+    auto client = factory.newSingleUseClientWithActorRetryMetadata(kj::none,
+        IoChannelFactory::ActorRetryRequestMetadata{
+          .nonce = 0x123456789abcdef0,
+          .createdAt = kj::UNIX_EPOCH + 123 * kj::MILLISECONDS,
+          .isRetry = IsActorRetry::YES,
+        });
+
+    KJ_IF_SOME(metadata, capturedMetadata) {
+      KJ_EXPECT(metadata.nonce == 0x123456789abcdef0);
+      KJ_EXPECT(metadata.createdAt == kj::UNIX_EPOCH + 123 * kj::MILLISECONDS);
+      KJ_EXPECT(metadata.isRetry == IsActorRetry::YES);
+    } else {
+      KJ_FAIL_EXPECT("actor retry metadata was not forwarded to the actor channel");
+    }
+  });
+}
+
+KJ_TEST("ReplicaActorOutgoingFactory places actor retry metadata on the actor subrequest") {
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> capturedMetadata;
+  TestFixture fixture;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    ReplicaActorOutgoingFactory factory(
+        kj::refcounted<RecordingActorChannel>(capturedMetadata), kj::str("actor-id"));
+    KJ_EXPECT(factory.supportsActorRetryMetadata());
 
     auto client = factory.newSingleUseClientWithActorRetryMetadata(kj::none,
         IoChannelFactory::ActorRetryRequestMetadata{

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1502,12 +1502,19 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
   // (Durable Object), to classify retry eligibility for disconnected calls; for other fetches the
   // value is simply overwritten by the next call and never read. The set->getClientWithTracing->
   // wrap*SubrequestClient sequence is synchronous, so there is no stale-attribution risk.
-  ioContext.getMetrics().setNextSubrequestBodyRewindable(
-      SubrequestBodyRewindable(jsRequest->canRewindBody()));
+  bool bodyRewindable = jsRequest->canRewindBody();
+  ioContext.getMetrics().setNextSubrequestBodyRewindable(SubrequestBodyRewindable(bodyRewindable));
+
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata;
+  if (bodyRewindable && fetcher->supportsActorRetryMetadata()) {
+    actorRetryRequestMetadata =
+        generateActorRetryRequestMetadata(kj::systemCoarseCalendarClock().now());
+  }
 
   // Get client and trace context (if needed) in one clean call
   auto clientWithTracing = fetcher->getClientWithTracing(ioContext,
-      jsRequest->serializeCfBlobJson(js), "fetch"_kjc, kj::none /* actorRetryRequestMetadata */);
+      jsRequest->serializeCfBlobJson(js), "fetch"_kjc,
+      kj::mv(actorRetryRequestMetadata));
   auto traceContext = kj::mv(clientWithTracing.traceContext);
 
   // TODO(cleanup): Don't convert to HttpClient. Use the HttpService interface instead. This
@@ -2478,7 +2485,7 @@ jsg::Promise<Fetcher::ScheduledResult> Fetcher::scheduled(
 kj::Own<WorkerInterface> Fetcher::getClient(
     IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
   auto clientWithTracing = getClientWithTracing(
-      ioContext, kj::mv(cfStr), kj::mv(operationName), kj::none /* actorRetryRequestMetadata */);
+      ioContext, kj::mv(cfStr), kj::mv(operationName), kj::none);
   return clientWithTracing.client.attach(kj::mv(clientWithTracing.traceContext));
 }
 
@@ -2490,6 +2497,8 @@ Fetcher::ClientWithTracing Fetcher::getClientWithTracing(
   KJ_IF_SOME(metadata, actorRetryRequestMetadata) {
     auto& outgoingFactory = KJ_REQUIRE_NONNULL(
         channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>(),
+        "actor retry metadata supplied to an unsupported Fetcher");
+    KJ_REQUIRE(outgoingFactory->supportsActorRetryMetadata(),
         "actor retry metadata supplied to an unsupported Fetcher");
     auto client = outgoingFactory->newSingleUseClientWithActorRetryMetadata(
         kj::mv(cfStr), kj::mv(metadata));
@@ -2532,6 +2541,13 @@ Fetcher::ClientWithTracing Fetcher::getClientWithTracing(
     }
   }
   KJ_UNREACHABLE;
+}
+
+bool Fetcher::supportsActorRetryMetadata() {
+  KJ_IF_SOME(outgoingFactory, channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>()) {
+    return outgoingFactory->supportsActorRetryMetadata();
+  }
+  return false;
 }
 
 kj::Own<IoChannelFactory::SubrequestChannel> Fetcher::getSubrequestChannel(IoContext& ioContext) {

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -236,6 +236,10 @@ class Fetcher: public JsRpcClientProvider {
    public:
     virtual kj::Own<WorkerInterface> newSingleUseClient(kj::Maybe<kj::String> cfStr) = 0;
 
+    virtual bool supportsActorRetryMetadata() const {
+      return false;
+    }
+
     // Factories that can carry actor retry metadata override this method. The default rejects the
     // metadata rather than silently starting a new logical call.
     virtual kj::Own<WorkerInterface> newSingleUseClientWithActorRetryMetadata(
@@ -303,6 +307,8 @@ class Fetcher: public JsRpcClientProvider {
       kj::Maybe<kj::String> cfStr,
       kj::ConstString operationName,
       kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata);
+
+  bool supportsActorRetryMetadata();
 
   // Get a SubrequestChannel representing this Fetcher.
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel(IoContext& ioContext);

--- a/src/workerd/io/io-channels.c++
+++ b/src/workerd/io/io-channels.c++
@@ -2,8 +2,26 @@
 
 #include <workerd/io/worker-interface.h>
 #include <workerd/io/worker.h>
+#include <workerd/util/entropy.h>
+
+#include <random>
 
 namespace workerd {
+
+IoChannelFactory::ActorRetryRequestMetadata generateActorRetryRequestMetadata(kj::Date createdAt) {
+  static thread_local auto generator = [] {
+    uint64_t seed;
+    getEntropy(kj::asBytes(seed));
+    return std::mt19937_64(seed);
+  }();
+  std::uniform_int_distribution<uint64_t> distribution(0, UINT64_MAX);
+
+  return IoChannelFactory::ActorRetryRequestMetadata{
+    .nonce = distribution(generator),
+    .createdAt = createdAt,
+    .isRetry = IsActorRetry::NO,
+  };
+}
 
 kj::Promise<kj::Array<byte>> IoChannelFactory::TokenizableChannel::getToken(
     ChannelTokenUsage usage) {

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -163,8 +163,8 @@ class IoChannelFactory: public virtual kj::Refcounted {
     // implementation of `ctx.restore()`, so that it can determine its own base token.
     kj::Maybe<kj::Own<SelfTokenFactory>> restoredSelfTokenFactory;
 
-    // Present when a global actor request belongs to a logical call whose retry token was selected
-    // by the caller. Actor channels generate a fresh first-attempt token when this is absent.
+    // Present when the caller classified this as a retry-eligible actor request and selected its
+    // logical-call token.
     kj::Maybe<ActorRetryRequestMetadata> actorRetryRequestMetadata;
 
     // True if this request was started on a channel that was reconstructed from a stored
@@ -645,5 +645,8 @@ kj::Own<IoChannelFactory::ActorClassChannel> newPromisedChannel<
 template <>
 kj::Own<IoChannelFactory::RpcChannel> newPromisedChannel<IoChannelFactory::RpcChannel>(
     kj::Promise<kj::Own<IoChannelFactory::RpcChannel>> promise);
+
+// Creates caller-owned metadata for the first attempt of a retry-eligible actor invocation.
+IoChannelFactory::ActorRetryRequestMetadata generateActorRetryRequestMetadata(kj::Date createdAt);
 
 }  // namespace workerd


### PR DESCRIPTION
Generate caller-owned tokens for rewindable global Durable Object fetches. Mark other Fetchers retry-ineligible and reject metadata at unsupported call sites, which will be added later where possible (e.g. RPC will follow in future).