### PR TITLE
Build macOS host tools against macOS 13.5 rather than 10.11

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -291,9 +291,9 @@ build:macos --config=unix
 build:macos --repo_env=BAZEL_USE_LEGACY_MACOS_TOOLCHAIN=0
 
 # Support macOS 13 as the minimum version. There should be at least a warning when backward
-# compatibility is broken as -Wunguarded-availability-new is enabled by default. Only enable for
-# target configuration as host configuration tools are only used during the build process.
+# compatibility is broken as -Wunguarded-availability-new is enabled by default.
 build:macos --macos_minimum_os=13.5
+build:macos --host_macos_minimum_os=13.5
 
 # Avoid emitting duplicate unwind info where compact unwind info can be used. This reduces the
 # object size by ~5% on average, improving disk space usage and link times. The final binary size


### PR DESCRIPTION
## Problem

Building on macOS can fail while compiling perfetto for the exec configuration:

```
external/perfetto+/include/perfetto/base/time.h:151:7: error: use of undeclared
identifier 'task_info'; did you mean 'task_vm_info'?
  151 |       task_info(mach_task_self(), TASK_BASIC_INFO,
```

The compile command for that action ends in `-target arm64-apple-macosx10.11`.

## Root cause

`--macos_minimum_os` applies only to the target configuration, so host tools were compiled with no
deployment target specified. That is not the same as imposing no constraint — the toolchain then
defaults to **macOS 10.11**, which is old enough to satisfy this guard in `perfetto/base/time.h`:

```c++
// Before MacOS 10.12 clock_gettime() was not implemented.
#if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
     __MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
```

So perfetto selects its pre-10.12 Mach fallback for reading CPU time instead of the `clock_gettime`
path any supported system would use. That fallback calls `task_info()` while including only
`<mach/mach_init.h>`, `<mach/mach_port.h>`, `<mach/mach_time.h>` and `<mach/thread_act.h>` — none of
which declare it. It therefore compiles only where the SDK happens to provide the declaration
transitively, which is why this reproduces against a CommandLineTools-only SDK but not on the macOS
CI runner.

## Fix

Give the exec configuration the same minimum version as the target configuration. Build-time tools
only ever run on the build machine, so nothing wants them targeting a 2015 release of macOS, and no
dependency has reason to compile its pre-10.12 compatibility paths.

The alternative would be patching the missing `#include <mach/task.h>` into perfetto. That is a real
perfetto bug and worth fixing upstream, but as a local patch it would be a third patch to rebase on
every perfetto bump while leaving us compiling obsolete code paths that only exist for systems we
don't support.

## Note for reviewers

This changes the exec configuration, so it invalidates cached host-tool actions once — expect one
slower build locally and on CI after merging. I went looking for whether the previous setting was
deliberate: it was, and the comment said host tools "are only used during the build process." That
reasoning is sound, but the conclusion doesn't follow, since unsetting the flag yields an old
constraint rather than none. The comment is updated accordingly.

## Testing

On macOS (arm64, CommandLineTools SDK), where `//src/workerd/server:server` previously failed to
build:

- `bazel build //...` — 3022 targets, completes successfully.
- `bazel test //... --nocache_test_results` — `Executed 1621 out of 1626 tests: 1621 tests pass and
  5 were skipped.`
- Confirmed via `bazel aquery` that all 40 `CppCompile` actions for perfetto's base library now use
  `apple-macosx13.5`.

The full test run matters here rather than just a build: host tools generate code that ends up in
the final binary (V8's `mksnapshot`, protoc, the capnp compiler), so changing how they are compiled
warrants checking runtime behaviour too.
