### PR TITLE
Bypass rpc flag on wrapped binding deserialization path

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -2205,8 +2205,21 @@ void Fetcher::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   JSG_FAIL_REQUIRE(DOMDataCloneError, "ServiceStub cannot be serialized in this context.");
 }
 
-jsg::Ref<Fetcher> Fetcher::deserialize(jsg::Lock& js,
-    rpc::SerializationTag tag, jsg::Deserializer& deserializer) {
+jsg::Ref<Fetcher> Fetcher::deserialize(
+    jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer) {
+  return deserializeImpl(js, tag, deserializer, RpcCompatGateBypassed::NO);
+}
+
+jsg::Ref<Fetcher> Fetcher::deserializeForWrappedBinding(
+    jsg::Lock& js, jsg::Deserializer& deserializer) {
+  return deserializeImpl(js, rpc::SerializationTag::SERVICE_STUB, deserializer,
+      RpcCompatGateBypassed::YES);
+}
+
+jsg::Ref<Fetcher> Fetcher::deserializeImpl(jsg::Lock& js,
+    rpc::SerializationTag tag,
+    jsg::Deserializer& deserializer,
+    RpcCompatGateBypassed rpcCompatGateBypassed) {
   KJ_IF_SOME(handler, deserializer.getExternalHandler()) {
     KJ_IF_SOME(frankenvalueHandler, kj::tryDowncast<Frankenvalue::CapTableReader>(handler)) {
       // Decoding a Frankenvalue (e.g. for dynamic loopback props or dynamic isolate env).
@@ -2215,12 +2228,13 @@ jsg::Ref<Fetcher> Fetcher::deserialize(jsg::Lock& js,
 
       KJ_IF_SOME(channel, kj::tryDowncast<IoChannelFactory::SubrequestChannel>(cap)) {
         // Probably decoding dynamic ctx.props.
-        return js.alloc<Fetcher>(IoContext::current().addObject(kj::addRef(channel)));
+        return js.alloc<Fetcher>(IoContext::current().addObject(kj::addRef(channel)),
+            RequiresHostAndProtocol::YES, /*isInHouse=*/false, rpcCompatGateBypassed);
       } else KJ_IF_SOME(channel, kj::tryDowncast<IoChannelCapTableEntry>(cap)) {
         // Probably decoding dynamic isolate env.
         return js.alloc<Fetcher>(
             channel.getChannelNumber(IoChannelCapTableEntry::Type::SUBREQUEST),
-            RequiresHostAndProtocol::YES, /*isInHouse=*/false);
+            RequiresHostAndProtocol::YES, /*isInHouse=*/false, rpcCompatGateBypassed);
       } else {
         KJ_FAIL_REQUIRE("ServiceStub capability in Frankenvalue is not a SubrequestChannel?");
       }
@@ -2242,7 +2256,8 @@ jsg::Ref<Fetcher> Fetcher::deserialize(jsg::Lock& js,
         KJ_FAIL_REQUIRE("wrong external type for Fetcher", external.which());
       }
 
-      return js.alloc<Fetcher>(ioctx.addObject(kj::mv(channel)));
+      return js.alloc<Fetcher>(ioctx.addObject(kj::mv(channel)),
+          RequiresHostAndProtocol::YES, /*isInHouse=*/false, rpcCompatGateBypassed);
     } else KJ_IF_SOME(storedHandler,
         kj::tryDowncast<StoredExternalHandler::Deserializer>(handler)) {
       // The allow_irrevocable_stub_storage flag allows us to just embed the token inline. This
@@ -2260,7 +2275,8 @@ jsg::Ref<Fetcher> Fetcher::deserialize(jsg::Lock& js,
         // Token stored out-of-line as an external.
         channel = storedHandler.readSubrequestChannel(ioctx.getIoChannelFactory());
       }
-      return js.alloc<Fetcher>(ioctx.addObject(kj::mv(channel)));
+      return js.alloc<Fetcher>(ioctx.addObject(kj::mv(channel)),
+          RequiresHostAndProtocol::YES, /*isInHouse=*/false, rpcCompatGateBypassed);
     }
   }
 

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -216,10 +216,12 @@ class Fetcher: public JsRpcClientProvider {
   // channel. This Fetcher will inherently be bound to the current I/O context.
   explicit Fetcher(IoOwn<IoChannelFactory::SubrequestChannel> subrequestChannel,
       RequiresHostAndProtocol requiresHost = RequiresHostAndProtocol::YES,
-      bool isInHouse = false)
+      bool isInHouse = false,
+      RpcCompatGateBypassed rpcCompatGateBypassed = RpcCompatGateBypassed::NO)
       : channelOrClientFactory(kj::mv(subrequestChannel)),
         requiresHost(requiresHost),
-        isInHouse(isInHouse) {}
+        isInHouse(isInHouse),
+        rpcCompatGateBypassed(rpcCompatGateBypassed) {}
 
   // Used by Fetchers that use ad-hoc, single-use WorkerInterface instances, such as ones
   // created for Actors.
@@ -473,6 +475,11 @@ class Fetcher: public JsRpcClientProvider {
   static jsg::Ref<Fetcher> deserialize(
       jsg::Lock& js, rpc::SerializationTag tag, jsg::Deserializer& deserializer);
 
+  // Rebuilds a wrapped binding's private fetcher without applying the receiving isolate's RPC
+  // compatibility gate.
+  static jsg::Ref<Fetcher> deserializeForWrappedBinding(
+      jsg::Lock& js, jsg::Deserializer& deserializer);
+
   JSG_SERIALIZABLE(rpc::SerializationTag::SERVICE_STUB);
 
   // Set up a connection string override for a random host and the given port. isHyperdrive
@@ -498,6 +505,11 @@ class Fetcher: public JsRpcClientProvider {
   kj::Maybe<uint16_t> port;
 
  private:
+  static jsg::Ref<Fetcher> deserializeImpl(jsg::Lock& js,
+      rpc::SerializationTag tag,
+      jsg::Deserializer& deserializer,
+      RpcCompatGateBypassed rpcCompatGateBypassed);
+
   kj::OneOf<uint,
       IoOwn<IoChannelFactory::SubrequestChannel>,
       kj::Own<CrossContextOutgoingFactory>,
@@ -506,8 +518,8 @@ class Fetcher: public JsRpcClientProvider {
   RequiresHostAndProtocol requiresHost;
   bool isInHouse;
 
-  // Defaulted so the constructors that no binding path uses need not name it. Deliberately not
-  // serialized: a stub deserialized elsewhere is subject to that isolate's own compat flags.
+  // Generic stubs use the receiving isolate's compat flags. Wrapped bindings explicitly bypass
+  // the gate while rebuilding their private inner fetcher.
   const RpcCompatGateBypassed rpcCompatGateBypassed = RpcCompatGateBypassed::NO;
 };
 

--- a/src/workerd/api/wrapped-binding.c++
+++ b/src/workerd/api/wrapped-binding.c++
@@ -40,7 +40,7 @@ jsg::Ref<WrappedBinding> WrappedBinding::deserialize(jsg::Lock& js,
     jsg::Deserializer& deserializer,
     const jsg::TypeHandler<jsg::Ref<Fetcher>>& innerHandler,
     const jsg::TypeHandler<jsg::Ref<WrappedBinding>>& selfHandler) {
-  auto inner = Fetcher::deserialize(js, rpc::SerializationTag::SERVICE_STUB, deserializer);
+  auto inner = Fetcher::deserializeForWrappedBinding(js, deserializer);
   auto wrapperModule = deserializer.readLengthDelimitedString();
   auto env = js.obj();
   env.createDataProperty(

--- a/src/workerd/server/tests/wrapped-binding-serialization/rpc-gated-receiver.js
+++ b/src/workerd/server/tests/wrapped-binding-serialization/rpc-gated-receiver.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { WorkerEntrypoint } from 'cloudflare:workers';
+
+export class RpcGatedReceiver extends WorkerEntrypoint {
+  async useDoor(door) {
+    return {
+      ordinaryFetcherRpcGated: typeof this.env.PEER.rpcPing === 'undefined',
+      value: `${door.label}:${await door.rpcPing()}`,
+    };
+  }
+}

--- a/src/workerd/server/tests/wrapped-binding-serialization/wrapped-binding-serialization-test.js
+++ b/src/workerd/server/tests/wrapped-binding-serialization/wrapped-binding-serialization-test.js
@@ -10,6 +10,10 @@ export const backend = {
   async fetch(req) {
     return new Response('pong');
   },
+
+  async rpcPing(_arg) {
+    return 'rpc-pong';
+  },
 };
 
 // An RPC entrypoint used to verify that a wrapped binding survives being:
@@ -66,6 +70,16 @@ export const test_rpc_argument = {
   async test(ctrl, env, ctx) {
     const result = await env.RECEIVER.useDoor(env.DOOR);
     assert.strictEqual(result, 'wrapped-door:pong');
+  },
+};
+
+// Reconstruct the binding in an RPC-gated worker, then call an RPC method on its private inner
+// fetcher. The wrapper's fetcher must bypass the receiving worker's compatibility gate.
+export const test_rpc_argument_gated_receiver = {
+  async test(ctrl, env, ctx) {
+    const result = await env.RPC_GATED_RECEIVER.useDoor(env.DOOR);
+    assert.strictEqual(result.ordinaryFetcherRpcGated, true);
+    assert.strictEqual(result.value, 'wrapped-door:rpc-pong');
   },
 };
 

--- a/src/workerd/server/tests/wrapped-binding-serialization/wrapped-binding-serialization-test.wd-test
+++ b/src/workerd/server/tests/wrapped-binding-serialization/wrapped-binding-serialization-test.wd-test
@@ -19,6 +19,19 @@ const unitTests :Workerd.Config = (
             )
           ),
           ( name = "RECEIVER", service = (name = "main", entrypoint = "Receiver") ),
+          ( name = "RPC_GATED_RECEIVER",
+            service = (name = "rpc-gated-receiver", entrypoint = "RpcGatedReceiver") ),
+        ],
+      )
+    ),
+    ( name = "rpc-gated-receiver",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "rpc-gated-receiver.js")
+        ],
+        compatibilityFlags = ["no_rpc"],
+        bindings = [
+          ( name = "PEER", service = (name = "main", entrypoint = "backend") )
         ],
       )
     ),

--- a/src/workerd/server/tests/wrapped-binding-serialization/wrapper.js
+++ b/src/workerd/server/tests/wrapped-binding-serialization/wrapper.js
@@ -24,6 +24,10 @@ class Door extends wrappedBinding.WrappedBinding {
     const resp = await this.#fetcher.fetch('http://placeholder/ping');
     return await resp.text();
   }
+
+  async rpcPing() {
+    return await this.#fetcher.rpcPing(null);
+  }
 }
 
 export default function makeDoor(env) {


### PR DESCRIPTION
Wrapped bindings are now serializable, which means that the previous `no_rpc` workaround needs to be implemented for the deserialization path. This fixes `this.ctx.props` or wrapped bindings passed on jsrpc params