### PR TITLE
Only require snapshot ID in snapshot restore

### DIFF
--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -229,6 +229,12 @@ class Container: public jsg::Object {
     JSG_STRUCT(id, size, name);
   };
 
+  struct SnapshotRestoreParams {
+    kj::String id;
+
+    JSG_STRUCT(id);
+  };
+
   struct SnapshotOptions {
     jsg::Optional<kj::String> name;
 
@@ -259,7 +265,7 @@ class Container: public jsg::Object {
     jsg::Optional<kj::OneOf<kj::String, StartResources>> instance;
     jsg::Optional<jsg::Dict<kj::String>> labels;
     jsg::Optional<kj::Array<DirectorySnapshotRestoreParams>> directorySnapshots;
-    jsg::Optional<Snapshot> containerSnapshot;
+    jsg::Optional<SnapshotRestoreParams> containerSnapshot;
 
     // TODO(containers): Allow intercepting stdin/stdout/stderr by specifying streams here.
 
@@ -291,7 +297,7 @@ class Container: public jsg::Object {
           | {
               image?: never;
               /** Cannot be used with `image`. */
-              containerSnapshot?: ContainerSnapshot;
+              containerSnapshot?: ContainerSnapshotRestoreParams;
             }
         ));
       } else {
@@ -304,7 +310,7 @@ class Container: public jsg::Object {
           instance?: never;
           labels?: Record<string, string>;
           directorySnapshots?: ContainerDirectorySnapshotRestoreParams[];
-          containerSnapshot?: ContainerSnapshot;
+          containerSnapshot?: ContainerSnapshotRestoreParams;
         });
       }
     }
@@ -434,7 +440,7 @@ class Container: public jsg::Object {
   api::ExecOutput, api::ExecOptions, api::ExecPtyOptions, api::ExecProcess, api::Container,        \
       api::Container::DirectorySnapshot, api::Container::DirectorySnapshotOptions,                 \
       api::Container::DirectorySnapshotRestoreParams, api::Container::Snapshot,                    \
-      api::Container::SnapshotOptions, api::Container::StartupOptions, api::Container::Info,       \
-      api::Container::StartResources
+      api::Container::SnapshotRestoreParams, api::Container::SnapshotOptions,                      \
+      api::Container::StartupOptions, api::Container::Info, api::Container::StartResources
 
 }  // namespace workerd::api

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4087,6 +4087,9 @@ interface ContainerSnapshot {
   size: number;
   name?: string;
 }
+interface ContainerSnapshotRestoreParams {
+  id: string;
+}
 interface ContainerSnapshotOptions {
   name?: string;
 }
@@ -4111,7 +4114,7 @@ type ContainerStartupOptions = {
     }
   | {
       image?: never;
-      containerSnapshot?: ContainerSnapshot;
+      containerSnapshot?: ContainerSnapshotRestoreParams;
     }
 );
 interface ContainerInfo {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4096,6 +4096,9 @@ export interface ContainerSnapshot {
   size: number;
   name?: string;
 }
+export interface ContainerSnapshotRestoreParams {
+  id: string;
+}
 export interface ContainerSnapshotOptions {
   name?: string;
 }
@@ -4120,7 +4123,7 @@ export type ContainerStartupOptions = {
     }
   | {
       image?: never;
-      containerSnapshot?: ContainerSnapshot;
+      containerSnapshot?: ContainerSnapshotRestoreParams;
     }
 );
 export interface ContainerInfo {

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -3997,6 +3997,9 @@ interface ContainerSnapshot {
   size: number;
   name?: string;
 }
+interface ContainerSnapshotRestoreParams {
+  id: string;
+}
 interface ContainerSnapshotOptions {
   name?: string;
 }
@@ -4006,7 +4009,7 @@ interface ContainerStartupOptions {
   env?: Record<string, string>;
   labels?: Record<string, string>;
   directorySnapshots?: ContainerDirectorySnapshotRestoreParams[];
-  containerSnapshot?: ContainerSnapshot;
+  containerSnapshot?: ContainerSnapshotRestoreParams;
 }
 interface ContainerStartResources {
   vcpu: number;

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -4006,6 +4006,9 @@ export interface ContainerSnapshot {
   size: number;
   name?: string;
 }
+export interface ContainerSnapshotRestoreParams {
+  id: string;
+}
 export interface ContainerSnapshotOptions {
   name?: string;
 }
@@ -4015,7 +4018,7 @@ export interface ContainerStartupOptions {
   env?: Record<string, string>;
   labels?: Record<string, string>;
   directorySnapshots?: ContainerDirectorySnapshotRestoreParams[];
-  containerSnapshot?: ContainerSnapshot;
+  containerSnapshot?: ContainerSnapshotRestoreParams;
 }
 export interface ContainerStartResources {
   vcpu: number;


### PR DESCRIPTION
When we restore a snapshot we don't care about `size` or `name`. They're not used in the Capnp RPC, only the ID is, so the generated Typescript types should reflect this.