### PR TITLE
container: DockerPort should hold a strong ref to ContainerClient (mirror DockerProcessHandle)

### DIFF
--- a/src/workerd/server/container-client-test.c++
+++ b/src/workerd/server/container-client-test.c++
@@ -13,7 +13,12 @@
 
 #include "container-client.h"
 
+#include "channel-token.h"
+
+#include <capnp/compat/byte-stream.h>
+#include <kj/async-io.h>
 #include <kj/test.h>
+#include <kj/timer.h>
 
 namespace workerd::server {
 namespace {
@@ -301,6 +306,137 @@ KJ_TEST("ContainerCreateRequest omits empty container privileges") {
   KJ_EXPECT(decodedHostConfig.getCapAdd().size() == 0);
   KJ_EXPECT(decodedHostConfig.getDevices().size() == 0);
   KJ_EXPECT(decodedHostConfig.getSecurityOpt().size() == 0);
+}
+
+// ======================================================================================
+// DockerPort::connect() use-after-free regression test.
+//
+// DockerPort dereferences its ContainerClient (network, byteStreamFactory) AFTER several co_await
+// points in connect(). If it holds only a bare `ContainerClient&`, then the safety of those derefs
+// depends entirely on nothing dropping the last ContainerClient reference while a connect() is
+// suspended. Nothing in the type system enforces that coupling. The sibling DockerProcessHandle
+// avoids the hazard by holding `containerClient.addRef()`; DockerPort should do the same.
+//
+// This test drives connect() to a suspension point (parseAddress), drops the only strong reference
+// to the ContainerClient, then resumes connect(). With a bare reference this reads freed memory and
+// AddressSanitizer aborts; with the addRef fix DockerPort keeps the ContainerClient alive and the
+// test passes.
+
+// A NetworkAddress whose connect() hands back a pre-supplied stream (the proxy connection).
+class MockAddress final: public kj::NetworkAddress {
+ public:
+  explicit MockAddress(kj::Own<kj::AsyncIoStream> streamParam): stream(kj::mv(streamParam)) {}
+  kj::Promise<kj::Own<kj::AsyncIoStream>> connect() override {
+    return kj::mv(KJ_ASSERT_NONNULL(stream));
+  }
+  kj::Own<kj::ConnectionReceiver> listen() override {
+    KJ_UNIMPLEMENTED("listen");
+  }
+  kj::Own<kj::NetworkAddress> clone() override {
+    KJ_UNIMPLEMENTED("clone");
+  }
+  kj::String toString() override {
+    return kj::str("mock");
+  }
+
+ private:
+  kj::Maybe<kj::Own<kj::AsyncIoStream>> stream;
+};
+
+// A Network whose parseAddress() suspends (returns a fulfiller-controlled promise) so the test can
+// free the ContainerClient while connect() is parked at its first co_await.
+class SuspendNetwork final: public kj::Network {
+ public:
+  kj::Promise<kj::Own<kj::NetworkAddress>> parseAddress(kj::StringPtr addr, uint = 0) override {
+    // Only the connect() path parses the 127.0.0.1 ingress-proxy address. The ctor's stale-snapshot
+    // check and ~ContainerClient's docker-socket cleanup also call parseAddress; leave those pending
+    // so they don't disturb the connect() suspension the test is controlling.
+    if (addr.contains("127.0.0.1"_kjc)) {
+      auto paf = kj::newPromiseAndFulfiller<kj::Own<kj::NetworkAddress>>();
+      fulfiller = kj::mv(paf.fulfiller);
+      return kj::mv(paf.promise);
+    }
+    return kj::NEVER_DONE;
+  }
+  kj::Own<kj::NetworkAddress> getSockaddr(const void*, uint) override {
+    KJ_UNIMPLEMENTED("getSockaddr");
+  }
+  kj::Own<kj::Network> restrictPeers(
+      kj::ArrayPtr<const kj::StringPtr>, kj::ArrayPtr<const kj::StringPtr>) override {
+    KJ_UNIMPLEMENTED("restrictPeers");
+  }
+
+  kj::Maybe<kj::Own<kj::PromiseFulfiller<kj::Own<kj::NetworkAddress>>>> fulfiller;
+};
+
+class MockResolver final: public ChannelTokenHandler::Resolver {
+ public:
+  kj::Own<IoChannelFactory::SubrequestChannel> resolveEntrypoint(
+      kj::StringPtr, kj::Maybe<kj::StringPtr>, Frankenvalue, Persistent) override {
+    KJ_UNIMPLEMENTED("resolveEntrypoint");
+  }
+  kj::Own<IoChannelFactory::ActorClassChannel> resolveActorClass(
+      kj::StringPtr, kj::Maybe<kj::StringPtr>, Frankenvalue, Persistent) override {
+    KJ_UNIMPLEMENTED("resolveActorClass");
+  }
+  kj::Own<IoChannelFactory::ActorChannel> resolveActor(
+      kj::StringPtr, kj::ArrayPtr<const byte>, kj::Maybe<kj::StringPtr>, Persistent) override {
+    KJ_UNIMPLEMENTED("resolveActor");
+  }
+};
+
+struct NullErrorHandler final: public kj::TaskSet::ErrorHandler {
+  void taskFailed(kj::Exception&&) override {}
+};
+
+KJ_TEST("DockerPort connect() use-after-free on ContainerClient freed mid-call") {
+  kj::EventLoop loop;
+  kj::WaitScope ws(loop);
+
+  capnp::ByteStreamFactory byteStreamFactory;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  SuspendNetwork network;
+  NullErrorHandler errorHandler;
+  kj::TaskSet waitUntilTasks(errorHandler);
+  MockResolver resolver;
+  ChannelTokenHandler channelTokenHandler(resolver);
+
+  auto container = kj::refcounted<ContainerClient>(byteStreamFactory, timer, network,
+      kj::str("docker"), kj::str("test-container"), kj::str("test-image"), kj::str("interceptor"),
+      waitUntilTasks, kj::Promise<void>(kj::READY_NOW), [](kj::Promise<void>) {}, channelTokenHandler,
+      ContainerPrivileges{});
+  container->setSidecarIngressHostPortForTest(8080);
+
+  // Wrap the ContainerClient as a capnp Container capability. This Own is the only strong reference.
+  rpc::Container::Client containerCap = kj::mv(container);
+
+  // getTcpPort -> Port capability (resolves immediately; mutationQueue is READY_NOW).
+  auto getPortReq = containerCap.getTcpPortRequest();
+  getPortReq.setPort(1234);
+  auto port = getPortReq.send().getPort();
+
+  // Start connect(). It runs to `co_await network.parseAddress(...)` and suspends there.
+  auto connectReq = port.connectRequest();
+  auto connectPromise = connectReq.send();
+
+  // Drive the loop until connect() has suspended at parseAddress.
+  KJ_ASSERT(!connectPromise.poll(ws));
+  KJ_ASSERT(network.fulfiller != kj::none, "connect() did not reach parseAddress");
+
+  // Drop the only external strong ref to ContainerClient. Without the addRef fix, DockerPort holds a
+  // bare reference, so nothing keeps ContainerClient alive across the suspended connect().
+  { auto drop = kj::mv(containerCap); }
+
+  // Resume connect(): supply a mock proxy connection, then a "200" so the HTTP CONNECT status
+  // resolves and connect() proceeds to the containerClient.byteStreamFactory deref -- against freed
+  // memory if the bare-reference bug is present.
+  auto httpPipe = kj::newTwoWayPipe();
+  auto serverEnd = kj::mv(httpPipe.ends[1]);
+  auto respTask = serverEnd->write("HTTP/1.1 200 OK\r\n\r\n"_kjb).eagerlyEvaluate(nullptr);
+  KJ_ASSERT_NONNULL(network.fulfiller)->fulfill(kj::heap<MockAddress>(kj::mv(httpPipe.ends[0])));
+
+  // With the bug present, ASAN aborts here when connect() dereferences the freed ContainerClient.
+  connectPromise.wait(ws);
 }
 
 }  // namespace

--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -1067,18 +1067,18 @@ class ContainerClient::DockerPort final: public rpc::Container::Port::Server,
                                          private kj::TaskSet::ErrorHandler {
  public:
   DockerPort(ContainerClient& containerClient, kj::String containerHost, uint16_t containerPort)
-      : containerClient(containerClient),
+      : containerClient(containerClient.addRef()),
         containerHost(kj::mv(containerHost)),
         containerPort(containerPort),
         pumpTasks(*this) {}
 
   kj::Promise<void> connect(ConnectContext context) override {
-    auto mappedPort = JSG_REQUIRE_NONNULL(containerClient.sidecarIngressHostPort, Error,
+    auto mappedPort = JSG_REQUIRE_NONNULL(containerClient->sidecarIngressHostPort, Error,
         "connect(): Container ingress proxy is not running.");
 
     auto dstAddr = kj::str(containerHost, ":", containerPort);
 
-    auto address = co_await containerClient.network.parseAddress(kj::str("127.0.0.1:", mappedPort));
+    auto address = co_await containerClient->network.parseAddress(kj::str("127.0.0.1:", mappedPort));
 
     kj::HttpHeaderTable::Builder headerTableBuilder;
     auto xDstAddrHeader = headerTableBuilder.add("X-Dst-Addr");
@@ -1112,9 +1112,9 @@ class ContainerClient::DockerPort final: public rpc::Container::Port::Server,
     auto upPipe = kj::newOneWayPipe();
     auto upEnd = kj::mv(upPipe.in);
     auto results = context.getResults();
-    results.setUp(containerClient.byteStreamFactory.kjToCapnp(kj::mv(upPipe.out)));
+    results.setUp(containerClient->byteStreamFactory.kjToCapnp(kj::mv(upPipe.out)));
     auto downEnd =
-        containerClient.byteStreamFactory.capnpToKjExplicitEnd(context.getParams().getDown());
+        containerClient->byteStreamFactory.capnpToKjExplicitEnd(context.getParams().getDown());
 
     auto& connectionRef = *connection;
     auto& downEndRef = *downEnd;
@@ -1131,8 +1131,13 @@ class ContainerClient::DockerPort final: public rpc::Container::Port::Server,
   }
 
  private:
-  // ContainerClient is owned by the Worker::Actor and keeps it alive.
-  ContainerClient& containerClient;
+  // Hold a strong ref to ContainerClient. connect() dereferences containerClient (network,
+  // byteStreamFactory) after co_await points, so it must keep ContainerClient alive across those
+  // suspensions itself rather than relying on an external owner. A bare reference here is safe only
+  // as long as every path that drops the last ContainerClient ref also cancels any in-flight
+  // connect() first; that coupling is unenforced by the type system. Mirrors DockerProcessHandle,
+  // which addRef()s for the same reason.
+  kj::Own<ContainerClient> containerClient;
   kj::String containerHost;
   uint16_t containerPort;
   kj::TaskSet pumpTasks;

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -116,6 +116,12 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
 
   kj::Own<ContainerClient> addRef();
 
+  // Test-only: lets a unit test drive DockerPort::connect() without a live sidecar container by
+  // presetting the ingress proxy port that connect() reads.
+  void setSidecarIngressHostPortForTest(uint16_t port) {
+    sidecarIngressHostPort = port;
+  }
+
  private:
   capnp::ByteStreamFactory& byteStreamFactory;
   kj::HttpHeaderTable headerTable;


### PR DESCRIPTION
> **Context.** This is a defensive-hardening change that came out of a private security report to Cloudflare, which was reviewed and closed as Informative — there is no reachable production trigger for a crash — and the triager encouraged opening the fix and its ASAN regression test here as a maintenance improvement, and flagging the dead `ActorContainer::containerClient` member along with it. No exploitable path is claimed.

`ContainerClient::DockerPort` holds its owner as a bare `ContainerClient&` and dereferences it (`containerClient.network`, `containerClient.byteStreamFactory`) *after* the `co_await` points in `connect()` (parse the ingress address, connect to the sidecar, read the CONNECT status). The sibling capability server `DockerProcessHandle` — created from `exec()` in the same file — holds its owner as a `kj::Own<ContainerClient>` via `containerClient.addRef()` and even attaches a ref to its background task, precisely so it can outlive teardown races. `DockerPort` does not.

Today `DockerPort`'s bare reference is safe only because of an **unenforced coupling**: nothing drops the last `ContainerClient` reference while a `connect()` is suspended. In the normal actor-teardown paths the JS-held `Port` capability is dropped first, which cancels the in-flight `connect()` before the `ContainerClient` is freed (`container.capnp` sets a file-level `$Cxx.allowCancellation`, so the cancellation does unwind the coroutine). Nothing in the type system enforces that ordering, though. Any future path that frees the `ContainerClient` without first cancelling an in-flight `connect()` — for example wiring up the currently-dead `ActorContainer::containerClient` member (see below), or introducing a `co_await` between actor destruction and the container-client drop — resumes `connect()` into freed memory.

This PR makes `DockerPort` hold `containerClient.addRef()` (a `kj::Own<ContainerClient>`), exactly like `DockerProcessHandle`. It removes the dependency on teardown ordering, is a no-op in the normal case, and does not create a reference cycle: `getTcpPort()` hands the `DockerPort` to the RPC layer via `results.setPort()` and `ContainerClient` keeps no reference back to it, so the new edge is released when the client drops the `Port` capability (identical to how `DockerProcessHandle` already behaves).

This fix is independent of the exact body of `connect()`: it holds the reference structurally, so it stays correct under refactors that relocate the connect logic (e.g. into a `ContainerClient` helper) as long as `DockerPort` keeps borrowing `ContainerClient`.

### Regression test

`container-client-test.c++` adds `KJ_TEST("DockerPort connect() use-after-free on ContainerClient freed mid-call")`. It vends a `DockerPort` via `getTcpPort`, drives `connect()` to its first suspension point (a `SuspendNetwork` whose `parseAddress` parks on a fulfiller), drops the only strong `ContainerClient` reference, then resumes `connect()`. Under ASAN, with a bare `ContainerClient&` the test aborts with a heap-use-after-free in `DockerPort::connect() (.resume)` (freed by `~ContainerClient()` when the last `Container::Client` capability reference is dropped mid-call); with the `addRef()` fix it passes. The test runs no JavaScript, so it exercises only the kj/capnp capability-lifetime path.

A one-line test-only accessor, `ContainerClient::setSidecarIngressHostPortForTest`, lets the test drive `connect()` without a live sidecar container.

```
bazel test //src/workerd/server:container-client-test --config=asan --test_output=all
```

### Separate observation: the dead `ActorContainer::containerClient` member

While tracing the container lifetime for this fix, `ActorContainer::containerClient` (`server.c++`, declared `kj::Maybe<kj::Own<ContainerClient>>`) appears to be dead: it is never assigned a value anywhere in `server.c++`; the `containerClient = kj::none;` statements are no-ops on an always-empty `Maybe`, and the comments around them describe ownership that is not wired up. The live container-client references are the raw `ContainerClient*` entries in the `containerClients` HashMap and the `Own` handed to the actor. Flagging it because it is exactly the kind of member that, if "fixed" to actually own a `ContainerClient` without also giving `DockerPort` a strong ref, would make the `connect()` use-after-free above reachable. Happy to split this into a separate issue/PR if the team prefers.
