### PR TITLE
STOR-5542: Allow ctx.abort() to disable alarm retries

### DIFF
--- a/src/rust/worker/bridge.h
+++ b/src/rust/worker/bridge.h
@@ -38,6 +38,8 @@ inline workerd::EventOutcome fromImpl(kj_rs::Rust*, workerd::rust::worker::Event
       return workerd::EventOutcome::INTERNAL_ERROR;
     case workerd::rust::worker::EventOutcome::ExceededWallTime:
       return workerd::EventOutcome::EXCEEDED_WALL_TIME;
+    case workerd::rust::worker::EventOutcome::Aborted:
+      return workerd::EventOutcome::ABORTED;
   }
 }
 

--- a/src/rust/worker/cxx_worker.rs
+++ b/src/rust/worker/cxx_worker.rs
@@ -183,6 +183,7 @@ impl From<bridge::EventOutcome> for EventOutcome {
             bridge::EventOutcome::ResponseStreamDisconnected => Self::ResponseStreamDisconnected,
             bridge::EventOutcome::InternalError => Self::InternalError,
             bridge::EventOutcome::ExceededWallTime => Self::ExceededWallTime,
+            bridge::EventOutcome::Aborted => Self::Aborted,
             other => {
                 // CXX shared enums are open (`#[repr]` value, not a closed set), so this
                 // catch-all is reachable only on discriminant drift — a variant added on the

--- a/src/rust/worker/ffi.c++
+++ b/src/rust/worker/ffi.c++
@@ -43,6 +43,8 @@ static EventOutcome toRustOutcome(workerd::EventOutcome outcome) {
       return EventOutcome::InternalError;
     case workerd::EventOutcome::EXCEEDED_WALL_TIME:
       return EventOutcome::ExceededWallTime;
+    case workerd::EventOutcome::ABORTED:
+      return EventOutcome::Aborted;
   }
   KJ_UNREACHABLE;
 }

--- a/src/rust/worker/ffi.rs
+++ b/src/rust/worker/ffi.rs
@@ -52,6 +52,7 @@ pub mod bridge {
         ResponseStreamDisconnected = 10,
         InternalError = 11,
         ExceededWallTime = 12,
+        Aborted = 13,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -323,6 +324,7 @@ impl From<outcome_capnp::EventOutcome> for bridge::EventOutcome {
             }
             outcome_capnp::EventOutcome::InternalError => Self::InternalError,
             outcome_capnp::EventOutcome::ExceededWallTime => Self::ExceededWallTime,
+            outcome_capnp::EventOutcome::Aborted => Self::Aborted,
         }
     }
 }

--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -1175,7 +1175,8 @@ jsg::Promise<jsg::JsRef<jsg::JsValue>> DurableObjectState::blockConcurrencyWhile
   return IoContext::current().blockConcurrencyWhile(js, kj::mv(callback));
 }
 
-void DurableObjectState::abort(jsg::Lock& js, jsg::Optional<kj::String> reason) {
+void DurableObjectState::abort(
+    jsg::Lock& js, jsg::Optional<kj::String> reason, jsg::Optional<AbortOptions> options) {
   kj::String description = kj::mv(reason)
                                .map([](kj::String&& text) {
     return kj::str("broken.outputGateBroken; jsg.Error: ", text);
@@ -1186,6 +1187,12 @@ void DurableObjectState::abort(jsg::Lock& js, jsg::Optional<kj::String> reason) 
 
   kj::Exception error(kj::Exception::Type::FAILED, __FILE__, __LINE__, kj::mv(description));
   error.setDetail(jsg::EXCEPTION_IS_USER_ERROR, kj::heapArray<byte>(0));
+  error.setDetail(jsg::EXCEPTION_DURABLE_OBJECT_ABORT, kj::heapArray<byte>(0));
+  KJ_IF_SOME(o, options) {
+    if (!o.retryAlarm.orDefault(true)) {
+      error.setDetail(jsg::EXCEPTION_DURABLE_OBJECT_ABORT_NO_RETRY, kj::heapArray<byte>(0));
+    }
+  }
 
   KJ_IF_SOME(s, storage) {
     // Make sure we _synchronously_ break storage so that there's no chance our promise fulfilling

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -637,9 +637,18 @@ class DurableObjectState: public jsg::Object {
   jsg::Promise<jsg::JsRef<jsg::JsValue>> blockConcurrencyWhile(
       jsg::Lock& js, jsg::Function<jsg::Promise<jsg::JsRef<jsg::JsValue>>()> callback);
 
+  struct AbortOptions {
+    // When false, an abort during an alarm handler prevents that alarm from being retried.
+    // Defaults to true and has no effect outside an alarm handler.
+    jsg::Optional<bool> retryAlarm;
+
+    JSG_STRUCT(retryAlarm);
+    JSG_STRUCT_TS_OVERRIDE(DurableObjectAbortOptions { retryAlarm?: boolean; });
+  };
+
   // Reset the object, including breaking the output gate and canceling any writes that haven't
   // been committed yet.
-  void abort(jsg::Lock& js, jsg::Optional<kj::String> reason);
+  void abort(jsg::Lock& js, jsg::Optional<kj::String> reason, jsg::Optional<AbortOptions> options);
 
   // Sets and returns a new hibernation manager in an actor if there's none or returns the existing.
   Worker::Actor::HibernationManager& maybeInitHibernationManager(Worker::Actor& actor);
@@ -809,7 +818,8 @@ class DurableObjectState: public jsg::Object {
 
 #define EW_ACTOR_STATE_ISOLATE_TYPES                                                               \
   api::ActorState, api::DurableObjectState, api::DurableObjectTransaction,                         \
-      api::DurableObjectStorage, api::DurableObjectState::ReadReplicationOptions,                  \
+      api::DurableObjectStorage, api::DurableObjectState::AbortOptions,                            \
+      api::DurableObjectState::ReadReplicationOptions,                                             \
       api::DurableObjectStorage::TransactionOptions,                                               \
       api::DurableObjectStorageOperations::ListOptions,                                            \
       api::DurableObjectStorageOperations::GetOptions,                                             \

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -580,6 +580,28 @@ bool isAlarmFailureUserError(kj::StringPtr description, bool hasUserErrorDetail)
   auto tunneled = jsg::tunneledErrorType(description);
   return tunneled.isJsgError && !tunneled.isInternal && !tunneled.isDurableObjectReset;
 }
+
+struct AlarmExceptionInfo {
+  bool isAbort;
+  bool retry;
+};
+
+AlarmExceptionInfo inspectAlarmException(const kj::Exception& exception, IoContext& context) {
+  // `exception` is the immediate promise rejection, which may differ from the original context
+  // abort reason after V8 termination or an output-gate failure. Details may survive on only one
+  // of these exceptions, so inspect both.
+  AlarmExceptionInfo result{
+    .isAbort = exception.getDetail(jsg::EXCEPTION_DURABLE_OBJECT_ABORT) != kj::none,
+    .retry = exception.getDetail(jsg::EXCEPTION_DURABLE_OBJECT_ABORT_NO_RETRY) == kj::none,
+  };
+  KJ_IF_SOME(abortReason, context.getAbortReason()) {
+    result.isAbort =
+        result.isAbort || abortReason.getDetail(jsg::EXCEPTION_DURABLE_OBJECT_ABORT) != kj::none;
+    result.retry = result.retry &&
+        abortReason.getDetail(jsg::EXCEPTION_DURABLE_OBJECT_ABORT_NO_RETRY) == kj::none;
+  }
+  return result;
+}
 }  // namespace
 
 kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj::Date scheduledTime,
@@ -669,14 +691,18 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj:
         auto description = kj::str(e.getDescription());  // because e is moved before this is used
         auto log = !jsg::isTunneledException(description) && !jsg::isDoNotLogException(description);
         auto isUserError = e.getDetail(jsg::EXCEPTION_IS_USER_ERROR) != kj::none;
+        auto alarmException = inspectAlarmException(e, context);
 
         // This will include the error in inspector/tracers and log to syslog if internal.
         context.logUncaughtExceptionAsync(UncaughtExceptionSource::ALARM_HANDLER, kj::mv(e));
 
         auto limitsExceeded = context.getLimitEnforcer().getLimitsExceeded();
-        EventOutcome outcome = EventOutcome::EXCEPTION;
-        KJ_IF_SOME(status, limitsExceeded) {
-          outcome = status;
+        EventOutcome outcome = EventOutcome::ABORTED;
+        if (!alarmException.isAbort) {
+          outcome = EventOutcome::EXCEPTION;
+          KJ_IF_SOME(status, limitsExceeded) {
+            outcome = status;
+          }
         }
 
         kj::String actorId;
@@ -709,7 +735,7 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj:
               "output lock broke during alarm execution without an interesting error description",
               actorId, description, shouldRetryCountsAgainstLimits);
         }
-        return WorkerInterface::AlarmResult{.retry = true,
+        return WorkerInterface::AlarmResult{.retry = alarmException.retry,
           .retryCountsAgainstLimit = shouldRetryCountsAgainstLimits,
           .outcome = outcome,
           .errorDescription = kj::str(description)};
@@ -755,9 +781,10 @@ kj::Promise<WorkerInterface::AlarmResult> ServiceWorkerGlobalScope::runAlarm(kj:
                 "output lock broke after executing alarm with tunneled non-user error", actorId,
                 e.getDescription());
           }
-          return WorkerInterface::AlarmResult{.retry = true,
+          auto alarmException = inspectAlarmException(e, context);
+          return WorkerInterface::AlarmResult{.retry = alarmException.retry,
             .retryCountsAgainstLimit = shouldRetryCountsAgainstLimits,
-            .outcome = EventOutcome::EXCEPTION,
+            .outcome = alarmException.isAbort ? EventOutcome::ABORTED : EventOutcome::EXCEPTION,
             .errorDescription = kj::str(e.getDescription())};
         });
       });

--- a/src/workerd/io/outcome.capnp
+++ b/src/workerd/io/outcome.capnp
@@ -29,4 +29,5 @@ enum EventOutcome {
   responseStreamDisconnected @10;
   internalError @11;
   exceededWallTime @12;
+  aborted @13;
 }

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -16,6 +16,7 @@ namespace workerd::tracing {
 namespace {
 
 #define STRS(V)                                                                                    \
+  V(ABORTED, "aborted")                                                                            \
   V(ALARM, "alarm")                                                                                \
   V(ATTRIBUTES, "attributes")                                                                      \
   V(BATCHSIZE, "batchSize")                                                                        \
@@ -343,6 +344,8 @@ jsg::JsValue ToJs(jsg::Lock& js, const EventOutcome& outcome, StringCache& cache
       return cache.get(js, INTERNALERROR_STR);
     case EventOutcome::EXCEEDED_WALL_TIME:
       return cache.get(js, EXCEEDEDWALLTIME_STR);
+    case EventOutcome::ABORTED:
+      return cache.get(js, ABORTED_STR);
     case EventOutcome::UNKNOWN:
       return cache.get(js, UNKNOWN_STR);
   }

--- a/src/workerd/jsg/exception.h
+++ b/src/workerd/jsg/exception.h
@@ -159,6 +159,13 @@ bool isExceptionFromInputGateBroken(kj::StringPtr description);
 
 constexpr kj::Exception::DetailTypeId EXCEPTION_IS_USER_ERROR = 0x82aff7d637c30e47ull;
 
+// Set when a Durable Object execution was terminated by a call to state.abort().
+constexpr kj::Exception::DetailTypeId EXCEPTION_DURABLE_OBJECT_ABORT = 0x2900166d61b404a7ull;
+
+// Set when a Durable Object abort should terminate the current alarm without retrying it.
+constexpr kj::Exception::DetailTypeId EXCEPTION_DURABLE_OBJECT_ABORT_NO_RETRY =
+    0xff8bb5686c6156deull;
+
 struct ExceptionToJsOptions {
   // When ignoreDetail is true, tells kjExceptionToJs() to ignore any serialized
   // exception detail in the kj::Exception.

--- a/src/workerd/server/alarm-scheduler-test.c++
+++ b/src/workerd/server/alarm-scheduler-test.c++
@@ -38,16 +38,31 @@ class AdjustableClock final: public kj::Clock {
   kj::Date time = kj::UNIX_EPOCH;
 };
 
-// Minimal WorkerInterface that only supports runAlarm(); every other entry point is unused by the
-// alarm scheduler tests. runAlarm() reports success (no retry) and invokes `onAlarm` so the test
-// can observe that the alarm fired.
+// Minimal WorkerInterface that supports runAlarm() and abandonAlarm(); every other entry point is
+// unused by the alarm scheduler tests. By default, runAlarm() reports success (no retry) and invokes
+// `onAlarm` so the test can observe that the alarm fired.
 class AlarmStubWorkerInterface final: public WorkerInterface {
  public:
-  explicit AlarmStubWorkerInterface(kj::Function<void()> onAlarm): onAlarm(kj::mv(onAlarm)) {}
+  explicit AlarmStubWorkerInterface(kj::Function<void()> onAlarm)
+      : onAlarm(kj::mv(onAlarm)),
+        onAbandon([]() { return kj::Maybe<kj::Date>(kj::none); }) {}
+
+  AlarmStubWorkerInterface(kj::Function<void()> onAlarm,
+      AlarmOutcome outcome,
+      kj::Function<kj::Promise<kj::Maybe<kj::Date>>()> onAbandon)
+      : onAlarm(kj::mv(onAlarm)),
+        outcome(outcome),
+        onAbandon(kj::mv(onAbandon)) {}
 
   kj::Promise<AlarmResult> runAlarm(kj::Date, uint32_t) override {
     onAlarm();
-    return AlarmResult{.retry = false, .outcome = EventOutcome::OK};
+    return AlarmResult{.retry = outcome.retry,
+      .retryCountsAgainstLimit = outcome.retryCountsAgainstLimit,
+      .outcome = outcome.outcome};
+  }
+
+  kj::Promise<kj::Maybe<kj::Date>> abandonAlarm(kj::Date) override {
+    return onAbandon();
   }
 
   kj::Promise<void> request(kj::HttpMethod,
@@ -76,6 +91,8 @@ class AlarmStubWorkerInterface final: public WorkerInterface {
 
  private:
   kj::Function<void()> onAlarm;
+  AlarmOutcome outcome{.retry = false, .outcome = EventOutcome::OK};
+  kj::Function<kj::Promise<kj::Maybe<kj::Date>>()> onAbandon;
 };
 
 KJ_TEST("AlarmScheduler migrates a database created before the actor_name column existed") {
@@ -211,6 +228,100 @@ KJ_TEST("AlarmScheduler restores the persisted actor_name onto the ActorKey when
 
   KJ_EXPECT(fired);
   KJ_EXPECT(KJ_ASSERT_NONNULL(observedName) == "my-name"_kj);
+}
+
+KJ_TEST("AlarmScheduler abandons an alarm when ctx.abort() sets retryAlarm to false") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+  AdjustableClock clock;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  SqliteDatabase::Vfs vfs(*dir);
+  kj::Path path({"alarms"});
+  auto scheduledTime = kj::UNIX_EPOCH + 1 * kj::HOURS;
+  auto actor = ActorKey{.actorId = "terminal-actor"_kj};
+
+  bool fired = false;
+  bool abandoned = false;
+  auto getActor = [&](const ActorKey&) -> kj::Own<WorkerInterface> {
+    return kj::heap<AlarmStubWorkerInterface>([&fired]() { fired = true; },
+        WorkerInterface::AlarmOutcome{
+          .retry = false,
+          .retryCountsAgainstLimit = true,
+          .outcome = EventOutcome::ABORTED,
+        },
+        [&abandoned]() {
+      abandoned = true;
+      return kj::Maybe<kj::Date>(kj::none);
+    });
+  };
+
+  AlarmScheduler scheduler(clock, timer, vfs, path.clone(), kj::mv(getActor));
+  scheduler.setAlarm(actor, scheduledTime);
+
+  clock.setTime(scheduledTime);
+  timer.advanceTo(kj::origin<kj::TimePoint>() + (scheduledTime - kj::UNIX_EPOCH));
+  for (uint i = 0; i < 100 && !abandoned; i++) {
+    waitScope.poll();
+  }
+
+  KJ_EXPECT(fired);
+  KJ_EXPECT(abandoned);
+  KJ_EXPECT(scheduler.getAlarm(actor) == kj::none);
+}
+
+KJ_TEST("AlarmScheduler preserves an alarm queued while abandonment is pending") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+  AdjustableClock clock;
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  SqliteDatabase::Vfs vfs(*dir);
+  kj::Path path({"alarms"});
+  auto scheduledTime = kj::UNIX_EPOCH + 1 * kj::HOURS;
+  auto replacementTime = kj::UNIX_EPOCH + 2 * kj::HOURS;
+  auto actor = ActorKey{.actorId = "terminal-actor"_kj};
+  auto pendingAbandon = kj::newPromiseAndFulfiller<kj::Maybe<kj::Date>>();
+  auto abandonPromise = pendingAbandon.promise.fork();
+  bool abandonStarted = false;
+
+  {
+    auto getActor = [&](const ActorKey&) -> kj::Own<WorkerInterface> {
+      return kj::heap<AlarmStubWorkerInterface>([]() {},
+          WorkerInterface::AlarmOutcome{
+            .retry = false,
+            .retryCountsAgainstLimit = true,
+            .outcome = EventOutcome::ABORTED,
+          },
+          [&abandonStarted, &abandonPromise]() {
+        abandonStarted = true;
+        return abandonPromise.addBranch();
+      });
+    };
+
+    AlarmScheduler scheduler(clock, timer, vfs, path.clone(), kj::mv(getActor));
+    scheduler.setAlarm(actor, scheduledTime);
+
+    clock.setTime(scheduledTime);
+    timer.advanceTo(kj::origin<kj::TimePoint>() + (scheduledTime - kj::UNIX_EPOCH));
+    for (uint i = 0; i < 100 && !abandonStarted; i++) {
+      waitScope.poll();
+    }
+
+    KJ_EXPECT(abandonStarted);
+    scheduler.setAlarm(actor, replacementTime);
+    pendingAbandon.fulfiller->fulfill(kj::none);
+
+    for (uint i = 0; i < 100 && scheduler.getAlarm(actor) != replacementTime; i++) {
+      waitScope.poll();
+    }
+    KJ_EXPECT(scheduler.getAlarm(actor) == replacementTime);
+  }
+
+  AlarmScheduler scheduler(clock, timer, vfs, path.clone(), failingGetActor());
+  KJ_EXPECT(scheduler.getAlarm(actor) == replacementTime);
 }
 
 }  // namespace

--- a/src/workerd/server/alarm-scheduler.c++
+++ b/src/workerd/server/alarm-scheduler.c++
@@ -176,14 +176,6 @@ bool AlarmScheduler::deleteAlarm(ActorKey actor) {
   return query.changeCount() > 0;
 }
 
-kj::Promise<AlarmScheduler::RetryInfo> AlarmScheduler::runAlarm(
-    const ActorKey& actor, kj::Date scheduledTime, uint32_t retryCount) {
-  auto result = co_await getActor(actor)->runAlarm(scheduledTime, retryCount);
-
-  co_return RetryInfo{.retry = result.outcome != EventOutcome::OK && result.retry,
-    .retryCountsAgainstLimit = result.retryCountsAgainstLimit};
-}
-
 AlarmScheduler::ScheduledAlarm AlarmScheduler::scheduleAlarm(
     kj::Date now, kj::Own<ActorKey> actor, kj::Date scheduledTime) {
   auto task = makeAlarmTask(scheduledTime - now, *actor, scheduledTime);
@@ -215,19 +207,23 @@ kj::Promise<void> AlarmScheduler::makeAlarmTask(
     retryCount = entry.value.countedRetry;
   }
 
-  auto retryInfo = co_await ([&]() -> kj::Promise<RetryInfo> {
+  auto alarmOutcome = co_await ([&]() -> kj::Promise<WorkerInterface::AlarmOutcome> {
     try {
-      co_return co_await runAlarm(actorRef, scheduledTime, retryCount);
+      auto result = co_await getActor(actorRef)->runAlarm(scheduledTime, retryCount);
+      auto outcome = result.asOutcome();
+      outcome.retry = outcome.outcome != EventOutcome::OK && outcome.retry;
+      co_return outcome;
     } catch (...) {
       auto exception = kj::getCaughtExceptionAsKj();
       KJ_LOG(WARNING, exception);
-      co_return RetryInfo{.retry = true,
+      co_return WorkerInterface::AlarmOutcome{.retry = true,
 
         // An exception here is "weird", they should normally
         // be turned into AlarmResult statuses in the sandbox
         // for any user-caused error. Let's not count this
         // retry attempt against the limit.
-        .retryCountsAgainstLimit = false};
+        .retryCountsAgainstLimit = false,
+        .outcome = EventOutcome::EXCEPTION};
     }
   })();
 
@@ -253,7 +249,7 @@ kj::Promise<void> AlarmScheduler::makeAlarmTask(
     // again.
     entry.value.status = AlarmStatus::FINISHED;
 
-    if (retryInfo.retry) {
+    if (alarmOutcome.retry) {
       // recreate the task, running after a delay determined using the retry factor
       if (entry.value.countedRetry >= AlarmScheduler::RETRY_MAX_TRIES) {
         // Notify the actor to clear its in-memory alarm state so getAlarm() reflects the
@@ -261,18 +257,10 @@ kj::Promise<void> AlarmScheduler::makeAlarmTask(
         // already has visibility into the actor's alarm state via its SQLite hooks.
         // If the notification fails, we keep the alarm in the scheduler so it is not silently
         // lost.
-        try {
-          co_await getActor(actorRef)->abandonAlarm(scheduledTime);
-        } catch (...) {
-          auto exception = kj::getCaughtExceptionAsKj();
-          KJ_LOG(
-              WARNING, "abandonAlarm notification failed, keeping alarm in scheduler", exception);
-          co_return;
-        }
-        deleteAlarm(*entry.value.actor);
+        entry.value.task = abandonAlarm(actorRef.clone(), scheduledTime);
         co_return;
       }
-      if (retryInfo.retryCountsAgainstLimit) {
+      if (alarmOutcome.retryCountsAgainstLimit) {
         entry.value.countedRetry++;
 
         if (!entry.value.previousRetryCountedAgainstLimit) {
@@ -285,7 +273,7 @@ kj::Promise<void> AlarmScheduler::makeAlarmTask(
           entry.value.backoff = 0;
         }
       }
-      entry.value.previousRetryCountedAgainstLimit = retryInfo.retryCountsAgainstLimit;
+      entry.value.previousRetryCountedAgainstLimit = alarmOutcome.retryCountsAgainstLimit;
 
       entry.value.backoff = kj::min(AlarmScheduler::RETRY_BACKOFF_MAX, entry.value.backoff);
       auto delay = (AlarmScheduler::RETRY_START_SECONDS << entry.value.backoff) * kj::SECONDS;
@@ -299,11 +287,40 @@ kj::Promise<void> AlarmScheduler::makeAlarmTask(
       entry.value.task = makeAlarmTask(delay, actorRef, scheduledTime);
     } else {
       KJ_ASSERT(entry.value.queuedAlarm == kj::none);
+      if (alarmOutcome.outcome == EventOutcome::ABORTED) {
+        entry.value.task = abandonAlarm(actorRef.clone(), scheduledTime);
+        co_return;
+      }
       deleteAlarm(actorRef);
     }
   } catch (...) {
     auto exception = kj::getCaughtExceptionAsKj();
     KJ_LOG(ERROR, "Failed to run alarm and was unable to schedule a retry", exception);
+  }
+}
+
+kj::Promise<void> AlarmScheduler::abandonAlarm(kj::Own<ActorKey> actor, kj::Date scheduledTime) {
+  try {
+    co_await getActor(*actor)->abandonAlarm(scheduledTime);
+  } catch (...) {
+    auto exception = kj::getCaughtExceptionAsKj();
+    KJ_LOG(WARNING, "abandonAlarm notification failed, keeping alarm in scheduler", exception);
+    co_return;
+  }
+
+  KJ_IF_SOME(entry, alarms.findEntry(*actor)) {
+    if (entry.value.status != AlarmStatus::FINISHED || entry.value.scheduledTime != scheduledTime) {
+      co_return;
+    }
+
+    // This task cannot remove or replace the promise that owns it until it has been moved out of
+    // the alarm entry.
+    tasks.add(kj::mv(entry.value.task));
+    KJ_IF_SOME(replacement, entry.value.queuedAlarm) {
+      entry.value = scheduleAlarm(clock.now(), kj::mv(entry.value.actor), replacement);
+    } else {
+      deleteAlarm(*actor);
+    }
   }
 }
 

--- a/src/workerd/server/alarm-scheduler.h
+++ b/src/workerd/server/alarm-scheduler.h
@@ -115,17 +115,11 @@ class AlarmScheduler final: kj::TaskSet::ErrorHandler {
 
   kj::HashMap<ActorKey, ScheduledAlarm> alarms;
 
-  struct RetryInfo {
-    bool retry;
-    bool retryCountsAgainstLimit;
-  };
-  kj::Promise<RetryInfo> runAlarm(
-      const ActorKey& actor, kj::Date scheduledTime, uint32_t retryCount);
-
   ScheduledAlarm scheduleAlarm(kj::Date now, kj::Own<ActorKey> actor, kj::Date scheduledTime);
 
   kj::Promise<void> makeAlarmTask(
       kj::Duration delay, const ActorKey& actor, kj::Date scheduledTime);
+  kj::Promise<void> abandonAlarm(kj::Own<ActorKey> actor, kj::Date scheduledTime);
 
   kj::Promise<void> checkTimestamp(kj::Duration delay, kj::Date scheduledTime);
 

--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -80,8 +80,8 @@ interface ConnectEventInfo {
 
 type EventOutcome = "ok" | "canceled" | "exception" | "unknown" | "killSwitch" |
                     "daemonDown" | "exceededCpu" | "exceededMemory" | "loadShed" |
-                    "responseStreamDisconnected" | "scriptNotFound" | "internalError" |
-                    "exceededWallTime";
+                     "responseStreamDisconnected" | "scriptNotFound" | "internalError" |
+                     "exceededWallTime" | "aborted";
 
 interface ScriptVersion {
   readonly id: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -715,7 +715,7 @@ interface DurableObjectState<Props = unknown> {
   setHibernatableWebSocketEventTimeout(timeoutMs?: number): void;
   getHibernatableWebSocketEventTimeout(): number | null;
   getTags(ws: WebSocket): string[];
-  abort(reason?: string): void;
+  abort(reason?: string, options?: DurableObjectAbortOptions): void;
   configureReadReplication(
     options: DurableObjectReadReplicationOptions,
   ): Promise<void>;
@@ -798,6 +798,9 @@ interface DurableObjectStorage {
   ensureReplicas(): void;
   /** @deprecated Use `ctx.configureReadReplication()` instead. */
   disableReplicas(): void;
+}
+interface DurableObjectAbortOptions {
+  retryAlarm?: boolean;
 }
 interface DurableObjectReadReplicationOptions {
   mode: "auto" | "disabled";
@@ -16744,7 +16747,8 @@ declare namespace TailStream {
     | "responseStreamDisconnected"
     | "scriptNotFound"
     | "internalError"
-    | "exceededWallTime";
+    | "exceededWallTime"
+    | "aborted";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -718,7 +718,7 @@ export interface DurableObjectState<Props = unknown> {
   setHibernatableWebSocketEventTimeout(timeoutMs?: number): void;
   getHibernatableWebSocketEventTimeout(): number | null;
   getTags(ws: WebSocket): string[];
-  abort(reason?: string): void;
+  abort(reason?: string, options?: DurableObjectAbortOptions): void;
   configureReadReplication(
     options: DurableObjectReadReplicationOptions,
   ): Promise<void>;
@@ -801,6 +801,9 @@ export interface DurableObjectStorage {
   ensureReplicas(): void;
   /** @deprecated Use `ctx.configureReadReplication()` instead. */
   disableReplicas(): void;
+}
+export interface DurableObjectAbortOptions {
+  retryAlarm?: boolean;
 }
 export interface DurableObjectReadReplicationOptions {
   mode: "auto" | "disabled";
@@ -16702,7 +16705,8 @@ export declare namespace TailStream {
     | "responseStreamDisconnected"
     | "scriptNotFound"
     | "internalError"
-    | "exceededWallTime";
+    | "exceededWallTime"
+    | "aborted";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -706,7 +706,7 @@ interface DurableObjectState<Props = unknown> {
   setHibernatableWebSocketEventTimeout(timeoutMs?: number): void;
   getHibernatableWebSocketEventTimeout(): number | null;
   getTags(ws: WebSocket): string[];
-  abort(reason?: string): void;
+  abort(reason?: string, options?: DurableObjectAbortOptions): void;
 }
 interface DurableObjectTransaction {
   get<T = unknown>(
@@ -779,6 +779,9 @@ interface DurableObjectStorage {
   getCurrentBookmark(): Promise<string>;
   getBookmarkForTime(timestamp: number | Date): Promise<string>;
   onNextSessionRestoreBookmark(bookmark: string): Promise<string>;
+}
+interface DurableObjectAbortOptions {
+  retryAlarm?: boolean;
 }
 interface DurableObjectListOptions {
   start?: string;
@@ -16469,7 +16472,8 @@ declare namespace TailStream {
     | "responseStreamDisconnected"
     | "scriptNotFound"
     | "internalError"
-    | "exceededWallTime";
+    | "exceededWallTime"
+    | "aborted";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -709,7 +709,7 @@ export interface DurableObjectState<Props = unknown> {
   setHibernatableWebSocketEventTimeout(timeoutMs?: number): void;
   getHibernatableWebSocketEventTimeout(): number | null;
   getTags(ws: WebSocket): string[];
-  abort(reason?: string): void;
+  abort(reason?: string, options?: DurableObjectAbortOptions): void;
 }
 export interface DurableObjectTransaction {
   get<T = unknown>(
@@ -782,6 +782,9 @@ export interface DurableObjectStorage {
   getCurrentBookmark(): Promise<string>;
   getBookmarkForTime(timestamp: number | Date): Promise<string>;
   onNextSessionRestoreBookmark(bookmark: string): Promise<string>;
+}
+export interface DurableObjectAbortOptions {
+  retryAlarm?: boolean;
 }
 export interface DurableObjectListOptions {
   start?: string;
@@ -16427,7 +16430,8 @@ export declare namespace TailStream {
     | "responseStreamDisconnected"
     | "scriptNotFound"
     | "internalError"
-    | "exceededWallTime";
+    | "exceededWallTime"
+    | "aborted";
   interface ScriptVersion {
     readonly id: string;
     readonly tag?: string;


### PR DESCRIPTION
Allow Durable Object alarm handlers to call `ctx.abort(reason, { retryAlarm: false })` to reset the object without retrying the alarm. Calls without the option retain the existing retry behavior.

Add an ABORTED event outcome and preserve the retry decision through both handler and output-gate error paths. Preserve replacement alarms queued while asynchronous abandonment is in progress.