### PR TITLE
Enforce kj::Own/kj::Rc/kj::Arc GC ownership barriers in jsg-visit-for-gc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,8 +253,10 @@ C++ classes are exposed to JavaScript via JSG macros in `src/workerd/jsg/`. See 
 - `JSG_RESOURCE_TYPE` for reference types, `JSG_STRUCT` for value types
 - `js.alloc<T>()` for resource allocation
 - The `jsg-visit-for-gc` clang-tidy check (`//tools/clang-tidy:workerd-lint`)
-  validates that GC-visitable fields are traced in `visitForGc()`. Run via
-  `just clang-tidy <target>`. See `build/AGENTS.md` for details.
+  validates that GC-visitable fields are traced in `visitForGc()` and that
+  visitation never reaches through the `kj::Own`/`kj::Rc`/`kj::Arc` ownership
+  barriers (such handles stay strong roots). Run via `just clang-tidy <target>`.
+  See `build/AGENTS.md` for details.
 - The `workerd-unsafe-continuation-capture` clang-tidy check flags lambdas
   passed to async sinks (`kj/jsg::Promise::then`, `IoContext::run/awaitIo/...`,
   `kj::evalLater`, ...) that capture bare references, `[this]`, or non-owning

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -35,9 +35,13 @@ Custom Bazel rules (`wd_*` macros) for C++, TypeScript, Rust, Cap'n Proto, and t
 that adds workerd-specific static checks:
 
 - `jsg-visit-for-gc`: flags JSG resource types whose visitable fields
-  (`jsg::Ref`, `jsg::JsRef`, `jsg::V8Ref`, `jsg::Function`, `jsg::Promise`,
-  `jsg::Value`, etc., plus `kj::Maybe`/`Array`/`Vector`/
+  (`jsg::Ref`, `jsg::JsRef`, `jsg::V8Ref`, `jsg::Name`, `jsg::Function`,
+  `jsg::Promise`, `jsg::Value`, etc., plus `kj::Maybe`/`Array`/`Vector`/
   `OneOf` and `jsg::Optional` wrappers thereof) are missing from `visitForGc()`.
+  `kj::Own`/`kj::Rc`/`kj::Arc` are ownership barriers: fields behind them are
+  held as strong roots, never visited, and the check rejects visitation that
+  reaches through a barrier (`visitor.visit(*owned)`,
+  `visitor.visit(owned->field)`, `owned->visitForGc(visitor)`).
 - `workerd-angled-includes` - requires includes of workers/capnproto code from
     different directories to use angled brackets
 - `workerd-consume`: flags calls to methods annotated with `WD_CONSUME` when
@@ -68,8 +72,8 @@ Usage:
   plugin via `--load=`.
 - Suppress an intentional non-visit with `// NOLINT(jsg-visit-for-gc)` plus a
   comment explaining why the field is safe to skip (see `src/workerd/api/streams/queue.h`
-  for `ByteQueue::Entry::store` and `src/workerd/api/node/diagnostics-channel.h`
-  for `Channel::name`).
+  for `ValueQueue::Entry::value` and `ByteQueue::Entry::store`, which sit behind
+  kj::Rc ownership barriers).
 
 ### Incremental check rollout
 

--- a/src/workerd/api/filesystem.h
+++ b/src/workerd/api/filesystem.h
@@ -588,9 +588,10 @@ class FileSystemWritableFileStream final: public WritableStream {
  private:
   kj::Rc<State> sharedState;
 
-  void visitForGc(jsg::GcVisitor& visitor) {
-    visitor.visit(sharedState->file);
-  }
+  // sharedState->file is not traced: State sits behind a kj::Rc (an ownership
+  // barrier) shared with sink write/abort/close callbacks that don't GC-trace,
+  // so tracing risks collection while a callback still uses it. Strong root.
+  void visitForGc(jsg::GcVisitor& visitor) {}
 };
 
 class StorageManager final: public jsg::Object {

--- a/src/workerd/api/node/diagnostics-channel.c++
+++ b/src/workerd/api/node/diagnostics-channel.c++
@@ -135,9 +135,7 @@ v8::Local<v8::Value> Channel::runStores(jsg::Lock& js,
 }
 
 void Channel::visitForGc(jsg::GcVisitor& visitor) {
-  // `name` (jsg::Name) is intentionally not visited here: jsg::Name's
-  // visitForGc is private and visitation happens through NameWrapper, not
-  // through GcVisitor::visit().
+  visitor.visit(name);
   for (auto& sub: subscribers) {
     visitor.visit(sub.key, sub.value);
   }

--- a/src/workerd/api/node/diagnostics-channel.h
+++ b/src/workerd/api/node/diagnostics-channel.h
@@ -73,10 +73,7 @@ class Channel: public jsg::Object {
     }
   };
 
-  // jsg::Name has a private visitForGc and is visited through NameWrapper
-  // rather than through the GcVisitor::visit() overload set, so we cannot
-  // and do not visit it from Channel::visitForGc.
-  jsg::Name name;  // NOLINT(jsg-visit-for-gc)
+  jsg::Name name;
   kj::HashMap<jsg::HashableV8Ref<v8::Object>, MessageCallback> subscribers;
   kj::Table<StoreEntry, kj::HashIndex<StoreCallbacks>> stores;
 

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -2461,7 +2461,10 @@ void WritableStreamInternalController::visitForGc(jsg::GcVisitor& visitor) {
         visitor.visit(flush.promise);
       }
       KJ_CASE_ONEOF(pipe, kj::Own<Pipe>) {
-        pipe->visitForGc(visitor);
+        // Not traced: Pipe sits behind a kj::Own (an ownership barrier) and is
+        // shared with pipeLoop() continuations (via Pipe::State) that don't
+        // GC-trace, so tracing risks collection while a continuation still
+        // uses its handles. They are held as strong roots.
       }
     }
   }

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -454,9 +454,8 @@ class WritableStreamInternalController: public WritableStreamController {
       return kj::rc<State>(parent.addRef(), addWeakToThis());
     }
 
-    void visitForGc(jsg::GcVisitor& visitor) {
-      visitor.visit(readable, promise, maybeSignal, capturedSourceError);
-    }
+    // No visitForGc: Pipe lives behind a kj::Own (an ownership barrier), so
+    // readable, promise, maybeSignal, and capturedSourceError are strong roots.
 
     void releaseSource(jsg::Lock& js, kj::Maybe<jsg::JsValue> maybeError = kj::none);
     bool checkSignal(jsg::Lock& js);

--- a/src/workerd/api/streams/queue.c++
+++ b/src/workerd/api/streams/queue.c++
@@ -49,10 +49,6 @@ size_t ValueQueue::Entry::getSize() const {
   return size;
 }
 
-void ValueQueue::Entry::visitForGc(jsg::GcVisitor& visitor) {
-  visitor.visit(value);
-}
-
 #pragma endregion ValueQueue::Entry
 
 #pragma region ValueQueue::QueueEntry
@@ -355,10 +351,6 @@ void ValueQueue::Consumer::cancelPendingReads(jsg::Lock& js, jsg::JsValue reason
   impl.cancelPendingReads(js, reason);
 }
 
-void ValueQueue::Consumer::visitForGc(jsg::GcVisitor& visitor) {
-  visitor.visit(impl);
-}
-
 #pragma endregion ValueQueue::Consumer
 
 ValueQueue::ValueQueue(size_t highWaterMark): impl(highWaterMark) {}
@@ -490,8 +482,6 @@ bool ValueQueue::hasPartiallyFulfilledRead() {
   return false;
 }
 
-void ValueQueue::visitForGc(jsg::GcVisitor& visitor) {}
-
 #pragma endregion ValueQueue
 
 // ======================================================================================
@@ -586,8 +576,6 @@ size_t ByteQueue::Entry::getSize() const {
 kj::Rc<ByteQueue::Entry> ByteQueue::Entry::clone(jsg::Lock& js) {
   return addRefToThis();
 }
-
-void ByteQueue::Entry::visitForGc(jsg::GcVisitor& visitor) {}
 
 #pragma endregion ByteQueue::Entry
 
@@ -859,10 +847,6 @@ jsg::Promise<DrainingReadResult> ByteQueue::Consumer::drainingRead(jsg::Lock& js
 
 void ByteQueue::Consumer::cancelPendingReads(jsg::Lock& js, jsg::JsValue reason) {
   impl.cancelPendingReads(js, reason);
-}
-
-void ByteQueue::Consumer::visitForGc(jsg::GcVisitor& visitor) {
-  visitor.visit(impl);
 }
 
 #pragma endregion ByteQueue::Consumer
@@ -1613,8 +1597,6 @@ bool ByteQueue::wantsRead() const {
 size_t ByteQueue::getConsumerCount() {
   return impl->getConsumerCount();
 }
-
-void ByteQueue::visitForGc(jsg::GcVisitor& visitor) {}
 
 #pragma endregion ByteQueue
 

--- a/src/workerd/api/streams/queue.h
+++ b/src/workerd/api/streams/queue.h
@@ -536,17 +536,11 @@ class ConsumerImpl final: public kj::PtrTarget {
   }
 
   void visitForGc(jsg::GcVisitor& visitor) {
-    // Technically we shouldn't really have to GC visit the stored error here but there
-    // should not be any harm in doing so.
-    KJ_IF_SOME(errored, state.tryGetErrorUnsafe()) {
-      visitor.visit(errored.reason);
-    }
-    // There's no reason to GC visit the promise resolver or buffer in Ready state and it is
-    // potentially problematic if we do. Since the read requests are queued, if we
-    // GC visit it once, remove it from the queue, and GC happens to kick in before
-    // we access the resolver, then v8 could determine that the resolver or buffered
-    // entries are no longer reachable via tracing and free them before we can
-    // actually try to access the held resolver.
+    // GC visitation is an intentional no-op for the queue/consumer implementation.
+    // The queue is held behind ownership barriers (kj::Own/kj::Rc) and is not
+    // reliably re-visited after those owners move, so every JS handle it holds
+    // (queued values, errors, read-request resolvers) is kept as a strong root
+    // until the queue drops it.
   }
 
   inline kj::StringPtr jsgGetMemoryName() const;
@@ -748,7 +742,11 @@ class ValueQueue final {
 
     size_t getSize() const;
 
-    void visitForGc(jsg::GcVisitor& visitor);
+    void visitForGc(jsg::GcVisitor& visitor) {
+      // GC visitation is an intentional no-op for Entry: it is shared via
+      // kj::Rc (an ownership barrier) and would not be reliably re-visited
+      // after the owner moves, so `value` is kept as a strong root.
+    }
 
     kj::Rc<Entry> clone(jsg::Lock& js);
 
@@ -757,7 +755,8 @@ class ValueQueue final {
     }
 
    private:
-    jsg::JsRef<jsg::JsValue> value;
+    // Intentionally not visited by visitForGc: Entry is not reachable from JS;
+    jsg::JsRef<jsg::JsValue> value;  // NOLINT(jsg-visit-for-gc)
     size_t size;
   };
 
@@ -814,7 +813,9 @@ class ValueQueue final {
     bool hasPendingDrainingRead();
     void cancelPendingReads(jsg::Lock& js, jsg::JsValue reason);
 
-    void visitForGc(jsg::GcVisitor& visitor);
+    void visitForGc(jsg::GcVisitor& visitor) {
+      // GC visitation is an intentional no-op for the consumer implementation.
+    }
 
     inline kj::StringPtr jsgGetMemoryName() const;
     inline size_t jsgGetMemorySelfSize() const;
@@ -846,7 +847,9 @@ class ValueQueue final {
 
   bool hasPartiallyFulfilledRead();
 
-  void visitForGc(jsg::GcVisitor& visitor);
+  void visitForGc(jsg::GcVisitor& visitor) {
+    // GC visitation is an intentional no-op for the queue implementation.
+  }
 
   inline kj::StringPtr jsgGetMemoryName() const;
   inline size_t jsgGetMemorySelfSize() const;
@@ -996,7 +999,11 @@ class ByteQueue final {
 
     size_t getSize() const;
 
-    void visitForGc(jsg::GcVisitor& visitor);
+    void visitForGc(jsg::GcVisitor& visitor) {
+      // GC visitation is an intentional no-op for Entry: it is shared via
+      // kj::Rc (an ownership barrier) and would not be reliably re-visited
+      // after the owner moves, so `store` is kept as a strong root.
+    }
 
     kj::Rc<Entry> clone(jsg::Lock& js);
 
@@ -1069,7 +1076,9 @@ class ByteQueue final {
     bool hasPendingDrainingRead();
     void cancelPendingReads(jsg::Lock& js, jsg::JsValue reason);
 
-    void visitForGc(jsg::GcVisitor& visitor);
+    void visitForGc(jsg::GcVisitor& visitor) {
+      // GC visitation is an intentional no-op for the consumer implementation.
+    }
 
     inline kj::StringPtr jsgGetMemoryName() const;
     inline size_t jsgGetMemorySelfSize() const;
@@ -1109,7 +1118,9 @@ class ByteQueue final {
   // will be disconnected as appropriate.
   kj::Maybe<kj::Own<ByobRequest>> nextPendingByobReadRequest();
 
-  void visitForGc(jsg::GcVisitor& visitor);
+  void visitForGc(jsg::GcVisitor& visitor) {
+    // GC visitation is an intentional no-op for the queue implementation.
+  }
 
   inline kj::StringPtr jsgGetMemoryName() const;
   inline size_t jsgGetMemorySelfSize() const;

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -1857,11 +1857,8 @@ struct ValueReadable final: public kj::PtrTarget,
     }
   }
 
-  void visitForGc(jsg::GcVisitor& visitor) {
-    KJ_IF_SOME(s, state) {
-      visitor.visit(s.controller, *s.consumer);
-    }
-  }
+  // No visitForGc: ValueReadable lives behind a kj::Own (an ownership
+  // barrier), so its controller ref and consumer handles are strong roots.
 
   ValueReadable(DefaultController controller, ReadableStreamJsController& owner)
       : state(State(kj::mv(controller), addWeakToThis(), owner)) {}
@@ -2053,11 +2050,8 @@ struct ByteReadable final: public kj::PtrTarget,
     }
   }
 
-  void visitForGc(jsg::GcVisitor& visitor) {
-    KJ_IF_SOME(s, state) {
-      visitor.visit(s.controller, *s.consumer);
-    }
-  }
+  // No visitForGc: ByteReadable lives behind a kj::Own (an ownership
+  // barrier), so its controller ref and consumer handles are strong roots.
 
   ByteReadable(ByobController controller,
       ReadableStreamJsController& owner,
@@ -3218,21 +3212,17 @@ void ReadableStreamJsController::visitForGc(jsg::GcVisitor& visitor) {
     visitor.visit(pendingError);
   }
 
-  // Note: We cannot use state.visitForGc(visitor) here because the state machine's
-  // visitForGc passes kj::Own<T>& to visitor.visit(), but GcVisitor expects T& for
-  // types with visitForGc methods. We must dereference kj::Own manually.
+  // The kj::Own<ValueReadable>/kj::Own<ByteReadable> states are intentionally
+  // not visited: kj::Own is an ownership barrier, so the readable's JSG
+  // handles are held as strong roots until the state is dropped.
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(initial, Initial) {}
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {}
     KJ_CASE_ONEOF(error, StreamStates::Errored) {
       visitor.visit(error);
     }
-    KJ_CASE_ONEOF(consumer, kj::Own<ValueReadable>) {
-      visitor.visit(*consumer);
-    }
-    KJ_CASE_ONEOF(consumer, kj::Own<ByteReadable>) {
-      visitor.visit(*consumer);
-    }
+    KJ_CASE_ONEOF(consumer, kj::Own<ValueReadable>) {}
+    KJ_CASE_ONEOF(consumer, kj::Own<ByteReadable>) {}
   }
   visitor.visit(lock);
 }

--- a/src/workerd/jsg/AGENTS.md
+++ b/src/workerd/jsg/AGENTS.md
@@ -94,12 +94,21 @@ These rules MUST be followed when writing or modifying JSG code:
 10. **Prefer `JSG_PROTOTYPE_PROPERTY`** over `JSG_INSTANCE_PROPERTY` unless there's a
     specific reason — instance properties break GC optimization
 11. **Use `// NOLINT(jsg-visit-for-gc)` to document intentional non-visits.** When a
-    GC-visitable field intentionally is not visited (e.g., a `kj::Rc`-owned object
-    unreachable from JS, or a type visited via a different mechanism), suppress the
-    `jsg-visit-for-gc` clang-tidy diagnostic with a `// NOLINT(jsg-visit-for-gc)`
-    comment and a brief explanation of *why* it's safe to skip.
+    GC-visitable field intentionally is not visited (e.g., a field of a `kj::Rc`-shared
+    object held as a strong root), suppress the `jsg-visit-for-gc` clang-tidy
+    diagnostic with a `// NOLINT(jsg-visit-for-gc)` comment and a brief explanation
+    of *why* it's safe to skip.
 
-12. **Module evaluation MUST NOT drain the microtask queue while nested.** Draining
+12. **`kj::Own`/`kj::Rc`/`kj::Arc` are GC traversal barriers.** An object behind an
+    owning pointer is not reliably re-visited after the owner moves, so a handle it
+    holds that was visited (marked weak) can be collected while the object is still
+    alive. Never trace through a barrier (`visitor.visit(*owned)`,
+    `visitor.visit(owned->field)`, `owned->visitForGc(visitor)`); JSG handles behind
+    a barrier stay strong until their owner drops them. This trades collectability
+    for correctness: a JS-visible cycle through a barrier-held object will not be
+    collected, so keep such ownership chains cycle-free.
+
+13. **Module evaluation MUST NOT drain the microtask queue while nested.** Draining
     while an ancestor module is still `kEvaluating` can run an async module's
     fulfillment callback early and trip a fatal V8 CHECK
     (`status() >= kEvaluatingAsync`). Evaluation depth is tracked by the RAII
@@ -112,8 +121,9 @@ These rules MUST be followed when writing or modifying JSG code:
     pending evaluation promise instead of an error.
 
 The `jsg-visit-for-gc` clang-tidy check (`//tools/clang-tidy:workerd-lint`)
-automatically detects missing `visitForGc` implementations and unvisited fields
-across the codebase, enforcing invariants 1 and 2 at build time.
+automatically detects missing `visitForGc` implementations, unvisited fields, and
+visitation that reaches through an ownership barrier, enforcing invariants 1, 2,
+and 12 at build time.
 
 ## CODE REVIEW RULE
 

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -250,6 +250,15 @@ This is intentionally weak and does NOT keep its target alive during GC.
 Attempting to `visitor.visit()` a weak ref field is a compile error — the correct
 signal that weak references should not be traced. Do not include them in `visitForGc()`.
 
+**Ownership barriers**: `kj::Own<T>`, `kj::Rc<T>`, and `kj::Arc<T>`.
+An object behind an owning pointer is not reliably re-visited after the owner
+moves, so a handle it holds that was visited (marked weak) can be collected while
+the object is still alive. Never trace through a barrier
+(`visitor.visit(*owned)`, `visitor.visit(owned->field)`,
+`owned->visitForGc(visitor)`); JSG handles behind a barrier are held as strong
+roots until their owner drops them. The `jsg-visit-for-gc` clang-tidy check
+enforces this.
+
 ## Weak References
 
 `jsg::WeakRef<T>` provides a non-owning, automatically-invalidated reference

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1849,6 +1849,8 @@ class Name final {
 
   kj::String toString(jsg::Lock& js);
 
+  void visitForGc(GcVisitor& visitor);
+
   JSG_MEMORY_INFO(Name) {
     KJ_SWITCH_ONEOF(inner) {
       KJ_CASE_ONEOF(str, kj::String) {
@@ -1867,9 +1869,6 @@ class Name final {
   kj::OneOf<kj::StringPtr, v8::Local<v8::Symbol>> getUnwrapped(v8::Isolate* isolate);
 
   friend class NameWrapper;
-
-  void visitForGc(GcVisitor& visitor);
-
   friend class MemoryTracker;
 };
 

--- a/tools/clang-tidy/BUILD.bazel
+++ b/tools/clang-tidy/BUILD.bazel
@@ -113,6 +113,22 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "visit-for-gc-test",
+    srcs = ["visit-for-gc-test.sh"],
+    data = [
+        ":visit-for-gc-negative-test.c++",
+        ":visit-for-gc-positive-test.c++",
+        ":workerd-lint",
+        "//tools:clang-tidy",
+    ],
+    tags = ["no-asan"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 # Tests the `custom-iocontext-run-manual-capture` query-based check, which is
 # defined in the workerd `.clang-tidy` config rather than in the plugin. The
 # test drives clang-tidy against the real merged config, so it does not need the

--- a/tools/clang-tidy/visit-for-gc-negative-test.c++
+++ b/tools/clang-tidy/visit-for-gc-negative-test.c++
@@ -1,0 +1,181 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Negative fixtures for the jsg-visit-for-gc check: nothing below may produce
+// a diagnostic. Self-contained stubs mirror the qualified names the check
+// keys on (jsg::Ref, jsg::Name, kj::Own, kj::Rc, kj::Arc, ...).
+
+namespace workerd::jsg {
+
+class GcVisitor;
+
+template <typename T>
+class Ref {
+ public:
+  void visitForGc(GcVisitor& visitor) {}
+};
+
+class Name {
+ public:
+  void visitForGc(GcVisitor& visitor) {}
+};
+
+template <typename T>
+class JsRef {
+ public:
+  void visitForGc(GcVisitor& visitor) {}
+};
+
+class JsValue {};
+
+class GcVisitor {
+ public:
+  template <typename... Args>
+  void visit(Args&&... args) {}
+  template <typename T>
+  void visitAll(T& collection) {}
+};
+
+class Object {
+ public:
+  void visitForGc(GcVisitor& visitor) {}
+};
+
+}  // namespace workerd::jsg
+
+namespace kj {
+
+template <typename T>
+class Maybe {};
+
+template <typename T>
+class Own {
+ public:
+  T& operator*() {
+    return *ptr;
+  }
+  T* operator->() {
+    return ptr;
+  }
+  T* get() {
+    return ptr;
+  }
+
+ private:
+  T* ptr = nullptr;
+};
+
+template <typename T>
+class Rc {
+ public:
+  T& operator*() {
+    return *ptr;
+  }
+  T* operator->() {
+    return ptr;
+  }
+
+ private:
+  T* ptr = nullptr;
+};
+
+template <typename T>
+class Arc {
+ public:
+  T& operator*() {
+    return *ptr;
+  }
+  T* operator->() {
+    return ptr;
+  }
+
+ private:
+  T* ptr = nullptr;
+};
+
+}  // namespace kj
+
+namespace jsg = workerd::jsg;
+
+struct Widget: public jsg::Object {};
+
+// Case 1: all visitable fields visited directly.
+struct AllVisited: public jsg::Object {
+  jsg::Ref<Widget> ref;
+  kj::Maybe<jsg::Ref<Widget>> maybeRef;
+  jsg::Name name;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(ref, maybeRef, name);
+  }
+};
+
+struct OwnedState {
+  jsg::Ref<Widget> ref;
+};
+
+struct SharedState {
+  jsg::JsRef<jsg::JsValue> value;
+};
+
+// Case 2: JSG handles behind kj::Own/kj::Rc/kj::Arc are ownership barriers.
+// They are held as strong (unvisited) roots; not visiting them is correct and
+// must not be diagnosed, including when wrapped in kj::Maybe.
+struct BarriersNotVisited: public jsg::Object {
+  kj::Own<OwnedState> owned;
+  kj::Rc<SharedState> shared;
+  kj::Arc<SharedState> atomicShared;
+  kj::Maybe<kj::Own<OwnedState>> maybeOwned;
+
+  void visitForGc(jsg::GcVisitor& visitor) {}
+};
+
+struct NestedState {
+  jsg::Ref<Widget> func;
+};
+
+// Case 3: a parent's visitForGc may reach into a directly-held (non-barrier)
+// nested struct member.
+struct ParentReachesNested: public jsg::Object {
+  NestedState state;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(state.func);
+  }
+};
+
+// Case 4: non-barrier deref arguments are fine (e.g. plain struct accessor
+// results); only kj::Own/kj::Rc/kj::Arc derefs are barriers.
+struct HolderByValue {
+  NestedState inner;
+  NestedState& get() {
+    return inner;
+  }
+};
+
+struct VisitThroughPlainAccessor: public jsg::Object {
+  HolderByValue holder;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(holder.get().func);
+  }
+};
+
+struct DelegatingState {
+  jsg::Ref<Widget> func;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(func);
+  }
+};
+
+// Case 5: delegating to a directly-held member's visitForGc is fine; only
+// delegation through a barrier is diagnosed.
+struct DelegateToDirectMember: public jsg::Object {
+  DelegatingState state;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    state.visitForGc(visitor);
+  }
+};

--- a/tools/clang-tidy/visit-for-gc-positive-test.c++
+++ b/tools/clang-tidy/visit-for-gc-positive-test.c++
@@ -1,0 +1,180 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Positive fixtures for the jsg-visit-for-gc check: every case below must
+// produce a diagnostic. Self-contained stubs mirror the qualified names the
+// check keys on (jsg::Ref, jsg::Name, kj::Own, kj::Rc, kj::Arc, ...).
+
+namespace workerd::jsg {
+
+class GcVisitor;
+
+template <typename T>
+class Ref {
+ public:
+  void visitForGc(GcVisitor& visitor) {}
+};
+
+class Name {
+ public:
+  void visitForGc(GcVisitor& visitor) {}
+};
+
+template <typename T>
+class JsRef {
+ public:
+  void visitForGc(GcVisitor& visitor) {}
+};
+
+class JsValue {};
+
+class GcVisitor {
+ public:
+  template <typename... Args>
+  void visit(Args&&... args) {}
+  template <typename T>
+  void visitAll(T& collection) {}
+};
+
+class Object {
+ public:
+  void visitForGc(GcVisitor& visitor) {}
+};
+
+}  // namespace workerd::jsg
+
+namespace kj {
+
+template <typename T>
+class Own {
+ public:
+  T& operator*() {
+    return *ptr;
+  }
+  T* operator->() {
+    return ptr;
+  }
+  T* get() {
+    return ptr;
+  }
+
+ private:
+  T* ptr = nullptr;
+};
+
+template <typename T>
+class Rc {
+ public:
+  T& operator*() {
+    return *ptr;
+  }
+  T* operator->() {
+    return ptr;
+  }
+  T* get() {
+    return ptr;
+  }
+
+ private:
+  T* ptr = nullptr;
+};
+
+template <typename T>
+class Arc {
+ public:
+  T& operator*() {
+    return *ptr;
+  }
+  T* operator->() {
+    return ptr;
+  }
+
+ private:
+  T* ptr = nullptr;
+};
+
+}  // namespace kj
+
+namespace jsg = workerd::jsg;
+
+struct Widget: public jsg::Object {};
+
+// Case 1: resource type with a visitForGc that misses a jsg::Ref field.
+struct MissedRefField: public jsg::Object {
+  jsg::Ref<Widget> visited;
+  jsg::Ref<Widget> missed;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(visited);
+  }
+};
+
+// Case 2: resource type with an unvisited jsg::Name field. jsg::Name holds a
+// V8Ref<v8::Symbol> and is directly visitable.
+struct MissedNameField: public jsg::Object {
+  jsg::Name name;
+
+  void visitForGc(jsg::GcVisitor& visitor) {}
+};
+
+struct OwnedState {
+  jsg::Ref<Widget> ref;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(ref);
+  }
+};
+
+// Case 3: visiting through a dereferenced kj::Own. Ownership is a traversal
+// barrier: the owned object is not reliably re-visited after a move, so a
+// visited handle can be left weak and collected.
+struct VisitThroughOwnDeref: public jsg::Object {
+  kj::Own<OwnedState> state;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(*state);
+  }
+};
+
+struct SharedState {
+  jsg::JsRef<jsg::JsValue> value;
+};
+
+// Case 4: reaching a field through kj::Rc's operator->.
+struct VisitThroughRcArrow: public jsg::Object {
+  kj::Rc<SharedState> shared;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(shared->value);
+  }
+};
+
+// Case 5: reaching through kj::Arc in a non-first argument position.
+struct VisitThroughArcDeref: public jsg::Object {
+  jsg::Ref<Widget> direct;
+  kj::Arc<OwnedState> state;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(direct, *state);
+  }
+};
+
+// Case 6: reaching through kj::Own via get().
+struct VisitThroughOwnGet: public jsg::Object {
+  kj::Own<SharedState> owned;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    visitor.visit(owned.get()->value);
+  }
+};
+
+// Case 7: a direct visitForGc call through a barrier crosses it just the same
+// as visitor.visit(*owned).
+struct DirectVisitCallThroughOwn: public jsg::Object {
+  kj::Own<OwnedState> state;
+
+  void visitForGc(jsg::GcVisitor& visitor) {
+    state->visitForGc(visitor);
+  }
+};

--- a/tools/clang-tidy/visit-for-gc-test.sh
+++ b/tools/clang-tidy/visit-for-gc-test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2017-2026 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+set -euo pipefail
+
+readonly ROOT="${TEST_SRCDIR}/${TEST_WORKSPACE}"
+readonly CLANG_TIDY="${ROOT}/tools/clang_tidy"
+readonly PLUGIN="${ROOT}/tools/clang-tidy/libworkerd-lint.so"
+readonly POSITIVE="${ROOT}/tools/clang-tidy/visit-for-gc-positive-test.c++"
+readonly NEGATIVE="${ROOT}/tools/clang-tidy/visit-for-gc-negative-test.c++"
+readonly CHECKS="-*,jsg-visit-for-gc"
+
+set +e
+positive_output=$("${CLANG_TIDY}" "--load=${PLUGIN}" --checks="${CHECKS}" \
+  --warnings-as-errors='*' "${POSITIVE}" -- -std=c++23 2>&1)
+positive_status=$?
+set -e
+
+if [[ ${positive_status} -eq 0 ]]; then
+  printf '%s\n' "Expected jsg-visit-for-gc to reject the positive fixtures." >&2
+  printf '%s\n' "${positive_output}" >&2
+  exit 1
+fi
+
+expect_diag() {
+  local needle="$1"
+  local description="$2"
+  if [[ "${positive_output}" != *"${needle}"* ]]; then
+    printf 'Missing expected diagnostic (%s): %s\n' "${description}" "${needle}" >&2
+    printf '%s\n' "${positive_output}" >&2
+    exit 1
+  fi
+}
+
+expect_diag "field 'missed' of visitable type" "unvisited jsg::Ref field"
+expect_diag "field 'name' of visitable type" "unvisited jsg::Name field"
+expect_diag "ownership barrier 'kj::Rc'" "visit through kj::Rc operator->"
+expect_diag "ownership barrier 'kj::Arc'" "visit through kj::Arc deref"
+expect_diag "ownership barrier 'kj::Own'" "visit through kj::Own deref"
+
+own_count=$(grep -c "ownership barrier 'kj::Own'" <<<"${positive_output}")
+if [[ "${own_count}" -lt 3 ]]; then
+  printf 'Expected kj::Own barrier diagnostics for *own, own.get(), and own->visitForGc(); got %s\n' \
+    "${own_count}" >&2
+  printf '%s\n' "${positive_output}" >&2
+  exit 1
+fi
+
+negative_output=$("${CLANG_TIDY}" "--load=${PLUGIN}" --checks="${CHECKS}" \
+  --warnings-as-errors='*' "${NEGATIVE}" -- -std=c++23 2>&1)
+
+if [[ "${negative_output}" == *"jsg-visit-for-gc"* ]]; then
+  printf '%s\n' "Expected the negative fixtures to be accepted." >&2
+  printf '%s\n' "${negative_output}" >&2
+  exit 1
+fi

--- a/tools/clang-tidy/visit-for-gc.c++
+++ b/tools/clang-tidy/visit-for-gc.c++
@@ -63,6 +63,80 @@ const llvm::StringRef kAnyArgContainers[] = {
     "kj::OneOf",
 };
 
+// Ownership templates that act as GC traversal barriers. An object behind
+// kj::Own/kj::Rc/kj::Arc is not reliably re-visited after the owning pointer
+// moves: a handle it holds that was visited (and therefore marked weak) can be
+// collected while the object is still alive. JSG handles behind an ownership
+// barrier must be held as strong roots — fields of these types are never
+// visitable, and visitForGc bodies must not reach through them.
+const llvm::StringRef kBarrierTemplates[] = {
+    "kj::Own",
+    "kj::Rc",
+    "kj::Arc",
+};
+
+// Returns the matched barrier template name ("kj::Own" etc.) if `qt` is an
+// ownership barrier type; otherwise an empty StringRef.
+llvm::StringRef getBarrierTypeName(clang::QualType qt) {
+  if (qt.isNull()) return {};
+  qt = qt.getNonReferenceType().getUnqualifiedType();
+  const auto *rd = qt.getTypePtr()->getAsCXXRecordDecl();
+  if (!rd) return {};
+  auto fqn = rd->getQualifiedNameAsString();
+  for (auto suffix : kBarrierTemplates) {
+    if (endsWithQualified(fqn, suffix)) return suffix;
+  }
+  return {};
+}
+
+// Returns the barrier template name if `expr` unwraps an ownership barrier:
+// operator*/operator-> on a barrier type, or a .get() call on one.
+llvm::StringRef getBarrierDeref(const clang::Expr *expr) {
+  if (const auto *opCall = llvm::dyn_cast<clang::CXXOperatorCallExpr>(expr)) {
+    auto op = opCall->getOperator();
+    if ((op == clang::OO_Star || op == clang::OO_Arrow) && opCall->getNumArgs() >= 1) {
+      return getBarrierTypeName(opCall->getArg(0)->getType());
+    }
+    return {};
+  }
+  if (const auto *memberCall = llvm::dyn_cast<clang::CXXMemberCallExpr>(expr)) {
+    if (const auto *method = memberCall->getMethodDecl()) {
+      if (method->getNameAsString() == "get") {
+        return getBarrierTypeName(memberCall->getImplicitObjectArgument()->getType());
+      }
+    }
+  }
+  return {};
+}
+
+// True if the member-access chain leading to `memberExpr` reaches through an
+// ownership barrier (e.g. `owned->field`, `(*owned).field`,
+// `owned.get()->field`). Such an access must not count as GC coverage of the
+// field: the barrier diagnostic fires instead.
+bool baseCrossesBarrier(const clang::MemberExpr *memberExpr) {
+  const clang::Expr *e = memberExpr->getBase();
+  while (e != nullptr) {
+    e = e->IgnoreParenImpCasts();
+    if (const auto *inner = llvm::dyn_cast<clang::MemberExpr>(e)) {
+      e = inner->getBase();
+      continue;
+    }
+    return !getBarrierDeref(e).empty();
+  }
+  return false;
+}
+
+// True if `call` invokes jsg::GcVisitor::visit or ::visitAll.
+bool isGcVisitorVisitCall(const clang::CXXMemberCallExpr *call) {
+  const auto *method = call->getMethodDecl();
+  if (method == nullptr) return false;
+  auto name = method->getNameAsString();
+  if (name != "visit" && name != "visitAll") return false;
+  const auto *parent = method->getParent();
+  if (parent == nullptr) return false;
+  return endsWithQualified(parent->getQualifiedNameAsString(), "jsg::GcVisitor");
+}
+
 ContainerKind getContainerKind(llvm::StringRef qualifiedName) {
   for (auto suffix : kFirstArgContainers) {
     if (endsWithQualified(qualifiedName, suffix)) return ContainerKind::FirstArg;
@@ -98,6 +172,11 @@ bool isVisitableType(clang::QualType qt) {
   // Template specialization: dispatch on outer template name.
   std::string tmpl = getTemplateQualifiedName(qt);
   if (tmpl.empty()) return false;
+
+  // Ownership barriers stop the walk: handles behind them are strong roots.
+  for (auto suffix : kBarrierTemplates) {
+    if (endsWithQualified(tmpl, suffix)) return false;
+  }
 
   for (auto suffix : kVisitableLeafTemplates) {
     if (endsWithQualified(tmpl, suffix)) return true;
@@ -196,7 +275,8 @@ void VisitForGcCheck::onEndOfTranslationUnit() {
   if (!mainFile || !isImplFile(mainFile->getName())) return;
 
   // First pass: walk every visible visitForGc body to populate
-  // transitivelyVisitedFields_ and holderVisitForGcVisible_. This lets us
+  // transitivelyVisitedFields_ and holderVisitForGcVisible_, and to flag
+  // visits that reach through ownership barriers. This lets us
   // (a) recognize when a parent's visitForGc reaches into a nested struct
   // field, and (b) restrict "used-as-field" diagnostics to TUs where some
   // holder's body is actually parseable here.
@@ -211,6 +291,7 @@ void VisitForGcCheck::onEndOfTranslationUnit() {
       if (!method->isDefined(defn) || defn == nullptr) continue;
       llvm::DenseSet<const clang::FieldDecl *> unused;
       collectVisitedFields(defn->getBody(), unused);
+      flagBarrierCrossings(defn->getBody());
     }
   }
 
@@ -361,7 +442,10 @@ void VisitForGcCheck::collectVisitedFields(
 
   if (auto *memberExpr = llvm::dyn_cast<clang::MemberExpr>(stmt)) {
     auto *memberDecl = memberExpr->getMemberDecl();
-    if (auto *fieldDecl = llvm::dyn_cast<clang::FieldDecl>(memberDecl)) {
+    auto *fieldDecl = llvm::dyn_cast<clang::FieldDecl>(memberDecl);
+    // Accesses that reach through an ownership barrier do not count as GC
+    // coverage; flagBarrierCrossings diagnoses them instead.
+    if (fieldDecl != nullptr && !baseCrossesBarrier(memberExpr)) {
       if (isVisitableType(fieldDecl->getType())) {
         visitedFields.insert(fieldDecl->getCanonicalDecl());
       }
@@ -385,6 +469,48 @@ void VisitForGcCheck::collectVisitedFields(
 
   for (const auto *child : stmt->children()) {
     collectVisitedFields(child, visitedFields);
+  }
+}
+
+void VisitForGcCheck::flagBarrierCrossings(const clang::Stmt *stmt) {
+  if (!stmt) return;
+
+  if (const auto *call = llvm::dyn_cast<clang::CXXMemberCallExpr>(stmt)) {
+    if (isGcVisitorVisitCall(call)) {
+      for (const auto *arg : call->arguments()) {
+        flagBarrierDerefsIn(arg);
+      }
+    } else if (const auto *method = call->getMethodDecl();
+               method != nullptr && method->getNameAsString() == "visitForGc") {
+      // Direct `owned->visitForGc(visitor)` calls cross the barrier just the
+      // same as `visitor.visit(*owned)`.
+      flagBarrierDerefsIn(call->getImplicitObjectArgument());
+    }
+  }
+
+  for (const auto *child : stmt->children()) {
+    flagBarrierCrossings(child);
+  }
+}
+
+void VisitForGcCheck::flagBarrierDerefsIn(const clang::Stmt *stmt) {
+  if (!stmt) return;
+
+  if (const auto *expr = llvm::dyn_cast<clang::Expr>(stmt)) {
+    auto barrier = getBarrierDeref(expr);
+    if (!barrier.empty()) {
+      diag(expr->getExprLoc(),
+           "GC visitation reaches through ownership barrier '%0'; JSG handles "
+           "behind kj::Own/kj::Rc/kj::Arc must be held as strong roots, not "
+           "visited: the owned object is not re-visited after the owner moves, "
+           "so a visited handle can be left weak and collected while still in "
+           "use")
+          << barrier;
+    }
+  }
+
+  for (const auto *child : stmt->children()) {
+    flagBarrierDerefsIn(child);
   }
 }
 

--- a/tools/clang-tidy/visit-for-gc.h
+++ b/tools/clang-tidy/visit-for-gc.h
@@ -14,12 +14,22 @@ namespace clang_tidy {
 
 // Clang-tidy check that validates JSG resource types correctly visit their
 // GC roots. Flags fields of visitable types (jsg::Ref, jsg::V8Ref, jsg::JsRef,
-// jsg::Function, jsg::Promise, jsg::Value, etc., plus
+// jsg::Name, jsg::Function, jsg::Promise, jsg::Value, etc., plus
 // kj::Maybe/Array/Vector/OneOf and jsg::Optional wrappers thereof) that are
 // not visited in the class's visitForGc() method.
 //
+// kj::Own, kj::Rc, and kj::Arc are ownership barriers: an object behind one
+// is not reliably re-visited after the owning pointer moves, so a handle it
+// holds that was visited (marked weak) can be collected while the object is
+// still alive. JSG handles behind a barrier must be held as strong
+// (unvisited) roots. Fields of barrier types are therefore never visitable,
+// and visitForGc bodies that reach through a barrier (`visitor.visit(*owned)`,
+// `visitor.visit(owned->field)`, `visitor.visit(rc.get()->field)`) are
+// diagnosed.
+//
 // This check helps prevent GC-related bugs where JavaScript objects are
-// prematurely collected because the C++ side failed to mark them as reachable.
+// prematurely collected because the C++ side failed to mark them as reachable
+// (or marked them reachable through an unstable ownership path).
 class VisitForGcCheck : public clang::tidy::ClangTidyCheck {
  public:
   VisitForGcCheck(clang::StringRef Name, clang::tidy::ClangTidyContext *Context)
@@ -59,6 +69,11 @@ class VisitForGcCheck : public clang::tidy::ClangTidyCheck {
   void checkRecord(const clang::CXXRecordDecl *record);
   void collectVisitedFields(const clang::Stmt *stmt,
                             llvm::DenseSet<const clang::FieldDecl *> &visitedFields);
+
+  // Walks a visitForGc body and diagnoses GcVisitor::visit/visitAll arguments
+  // that reach through an ownership barrier (kj::Own/kj::Rc/kj::Arc).
+  void flagBarrierCrossings(const clang::Stmt *stmt);
+  void flagBarrierDerefsIn(const clang::Stmt *stmt);
 
   // True if `record` declares its own visitForGc method or transitively
   // inherits one.


### PR DESCRIPTION
This makes the `jsg-visit-for-gc` clang-tidy check ownership-aware: `kj::Own`, `kj::Rc`, and `kj::Arc` are now GC traversal barriers, and visitation that reaches through them is rejected. It also fixes the existing through-barrier tracing in the tree and corrects `jsg::Name`'s visitability.

An object behind an owning pointer is not reliably re-visited after the owner moves: a handle it holds that was visited (marked weak) can be collected while the object is still alive. This is the hazard originally described in the unlanded queue hardening (4ead165a9-era work on the internal side); the safe model is that JSG handles behind an ownership barrier stay strong roots until their owner drops them, trading collectability for correctness.

Lint changes:

* `kj::Own`/`kj::Rc`/`kj::Arc` fields are never visitable, explicitly
* new diagnostic for visitation crossing a barrier, in all four spellings: `visitor.visit(*owned)`, `visitor.visit(owned->field)`, `visitor.visit(owned.get()->field)`, and direct `owned->visitForGc(visitor)` calls
* barrier-crossing member accesses no longer count as coverage in the missing-visit analysis
* first regression fixtures for the check: positive/negative self-contained stubs driven by a `sh_test`, following the `consume-test` pattern

Violations fixed (the audit over `//src/workerd/api/... //src/workerd/jsg/...` is now clean):

* `queue.{h,c++}`: queue/consumer/entry visitation is now an intentional no-op; queued values, errors, and read-request resolvers stay strong until dropped
* `standard.c++`: `ReadableStreamJsController` no longer visits `*consumer` through its `kj::Own<ValueReadable>/kj::Own<ByteReadable>` states, and the readables no longer trace their controller ref and consumer
* `internal.{h,c++}`: removed `pipe->visitForGc(visitor)` through the `kj::Own<Pipe>` queue event — `Pipe::State` is refcounted and shared with `pipeLoop()` continuations that don't GC-trace
* `filesystem.h`: `FileSystemWritableFileStream` no longer visits `sharedState->file` through the `kj::Rc<State>` shared with sink callbacks

Separately, `jsg::Name` was documented and linted as directly visitable, but its `visitForGc` was private (friend-only) and nothing actually called it — the old `Channel::name` NOLINT comment attributed tracing to `NameWrapper`, which only converts values. `visitForGc` is now public so `Name` is genuinely visitable, and `Channel` visits its `name`.

Before:

```cpp
KJ_CASE_ONEOF(consumer, kj::Own<ValueReadable>) {
  visitor.visit(*consumer);  // handle marked weak; owner move loses re-visit
}
```

After:

```cpp
KJ_CASE_ONEOF(consumer, kj::Own<ValueReadable>) {}  // strong roots behind the barrier
```

Notably, once `ValueReadable`/`ByteReadable` lost their `visitForGc`, the old pattern becomes a compile error as well (no matching `GcVisitor::visit` overload), so the lint and the type system now agree.

Test coverage: new `//tools/clang-tidy:visit-for-gc-test` fixtures (7 positive, 5 negative cases); full clang-tidy audit clean over `api` + `jsg`; streams kj-tests, jsg tests, diagnostics-channel (incl. gc-stress), gc-tracing, and webfs tests all pass. The docs (`jsg/AGENTS.md` invariant 12, `jsg/README.md`, `build/AGENTS.md`) describe the barrier rule. A JS-visible cycle through a barrier-held object will no longer be collected — such ownership chains must stay cycle-free, which the deterministic C++ ownership already implies.
