### PR TITLE
[build] Assign more CPUs for link actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -341,6 +341,9 @@ build:linux --copt="-fdata-sections" --host_copt="-fdata-sections"
 
 # On Linux, use clang lld.
 build:linux --linkopt="-fuse-ld=lld"
+# Improve link performance by limiting the link stage to 8 threads – LLD link times see little if
+# any improvement beyond 8 threads (see https://reviews.llvm.org/D147493).
+build:linux --linkopt="-Wl,--threads=8"
 
 #
 # Windows

--- a/build/kj_test.bzl
+++ b/build/kj_test.bzl
@@ -23,7 +23,8 @@ def kj_test(
             "//conditions:default": 1,
         }),
         data = data,
-        tags = tags,
+        # Tag with cpu:4 since this target depends on linkopts_default.
+        tags = tags + ["cpu:4"],
         target_compatible_with = select({
             "@//build/config:no_build": ["@platforms//:incompatible"],
             "//conditions:default": [],

--- a/build/wd_cc_benchmark.bzl
+++ b/build/wd_cc_benchmark.bzl
@@ -30,7 +30,8 @@ def wd_cc_benchmark(
         ],
         # use the same malloc we use for server
         malloc = "//src/workerd/server:malloc",
-        tags = ["workerd-benchmark", "google_benchmark"] + tags,
+        # Tag with cpu:4 since this target depends on linkopts_default.
+        tags = ["workerd-benchmark", "google_benchmark", "cpu:4"] + tags,
         size = "large",
         **kwargs
     )

--- a/build/wd_cc_binary.bzl
+++ b/build/wd_cc_binary.bzl
@@ -6,6 +6,7 @@ def wd_cc_binary(
         name,
         visibility = None,
         deps = [],
+        tags = [],
         target_compatible_with = [],
         **kwargs):
     """Wrapper for cc_binary that sets common attributes
@@ -17,6 +18,8 @@ def wd_cc_binary(
             "//conditions:default": [],
         }) + target_compatible_with,
         visibility = visibility,
+        # Tag with cpu:8 since this target depends on linkopts_tool.
+        tags = tags + ["cpu:8"],
         deps = deps + ["//build/deps:linkopts_tool"],
         **kwargs
     )

--- a/build/wd_rust_binary.bzl
+++ b/build/wd_rust_binary.bzl
@@ -60,6 +60,8 @@ def wd_rust_binary(
         data = data,
         experimental_use_cc_common_link = 1,
         proc_macro_deps = proc_macro_deps,
+        # Tag with cpu:4 since this target depends on linkopts_default.
+        tags = tags + ["cpu:4"],
         target_compatible_with = select({
             "@//build/config:no_build": ["@platforms//:incompatible"],
             "//conditions:default": [],
@@ -83,5 +85,6 @@ def wd_rust_binary(
         experimental_use_cc_common_link = 1,
         link_deps = ["//build/deps:linkopts_default", "@@//deps:rust_runtime"],
         size = test_size,
-        tags = ["no-coverage"],
+        # Tag with cpu:4 since this target depends on linkopts_default.
+        tags = ["no-coverage", "cpu:4"],
     )

--- a/build/wd_rust_crate.bzl
+++ b/build/wd_rust_crate.bzl
@@ -162,7 +162,8 @@ def wd_rust_crate(
             "RUST_TEST_THREADS": "1",
         } | test_env,
         size = test_size,
-        tags = test_tags + ["no-coverage"],
+        # Tag with cpu:4 since this target depends on linkopts_default.
+        tags = test_tags + ["no-coverage", "cpu:4"],
         experimental_use_cc_common_link = 1,
         crate_features = crate_features,
         deps = test_deps,

--- a/build/wd_rust_proc_macro.bzl
+++ b/build/wd_rust_proc_macro.bzl
@@ -46,7 +46,8 @@ def wd_rust_proc_macro(
             "RUST_TEST_THREADS": "1",
         } | test_env,
         experimental_use_cc_common_link = 1,
-        tags = test_tags + ["no-coverage"],
+        # Tag with cpu:4 since this target depends on linkopts_default.
+        tags = test_tags + ["no-coverage", "cpu:4"],
         deps = test_deps,
         link_deps = ["@@//deps:rust_runtime", "//build/deps:linkopts_default"],
         target_compatible_with = select({


### PR DESCRIPTION
Starting with Bazel 9.2.0, we can indicate expected resource usage for non-test actions (see bazelbuild/bazel#29426). This can be useful for link actions, which lld runs in parallel by default. Reserve 4 or 8 CPUs for link actions. This change is primarily useful for the downstream build, but the workerd build will also benefit from having fewer CPU usage spikes due to trying to link too many targets at once.
Also limit lld's link parallelism since lld is slightly less efficient when linking with too many threads at once as discussed in https://reviews.llvm.org/D147493. Note that we deliberately apply a limit of 8 threads while only allocating 4 CPUs for most targets since lld usually doesn't reach the maximum allowed parallelism for long (i.e. average link CPU is expected to be well below 800%).

Clone of the now obsolete internal PR (!494)