### PR TITLE
kj-rs-tokio: a kj::EventPort driven by a per-thread tokio runtime

### DIFF
--- a/src/rust/cxx/AGENTS.md
+++ b/src/rust/cxx/AGENTS.md
@@ -33,6 +33,9 @@ Bazel module, Cargo workspace, toolchain configuration, or external `workerd-cxx
 - `src/` and `include/` — cxx Rust and C++ runtimes
 - `syntax/`, `gen/`, and `macro/` — bridge parser and code generators
 - `kj-rs/` — KJ promises/futures, exceptions, ownership, refcounting, dates, and `Maybe`
+- `kj-rs-tokio/` — `TokioEventPort`: a `kj::EventPort` backed by a per-thread tokio
+  `current_thread` runtime, plus `setupTokioAsyncIo()` (no I/O providers) and
+  `kj_rs_tokio::spawn()`
 - `tests/` and `kj-rs/tests/` — Rust and C++ bridge integration tests
 - `tools/bazel/` — Bazel bridge-generation macro used by this component's tests
 

--- a/src/rust/cxx/kj-rs-tokio/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-tokio/BUILD.bazel
@@ -1,0 +1,65 @@
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
+load("//:build/wd_rust_test.bzl", "wd_rust_test")
+load("//src/rust/cxx/tools/bazel:rust_cxx_bridge.bzl", "rust_cxx_bridge")
+
+wd_cc_library(
+    name = "kj-rs-tokio-lib",
+    srcs = glob(["*.c++"]),
+    hdrs = glob(["*.h"]),
+    include_prefix = "kj-rs-tokio",
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    strip_include_prefix = "/src/rust/cxx/kj-rs-tokio",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bridge",
+    ],
+)
+
+rust_library(
+    name = "kj-rs-tokio",
+    srcs = glob(["*.rs"]),
+    compile_data = glob(["*.h"]),
+    edition = "2024",
+    link_deps = [
+        ":bridge",
+        ":kj-rs-tokio-lib",
+    ],
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/rust/cxx",
+        "@crates_vendor//:tokio",
+    ],
+)
+
+wd_rust_test(
+    name = "kj-rs-tokio_test",
+    crate = "kj-rs-tokio",
+    edition = "2024",
+)
+
+rust_cxx_bridge(
+    name = "bridge",
+    src = "ffi.rs",
+    hdrs = glob(["*.h"]),
+    include_prefix = "kj-rs-tokio",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj:kj",
+        # kj-rs-tokio only needs the abstract async core (Promise / EventLoop / EventPort /
+        # Timer) to build the tokio-backed EventPort; it uses neither the abstract kj streams
+        # (:kj-async-io) nor the OS event loop (setupAsyncIo / UnixEventPort). Depending on
+        # :kj-async-core (not the :kj-async umbrella) keeps the tokio event loop off the
+        # concrete kj OS I/O layer (:kj-async-os), which the workerd rust-io hermeticity aspect
+        # forbids.
+        "@capnp-cpp//src/kj:kj-async-core",
+        "//src/rust/cxx:core",
+    ],
+)

--- a/src/rust/cxx/kj-rs-tokio/ffi.rs
+++ b/src/rust/cxx/kj-rs-tokio/ffi.rs
@@ -1,0 +1,146 @@
+//! The `#[cxx::bridge]` FFI island for kj-rs-tokio.
+//!
+//! This is the crate's single dedicated FFI-island file (file-top `#![allow(unsafe_code)]`). It
+//! holds the `#[cxx::bridge] mod bridge` -- the C++ <-> Rust wire the C++
+//! `kj_rs_tokio::TokioEventPort` drives (see `tokio-event-port.h`) -- and [`EnteredRuntime`], the
+//! one hand-written `unsafe` in the crate (a lifetime extension on tokio's `EnterGuard`).
+//! Everything else -- `lib.rs` and the entire event-port business logic in `port.rs` -- is
+//! wholly-safe, compiler-proven unsafe-free under the crate-root `#![deny(unsafe_code)]`.
+#![allow(unsafe_code)]
+
+use std::mem::ManuallyDrop;
+use std::ops::Deref;
+
+use tokio::runtime::EnterGuard;
+use tokio::runtime::Runtime;
+
+use crate::port::TokioPort;
+use crate::port::new_tokio_port;
+
+struct TokioContextSentinel;
+
+impl Drop for TokioContextSentinel {
+    fn drop(&mut self) {}
+}
+
+thread_local! {
+    // Initialized after Tokio's context TLS. During thread teardown this sentinel is therefore
+    // destroyed first, making `try_with()` a reliable guard against touching Tokio's context
+    // after its destructor has run.
+    static TOKIO_CONTEXT_SENTINEL: TokioContextSentinel = const { TokioContextSentinel };
+}
+
+/// A tokio runtime whose context is entered on the owning thread for the runtime's whole life.
+///
+/// The KJ event loop turns its events *outside* `block_on` (only `wait()`/`poll()` are inside),
+/// yet code running in those turns -- bridged futures being polled, C++ calling into kj-rs-io --
+/// creates tokio resources (`TcpStream::from_std`, `AsyncFd`, `signal()`, timers) that must be
+/// registered with this runtime's drivers. tokio finds the runtime through the thread's current
+/// context, so without this the loop thread would have to re-enter the context around every
+/// single poll of every I/O future (a TLS swap plus an `Arc` clone each time) and around every
+/// synchronous resource creation. Entering once for the thread's lifetime removes all of that:
+/// `Handle::current()` on the loop thread is this runtime, always. `block_on` still works
+/// underneath (`Handle::enter` sets only the current handle, not the "inside a runtime" flag
+/// that `block_on` checks for nesting).
+///
+/// This is the one self-referential pair in the crate: `EnterGuard<'a>` borrows the `Runtime`
+/// it came from, but only nominally -- its `'a` is a `PhantomData<&'a Handle>`; the guard holds
+/// no pointer into the runtime and its `Drop` only restores the thread's previous context. We
+/// extend the lifetime to `'static` and guarantee by construction (a manual `Drop`) that the
+/// guard is dropped before the runtime. Like the guard it wraps, this type is `!Send` (the
+/// context must be left on the thread that entered it) and `Sync`.
+pub struct EnteredRuntime {
+    // Dropped first, explicitly, in `Drop::drop`; declared first as documentation of that order.
+    guard: ManuallyDrop<EnterGuard<'static>>,
+    runtime: ManuallyDrop<Runtime>,
+}
+
+impl EnteredRuntime {
+    pub fn new(runtime: Runtime) -> Self {
+        let guard: EnterGuard<'_> = runtime.enter();
+        TOKIO_CONTEXT_SENTINEL.with(|_| {});
+        // SAFETY: `EnterGuard<'a>`'s lifetime parameter exists only as `PhantomData<&'a Handle>`
+        // (tokio `runtime/handle.rs`); the guard stores no reference or pointer into the runtime,
+        // and its `Drop` touches only thread-local context state. Extending `'a` therefore cannot
+        // create a dangling access. We additionally uphold the *intent* of the borrow -- the
+        // guard does not outlive the runtime -- by dropping `guard` before `runtime` in `Drop`.
+        let guard: EnterGuard<'static> =
+            unsafe { std::mem::transmute::<EnterGuard<'_>, EnterGuard<'static>>(guard) };
+        Self {
+            guard: ManuallyDrop::new(guard),
+            runtime: ManuallyDrop::new(runtime),
+        }
+    }
+}
+
+impl Deref for EnteredRuntime {
+    type Target = Runtime;
+    fn deref(&self) -> &Runtime {
+        &self.runtime
+    }
+}
+
+impl Drop for EnteredRuntime {
+    fn drop(&mut self) {
+        // SAFETY: `guard` is initialized (constructed in `new`, never taken out) and this is the
+        // only place it is dropped -- `Drop::drop` runs exactly once. It must go before `runtime`
+        // (which the compiler drops right after this body), restoring the thread's previous
+        // tokio context while the runtime it referred to is still alive.
+        if TOKIO_CONTEXT_SENTINEL.try_with(|_| {}).is_ok() {
+            // SAFETY: The sentinel proves Tokio's thread-local context is still available.
+            unsafe { ManuallyDrop::drop(&mut self.guard) };
+        }
+        // SAFETY: `runtime` is initialized in `new`, never taken elsewhere, and this `Drop`
+        // implementation runs once. Background shutdown cancels async work without waiting
+        // indefinitely for user-submitted blocking tasks.
+        let runtime = unsafe { ManuallyDrop::take(&mut self.runtime) };
+        runtime.shutdown_background();
+    }
+}
+
+#[cxx::bridge(namespace = "kj_rs_tokio")]
+// FFI island: the cxx bridge macro generates the `unsafe` extern shims.
+// unnecessary_box_returns: returning the opaque `TokioPort` to C++ boxed is the cxx idiom. The
+// lint's firing is platform-dependent (it has a size threshold and `TokioPort`'s size differs by
+// target), so `#[expect]` would be unfulfilled on some targets.
+#[expect(clippy::allow_attributes)]
+#[allow(clippy::unnecessary_box_returns)]
+mod bridge {
+    // None of these are `Result`: they cannot fail in a way C++ could handle. The panics that CAN
+    // occur -- a second port on one thread (`TokioPort::new`), a nested `block_on` from a task
+    // that re-entered `promise.wait()` (`wait_*`/`poll`), the LocalSet slot being gone -- are
+    // caller-contract violations, and the in-tree cxx fork converts every panic escaping an
+    // `extern "Rust"` fn into a `kj::Exception` thrown at the C++ call site.
+    extern "Rust" {
+        type TokioPort;
+
+        fn new_tokio_port() -> Box<TokioPort>;
+
+        /// Cancel every task spawned onto this thread's `LocalSet` (dropping their state now, on
+        /// this thread). `TokioEventPort`'s destructor calls this before destroying the KJ event
+        /// loop and timer it owns, because spawned tasks may own KJ promises. This terminal
+        /// operation is a no-op when repeated; the port must not be driven afterward.
+        fn cancel_spawned_tasks(&self);
+
+        /// Block until `wake()` or `notify_kj_service()` is called, running tokio tasks in the
+        /// meantime. Returns the wake latch (see `TokioPort::take_wake_latch`).
+        fn wait_forever(&self) -> bool;
+
+        /// Like `wait_forever`, but additionally returns after `timeout_ns` nanoseconds. The
+        /// C++ side computes the timeout from `kj::TimerImpl::timeoutToNextEvent()`.
+        fn wait_timeout_ns(&self, timeout_ns: u64) -> bool;
+
+        /// Non-blocking: let the tokio scheduler run already-ready tasks for a bounded number of
+        /// turns. Never sleeps. Returns the wake latch.
+        fn poll(&self) -> bool;
+
+        /// Set the wake latch and unblock a concurrent `wait_*`. Callable from any thread.
+        fn wake(&self);
+
+        /// Loop thread only: KJ has told the port it needs the thread back -- through
+        /// `EventPort::setRunnable(true)` (an event was armed) or through the port's
+        /// `TimerImpl::SleepHooks` (a sooner timer was armed while sleeping). Unblocks a
+        /// concurrent `wait_*` without setting the wake latch; a no-op outside `wait_*`.
+        fn notify_kj_service(&self);
+    }
+}

--- a/src/rust/cxx/kj-rs-tokio/lib.rs
+++ b/src/rust/cxx/kj-rs-tokio/lib.rs
@@ -1,0 +1,46 @@
+//! Rust half of the tokio-backed KJ event loop foundation.
+//!
+//! This crate owns a per-thread tokio `current_thread` runtime and exposes the primitives the
+//! C++ `kj_rs_tokio::TokioEventPort` (see `tokio-event-port.h` for the full contract) needs to
+//! implement `kj::EventPort`: parking the thread in `Runtime::block_on` (which drives the
+//! whole tokio scheduler while C++ is "blocked"), a bounded non-blocking `poll`, and the
+//! cross-thread `wake()` latch that `kj::Executor` and
+//! `kj::newPromiseAndCrossThreadFulfiller` depend on, and the `notify_kj_service` entry point KJ
+//! reaches (via `setRunnable(true)` / the port's `TimerImpl::SleepHooks`) to hand the thread
+//! back whenever a tokio task has queued KJ work.
+
+// Safety & panic enforcement walls. Test code exempted.
+//
+// `unsafe` is quarantined into a single named FFI island: the crate root denies `unsafe_code`, so
+// the entire event-port business logic (`TokioPort`, the `wait`/`poll`/`wake` machinery) is
+// *compiler-proven* to contain no hand-written unsafe. The one island that opts back in
+// via `#![allow(unsafe_code)]` is `ffi.rs`: the `#[cxx::bridge]` wire.
+#![deny(unsafe_op_in_unsafe_fn)]
+#![deny(unsafe_code)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::todo,
+    clippy::unimplemented
+)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
+
+pub use port::TokioPort;
+pub use port::current_handle;
+pub use port::spawn;
+
+mod ffi;
+mod port;

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -1,0 +1,641 @@
+//! Per-thread tokio `current_thread` runtime management and the Rust half of `TokioEventPort`.
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use tokio::runtime::Builder;
+use tokio::runtime::Handle;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tokio::task::LocalSet;
+
+use crate::ffi::EnteredRuntime;
+
+/// How many bounded yield points `poll()` grants the runtime. This gives ready work opportunities
+/// to run without promising an ordering or an exact number of task or driver polls, which are
+/// Tokio scheduler implementation details.
+///
+/// The value is a latency/throughput compromise, not derived from any tokio internal: large
+/// enough to drain a typical burst of already-ready tasks in one `poll()` call, small enough to
+/// bound how long `poll()` withholds control from the KJ loop when spawned tasks keep re-readying
+/// each other. Safe to retune if profiling shows either starvation or excessive poll latency.
+const POLL_YIELD_BUDGET: u32 = 16;
+
+thread_local! {
+    /// Handle to the `TokioPort` runtime driving the KJ event loop on this thread, if any.
+    /// Registered by `TokioPort::new` and cleared on drop. Used by code (e.g. kj-rs-io) that
+    /// needs to *enter* the runtime context so tokio resources can register with its I/O driver
+    /// and timers.
+    static LOOP_RUNTIME_HANDLE: RefCell<Option<Handle>> = const { RefCell::new(None) };
+
+    /// The `LocalSet` onto which [`spawn`] enqueues tasks, and which `wait_*`/`poll` drive. Held
+    /// behind an `Rc` so `spawn` (which has no `&TokioPort`) can reach it while the port keeps
+    /// driving it. The `LocalSet` is `!Send`/`!Sync` and lives entirely on the loop thread, so it
+    /// cannot be stored in the `Sync` TokioPort shared with cross-thread `wake()` callers;
+    /// ownership lives here. It is dropped -- cancelling every still-pending spawned
+    /// task -- by [`TokioPort::cancel_spawned_tasks`], which the C++ `TokioEventPort` destructor
+    /// calls while the KJ event loop and timer are still alive (spawned tasks may own KJ
+    /// promises), with `TokioPort::drop` as the fallback.
+    static LOOP_LOCAL_SET: RefCell<Option<Rc<LocalSet>>> = const { RefCell::new(None) };
+}
+
+/// Returns a handle to this thread's KJ-loop tokio runtime, if a `TokioEventPort` exists on this
+/// thread.
+#[must_use]
+pub fn current_handle() -> Option<Handle> {
+    LOOP_RUNTIME_HANDLE.with(|h| h.borrow().clone())
+}
+
+/// Returns this thread's KJ-loop `LocalSet`, if a `TokioEventPort` exists on this thread.
+fn current_local_set() -> Option<Rc<LocalSet>> {
+    LOOP_LOCAL_SET.with(|l| l.borrow().clone())
+}
+
+/// Spawns a future onto this thread's KJ-loop tokio runtime.
+///
+/// The task runs whenever the KJ event loop sleeps (i.e. whenever C++ is blocked in
+/// `promise.wait(waitScope)` or pumping via `poll()`), driven by the port's [`LocalSet`].
+///
+/// The future is spawned with [`LocalSet::spawn_local`], so it is pinned to this (the loop)
+/// thread and does **not** need to be `Send`: the per-thread `current_thread` runtime never
+/// migrates a task to another thread. This is what lets bridged futures that hold `!Send` KJ
+/// handles (`OwnPromiseNode`, `kj::Own`, ...) be spawned directly. Dropping the returned
+/// `JoinHandle` detaches the task, matching `tokio::spawn`; port teardown cancels detached tasks.
+///
+/// A spawned task may use KJ freely: complete bridged futures, fulfill `kj::PromiseFulfiller`s,
+/// arm KJ timers, create and await bridged promises. Every one of those either arms a KJ event,
+/// which KJ reports to the port through `EventPort::setRunnable(true)`, or moves the next KJ
+/// timer deadline, which KJ reports through the `TimerImpl::SleepHooks` the port installs while
+/// sleeping; either way the port ends the park. The one thing a task must not do is re-enter
+/// `promise.wait()` / `waitScope.poll()` on this thread: that nests `block_on` inside
+/// `block_on`, which tokio rejects (the panic surfaces as a `kj::Exception`).
+///
+/// # Panics
+///
+/// Panics if no `TokioEventPort` has been created on this thread.
+pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + 'static,
+    F::Output: 'static,
+{
+    #[expect(
+        clippy::expect_used,
+        reason = "documented `# Panics` on this public API: calling spawn() without first creating a TokioEventPort on this thread is a caller-contract violation, not a recoverable runtime path"
+    )]
+    let local = current_local_set()
+        .expect("no kj-rs-tokio runtime on this thread; create a TokioEventPort first");
+    local.spawn_local(future)
+}
+
+/// State shared with `wake()` callers on other threads.
+struct SharedState {
+    /// Unblocks the `block_on(...)` inside `wait_*` when `wake()` fires, or when KJ reports (via
+    /// `notify_kj_service`) that it has work.
+    notify: Notify,
+
+    /// The `kj::EventPort::wake()` latch: set by `wake()`, consumed (swapped to `false`) by the
+    /// return value of `wait_*`/`poll`. The KJ event loop uses a `true` return to know it must
+    /// drain cross-thread events (`kj::Executor`, `CrossThreadPromiseFulfiller`).
+    woken: AtomicBool,
+
+    /// True while the loop thread is inside `wait_*`'s `block_on`. `notify_kj_service` only acts
+    /// then: KJ also reports runnable transitions while it is turning events itself, and a permit
+    /// stored then would only make the next wait return spuriously once. Only mutated from the
+    /// loop thread; atomic so the struct stays `Sync`.
+    in_wait: AtomicBool,
+}
+
+/// The Rust backing of one `kj_rs_tokio::TokioEventPort` (C++): owns the per-thread
+/// `current_thread` tokio runtime.
+///
+/// The loop thread stays inside that runtime's context for the port's whole life (see
+/// [`EnteredRuntime`]): tokio resources created anywhere on the loop thread -- inside or outside
+/// `block_on` -- register with this runtime's drivers without any per-call `enter()`.
+///
+/// One instance per KJ event loop, created on (and driven by) that loop's thread. Only `wake()`
+/// may be called from other threads. `!Send` by type: the entered context must be left on the
+/// thread that entered it, which is also the only thread that may drive or drop the port.
+pub struct TokioPort {
+    runtime: EnteredRuntime,
+    state: Arc<SharedState>,
+    owner_thread: std::thread::ThreadId,
+}
+
+// `wake()` is called through a `&TokioPort` shared with arbitrary threads, so the type must be
+// `Sync` (`Runtime`, `Notify`, the atomics and the entered guard all are). It is deliberately
+// NOT `Send` (the guard is not), matching the one-thread contract above.
+const _: () = {
+    const fn assert_sync<T: Sync>() {}
+    assert_sync::<TokioPort>();
+};
+
+// Opaque cxx types must cross the bridge boxed. The lint's firing is platform-dependent (it has
+// a size threshold and `TokioPort`'s size differs by target), so `#[expect]` would be unfulfilled
+// on some targets.
+#[expect(clippy::allow_attributes)]
+#[allow(clippy::unnecessary_box_returns)]
+pub fn new_tokio_port() -> Box<TokioPort> {
+    Box::new(TokioPort::new())
+}
+
+impl TokioPort {
+    /// # Panics
+    ///
+    /// Panics if the tokio runtime cannot be built.
+    #[must_use]
+    pub fn new() -> Self {
+        let state = Arc::new(SharedState {
+            notify: Notify::new(),
+            woken: AtomicBool::new(false),
+            in_wait: AtomicBool::new(false),
+        });
+        #[expect(
+            clippy::expect_used,
+            reason = "startup-only: building the per-thread current_thread runtime fails only under resource exhaustion, at which point fail-fast at port construction is the correct behavior"
+        )]
+        let runtime = Builder::new_current_thread()
+            .enable_time()
+            // The I/O driver dispatches readiness for tokio sockets (used by kj-rs-io's
+            // tokio-backed KJ streams). It is only *driven* while this runtime is inside
+            // `block_on` (i.e. in `wait_*`/`poll`), which is exactly when the KJ loop sleeps.
+            .enable_io()
+            .build()
+            .expect("failed to build current_thread tokio runtime");
+        // Enter the runtime context for the life of the port (see EnteredRuntime): from here on,
+        // `Handle::current()` on this thread is this runtime.
+        let runtime = EnteredRuntime::new(runtime);
+        LOOP_RUNTIME_HANDLE.with(|h| {
+            let mut slot = h.borrow_mut();
+            assert!(
+                slot.is_none(),
+                "a kj-rs-tokio runtime already exists on this thread (one KJ event loop per \
+                 thread, hence one TokioEventPort per thread)"
+            );
+            *slot = Some(runtime.handle().clone());
+        });
+        // The `LocalSet` that `spawn()` enqueues onto and `wait_*`/`poll` drive. Owned by the
+        // thread-local (not by `TokioPort`, which must stay `Send + Sync`); dropped in `drop()`.
+        LOOP_LOCAL_SET.with(|l| {
+            *l.borrow_mut() = Some(Rc::new(LocalSet::new()));
+        });
+        Self {
+            runtime,
+            state,
+            owner_thread: std::thread::current().id(),
+        }
+    }
+
+    /// Handle to this port's runtime, usable to spawn tasks from any thread. (On the loop thread
+    /// itself `tokio::runtime::Handle::current()` is the same runtime; see [`EnteredRuntime`].)
+    #[must_use]
+    pub fn handle(&self) -> Handle {
+        self.runtime.handle().clone()
+    }
+
+    /// Cancels every task spawned onto this thread's `LocalSet` via [`spawn`], by dropping the
+    /// `LocalSet` (their `Drop` impls run synchronously, here, on the loop thread).
+    ///
+    /// Spawned tasks routinely own KJ objects -- a bridged `PromiseFuture` holds an
+    /// `OwnPromiseNode` and an armed `RustPromiseAwaiter` event; a KJ timer promise holds a
+    /// registration in the port's `kj::TimerImpl` -- and dropping those requires the KJ event
+    /// loop and timer to still exist. The C++ `TokioEventPort` owns both and calls this FIRST in
+    /// its destructor, before any member is destroyed, which makes the teardown order a
+    /// structural guarantee rather than a rule spawned tasks have to follow. This is a terminal
+    /// operation: repeated calls find nothing to do, but later spawn, wait, or poll operations are
+    /// invalid. A call from another thread is a no-op and never touches that caller's `LocalSet`.
+    ///
+    /// Tasks spawned with plain `tokio::spawn` onto the runtime are unaffected (they are
+    /// cancelled when the runtime drops); being `Send`, they cannot hold KJ objects
+    /// (`OwnPromiseNode` and friends are `!Send`), so their order relative to the loop does
+    /// not matter.
+    pub fn cancel_spawned_tasks(&self) {
+        if self.owner_thread != std::thread::current().id() {
+            return;
+        }
+        // Take the `Rc` out of the slot and drop it AFTER the borrow ends, so a cancelled
+        // task's `Drop` that itself borrows the slot does not hit a re-entrant-borrow panic.
+        // (A task `Drop` that tries to *spawn* during cancellation is unsupported: the slot is
+        // already `None`, so `spawn()` panics per its documented contract. Rescheduling from a
+        // destructor during teardown is not a sane pattern.)
+        let local_set = LOOP_LOCAL_SET
+            .try_with(|l| l.borrow_mut().take())
+            .ok()
+            .flatten();
+        drop(local_set);
+    }
+
+    pub(crate) fn wait_forever(&self) -> bool {
+        self.wait_impl(None)
+    }
+
+    pub(crate) fn wait_timeout_ns(&self, timeout_ns: u64) -> bool {
+        self.wait_impl(Some(Duration::from_nanos(timeout_ns)))
+    }
+
+    fn wait_impl(&self, timeout: Option<Duration>) -> bool {
+        let state = &self.state;
+
+        // This `block_on` is where tokio owns the thread: it drives *all* tasks — those spawned
+        // onto the port's `LocalSet` via `spawn()` (driven by `LocalSet::block_on`'s `run_until`)
+        // as well as any `tokio::spawn`ed tasks on the current_thread runtime — not just the
+        // future passed to it. Wake-up sources: `wake()` from another thread (with the `woken`
+        // latch set), KJ itself via `notify_kj_service` (a task in this very `block_on` armed a
+        // KJ event -- `EventPort::setRunnable(true)` -- or a sooner KJ timer -- the port's
+        // `TimerImpl::SleepHooks`), and the next KJ timer deadline via the tokio timer wheel.
+        // `Notify` stores a permit if `notify_one()` arrives before `notified()` is polled, so
+        // there is no lost-wakeup window; spurious early returns are explicitly allowed by the
+        // `kj::EventPort::wait()` contract.
+        #[expect(
+            clippy::expect_used,
+            reason = "TokioPort::new registers this thread's LocalSet; wait() only runs while this port drives its own thread, so the LocalSet is always present — absence is an unreachable internal invariant"
+        )]
+        let local =
+            current_local_set().expect("TokioPort is driving without a registered LocalSet");
+        state.in_wait.store(true, Ordering::Relaxed);
+        local.block_on(&self.runtime, async {
+            match timeout {
+                Some(t) => {
+                    let _ = tokio::time::timeout(t, state.notify.notified()).await;
+                }
+                None => state.notify.notified().await,
+            }
+        });
+        state.in_wait.store(false, Ordering::Relaxed);
+
+        self.take_wake_latch()
+    }
+
+    pub(crate) fn poll(&self) -> bool {
+        // Bounded, non-blocking pump: each yield gives ready LocalSet and runtime work an
+        // opportunity to run. Tokio does not guarantee exact scheduling order or driver-poll
+        // counts here, so only the number of yield attempts is part of this implementation.
+        #[expect(
+            clippy::expect_used,
+            reason = "TokioPort::new registers this thread's LocalSet; poll() only runs while this port drives its own thread, so the LocalSet is always present — absence is an unreachable internal invariant"
+        )]
+        let local =
+            current_local_set().expect("TokioPort is driving without a registered LocalSet");
+        local.block_on(&self.runtime, async {
+            for _ in 0..POLL_YIELD_BUDGET {
+                tokio::task::yield_now().await;
+            }
+        });
+        self.take_wake_latch()
+    }
+
+    pub(crate) fn wake(&self) {
+        self.state.woken.store(true, Ordering::SeqCst);
+        self.state.notify.notify_one();
+    }
+
+    /// See the bridge doc (ffi.rs): KJ has told the C++ port it has work (`setRunnable(true)`,
+    /// or a sooner timer through the port's `TimerImpl::SleepHooks`). Wake the `notified()`
+    /// future if we are parked in `wait_*`; a no-op otherwise.
+    pub(crate) fn notify_kj_service(&self) {
+        if self.state.in_wait.load(Ordering::Relaxed) {
+            self.state.notify.notify_one();
+        }
+    }
+
+    /// Consumes the wake latch: returns `true` iff `wake()` was called since the last `true`
+    /// return from `wait_*`/`poll`.
+    fn take_wake_latch(&self) -> bool {
+        self.state.woken.swap(false, Ordering::SeqCst)
+    }
+}
+
+impl Default for TokioPort {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for TokioPort {
+    fn drop(&mut self) {
+        // `try_with`, not `with`: a port owned by an object destroyed during thread/process
+        // teardown (e.g. under KJ_CLEAN_SHUTDOWN) can be dropped after this thread's Rust TLS
+        // destructors have already run, where `with` panics with an AccessError. If the TLS is
+        // gone, its values (including the LocalSet) were already dropped with it, so there is
+        // nothing left to clear.
+        let _ = LOOP_RUNTIME_HANDLE.try_with(|h| {
+            *h.borrow_mut() = None;
+        });
+        // Fallback cancellation of spawned tasks (normally already done, while the KJ loop was
+        // still alive, by the C++ `TokioEventPort` destructor -- see `cancel_spawned_tasks`). A
+        // bare `TokioPort` (Rust unit tests) reaches here with its tasks still pending.
+        self.cancel_spawned_tasks();
+        // Dropping `self.runtime` cancels any tasks spawned via `tokio::spawn` (as opposed to the
+        // LocalSet); those are `Send` and so cannot hold KJ objects.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    thread_local! {
+        static LATE_DROP_PORT: RefCell<Option<TokioPort>> = const { RefCell::new(None) };
+    }
+
+    #[test]
+    fn port_can_outlive_tokio_thread_locals() {
+        std::thread::spawn(|| {
+            // Initialize the holder before Tokio's context TLS. Thread-local values are dropped
+            // in reverse initialization order, so the stored port is destroyed after Tokio's
+            // context has already been torn down.
+            LATE_DROP_PORT.with(|holder| {
+                assert!(holder.borrow().is_none());
+            });
+            let port = TokioPort::new();
+            LATE_DROP_PORT.with(|holder| {
+                *holder.borrow_mut() = Some(port);
+            });
+        })
+        .join()
+        .expect("late TokioPort destruction must not panic");
+    }
+
+    #[test]
+    fn port_drop_does_not_wait_for_blocking_tasks() {
+        let port = TokioPort::new();
+        let release = Arc::new(AtomicBool::new(false));
+        let task_release = Arc::clone(&release);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        port.handle().spawn_blocking(move || {
+            started_tx.send(()).unwrap();
+            while !task_release.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            done_tx.send(()).unwrap();
+        });
+        started_rx.recv().unwrap();
+
+        let watchdog_release = Arc::clone(&release);
+        let watchdog = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(250));
+            watchdog_release.store(true, Ordering::SeqCst);
+        });
+        let start = std::time::Instant::now();
+        drop(port);
+        let elapsed = start.elapsed();
+        release.store(true, Ordering::SeqCst);
+        done_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        watchdog.join().unwrap();
+
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "port teardown waited for a blocking task: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn foreign_cancellation_does_not_cancel_the_callers_loop() {
+        let owner_port = TokioPort::new();
+        std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let caller_port = TokioPort::new();
+                    let ran = Arc::new(AtomicBool::new(false));
+                    let task_ran = Arc::clone(&ran);
+                    let _task = spawn(async move {
+                        task_ran.store(true, Ordering::SeqCst);
+                    });
+
+                    owner_port.cancel_spawned_tasks();
+                    assert!(!caller_port.poll());
+                    assert!(ran.load(Ordering::SeqCst));
+                })
+                .join()
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn bare_port_drop_cancels_spawned_tasks() {
+        // A TokioPort NOT owned by a TokioEventPort: dropping it must still cancel tasks
+        // spawned onto its LocalSet (the Drop fallback), and leave the thread clean so a fresh
+        // port can be created afterward.
+        {
+            let port = TokioPort::new();
+            drop(spawn(std::future::pending::<()>()));
+            assert!(current_handle().is_some());
+            drop(port);
+        }
+        // TLS is cleared: a new port on this thread succeeds (would panic-on-double-register
+        // otherwise).
+        assert!(current_handle().is_none());
+        let port2 = TokioPort::new();
+        assert!(current_handle().is_some());
+        drop(port2);
+    }
+
+    #[test]
+    fn concurrent_wake_storm_from_many_threads_terminates() {
+        // TSAN stressor for SharedState (notify + woken latch): four threads hammer wake()
+        // concurrently while the loop thread services wait_timeout_ns. The assertion is
+        // deliberately interleaving-agnostic -- it only requires termination and that at least
+        // one wake was observed -- because exact latch counts are inherently racy. (Scoped
+        // threads borrowing `&TokioPort`: the port is `Sync` but, by design, not `Send`.)
+        use std::sync::atomic::AtomicUsize;
+        let port = TokioPort::new();
+        let done = AtomicUsize::new(0);
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                scope.spawn(|| {
+                    for _ in 0..250 {
+                        port.wake();
+                    }
+                    done.fetch_add(1, Ordering::SeqCst);
+                });
+            }
+            let mut latched = 0u64;
+            loop {
+                if port.wait_timeout_ns(1_000_000) {
+                    latched += 1;
+                }
+                // Once every waker has finished, one more wait must eventually drain to `false`.
+                if done.load(Ordering::SeqCst) == 4 && !port.wait_timeout_ns(1_000_000) {
+                    break;
+                }
+            }
+            assert!(latched >= 1);
+        });
+    }
+
+    #[test]
+    fn handle_spawns_a_runtime_task_from_another_thread() {
+        // `handle()` + `tokio::spawn` (the runtime-driven path, distinct from spawn()/LocalSet)
+        // from a foreign thread: the Send task runs when the loop next drives block_on.
+        let port = TokioPort::new();
+        let flag = Arc::new(AtomicBool::new(false));
+        let handle = port.handle();
+        let f2 = Arc::clone(&flag);
+        std::thread::spawn(move || {
+            handle.spawn(async move {
+                f2.store(true, Ordering::SeqCst);
+            });
+        })
+        .join()
+        .unwrap();
+        let mut ran = false;
+        for _ in 0..1000 {
+            let _ = port.wait_timeout_ns(1_000_000);
+            if flag.load(Ordering::SeqCst) {
+                ran = true;
+                break;
+            }
+        }
+        assert!(ran);
+    }
+
+    #[test]
+    fn poll_advances_a_ready_local_task() {
+        // Complements poll_never_sleeps (pending task): a ready LocalSet task (no await) is
+        // actually driven to completion by poll() within its budget, and poll() never latches.
+        let port = TokioPort::new();
+        let flag = Arc::new(AtomicBool::new(false));
+        let f2 = Arc::clone(&flag);
+        let _jh = spawn(async move {
+            f2.store(true, Ordering::SeqCst);
+        });
+        let mut ran = false;
+        for _ in 0..10 {
+            assert!(!port.poll(), "poll() must not report a wake latch here");
+            if flag.load(Ordering::SeqCst) {
+                ran = true;
+                break;
+            }
+        }
+        assert!(ran);
+    }
+
+    #[test]
+    fn wake_latch_semantics() {
+        let port = TokioPort::new();
+        // No wake: a timed-out wait reports false.
+        assert!(!port.wait_timeout_ns(1_000_000));
+        // Wake before wait: latch is reported exactly once.
+        port.wake();
+        assert!(port.wait_timeout_ns(1_000_000));
+        assert!(!port.wait_timeout_ns(1_000_000));
+        // Wake is also consumed by poll().
+        port.wake();
+        assert!(port.poll());
+        assert!(!port.poll());
+    }
+
+    #[test]
+    fn wake_from_other_thread_unblocks_wait_forever() {
+        let port = TokioPort::new();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                std::thread::sleep(Duration::from_millis(10));
+                port.wake();
+            });
+            assert!(port.wait_forever());
+        });
+    }
+
+    /// The loop thread is inside the runtime's context for the port's whole life, so tokio
+    /// resources can be created outside `block_on` without any explicit `enter()`.
+    #[test]
+    fn loop_thread_is_permanently_in_the_runtime_context() {
+        assert!(tokio::runtime::Handle::try_current().is_err());
+        {
+            let port = TokioPort::new();
+            let current = tokio::runtime::Handle::try_current().expect("entered");
+            assert_eq!(current.id(), port.handle().id());
+            // A resource needing the I/O driver, created from plain sync code on this thread.
+            let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            std_listener.set_nonblocking(true).unwrap();
+            let _listener = tokio::net::TcpListener::from_std(std_listener).unwrap();
+        }
+        // Dropping the port leaves the context.
+        assert!(tokio::runtime::Handle::try_current().is_err());
+    }
+
+    #[test]
+    fn spawned_tasks_run_during_wait() {
+        let port = TokioPort::new();
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<u32>();
+        let mut jh = spawn(async move {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            tx.send(42).unwrap();
+        });
+        // The task only runs inside wait_impl's block_on.
+        let mut done = false;
+        for _ in 0..100 {
+            let _ = port.wait_timeout_ns(20_000_000);
+            if let Ok(v) = rx.try_recv() {
+                assert_eq!(v, 42);
+                done = true;
+                break;
+            }
+        }
+        assert!(done);
+        // The JoinHandle should complete promptly now.
+        port.runtime.block_on(&mut jh).unwrap();
+    }
+
+    #[test]
+    fn poll_never_sleeps() {
+        let port = TokioPort::new();
+        // A pending spawned task must not make poll() block.
+        let _jh = spawn(std::future::pending::<()>());
+        let start = std::time::Instant::now();
+        assert!(!port.poll());
+        assert!(start.elapsed() < Duration::from_millis(100));
+    }
+
+    /// `spawn` accepts `!Send` futures because it is backed by `LocalSet::spawn_local`. This
+    /// future holds an `Rc` — which is `!Send` — across an await point, exercising that path,
+    /// and proves such a task actually runs to completion on the loop thread.
+    #[test]
+    fn spawn_accepts_non_send_futures() {
+        use std::cell::Cell;
+        let port = TokioPort::new();
+        let counter = Rc::new(Cell::new(0u32));
+        let task_counter = Rc::clone(&counter);
+        // Detached on purpose; the `Rc` capture makes the future `!Send`.
+        let _jh = spawn(async move {
+            for _ in 0..3 {
+                tokio::task::yield_now().await;
+            }
+            task_counter.set(task_counter.get() + 1);
+        });
+        let mut done = false;
+        for _ in 0..100 {
+            let _ = port.wait_timeout_ns(1_000_000);
+            if counter.get() == 1 {
+                done = true;
+                break;
+            }
+        }
+        assert!(done, "non-Send spawned task did not run to completion");
+    }
+
+    /// Timed waits stay on tokio's timer wheel and remain accurate to its ~1 ms granularity --
+    /// the same granularity KJ's own epoll-based port has (`epoll_pwait` takes a millisecond
+    /// timeout).
+    #[test]
+    fn timeouts_are_accurate_to_the_wheel() {
+        let port = TokioPort::new();
+        let start = std::time::Instant::now();
+        let _ = port.wait_timeout_ns(20_000_000);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(19),
+            "woke early: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "woke far too late: {elapsed:?}"
+        );
+    }
+}

--- a/src/rust/cxx/kj-rs-tokio/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-tokio/tests/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//src/rust/cxx/tools/bazel:rust_cxx_bridge.bzl", "rust_cxx_bridge")
+
+rust_library(
+    name = "tests",
+    srcs = glob(["*.rs"]),
+    edition = "2024",
+    link_deps = [
+        ":bridge",
+    ],
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//src/rust/cxx",
+        "//src/rust/cxx/kj-rs",
+        "//src/rust/cxx/kj-rs-tokio",
+        "@crates_vendor//:tokio",
+    ],
+)
+
+rust_cxx_bridge(
+    name = "bridge",
+    src = "lib.rs",
+    hdrs = ["test-helpers.h"],
+    include_prefix = "kj-rs-tokio-test",
+    deps = [
+        "//src/rust/cxx/kj-rs",
+    ],
+)
+
+cc_test(
+    name = "tokio-event-port-test",
+    size = "medium",
+    srcs = [
+        "tokio-event-port-test.c++",
+    ],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":bridge",
+        ":tests",
+        "//src/rust/cxx/kj-rs-tokio:kj-rs-tokio-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/src/rust/cxx/kj-rs-tokio/tests/lib.rs
+++ b/src/rust/cxx/kj-rs-tokio/tests/lib.rs
@@ -1,0 +1,107 @@
+#![allow(clippy::unused_async)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::missing_panics_doc)]
+
+mod test_helpers;
+
+use test_helpers::completed_task_count;
+use test_helpers::has_loop_runtime_handle;
+use test_helpers::nested_wait_from_task;
+use test_helpers::spawn_detached_completing_task;
+use test_helpers::spawn_panicking_task;
+use test_helpers::spawn_pending_task;
+use test_helpers::spawn_task_awaiting_kj_never_promise;
+use test_helpers::spawn_task_holding_kj_timer;
+use test_helpers::spawn_task_on_runtime;
+use test_helpers::spawn_yield_loop_task;
+use test_helpers::std_thread_wake_future;
+use test_helpers::task_awaits_kj_timer;
+use test_helpers::task_fulfills_kj_fulfiller;
+use test_helpers::threaded_wake_future;
+use test_helpers::tokio_sleep_on_runtime;
+
+type Result<T> = std::io::Result<T>;
+type Error = std::io::Error;
+
+#[cxx::bridge(namespace = "kj_rs_tokio_test")]
+mod ffi {
+    extern "Rust" {
+        /// Spawns a task on this thread's KJ-loop tokio runtime which sleeps `delay_ms` (real
+        /// tokio time) and then produces `value`; awaits its `JoinHandle`. The returned future is
+        /// bridged to a `kj::Promise` by kj-rs and polled by the KJ event loop; the spawned task
+        /// itself only runs while the loop sleeps inside `TokioEventPort::wait()`/`poll()`.
+        async fn spawn_task_on_runtime(delay_ms: u64, value: u32) -> Result<u32>;
+
+        /// Spawns a `tokio::time::sleep` on the loop runtime and awaits it (via the task's
+        /// `JoinHandle`).
+        async fn tokio_sleep_on_runtime(delay_ms: u64) -> Result<()>;
+
+        /// A bridged Rust future that, on its first poll, spawns a task on the loop runtime which
+        /// sleeps ~10ms (real tokio time) and then wakes a clone of the future's waker. The wake
+        /// therefore arrives same-thread (the runtime is driven by the port on the loop thread),
+        /// exercising the future⇄promise bridge's asynchronous same-thread re-drive path.
+        async fn threaded_wake_future() -> Result<()>;
+
+        /// Detaches a never-completing task onto the loop runtime (for teardown testing: the
+        /// runtime must drop it cleanly when the port is destroyed).
+        fn spawn_pending_task();
+
+        /// Number of `spawn_task_on_runtime` tasks that ran to completion (process-wide).
+        fn completed_task_count() -> u64;
+
+        /// True if `kj_rs_tokio::current_handle()` finds a runtime on this thread.
+        fn has_loop_runtime_handle() -> bool;
+
+        /// Detaches a task onto the loop's LocalSet that awaits a 60s KJ timer promise (via
+        /// `kjTimerDelay`), so the task HOLDS live KJ objects -- a TimerPromiseAdapter in the
+        /// port's TimerImpl and an armed RustPromiseAwaiter Event -- when the context is torn
+        /// down. Teardown-ordering regression: the LocalSet must be dropped while those KJ
+        /// objects' owners (timer, event loop) are still alive.
+        fn spawn_task_holding_kj_timer();
+        /// Same shape, but the task awaits a never-resolving bridged KJ promise.
+        fn spawn_task_awaiting_kj_never_promise();
+        /// Woken from a plain std::thread while the loop is parked in the tokio port.
+        async fn std_thread_wake_future() -> Result<()>;
+        /// A task that yields forever; poll() must stay bounded.
+        fn spawn_yield_loop_task();
+        /// A task re-enters promise.wait(); must surface as an Err, not an abort.
+        async fn nested_wait_from_task() -> Result<()>;
+        /// A spawned task panics; the JoinHandle error surfaces as an Err (never an abort).
+        async fn spawn_panicking_task() -> Result<()>;
+        /// Detaches a task (drops its JoinHandle) that still runs to completion, bumping
+        /// completed_task_count().
+        fn spawn_detached_completing_task();
+
+        /// Spawns a task that sleeps `delay_ms` (tokio time, i.e. while the KJ loop is parked
+        /// inside the port) and then fulfills the test fulfiller installed by C++
+        /// (`setTestFulfiller`) with `value` -- a KJ event armed from a tokio task, by a means
+        /// other than a bridged waker, while the loop is parked. KJ's setRunnable(true) must
+        /// hand the thread back to KJ; nothing else will.
+        fn task_fulfills_kj_fulfiller(delay_ms: u64, value: i32);
+
+        /// Spawns a task that sleeps `delay_ms` (tokio time), then arms and awaits a KJ timer of
+        /// `timer_ms` (via `kjTimerDelay`) to completion, and awaits the task's JoinHandle. The
+        /// KJ timer is registered while the loop is parked with a longer (or no) planned
+        /// deadline; the port's TimerImpl::SleepHooks must notice the sooner deadline.
+        async fn task_awaits_kj_timer(delay_ms: u64, timer_ms: u64) -> Result<()>;
+    }
+
+    unsafe extern "C++" {
+        include!("kj-rs-tokio-test/test-helpers.h");
+
+        /// `timer.afterDelay(ms)` on the test's current context timer (see setTestTimer).
+        #[cxx_name = "kjTimerDelay"]
+        async fn kj_timer_delay(ms: u64);
+        /// `kj::NEVER_DONE` as a bridged promise.
+        #[cxx_name = "kjNeverPromise"]
+        async fn kj_never_promise();
+        /// Re-enters `promise.wait()` on the test's WaitScope from wherever it is called. Throws
+        /// (-> `Err`) when called from inside a spawned task.
+        #[cxx_name = "nestedWait"]
+        fn nested_wait() -> Result<()>;
+        /// Fulfills the kj::PromiseFulfiller the C++ test installed with `setTestFulfiller`.
+        #[cxx_name = "fulfillTestFulfiller"]
+        fn fulfill_test_fulfiller(value: i32) -> Result<()>;
+    }
+}

--- a/src/rust/cxx/kj-rs-tokio/tests/test-helpers.h
+++ b/src/rust/cxx/kj-rs-tokio/tests/test-helpers.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <kj/async.h>
+
+namespace kj_rs_tokio_test {
+
+// A KJ timer promise from the test's current TokioAsyncIoContext (the C++ test installs the
+// timer before spawning). Lets a Rust task spawned on the loop's LocalSet hold a live KJ promise
+// (a TimerPromiseAdapter registered with the port's kj::TimerImpl, plus an armed
+// RustPromiseAwaiter Event) across context teardown.
+kj::Promise<void> kjTimerDelay(uint64_t ms);
+
+// kj::NEVER_DONE, so a spawned Rust task can hold a live OwnPromiseNode + armed
+// RustPromiseAwaiter event across context teardown.
+kj::Promise<void> kjNeverPromise();
+
+// Re-enters promise.wait() on the test's current WaitScope (installed by the C++ test). From a
+// spawned task this nests block_on inside the port's block_on; the failure must surface as a
+// kj::Exception (which the bridge turns into a Rust Err), never an abort.
+void nestedWait();
+
+// Fulfills the kj::PromiseFulfiller<int> the current C++ test installed (setTestFulfiller).
+// Called from a spawned tokio task while the loop is parked: arms a KJ event by a means other than
+// a bridged waker.
+void fulfillTestFulfiller(int32_t value);
+
+}  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/test_helpers.rs
+++ b/src/rust/cxx/kj-rs-tokio/tests/test_helpers.rs
@@ -1,0 +1,215 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+
+use crate::Error;
+use crate::Result;
+
+/// Process-wide counter of completed `spawn_task_on_runtime` tasks, so C++ tests can verify the
+/// spawned task really ran (on the loop runtime) rather than the value being produced some other
+/// way.
+static COMPLETED_TASKS: AtomicU64 = AtomicU64::new(0);
+
+pub fn completed_task_count() -> u64 {
+    COMPLETED_TASKS.load(Ordering::SeqCst)
+}
+
+pub fn has_loop_runtime_handle() -> bool {
+    kj_rs_tokio::current_handle().is_some()
+}
+
+pub async fn spawn_task_on_runtime(delay_ms: u64, value: u32) -> Result<u32> {
+    let join_handle = kj_rs_tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        COMPLETED_TASKS.fetch_add(1, Ordering::SeqCst);
+        value
+    });
+    join_handle.await.map_err(Error::other)
+}
+
+pub async fn tokio_sleep_on_runtime(delay_ms: u64) -> Result<()> {
+    let join_handle = kj_rs_tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+    });
+    join_handle.await.map_err(Error::other)
+}
+
+pub fn spawn_pending_task() {
+    // Deliberately detached: dropping the JoinHandle does not cancel the task; it stays pending
+    // in the runtime until the runtime itself is dropped with the TokioEventPort.
+    drop(kj_rs_tokio::spawn(std::future::pending::<()>()));
+}
+
+/// A future that, on its first poll, spawns a task on the loop's own tokio runtime which sleeps
+/// briefly and then wakes a clone of the future's waker. Because that runtime is driven by the
+/// `TokioEventPort` on the event loop's own thread, the wake arrives *same-thread*. Exercises a
+/// bridged future being suspended and re-driven by an asynchronous same-thread wake (via a cloned
+/// waker) under the tokio-backed event port.
+struct DelayedWakeFuture {
+    spawned: bool,
+    done: Arc<AtomicBool>,
+}
+
+impl Future for DelayedWakeFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.done.load(Ordering::SeqCst) {
+            return Poll::Ready(());
+        }
+        if !self.spawned {
+            self.spawned = true;
+            let waker = cx.waker().clone();
+            let done = Arc::clone(&self.done);
+            // Detached task on the loop runtime; it runs on the loop thread when the port drives
+            // the runtime, so `waker.wake()` arms the FuturePollEvent same-thread.
+            drop(kj_rs_tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                done.store(true, Ordering::SeqCst);
+                waker.wake();
+            }));
+        }
+        Poll::Pending
+    }
+}
+
+pub async fn threaded_wake_future() -> Result<()> {
+    DelayedWakeFuture {
+        spawned: false,
+        done: Arc::new(AtomicBool::new(false)),
+    }
+    .await;
+    Ok(())
+}
+
+/// See the bridge doc on `spawn_task_holding_kj_timer` (lib.rs).
+pub fn spawn_task_holding_kj_timer() {
+    drop(kj_rs_tokio::spawn(async {
+        let _ = crate::ffi::kj_timer_delay(60_000).await;
+    }));
+}
+
+/// Like `spawn_task_holding_kj_timer`, but the detached task awaits a bridged KJ promise that
+/// never resolves (`kjNeverPromise`): at teardown it holds an `OwnPromiseNode` and an armed
+/// `RustPromiseAwaiter` event registered with the loop, which the `LocalSet` cancellation must
+/// drop while the loop still exists.
+pub fn spawn_task_awaiting_kj_never_promise() {
+    drop(kj_rs_tokio::spawn(async {
+        let _ = crate::ffi::kj_never_promise().await;
+    }));
+}
+
+/// A bridged future woken from a plain `std::thread` (no tokio, no KJ) ~20ms after its first
+/// poll, while the loop is parked in the port's `wait()`. Exercises the full cross-thread path
+/// into a PARKED tokio port: `FutureWakerCell` cross-thread fulfiller -> loop `Executor` -> port
+/// `wake()` -> `block_on` unpark. (Prep's cross-thread tests all run on a plain `kj::EventLoop`.)
+pub async fn std_thread_wake_future() -> Result<()> {
+    struct F {
+        woken: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        spawned: bool,
+    }
+    impl std::future::Future for F {
+        type Output = ();
+        fn poll(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<()> {
+            if self.woken.load(Ordering::SeqCst) {
+                return std::task::Poll::Ready(());
+            }
+            if !self.spawned {
+                self.spawned = true;
+                let waker = cx.waker().clone();
+                let woken = std::sync::Arc::clone(&self.woken);
+                std::thread::spawn(move || {
+                    std::thread::sleep(Duration::from_millis(20));
+                    woken.store(true, Ordering::SeqCst);
+                    waker.wake();
+                });
+            }
+            std::task::Poll::Pending
+        }
+    }
+    F {
+        woken: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spawned: false,
+    }
+    .await;
+    Ok(())
+}
+
+/// Detaches a task that re-readies itself forever (`yield_now` in a loop). `poll()` must stay
+/// bounded (`POLL_YIELD_BUDGET`) and the KJ loop must not be starved; the task is cancelled at
+/// teardown.
+pub fn spawn_yield_loop_task() {
+    drop(kj_rs_tokio::spawn(async {
+        loop {
+            tokio::task::yield_now().await;
+        }
+    }));
+}
+
+/// Spawns a task that re-enters `promise.wait()` on the loop thread (via the C++ helper
+/// `nestedWait`), which nests `block_on` inside the port's `block_on`. The resulting panic must
+/// surface to the task as a catchable `kj::Exception` (an `Err` here), never an abort, and the
+/// outer loop must keep working. Resolves `Ok` if the task observed the error.
+pub async fn nested_wait_from_task() -> Result<()> {
+    let observed_error = kj_rs_tokio::spawn(async { crate::ffi::nested_wait().is_err() })
+        .await
+        .map_err(Error::other)?;
+    if observed_error {
+        Ok(())
+    } else {
+        Err(Error::other(
+            "nested wait() inside a spawned task unexpectedly succeeded",
+        ))
+    }
+}
+
+/// Spawns a task that panics and awaits its `JoinHandle`. tokio isolates the panic into a
+/// `JoinError` (never an abort), which this maps to an `Err` -> a rejected bridged promise. The
+/// C++ test asserts it throws and that the loop stays healthy afterward. This is the only
+/// coverage of the `JoinHandle` error path (`join_handle.await.map_err(...)`).
+pub async fn spawn_panicking_task() -> Result<()> {
+    kj_rs_tokio::spawn(async {
+        panic!("deliberate panic in a spawned task");
+    })
+    .await
+    .map_err(Error::other)?;
+    Ok(())
+}
+
+/// Detaches (drops the `JoinHandle` of) a task that, after a short delay, bumps
+/// `COMPLETED_TASKS`. The positive counterpart of `spawn_pending_task`: a detached task still
+/// runs to completion (dropping the handle does not cancel it).
+pub fn spawn_detached_completing_task() {
+    drop(kj_rs_tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        COMPLETED_TASKS.fetch_add(1, Ordering::SeqCst);
+    }));
+}
+
+/// See the bridge doc on `task_fulfills_kj_fulfiller` (lib.rs).
+pub fn task_fulfills_kj_fulfiller(delay_ms: u64, value: i32) {
+    drop(kj_rs_tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        let _ = crate::ffi::fulfill_test_fulfiller(value);
+    }));
+}
+
+/// See the bridge doc on `task_awaits_kj_timer` (lib.rs).
+pub async fn task_awaits_kj_timer(delay_ms: u64, timer_ms: u64) -> Result<()> {
+    kj_rs_tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        // Infallible on the C++ side; the bridge still types it as a Result.
+        let _ = crate::ffi::kj_timer_delay(timer_ms).await;
+    })
+    .await
+    .map_err(Error::other)
+}

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -1,0 +1,755 @@
+// Tests for TokioEventPort / setupTokioAsyncIo: a kj::EventLoop driven by a per-thread tokio
+// current_thread runtime. Following kj-rs conventions, C++ KJ_TESTs drive; Rust helpers (see
+// tests/lib.rs, bridged by workerd-cxx) provide async behaviors.
+
+#include "kj-rs-tokio-test/lib.rs.h"
+#include "kj-rs-tokio/tokio-event-port.h"
+
+#include <kj/async.h>
+#include <kj/debug.h>
+#include <kj/test.h>
+#include <kj/thread.h>
+#include <kj/vector.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <type_traits>
+
+namespace kj_rs_tokio_test {
+namespace {
+
+using kj_rs_tokio::setupTokioAsyncIo;
+
+static_assert(!std::is_move_constructible_v<kj_rs_tokio::TokioAsyncIoContext>);
+
+void delayMillis(uint64_t millis) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(millis));
+}
+
+// =======================================================================================
+// Basics: the KJ event loop works as usual on top of the tokio-backed port.
+
+KJ_TEST("Tokio setup rejects an already-current KJ event loop before installing runtime TLS") {
+  {
+    kj::EventLoop loop;
+    kj::WaitScope waitScope(loop);
+    KJ_EXPECT_THROW_MESSAGE("cannot create a TokioEventPort while another KJ event loop is current",
+        setupTokioAsyncIo());
+  }
+
+  auto io = setupTokioAsyncIo();
+  KJ_EXPECT(kj::Promise<int>(42).wait(io.getWaitScope()) == 42);
+}
+
+KJ_TEST("Tokio event-port operations reject a foreign physical thread") {
+  auto io = setupTokioAsyncIo();
+  auto &port = io.getPort();
+
+  kj::Thread thread([&port]() {
+    auto other = setupTokioAsyncIo();
+    KJ_EXPECT_THROW_MESSAGE("TokioEventPort used from a thread other than its owner", port.poll());
+    KJ_EXPECT(kj::Promise<int>(7).wait(other.getWaitScope()) == 7);
+  });
+
+  KJ_EXPECT(kj::Promise<int>(11).wait(io.getWaitScope()) == 11);
+}
+
+KJ_TEST("promises resolve on a TokioEventPort loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  KJ_EXPECT(kj::evalLater([]() { return 123; }).wait(ws) == 123);
+  KJ_EXPECT(kj::Promise<int>(42).wait(ws) == 42);
+}
+
+KJ_TEST("evalLater ordering is preserved") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  kj::Vector<int> order;
+  // eagerlyEvaluate arms each promise immediately (KJ promises are otherwise lazy: continuations
+  // only get scheduled once awaited), so all three events sit in the queue in creation order.
+  auto p1 = kj::evalLater([&]() { order.add(1); }).eagerlyEvaluate(nullptr);
+  auto p2 = kj::evalLater([&]() { order.add(2); }).eagerlyEvaluate(nullptr);
+  auto p3 = kj::evalLater([&]() { order.add(3); }).eagerlyEvaluate(nullptr);
+
+  // Waiting on the last promise runs all three events in FIFO order.
+  p3.wait(ws);
+  p1.wait(ws);
+  p2.wait(ws);
+
+  KJ_ASSERT(order.size() == 3);
+  KJ_EXPECT(order[0] == 1);
+  KJ_EXPECT(order[1] == 2);
+  KJ_EXPECT(order[2] == 3);
+}
+
+KJ_TEST("promise chains resolve") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto promise =
+      kj::evalLater([]() { return 1; }).then([](int v) {
+    return kj::Promise<int>(v + 1);
+  }).then([](int v) { return v * 10; });
+  KJ_EXPECT(promise.wait(ws) == 20);
+}
+
+KJ_TEST("evalLast fires when the loop would sleep") {
+  // kj::evalLast events live on the would-sleep queue, which is only serviced through the
+  // EventLoop::poll() path (EventLoop::wait() switches to poll() when would-sleep waiters
+  // exist). This test hangs or misorders if the port's poll() is broken.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  kj::Vector<int> order;
+  auto last = kj::evalLast([&]() { order.add(2); });
+  auto later = kj::evalLater([&]() { order.add(1); });
+
+  later.wait(ws);
+  // evalLast must not have run yet: the loop never ran out of work while waiting on `later`.
+  KJ_ASSERT(order.size() == 1);
+  KJ_EXPECT(order[0] == 1);
+
+  last.wait(ws);
+  KJ_ASSERT(order.size() == 2);
+  KJ_EXPECT(order[1] == 2);
+}
+
+// =======================================================================================
+// Timers: kj::TimerImpl fed by the port; advanceTo() after every wait()/poll().
+
+KJ_TEST("timer.afterDelay fires with real elapsed time") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+  auto before = sysClock.now();
+  auto timerBefore = timer.now();
+
+  // If the port forgot timerImpl.advanceTo() after waits, this would never resolve (caught by
+  // the test timeout).
+  timer.afterDelay(30 * kj::MILLISECONDS).wait(ws);
+
+  KJ_EXPECT(sysClock.now() - before >= 30 * kj::MILLISECONDS);
+  // Timer time is synced to the monotonic clock at each wait return.
+  KJ_EXPECT(timer.now() - timerBefore >= 30 * kj::MILLISECONDS);
+}
+
+KJ_TEST("multiple timers fire in deadline order") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  kj::Vector<int> order;
+  auto p3 = timer.afterDelay(30 * kj::MILLISECONDS).then([&]() {
+    order.add(3);
+  }).eagerlyEvaluate(nullptr);
+  auto p1 =
+      timer.afterDelay(5 * kj::MILLISECONDS).then([&]() { order.add(1); }).eagerlyEvaluate(nullptr);
+  auto p2 = timer.afterDelay(15 * kj::MILLISECONDS).then([&]() {
+    order.add(2);
+  }).eagerlyEvaluate(nullptr);
+
+  p3.wait(ws);
+  KJ_ASSERT(order.size() == 3);
+  KJ_EXPECT(order[0] == 1);
+  KJ_EXPECT(order[1] == 2);
+  KJ_EXPECT(order[2] == 3);
+  p1.wait(ws);
+  p2.wait(ws);
+}
+
+KJ_TEST("timer fires while blocked waiting on a cross-thread event") {
+  // The port must bound each sleep by timeoutToNextEvent(): the loop first wakes at the timer
+  // deadline (long before the cross-thread fulfill), fires the timer, then goes back to sleep.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
+  bool timerFired = false;
+  auto timerPromise = timer.afterDelay(10 * kj::MILLISECONDS).then([&]() {
+    timerFired = true;
+  }).eagerlyEvaluate(nullptr);
+
+  kj::Thread thread([fulfiller = kj::mv(paf.fulfiller)]() mutable {
+    delayMillis(100);
+    fulfiller->fulfill();
+  });
+
+  paf.promise.wait(ws);
+  KJ_EXPECT(timerFired);
+  timerPromise.wait(ws);
+}
+
+// =======================================================================================
+// Timer precision: tokio's timer wheel (~1 ms granularity, the same as KJ's own epoll-based
+// port, whose epoll_pwait takes a millisecond timeout). No high-resolution side channel.
+
+KJ_TEST("wake() from another thread interrupts a loop cycling through short timers promptly") {
+  // While the loop keeps re-arming a short timer (so wait() is always a short timed sleep), a
+  // cross-thread fulfill must still get through promptly: the timer wakeup and wake() share the
+  // same Notify, and the wake latch must survive interleaved timer wakeups.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+
+  struct Chain {
+    static kj::Promise<void> run(kj::Timer &timer) {
+      return timer.afterDelay(1 * kj::MILLISECONDS).then([&timer]() { return run(timer); });
+    }
+  };
+  auto keepBusy = Chain::run(timer).eagerlyEvaluate(nullptr);
+
+  auto paf = kj::newPromiseAndCrossThreadFulfiller<int>();
+  auto before = sysClock.now();
+  kj::Thread thread([fulfiller = kj::mv(paf.fulfiller)]() mutable {
+    delayMillis(5);
+    fulfiller->fulfill(7);
+  });
+
+  KJ_EXPECT(paf.promise.wait(ws) == 7);
+  auto elapsed = sysClock.now() - before;
+  KJ_EXPECT(elapsed >= 5 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+  KJ_EXPECT(elapsed < 1000 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+}
+
+KJ_TEST("absolute timer deadlines remain accurate after time outside the loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+
+  // Time spent outside the event loop can leave the timer's cached clock behind the real clock.
+  delayMillis(5);
+  auto before = sysClock.now();
+  timer.atTime(before + 20 * kj::MILLISECONDS).wait(ws);
+  auto elapsed = sysClock.now() - before;
+  KJ_EXPECT(elapsed >= 20 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+  KJ_EXPECT(elapsed < 1000 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+}
+
+KJ_TEST("a cancelled timer does not fire and a later one still does") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  bool earlyFired = false;
+  auto early = timer.afterDelay(5 * kj::MILLISECONDS).then([&]() {
+    earlyFired = true;
+  }).eagerlyEvaluate(nullptr);
+  auto late = timer.afterDelay(30 * kj::MILLISECONDS);
+  early = nullptr;  // cancel: deregisters from TimerImpl before the loop ever sleeps
+
+  auto before = timer.now();
+  late.wait(ws);
+  KJ_EXPECT(!earlyFired);
+  KJ_EXPECT(timer.now() - before >= 30 * kj::MILLISECONDS);
+}
+
+// =======================================================================================
+// Cross-thread: the wake() -> wait()-returns-true latch is what drains kj::Executor events and
+// cross-thread fulfillers.
+
+KJ_TEST("executeAsync from another thread runs on the tokio-ported loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  const kj::Executor &executor = kj::getCurrentThreadExecutor();
+  auto paf = kj::newPromiseAndFulfiller<int>();
+  auto fulfiller = kj::mv(paf.fulfiller);
+
+  kj::Thread thread([&executor, &fulfiller]() {
+    // A plain portless loop so this thread can wait on the cross-thread promise.
+    kj::EventLoop loop;
+    kj::WaitScope threadWs(loop);
+    kj::uint result = executor
+                          .executeAsync([&fulfiller]() {
+      // Runs on the main (tokio-ported) loop.
+      fulfiller->fulfill(42);
+      return 99u;
+    }).wait(threadWs);
+    KJ_ASSERT(result == 99);
+  });
+
+  // While we are blocked here, the other thread's executeAsync must wake the port (wake() ->
+  // wait() returns true -> executor drained).
+  KJ_EXPECT(paf.promise.wait(ws) == 42);
+}
+
+KJ_TEST("cross-thread fulfiller wakes a blocked wait()") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto paf = kj::newPromiseAndCrossThreadFulfiller<int>();
+  kj::Thread thread([fulfiller = kj::mv(paf.fulfiller)]() mutable {
+    delayMillis(10);  // Give the main thread time to actually block in wait().
+    fulfiller->fulfill(123);
+  });
+
+  KJ_EXPECT(paf.promise.wait(ws) == 123);
+}
+
+// =======================================================================================
+// Rust integration: spawned tokio tasks run while C++ is blocked in promise.wait(), and the
+// existing kj-rs future<->promise bridge works unchanged under the new port.
+
+KJ_TEST("Rust task spawned on the loop's runtime completes while C++ is "
+        "blocked in wait()") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  KJ_EXPECT(has_loop_runtime_handle());
+
+  uint64_t completedBefore = completed_task_count();
+  auto promise = spawn_task_on_runtime(20, 42);
+  // This top-level wait() parks the thread inside the tokio runtime's block_on, which is what
+  // drives the spawned task (and its tokio sleep) to completion.
+  KJ_EXPECT(promise.wait(ws) == 42);
+  KJ_EXPECT(completed_task_count() == completedBefore + 1);
+}
+
+KJ_TEST("tokio timers inside spawned tasks work") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+  auto before = sysClock.now();
+  tokio_sleep_on_runtime(25).wait(ws);
+  KJ_EXPECT(sysClock.now() - before >= 25 * kj::MILLISECONDS);
+}
+
+KJ_TEST("promise.poll() pumps the tokio scheduler without blocking") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto promise = spawn_task_on_runtime(500, 7);
+  // Not done yet; poll() must not sleep the task's 500 ms away. The bound is generous on
+  // purpose: it distinguishes "returned without parking" from "slept until the task finished",
+  // not scheduler latency.
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+  auto before = sysClock.now();
+  KJ_EXPECT(!promise.poll(ws));
+  KJ_EXPECT(sysClock.now() - before < 250 * kj::MILLISECONDS);
+
+  KJ_EXPECT(promise.wait(ws) == 7);
+}
+
+KJ_TEST("kj-rs bridged Rust future with same-thread delayed waker works under the new "
+        "port") {
+  // A bridged Rust future that suspends, then is re-driven by a wake delivered from a task on the
+  // loop's own tokio runtime (same thread, via the TokioEventPort). Exercises the future⇄promise
+  // bridge's asynchronous same-thread re-drive path under the new port.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  threaded_wake_future().wait(ws);
+
+  []() -> kj::Promise<void> { co_await threaded_wake_future(); }().wait(ws);
+}
+
+KJ_TEST("KJ coroutine can co_await spawned Rust tasks and KJ timers together") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  int result = [&timer]() -> kj::Promise<int> {
+    co_await timer.afterDelay(5 * kj::MILLISECONDS);
+    uint32_t value = co_await spawn_task_on_runtime(5, 11);
+    co_await timer.afterDelay(5 * kj::MILLISECONDS);
+    co_return static_cast<int>(value) + 1;
+  }().wait(ws);
+  KJ_EXPECT(result == 12);
+}
+
+// =======================================================================================
+// Teardown.
+
+kj::Timer *testTimer = nullptr;
+void setTestTimer(kj::Timer *timer) {
+  testTimer = timer;
+}
+kj::WaitScope *testWaitScope = nullptr;
+void setTestWaitScope(kj::WaitScope *ws) {
+  testWaitScope = ws;
+}
+kj::Maybe<kj::Own<kj::PromiseFulfiller<int>>> testFulfiller;
+}  // namespace
+
+// External linkage: called by the cxx bridge (kj_rs_tokio_test::kjTimerDelay etc.).
+kj::Promise<void> kjTimerDelay(uint64_t ms) {
+  KJ_REQUIRE(testTimer != nullptr, "setTestTimer() not called");
+  return testTimer->afterDelay(ms * kj::MILLISECONDS);
+}
+
+kj::Promise<void> kjNeverPromise() {
+  return kj::NEVER_DONE;
+}
+
+void nestedWait() {
+  KJ_REQUIRE(testWaitScope != nullptr, "setTestWaitScope() not called");
+  kj::evalLater([]() {}).wait(*testWaitScope);
+}
+
+void fulfillTestFulfiller(int32_t value) {
+  KJ_ASSERT_NONNULL(testFulfiller, "setTestFulfiller() not called")->fulfill(kj::cp(value));
+}
+
+namespace {
+
+KJ_TEST("context destruction with a spawned task HOLDING a KJ timer promise is clean") {
+  // Unlike the test below, the spawned task itself owns live KJ objects (TimerPromiseAdapter in
+  // the port's TimerImpl, armed RustPromiseAwaiter Event on the loop) at teardown. The LocalSet
+  // cancellation that drops them must run while the timer and loop still exist.
+  {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    setTestTimer(&io.getTimer());
+    KJ_DEFER(setTestTimer(nullptr));
+    spawn_task_holding_kj_timer();
+    // Let the task start: it registers the timer and arms its awaiter, then parks.
+    kj::evalLater([]() {}).wait(ws);
+    ws.poll();
+  }
+  {
+    auto io = setupTokioAsyncIo();
+    KJ_EXPECT(kj::evalLater([]() { return 7; }).wait(io.getWaitScope()) == 7);
+  }
+}
+
+KJ_TEST("context destruction with pending spawned tasks and armed timers is "
+        "clean") {
+  {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    auto &timer = io.getTimer();
+
+    // A detached, never-completing Rust task: must be dropped by the runtime at teardown.
+    spawn_pending_task();
+
+    // Armed timer and an in-flight spawned task; their promises are destroyed (canceling the
+    // KJ side) before the context itself, per declaration order.
+    auto timerPromise = timer.afterDelay(60 * kj::SECONDS);
+    auto spawnedPromise = spawn_task_on_runtime(60'000, 1);
+    KJ_EXPECT(!spawnedPromise.poll(ws));
+    KJ_EXPECT(!timerPromise.poll(ws));
+  }
+
+  // The thread is fully cleaned up: a fresh context on the same thread works.
+  {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    KJ_EXPECT(kj::evalLater([]() { return 5; }).wait(ws) == 5);
+    KJ_EXPECT(has_loop_runtime_handle());
+  }
+  KJ_EXPECT(!has_loop_runtime_handle());
+}
+
+KJ_TEST("context destruction with a spawned task awaiting a KJ promise is clean") {
+  // The task owns an OwnPromiseNode plus an armed RustPromiseAwaiter event registered with the
+  // loop. Cancellation must drop them while the loop still exists (else ~Event unlinks from a
+  // freed queue).
+  {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    spawn_task_awaiting_kj_never_promise();
+    kj::evalLater([]() {}).wait(ws);
+    ws.poll();
+  }
+  auto io = setupTokioAsyncIo();
+  KJ_EXPECT(kj::evalLater([]() { return 8; }).wait(io.getWaitScope()) == 8);
+}
+
+KJ_TEST("one TokioEventPort per thread") {
+  auto io = setupTokioAsyncIo();
+  // A second port on this thread is refused (KJ's one-loop-per-thread model): the C++ side
+  // KJ_REQUIREs it and the Rust side asserts it; either surfaces as a kj::Exception.
+  KJ_EXPECT_THROW(FAILED, kj::heap<kj_rs_tokio::TokioEventPort>());
+  // The failed construction must not have disturbed the live port.
+  KJ_EXPECT(kj::evalLater([]() { return 1; }).wait(io.getWaitScope()) == 1);
+  KJ_EXPECT(spawn_task_on_runtime(1, 4).wait(io.getWaitScope()) == 4);
+}
+
+KJ_TEST("bridged future woken from a plain std::thread while the loop is parked") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // The wake comes from a thread with neither a KJ loop nor a tokio context, ~20ms after the
+  // loop parks in the port's block_on: FutureWakerCell's cross-thread fulfiller -> this loop's
+  // Executor -> TokioEventPort::wake() -> unpark. A lost hop hangs this wait().
+  std_thread_wake_future().wait(ws);
+  // And again, back to back, so the second wake targets a freshly renewed fulfiller.
+  std_thread_wake_future().wait(ws);
+}
+
+// =======================================================================================
+// A tokio task hands KJ work by means other than a bridged waker while the loop is parked in
+// wait(): KJ reports it to the port (setRunnable(true) for events, the TimerImpl SleepHooks for
+// timers) and the park must end. Each test is bounded by a long timer that turns "hangs forever"
+// into a failed assertion.
+
+KJ_TEST("a spawned task fulfilling a kj::PromiseFulfiller while the loop is parked wakes it") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+
+  auto paf = kj::newPromiseAndFulfiller<int>();
+  testFulfiller = kj::mv(paf.fulfiller);
+  KJ_DEFER(testFulfiller = kj::none);
+
+  // The task fulfills ~20 ms into the park; the 10 s timer is the "we hung" bound. Without KJ
+  // reporting the arm (setRunnable(true)) it sits unserviced until that timer.
+  task_fulfills_kj_fulfiller(20, 42);
+  auto before = sysClock.now();
+  int value = paf.promise
+                  .exclusiveJoin(timer.afterDelay(10 * kj::SECONDS).then([]() -> int {
+    KJ_FAIL_ASSERT("KJ event armed by a tokio task was not serviced while the loop was parked");
+  })).wait(ws);
+  KJ_EXPECT(value == 42);
+  KJ_EXPECT(sysClock.now() - before < 2 * kj::SECONDS);
+}
+
+KJ_TEST("a spawned task fulfilling a kj::PromiseFulfiller during a wait-forever park wakes it") {
+  // No timer at all: wait() plans to sleep forever. A hang here is a real hang, so this test
+  // guards itself with a cross-thread kill switch instead of a KJ timer.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto paf = kj::newPromiseAndFulfiller<int>();
+  testFulfiller = kj::mv(paf.fulfiller);
+  KJ_DEFER(testFulfiller = kj::none);
+
+  auto bound = kj::newPromiseAndCrossThreadFulfiller<int>();
+  std::atomic<bool> done{false};
+  kj::Thread watchdog([&done, fulfiller = kj::mv(bound.fulfiller)]() mutable {
+    for (int i = 0; i < 1000 && !done.load(); i++) delayMillis(10);
+    if (!done.load()) fulfiller->fulfill(-1);
+  });
+
+  task_fulfills_kj_fulfiller(20, 7);
+  int value = paf.promise.exclusiveJoin(kj::mv(bound.promise)).wait(ws);
+  done.store(true);
+  KJ_EXPECT(
+      value == 7, "KJ event armed by a tokio task was not serviced during a wait-forever park");
+}
+
+KJ_TEST("a KJ timer armed by a spawned task during the park is honored at its own deadline") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+  setTestTimer(&timer);
+  KJ_DEFER(setTestTimer(nullptr));
+
+  // wait() plans against the 10 s bound; 10 ms (wall clock) into the park the task arms a 20 ms
+  // KJ timer and awaits it to completion. The park must end at that timer, not at 10 s.
+  //
+  // The port is the TimerImpl's SleepHooks while parked, so kj::Timer::now() reads the live
+  // clock: the task's afterDelay(20ms) is measured from the moment it is armed (~10 ms in), and
+  // the timer is due at ~30 ms of wall time -- KJ's intended semantics for code using the timer
+  // while the loop sleeps (see kj::TimerImpl::setSleeping).
+  auto before = sysClock.now();
+  task_awaits_kj_timer(10, 20)
+      .exclusiveJoin(timer.afterDelay(10 * kj::SECONDS).then([]() {
+    KJ_FAIL_ASSERT("KJ timer armed by a tokio task during the park was not honored");
+  })).wait(ws);
+  auto elapsed = sysClock.now() - before;
+  KJ_EXPECT(elapsed >= 30 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+  KJ_EXPECT(elapsed < 2 * kj::SECONDS, elapsed / kj::MILLISECONDS);
+}
+
+KJ_TEST("a KJ timer armed by a spawned task during a wait-forever park is honored") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  setTestTimer(&io.getTimer());
+  KJ_DEFER(setTestTimer(nullptr));
+
+  auto bound = kj::newPromiseAndCrossThreadFulfiller<void>();
+  std::atomic<bool> done{false};
+  kj::Thread watchdog([&done, fulfiller = kj::mv(bound.fulfiller)]() mutable {
+    for (int i = 0; i < 1000 && !done.load(); i++) delayMillis(10);
+    if (!done.load()) fulfiller->reject(KJ_EXCEPTION(FAILED, "park never ended"));
+  });
+
+  task_awaits_kj_timer(10, 20).exclusiveJoin(kj::mv(bound.promise)).wait(ws);
+  done.store(true);
+}
+
+KJ_TEST("cross-thread bridged wake arriving while the loop is busy (not parked) is delivered") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+
+  // The wake lands ~20 ms in; keep the loop turning events (never parking) for ~60 ms. The wake
+  // then travels cell -> cross-thread fulfiller -> Executor -> port.wake(); the loop only sees
+  // the latch through busy-poll's port.poll() (enabled here; KJ's default never busy-polls),
+  // never through wait().
+  ws.setBusyPollInterval(8);
+  auto woken = std_thread_wake_future();
+  auto busyUntil = sysClock.now() + 60 * kj::MILLISECONDS;
+  [&]() -> kj::Promise<void> {
+    while (sysClock.now() < busyUntil) {
+      co_await kj::evalLater([]() {});
+    }
+  }().wait(ws);
+
+  woken
+      .exclusiveJoin(timer.afterDelay(10 * kj::SECONDS).then([]() {
+    KJ_FAIL_ASSERT("cross-thread wake during a busy loop was lost");
+  })).wait(ws);
+}
+
+KJ_TEST("a bare TokioEventPort (no context) tears down cleanly with tasks holding KJ objects") {
+  // The port owns its loop and cancels spawned tasks before destroying anything, so even without
+  // a TokioAsyncIoContext a task holding a KJ timer promise and an armed awaiter event is dropped
+  // while the loop and timer are alive. ASAN target.
+  {
+    auto port = kj::heap<kj_rs_tokio::TokioEventPort>();
+    kj::WaitScope ws(port->getLoop());
+    setTestTimer(&port->getTimer());
+    KJ_DEFER(setTestTimer(nullptr));
+    spawn_task_holding_kj_timer();
+    spawn_task_awaiting_kj_never_promise();
+    kj::evalLater([]() {}).wait(ws);
+    ws.poll();
+    // `ws` is destroyed first (declared after `port`), then the port: tasks, loop, runtime, timer.
+  }
+  auto io = setupTokioAsyncIo();
+  KJ_EXPECT(kj::evalLater([]() { return 9; }).wait(io.getWaitScope()) == 9);
+}
+
+KJ_TEST("a task that yields forever keeps poll() bounded and does not starve the KJ loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  spawn_yield_loop_task();
+  // poll() lets ready tasks run for a bounded number of turns (POLL_YIELD_BUDGET) and returns.
+  ws.poll();
+  ws.poll();
+  // The KJ side still makes progress alongside the spinning task.
+  KJ_EXPECT(kj::evalLater([]() { return 21; }).wait(ws) == 21);
+  KJ_EXPECT(spawn_task_on_runtime(1, 9).wait(ws) == 9);
+  // The spinning task is cancelled at teardown (LocalSet cancellation, above).
+}
+
+KJ_TEST("a spawned task re-entering promise.wait() gets a kj::Exception, not an abort") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  setTestWaitScope(&ws);
+  KJ_DEFER(setTestWaitScope(nullptr));
+
+  // Documented in tokio-event-port.h: nesting block_on inside block_on is rejected by tokio;
+  // the panic must reach the task as a catchable exception (an Err across the bridge), and the
+  // outer loop must stay healthy.
+  nested_wait_from_task().wait(ws);
+  KJ_EXPECT(kj::evalLater([]() { return 3; }).wait(ws) == 3);
+}
+
+KJ_TEST("already-due timer returns promptly from wait()") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  // timeoutToNextEvent() is zero: wait() must not sleep; it returns and advanceTo() fires the
+  // timer.
+  auto start = kj::systemPreciseMonotonicClock().now();
+  timer.afterDelay(0 * kj::MILLISECONDS).wait(ws);
+  timer.atTime(timer.now()).wait(ws);
+  KJ_EXPECT(kj::systemPreciseMonotonicClock().now() - start < 200 * kj::MILLISECONDS);
+}
+
+KJ_TEST("two tokio-ported loops on two threads executeAsync into each other concurrently") {
+  // Both directions at once, N round trips each way, so both ports' wake paths (Executor ->
+  // wake() -> block_on unpark) race under load. TSAN target. A lost wake hangs the test.
+  //
+  // Protocol: each side publishes its Executor, runs N round trips into the peer while its own
+  // loop services the peer's round trips, then fulfills the peer's "I'm finished" cross-thread
+  // fulfiller and waits (on its own loop, still servicing) for the peer's. Only when both have
+  // finished does either loop go away, so no call is ever left without a live target.
+  constexpr kj::uint N = 200;
+  using ExecSlot = kj::MutexGuarded<kj::Maybe<kj::Own<const kj::Executor>>>;
+  using FulfillerSlot =
+      kj::MutexGuarded<kj::Maybe<kj::Own<const kj::CrossThreadPromiseFulfiller<void>>>>;
+  ExecSlot mainExecSlot;
+  ExecSlot otherExecSlot;
+  // Each side creates its own PAF (the promise stays on its loop) and hands the fulfiller over.
+  FulfillerSlot mainFinishedSlot;   // fulfilled by `other` when it is done
+  FulfillerSlot otherFinishedSlot;  // fulfilled by main when it is done
+
+  auto takeFromSlot = [](auto &slot) {
+    auto lock = slot.lockExclusive();
+    lock.wait([](auto &v) { return v != kj::none; });
+    return kj::mv(KJ_ASSERT_NONNULL(*lock));
+  };
+
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto mainFinished = kj::newPromiseAndCrossThreadFulfiller<void>();
+  *mainFinishedSlot.lockExclusive() = kj::mv(mainFinished.fulfiller);
+  *mainExecSlot.lockExclusive() = kj::getCurrentThreadExecutor().addRef();
+
+  kj::Thread other([&]() noexcept {
+    auto io2 = setupTokioAsyncIo();
+    auto &ws2 = io2.getWaitScope();
+    auto otherFinished = kj::newPromiseAndCrossThreadFulfiller<void>();
+    *otherFinishedSlot.lockExclusive() = kj::mv(otherFinished.fulfiller);
+    *otherExecSlot.lockExclusive() = kj::getCurrentThreadExecutor().addRef();
+
+    auto mainExec = takeFromSlot(mainExecSlot);
+    for (kj::uint i = 0; i < N; i++) {
+      KJ_ASSERT(mainExec->executeAsync([i]() { return i; }).wait(ws2) == i);
+    }
+    takeFromSlot(mainFinishedSlot)->fulfill();
+    // Keep servicing main's round trips until it reports finished.
+    otherFinished.promise.wait(ws2);
+  });
+
+  auto otherExec = takeFromSlot(otherExecSlot);
+  for (kj::uint i = 0; i < N; i++) {
+    KJ_EXPECT(otherExec->executeAsync([i]() { return i * 2; }).wait(ws) == i * 2);
+  }
+  takeFromSlot(otherFinishedSlot)->fulfill();
+  mainFinished.promise.wait(ws);
+}
+
+KJ_TEST("a spawned task that panics surfaces as a kj::Exception, not an abort") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // tokio isolates a spawned task's panic into a JoinError; the bridged future maps it to an
+  // Err, so co_await throws rather than aborting the process.
+  kj::Maybe<kj::Exception> maybeException;
+  try {
+    spawn_panicking_task().wait(ws);
+  } catch (...) {
+    maybeException = kj::getCaughtExceptionAsKj();
+  }
+  KJ_EXPECT(maybeException != kj::none, "a panicking spawned task must throw");
+
+  // The loop is still healthy afterward.
+  KJ_EXPECT(kj::evalLater([]() { return 11; }).wait(ws) == 11);
+}
+
+KJ_TEST("a detached spawned task (JoinHandle dropped) still runs to completion") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  uint64_t before = completed_task_count();
+  spawn_detached_completing_task();  // drops the JoinHandle immediately
+  // Drive the loop until the detached task has run (bounded; each afterDelay lets the runtime
+  // turn). Dropping the handle must NOT have cancelled it.
+  for (int i = 0; i < 200 && completed_task_count() == before; i++) {
+    io.getTimer().afterDelay(2 * kj::MILLISECONDS).wait(ws);
+  }
+  KJ_EXPECT(completed_task_count() == before + 1);
+}
+
+}  // namespace
+}  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.c++
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.c++
@@ -1,0 +1,135 @@
+#include "kj-rs-tokio/tokio-event-port.h"
+
+#include <kj/debug.h>
+
+#include <cstdlib>
+
+namespace kj_rs_tokio {
+
+namespace {
+// The port active on this loop thread, to enforce one port per thread (KJ's one-loop-per-thread
+// model); set by the constructor, cleared by the destructor.
+thread_local TokioEventPort* activePort = nullptr;
+
+// Enforce one port per thread on the C++ side too (the Rust half asserts the same when it
+// registers its runtime handle), so the `activePort` invariant is guaranteed where the pointer
+// lives rather than relied upon from across the bridge.
+const kj::MonotonicClock& requireNoActivePort() {
+  KJ_REQUIRE(activePort == nullptr,
+      "only one TokioEventPort may exist per thread (KJ's one-loop-per-thread model)");
+  KJ_REQUIRE(kj::tryGetCurrentThreadExecutor() == kj::none,
+      "cannot create a TokioEventPort while another KJ event loop is current");
+  return kj::systemPreciseMonotonicClock();
+}
+}  // namespace
+
+TokioEventPort::TokioEventPort()
+    : ownerThread(kj::ThreadId::current()),
+      clock(requireNoActivePort()),
+      timerImpl(clock.now()),
+      rustPort(new_tokio_port()),
+      loop(kj::heap<kj::EventLoop>(*this)) {
+  activePort = this;
+}
+
+TokioEventPort::~TokioEventPort() noexcept(false) {
+  KJ_ASSERT(ownerThread == kj::ThreadId::current(),
+      "TokioEventPort destroyed on a thread other than its owner") {
+    std::abort();
+  }
+  // Cancel spawned tasks while the loop and timer -- our members, destroyed after this body --
+  // are still alive: a cancelled task's destructors may unlink an armed kj::_::Event from the
+  // loop or deregister a kj::TimerImpl timer.
+  cancelSpawnedTasks();
+  if (activePort == this) {
+    activePort = nullptr;
+  }
+}
+
+void TokioEventPort::assertOwnerThread() const {
+  KJ_REQUIRE(ownerThread == kj::ThreadId::current(),
+      "TokioEventPort used from a thread other than its owner");
+}
+
+void TokioEventPort::cancelSpawnedTasks() {
+  assertOwnerThread();
+  // Guarded so a task-drop panic (surfaced as a kj::Exception by the cxx fork) does not
+  // std::terminate if the caller is already unwinding (this runs from destructors).
+  unwindDetector.catchExceptionsIfUnwinding([this]() { rustPort->cancel_spawned_tasks(); });
+}
+
+void TokioEventPort::setRunnable(bool runnable) {
+  assertOwnerThread();
+  // Called by the EventLoop on the loop thread on empty <-> runnable transitions. The loop
+  // reports `false` right before it calls wait(), so a `true` that arrives while we are parked
+  // means a tokio task armed a KJ event: hand the thread back to KJ.
+  if (runnable) {
+    rustPort->notify_kj_service();
+  }
+}
+
+void TokioEventPort::updateNextTimerEvent(kj::Maybe<kj::TimePoint> time) {
+  assertOwnerThread();
+  // A timer was armed or cancelled while we sleep. Only a deadline sooner than the one this
+  // wait() was planned against needs the thread back: KJ must re-plan the sleep.
+  KJ_IF_SOME(next, time) {
+    bool sooner =
+        plannedNextEvent.map([&](kj::TimePoint planned) { return next < planned; }).orDefault(true);
+    if (sooner) {
+      rustPort->notify_kj_service();
+    }
+  }
+}
+
+bool TokioEventPort::wait() {
+  assertOwnerThread();
+  bool woken;
+  // Bound the sleep by the next KJ timer deadline, if any, and remember which deadline that was
+  // so updateNextTimerEvent() can spot a sooner one armed during the park. `timeoutToNextEvent()`
+  // rounds up, so we always sleep until just *after* the timer is due.
+  plannedNextEvent = timerImpl.nextEvent();
+  KJ_DEFER(plannedNextEvent = kj::none);
+  // While parked, be the timer's sleep hooks: tokio tasks arming KJ timers mid-park get live
+  // time from now() and re-plan the sleep if their deadline is sooner. advanceTo() below clears
+  // the hooks (KJ's contract for setSleeping()).
+  timerImpl.setSleeping(*this);
+  KJ_IF_SOME(timeoutNs, timerImpl.timeoutToNextEvent(clock.now(), kj::NANOSECONDS, kj::maxValue)) {
+    woken = rustPort->wait_timeout_ns(timeoutNs);
+  } else {
+    woken = rustPort->wait_forever();
+  }
+
+  // Load-bearing: TimerImpl only fires timer events from advanceTo(). Forgetting this after a
+  // wait means every kj::Timer promise silently never resolves. (This also clears the sleep
+  // hooks installed above.)
+  timerImpl.advanceTo(clock.now());
+  return woken;
+}
+
+bool TokioEventPort::poll() {
+  assertOwnerThread();
+  bool woken = rustPort->poll();
+  timerImpl.advanceTo(clock.now());
+  return woken;
+}
+
+void TokioEventPort::wake() const {
+  // Callable from any thread; the Rust side latches the flag and unblocks a concurrent wait().
+  rustPort->wake();
+}
+
+TokioAsyncIoContext::~TokioAsyncIoContext() noexcept(false) {
+  // Cancel spawned tasks while the WaitScope is still alive as well (the port's destructor
+  // repeats this harmlessly). A moved-from context (null port) owns nothing.
+  if (port.get() != nullptr) {
+    port->cancelSpawnedTasks();
+  }
+}
+
+TokioAsyncIoContext setupTokioAsyncIo() {
+  auto port = kj::heap<TokioEventPort>();
+  auto waitScope = kj::heap<kj::WaitScope>(port->getLoop());
+  return TokioAsyncIoContext(kj::mv(port), kj::mv(waitScope));
+}
+
+}  // namespace kj_rs_tokio

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
@@ -1,0 +1,175 @@
+#pragma once
+// TokioEventPort: a kj::EventPort backed by a per-thread tokio current_thread runtime.
+// Ownership inversion, not replacement: C++ keeps creating and awaiting kj::Promises exactly
+// as today; what changes is *who sleeps*. When the KJ loop would block in the OS, wait()
+// parks the thread inside `tokio::Runtime::block_on`, driving the whole tokio scheduler, so
+// every Rust task on the loop's runtime makes progress while C++ is "blocked".
+//
+// Notes on the kj::EventPort contract (see kj/async.h):
+//  - wait()/poll() return true iff wake() latched. This is load-bearing: kj::Executor's
+//    executeAsync and kj::newPromiseAndCrossThreadFulfiller only get drained on `true`.
+//  - The kj::TimerImpl is advanced after every wait()/poll(). Timer precision is tokio's timer
+//    wheel (~1 ms), the same granularity KJ's own epoll-based port has.
+//  - One TokioEventPort (and hence one runtime, one kj::EventLoop) per thread, matching KJ's
+//    one-loop-per-thread model. The port owns its EventLoop: the loop is constructed on the port
+//    and destroyed before any of the port's other members, so the port can always ask the loop
+//    whether it needs service (below) and can always cancel spawned tasks while the loop and
+//    timer are alive.
+//  - Tokio tasks on this runtime may use KJ freely -- fulfill a PromiseFulfiller, arm a timer,
+//    add to a TaskSet, create or await bridged promises, wake bridged futures. Every one of those
+//    either arms a KJ event or moves the next KJ timer deadline, and KJ reports both to the port
+//    while it sleeps: kj::EventLoop reports setRunnable(false) before calling wait() and so
+//    setRunnable(true) on the first arm during it, and the port is the kj::TimerImpl's SleepHooks
+//    for the duration of the park (updateNextTimerEvent() on a changed earliest deadline;
+//    kj::Timer::now() reads the live clock). Either report ends the park. The one thing a task
+//    must never do is re-enter `promise.wait()` / `waitScope.poll()` on this thread: that nests
+//    block_on inside block_on, which tokio rejects (the panic surfaces as a kj::Exception).
+//
+// Object relationships (one loop thread):
+//
+//   TokioAsyncIoContext                       -- kj::setupAsyncIo() analogue
+//       ├── Own<TokioEventPort>               -- the kj::EventPort; one per thread
+//       │       ├── kj::TimerImpl             -- fed from wait()/poll(); declared BEFORE the
+//       │       │                                 Rust half so it outlives cancelled tasks
+//       │       ├── rust::Box<TokioPort>      -- Sync but not Send; wake() is cross-thread
+//       │       │       ├── tokio::Runtime (current_thread, I/O + time drivers)
+//       │       │       └── Arc<SharedState>  -- Notify + `woken` latch + `in_wait` flag; the
+//       │       │                                ONE thing every wake source touches
+//       │       └── Own<kj::EventLoop>        -- constructed on the port; declared LAST so it
+//       │                                        is destroyed first
+//       │   (the port is also the TimerImpl's SleepHooks while parked)
+//       └── Own<kj::WaitScope>
+//
+//   Thread-locals (loop thread only), all installed by construction / cleared by destruction:
+//       LOOP_RUNTIME_HANDLE                   -- for kj_rs_tokio::current_handle()
+//       LOOP_LOCAL_SET: Rc<LocalSet>          -- what kj_rs_tokio::spawn() enqueues onto and
+//                                                wait()/poll() drive. Not a TokioPort member
+//                                                because LocalSet is !Send; dropped by
+//                                                TokioEventPort's destructor
+//       activePort                            -- enforces one port per thread
+//
+//   Wake sources -> SharedState.notify: wake() from any thread (kj::Executor,
+//   CrossThreadPromiseFulfiller); on the loop thread setRunnable(true) and the SleepHooks timer
+//   callback; and the planned timer deadline via tokio's timer wheel.
+//
+// Teardown order is structural, not a convention: ~TokioEventPort cancels the LocalSet's spawned
+// tasks FIRST (they may own KJ promises whose destructors need the loop and timer), then destroys
+// the loop (asserting its queue is empty), the runtime, and finally the timer.
+
+#include "kj-rs-tokio/ffi.rs.h"
+
+#include <kj/async.h>
+#include <kj/exception.h>
+#include <kj/time.h>
+#include <kj/timer.h>
+
+namespace kj_rs_tokio {
+
+class TokioEventPort final: public kj::EventPort, private kj::TimerImpl::SleepHooks {
+ public:
+  TokioEventPort();
+  ~TokioEventPort() noexcept(false);
+  KJ_DISALLOW_COPY_AND_MOVE(TokioEventPort);
+
+  // kj::EventPort implementation. setRunnable(true) during wait() -- an event armed by a tokio
+  // task running inside the park -- ends the park; kj::EventLoop guarantees setRunnable(false)
+  // right before wait(), so that edge is always delivered.
+  bool wait() override;
+  bool poll() override;
+  void wake() const override;
+  void setRunnable(bool runnable) override;
+
+  // The kj::EventLoop this port drives. Owned by the port (see the file comment).
+  kj::EventLoop &getLoop() {
+    assertOwnerThread();
+    return *loop;
+  }
+
+  // Timer fed by this port. now() is frozen while KJ events run and advances only when the loop
+  // waits/polls, preserving stock KJ timer semantics (the port calls timerImpl.advanceTo() after
+  // every wait()/poll() return; timers would silently never fire otherwise).
+  kj::Timer &getTimer() {
+    assertOwnerThread();
+    return timerImpl;
+  }
+
+  // The Rust half (runtime + wake state). Rust code on this thread can also reach the runtime
+  // via kj_rs_tokio::current_handle() / kj_rs_tokio::spawn().
+  const TokioPort &getRustPort() const {
+    assertOwnerThread();
+    return *rustPort;
+  }
+
+  // Cancel every task spawned onto this thread's LocalSet (kj_rs_tokio::spawn()), running their
+  // destructors now. The destructor does this itself, first; TokioAsyncIoContext also does it
+  // while its WaitScope is still alive. This terminal operation is a no-op when repeated.
+  void cancelSpawnedTasks();
+
+ private:
+  // kj::TimerImpl::SleepHooks, installed by wait() for the duration of the park (KJ clears them
+  // in advanceTo()). KJ calls updateNextTimerEvent() whenever the earliest deadline changes; a
+  // deadline sooner than the one this wait() was planned against ends the park. While installed,
+  // kj::Timer::now() reads the live clock through getTimeWhileSleeping().
+  void updateNextTimerEvent(kj::Maybe<kj::TimePoint> time) override;
+  kj::TimePoint getTimeWhileSleeping() override {
+    assertOwnerThread();
+    return clock.now();
+  }
+
+  void assertOwnerThread() const;
+
+  const kj::ThreadId ownerThread;
+  const kj::MonotonicClock &clock;
+  // Declaration order is destruction order in reverse, and it matters: `loop` is destroyed
+  // first, then `rustPort` (the runtime), then `timerImpl`. The destructor body cancels spawned
+  // tasks before any of them go.
+  kj::TimerImpl timerImpl;
+  ::rust::Box<TokioPort> rustPort;
+  kj::Own<kj::EventLoop> loop;
+
+  // The earliest timer deadline wait() computed its sleep from (none = no timer; sleep forever).
+  // updateNextTimerEvent() compares against it so only a *sooner* deadline ends the park. Loop
+  // thread only; meaningful only inside wait().
+  kj::Maybe<kj::TimePoint> plannedNextEvent;
+
+  // Guards the Rust call in cancelSpawnedTasks(): a cancelled task's drop can throw (a panic
+  // surfaced as a kj::Exception by the cxx fork); if the caller is already unwinding, swallow
+  // rather than std::terminate (same pattern as ~RustPromiseAwaiter in kj-rs/awaiter.c++).
+  kj::UnwindDetector unwindDetector;
+};
+
+// Mirrors the shape of kj::setupAsyncIo() (see kj/async-io.h) for the tokio-backed loop. Owns
+// the event port (and thus the per-thread tokio runtime and the kj::EventLoop) and the
+// kj::WaitScope.
+//
+// Teardown: spawned tasks are cancelled first, while the WaitScope is still alive (the port's
+// own destructor would do it too, but by then the WaitScope is gone), then the WaitScope, then
+// the port (loop, runtime, timer -- see TokioEventPort). Bridged Rust futures that C++ co_awaits
+// are separate: they are cancelled through KJ promise destruction and never outlive the loop.
+struct TokioAsyncIoContext {
+  TokioAsyncIoContext(kj::Own<TokioEventPort> port, kj::Own<kj::WaitScope> waitScope)
+      : port(kj::mv(port)),
+        waitScope(kj::mv(waitScope)) {}
+  ~TokioAsyncIoContext() noexcept(false);
+  KJ_DISALLOW_COPY_AND_MOVE(TokioAsyncIoContext);
+
+  kj::Own<TokioEventPort> port;
+  kj::Own<kj::WaitScope> waitScope;
+
+  TokioEventPort &getPort() {
+    return *port;
+  }
+  kj::EventLoop &getLoop() {
+    return port->getLoop();
+  }
+  kj::WaitScope &getWaitScope() {
+    return *waitScope;
+  }
+  kj::Timer &getTimer() {
+    return port->getTimer();
+  }
+};
+
+TokioAsyncIoContext setupTokioAsyncIo();
+
+}  // namespace kj_rs_tokio


### PR DESCRIPTION
Groundwork for the tokio-backed Rust I/O backend (kj-rs-tokio / kj-rs-io,
landing separately); kj-rs itself stays a pure Promise<->Future bridge.

- Replace KjWaker with FutureWakerCell: every cloned waker is a same-thread
  cell (non-atomic kj::Refcounted; the bridge's single-thread axiom) that
  arms the owning FuturePollEvent directly via Event::armDepthFirst(). The
  cell's link to the event is weak and structurally invalidated when the
  event dies, so wakers Rust retains past the future's lifetime (e.g.
  parked in a channel's AtomicWaker) neutralize into safe no-ops instead of
  arming a freed event. Waker ownership round-trips through RawWaker data
  slots via kj::Rc::disown()/reown() -- hence the capnp-cpp pin bump to the
  current v2 head, which carries those (merged upstream).
- Replace the LinkedGroup machinery (linked-group.h + test) with an
  intrusive weak link (RustPromiseAwaiter::link / FuturePollEvent::leaves).
- Make bridged kj::Promise<T>s eager by default: the Rust future is polled
  to its first suspension point at conversion, so KJ callers no longer need
  a manual .eagerlyEvaluate(nullptr); RustFuture::lazily() is the escape
  hatch for the rare cold case.
- Convert panics escaping a bridged future's poll into kj::Exceptions (a
  rejected promise) instead of aborting the process, mirroring the sync
  bridge's catch_unwind path.
- Add a thread-local armed-waker hook so an integrating kj::EventPort that
  drives tokio tasks inside its own wait() (the upcoming kj-rs-tokio) can
  nudge itself out of a blocking park; null/no-op by default.
- Split the cxx bridge module out of lib.rs into ffi.rs, and quarantine
  unsafe into named FFI islands: deny(unsafe_code) crate-wide, re-allowed
  per-module only where the FFI seam genuinely needs it.
- Depend on @capnp-cpp//src/kj:kj-async-core instead of the :kj-async
  umbrella, keeping kj-rs (and everything built on it) off the concrete kj
  OS event loop.
- New tests: waker neutralization across event death (neutralize-waker-test),
  FuturePollEvent shared-event semantics (shared-event-test), and expanded
  future/awaiter coverage.