### PR TITLE
Add ci report opencode skill

### DIFF
--- a/.opencode/commands/ci.md
+++ b/.opencode/commands/ci.md
@@ -1,0 +1,25 @@
+---
+description: CI status report for a workerd PR
+subtask: true
+---
+
+Load the `ci-report` skill and produce a full CI report.
+
+**Arguments:** $ARGUMENTS
+
+If a PR number (e.g., `7010`) or URL (e.g.,
+`https://github.com/cloudflare/workerd/pull/7010`) is provided, use that PR.
+Otherwise, detect the PR associated with the current local branch. If there
+is no associated PR, say so and stop — do not prompt the user for a number.
+
+Follow the skill workflow:
+
+1. Use the `ci-report` custom tool (or replicate its logic) to gather all
+   GitHub Actions data in a single call. If no argument was provided, call
+   it without a `pr` parameter so it auto-detects the current branch.
+2. Use a single `portal_codemode_execute` call to gather all internal GitLab
+   pipeline data (if accessible).
+3. Triage every failure as material, pre-existing, or flaky by correlating
+   errors against the PR's changed files.
+4. Present the combined report with verdict.
+5. Offer to retry flaky jobs (never material failures).

--- a/.opencode/skills/ci-report/SKILL.md
+++ b/.opencode/skills/ci-report/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: ci-report
+description: CI status report for a workerd PR. Covers GitHub Actions checks and, for Cloudflare employees, the internal GitLab pipeline. Reports pass/fail for every job, extracts error details from failures, and offers to retry flaky jobs on either platform. Load this skill when the user asks about CI status, test failures, build failures, or wants to retry a failed CI job.
+---
+
+# CI Report
+
+Produce a CI status report for a workerd PR. The report covers GitHub Actions
+and, when accessible, the internal GitLab CI pipeline.
+
+## Inputs
+
+The user provides a PR number or URL. If omitted, the tool detects the current
+branch's open PR automatically.
+
+## Step 1: Gather GitHub CI data
+
+Use the **`ci-report`** custom tool to collect all GitHub-side data in a single
+call:
+
+```
+ci-report({ pr: 7017 })
+```
+
+This returns a JSON object containing:
+- `github.checks` — all GitHub Actions check statuses
+- `github.failures` — error snippets extracted from failed job logs
+- `internalBuild` — metadata parsed from the `internal-build` job log:
+  - `projectPath` and `pipelineId` (from failure URL, if present)
+  - `headRef` and `userLogin` (from log env vars)
+  - `branchRef` (the ref passed to the internal build script)
+  - `status` (pass/fail/absent)
+- `changedFiles` — files modified by the PR (for triage)
+- `mainBranch` — recent CI runs on `main` (for comparison)
+
+If `internalBuild.pipelineUrl` is present, use `projectPath` and `pipelineId`
+directly for GitLab queries. If it is null (the URL only appears on failure),
+use the `headRef` to search for the pipeline via `list_pipelines`, trying both
+the direct branch name and the `workerd-robot/` prefixed variant.
+
+## Step 2: Internal GitLab Pipeline
+
+Gather all GitLab data in a **single** `portal_codemode_execute` call. This
+replaces 4-6 separate MCP tool calls with one.
+
+If the project path is not known from Step 1, determine it from parent project
+context: check `../../.git/config` or `../../.gitlab-ci.yml`, or load the
+`parent-project-skills` skill. If it cannot be determined, skip this step.
+
+```javascript
+// portal_codemode_execute — single call for all GitLab CI data
+async () => {
+  const projectId = "<project-path>";
+
+  // If we have a pipeline ID from Step 1, use it directly.
+  // Otherwise, find the pipeline by branch ref.
+  let pipelineId = <ID or null>;
+
+  if (!pipelineId) {
+    // Try workerd-robot/ prefix first, then direct branch name
+    for (const ref of ["workerd-robot/<headRef>", "<headRef>"]) {
+      try {
+        const res = await codemode.gitlab_mcp_server_list_pipelines({
+          query: { project_id: projectId, ref, per_page: 3 }
+        });
+        const pipelines = JSON.parse(res[0].text);
+        if (pipelines.length > 0) {
+          pipelineId = pipelines[0].id;
+          break;
+        }
+      } catch { continue; }
+    }
+    if (!pipelineId) return { error: "No pipeline found" };
+  }
+
+  // Fetch failed and successful jobs in parallel
+  const [failedRes, successRes] = await Promise.allSettled([
+    codemode.gitlab_mcp_server_list_pipeline_jobs({
+      query: { project_id: projectId, pipeline_id: pipelineId,
+               scope: "failed", per_page: 50 }
+    }),
+    codemode.gitlab_mcp_server_list_pipeline_jobs({
+      query: { project_id: projectId, pipeline_id: pipelineId,
+               scope: "success", per_page: 50 }
+    }),
+  ]);
+
+  const failedJobs = failedRes.status === "fulfilled"
+    ? JSON.parse(failedRes.value[0].text) : [];
+  const successJobs = successRes.status === "fulfilled"
+    ? JSON.parse(successRes.value[0].text) : [];
+
+  // Fetch logs for failed jobs in parallel, extract errors
+  const failures = await Promise.all(failedJobs.map(async (j) => {
+    try {
+      const log = await codemode.gitlab_mcp_server_get_job_log({
+        query: { project_id: projectId, job_id: j.id }
+      });
+      const logText = JSON.parse(log[0].text).log;
+      const errors = [];
+      const lines = logText.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (/error:|error\[|ERROR:|FAILED|FAIL:|fatal:|make: \*\*\*/.test(lines[i])) {
+          const snippet = lines.slice(Math.max(0,i-2), Math.min(lines.length,i+6)).join("\n");
+          if (errors.length < 5) errors.push(snippet);
+        }
+      }
+      return { id: j.id, name: j.name, status: j.status,
+               allow_failure: j.allow_failure,
+               duration: Math.round(j.duration)+"s", errors };
+    } catch {
+      return { id: j.id, name: j.name, status: j.status,
+               allow_failure: j.allow_failure,
+               duration: Math.round(j.duration)+"s",
+               errors: ["Failed to fetch log"] };
+    }
+  }));
+
+  return {
+    pipelineId,
+    passed: successJobs.map(j => ({
+      name: j.name, duration: Math.round(j.duration)+"s"
+    })),
+    failures,
+  };
+}
+```
+
+If the call fails with an authentication or authorization error, report:
+
+> GitLab CI: not accessible (you may not have the GitLab MCP server enabled
+> or lack project access). GitHub-only report shown above.
+
+## Step 3: Failure Triage
+
+For every failure found in Steps 1-2, determine whether it is **material**
+(caused by this PR's changes) or **likely a flake / pre-existing breakage**.
+This is the most important part of the report.
+
+### 3a. Files changed
+
+Use `changedFiles` from the Step 1 tool output — no additional call needed.
+
+### 3b. Classify each failure
+
+For each failure, apply these checks in order:
+
+**Material (caused by this PR):**
+- The error references a file, symbol, type, or crate that the PR modifies
+- The error is a compile error in code the PR touches or in code that directly
+  depends on code the PR touches (e.g., a type change that breaks a downstream
+  consumer)
+- The error is a test failure in a test the PR modifies, or a test that
+  exercises functionality the PR changes
+- The error mentions a symbol the PR added, removed, renamed, or changed the
+  signature of
+
+**Likely flake / pre-existing:**
+- The error is an infrastructure issue: runner failures, DNS resolution,
+  network timeouts, Docker pull failures, disk space, OOM kills
+- The error is in code completely unrelated to the PR's changes (different
+  crate, different directory, no dependency relationship)
+- The same failure appears on the `main` branch or other recent PRs (check
+  via `gh run list --repo cloudflare/workerd --branch main --limit 5` if
+  uncertain)
+- The error is a test timeout with no assertion failure
+- The error references `sudo: unable to resolve host` or similar CI
+  environment issues
+
+**Uncertain:**
+- If the relationship is unclear, say so and explain what would need to be
+  checked. Do not guess.
+
+### 3c. Check main branch for comparison (when helpful)
+
+Use `mainBranch` from the Step 1 tool output to see if `main` is also failing.
+If a specific workflow is failing on `main` with the same conclusion, the
+failure is pre-existing and not caused by this PR.
+
+## Step 4: Combined Report
+
+Present a single combined report with two sections:
+
+### GitHub Actions
+- Total: N jobs, N passed, N failed, N skipped/pending
+- Table of all jobs
+- Error details for failures (collapsed if many)
+
+### Internal GitLab CI
+- Pipeline URL (the full URL extracted from `internal-build` logs)
+- Total: N jobs, N passed, N failed
+- Table of all jobs
+- Error details for failures
+
+### Failure Classification
+
+For each failure, state the classification clearly:
+
+| Failure | Classification | Reasoning |
+| ------- | -------------- | --------- |
+
+### Verdict
+
+State one of:
+- **All green** — all jobs on both platforms pass
+- **GitHub green, GitLab failing** — with root cause summary
+- **GitHub failing** — with root cause summary
+- **Both failing** — with root cause summary
+- **GitHub green, GitLab unknown** — if GitLab is inaccessible
+
+Qualify the verdict with the triage results. For example: "GitLab failing, but
+all failures are material — the PR removes `Send` from `KjOwn` and an internal
+consumer relies on it" or "GitLab failing, but the failure is pre-existing on
+main and unrelated to this PR."
+
+If the same error appears across multiple GitLab jobs (common for compile
+errors), deduplicate: show the error once and list which jobs hit it.
+
+## Step 5: Retry Offer
+
+If any jobs failed, offer to retry based on the triage from Step 3.
+
+### GitHub retry capabilities
+
+Retry individual failed runs or all failed jobs:
+
+```bash
+# Rerun only failed jobs in a run
+gh run rerun <run-id> --failed --repo cloudflare/workerd
+
+# Rerun a specific job (use databaseId, NOT the job number from the URL)
+# First get the correct ID:
+gh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId}'
+# Then:
+gh run rerun <run-id> --job <databaseId> --repo cloudflare/workerd
+```
+
+### GitLab retry capabilities
+
+Retry individual jobs or the entire pipeline (using the project path and IDs
+extracted from the `internal-build` log):
+
+```javascript
+// Retry a single job
+gitlab_mcp_server_retry_job({
+  query: {
+    project_id: "<project-path>",
+    job_id: <job_id>
+  }
+})
+
+// Retry all failed jobs in a pipeline
+gitlab_mcp_server_retry_pipeline({
+  query: {
+    project_id: "<project-path>",
+    pipeline_id: <pipeline_id>
+  }
+})
+```
+
+### When to suggest retries
+
+Use the classification from Step 3 to guide the recommendation:
+
+- **Flaky/infra failures**: suggest retry. These are timeouts, network errors,
+  runner issues, DNS resolution failures, Docker pull failures, etc.
+- **Pre-existing failures**: suggest retry only if there is reason to believe
+  the failure is intermittent. If it fails consistently on `main`, a retry
+  will not help — say so.
+- **Material failures**: do NOT suggest retry — these are real failures caused
+  by the PR that need code fixes. Explain what needs to change.
+- **Mixed**: separate the flaky from the material and offer to retry only the
+  flaky ones.
+
+Always confirm with the user before executing any retry.
+
+## Notes
+
+- The `internal-build` GitHub job triggers GitLab via
+  `tools/cross/internal_build.py`. The GitLab branch name depends on whether
+  a matching branch already exists in the internal project: if it does, that
+  branch is used directly; otherwise, the branch is prefixed with
+  `workerd-robot/`. The actual branch used is visible in the `internal-build`
+  job log and in the GitLab pipeline's `ref` field.
+- Internal patches are applied on top of the workerd checkout in GitLab
+  (visible in the log as "Applying ... to deps/workerd..."). Failures caused
+  by patch conflicts are distinct from code errors — flag them as such.
+- GitLab job names typically follow patterns like `x64-release-build`,
+  `x64-debug-build`, `x64-asan-debug-build`, `x64-ubsan-build`,
+  `arm64-build`, `lint-build`. The lint job runs clippy and formatting checks
+  and is typically the fastest to finish.

--- a/.opencode/tools/ci-report.ts
+++ b/.opencode/tools/ci-report.ts
@@ -1,0 +1,288 @@
+import { tool } from '@opencode-ai/plugin';
+
+export default tool({
+  description:
+    'Gather CI status for a workerd GitHub PR. Returns a structured report of all ' +
+    'GitHub Actions checks, error details from failed jobs, internal GitLab pipeline ' +
+    'metadata (project path, pipeline ID, branch ref) extracted from the internal-build ' +
+    'job log, the list of files changed by the PR, and recent main branch CI status ' +
+    'for comparison. This single call replaces 6-8 individual gh/grep/tail calls.',
+  args: {
+    pr: tool.schema
+      .number()
+      .describe('PR number. If omitted, detects from the current branch.')
+      .optional(),
+  },
+  async execute(args, ctx) {
+    const repo = 'cloudflare/workerd';
+
+    // Resolve PR number
+    let pr = args.pr;
+    if (!pr) {
+      try {
+        const result =
+          await Bun.$`gh pr view --repo ${repo} --json number --jq .number`
+            .text();
+        pr = parseInt(result.trim(), 10);
+        if (isNaN(pr)) return 'No open PR found for the current branch.';
+      } catch {
+        return 'No open PR found for the current branch. Provide a PR number.';
+      }
+    }
+
+    // Run independent queries in parallel
+    const [checksRaw, diffRaw, mainRunsRaw] = await Promise.all([
+      Bun.$`gh pr checks ${pr} --repo ${repo}`.text().catch((e: any) => e.stdout?.toString() ?? ''),
+      Bun.$`gh pr diff ${pr} --repo ${repo} --name-only`.text().catch(() => ''),
+      Bun.$`gh run list --repo ${repo} --branch main --limit 5 --json databaseId,conclusion,displayTitle,event,headBranch,workflowName`
+        .text()
+        .catch(() => '[]'),
+    ]);
+
+    // Parse checks
+    const checks = parseChecks(checksRaw);
+    const failedChecks = checks.filter((c) => c.status === 'fail');
+
+    // Extract error details from failed jobs (parallel)
+    const failureDetails = await Promise.all(
+      failedChecks.map(async (check) => {
+        const jobId = extractJobId(check.url);
+        if (!jobId) return { ...check, errors: [], log: '' };
+        try {
+          const log =
+            await Bun.$`gh api repos/${repo}/actions/jobs/${jobId}/logs`
+              .text();
+          const errors = extractErrors(log);
+          return { ...check, errors, log };
+        } catch {
+          return { ...check, errors: ['Failed to fetch job log'], log: '' };
+        }
+      })
+    );
+
+    // Extract internal-build info
+    const internalBuild = extractInternalBuildInfo(failureDetails, checks);
+
+    // If internal-build passed but we didn't get a pipeline URL from failures,
+    // fetch its log separately to get the branch ref
+    if (!internalBuild.pipelineUrl && internalBuild.jobId) {
+      try {
+        const log =
+          await Bun.$`gh api repos/${repo}/actions/jobs/${internalBuild.jobId}/logs`
+            .text();
+        const info = parseInternalBuildLog(log);
+        Object.assign(internalBuild, info);
+      } catch {
+        // Not critical
+      }
+    }
+
+    // Parse changed files
+    const changedFiles = diffRaw
+      .trim()
+      .split('\n')
+      .filter((f) => f.length > 0);
+
+    // Parse main branch runs
+    let mainRuns: any[] = [];
+    try {
+      mainRuns = JSON.parse(mainRunsRaw);
+    } catch {
+      // ignore
+    }
+
+    // Build the report
+    const report: CIReport = {
+      pr,
+      github: {
+        total: checks.length,
+        passed: checks.filter((c) => c.status === 'pass').length,
+        failed: failedChecks.length,
+        skipped: checks.filter(
+          (c) => c.status !== 'pass' && c.status !== 'fail'
+        ).length,
+        checks,
+        failures: failureDetails.filter((f) => f.errors.length > 0),
+      },
+      internalBuild,
+      changedFiles,
+      mainBranch: mainRuns.map((r: any) => ({
+        id: r.databaseId,
+        conclusion: r.conclusion,
+        workflow: r.workflowName,
+        title: r.displayTitle,
+      })),
+    };
+
+    return JSON.stringify(report, null, 2);
+  },
+});
+
+// --- Types ---
+
+interface Check {
+  name: string;
+  status: string;
+  duration: string;
+  url: string;
+}
+
+interface CIReport {
+  pr: number;
+  github: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    checks: Check[];
+    failures: Array<Check & { errors: string[]; log: string }>;
+  };
+  internalBuild: InternalBuildInfo;
+  changedFiles: string[];
+  mainBranch: Array<{
+    id: number;
+    conclusion: string;
+    workflow: string;
+    title: string;
+  }>;
+}
+
+interface InternalBuildInfo {
+  status: string;
+  jobId: string | null;
+  runId: string | null;
+  pipelineUrl: string | null;
+  pipelineId: string | null;
+  projectPath: string | null;
+  branchRef: string | null;
+  headRef: string | null;
+  userLogin: string | null;
+}
+
+// --- Parsing helpers ---
+
+function parseChecks(raw: string): Check[] {
+  return raw
+    .trim()
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const parts = line.split('\t');
+      return {
+        name: parts[0]?.trim() ?? '',
+        status: parts[1]?.trim() ?? '',
+        duration: parts[2]?.trim() ?? '',
+        url: parts[3]?.trim() ?? '',
+      };
+    })
+    .filter((c) => c.name.length > 0);
+}
+
+function extractJobId(url: string): string | null {
+  // URL format: .../actions/runs/<run-id>/job/<job-id>
+  const m = url.match(/\/job(?:s)?\/(\d+)/);
+  return m ? m[1] : null;
+}
+
+function extractErrors(log: string): string[] {
+  const lines = log.split('\n');
+  const errors: string[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (
+      /\b(ERROR:|FAILED:|error\[|error:|fatal:|make: \*\*\*|Process completed with exit code [^0])/.test(
+        line
+      )
+    ) {
+      // Grab context: 2 lines before, 5 after
+      const start = Math.max(0, i - 2);
+      const end = Math.min(lines.length - 1, i + 5);
+      const snippet = lines
+        .slice(start, end + 1)
+        .map((l) => l.replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*\d+[OE]\s*/, ''))
+        .join('\n');
+
+      // Deduplicate identical snippets
+      const key = snippet.slice(0, 200);
+      if (!seen.has(key)) {
+        seen.add(key);
+        errors.push(snippet);
+      }
+    }
+  }
+
+  // Cap at 10 error snippets to avoid huge output
+  return errors.slice(0, 10);
+}
+
+function extractInternalBuildInfo(
+  failureDetails: Array<Check & { errors: string[]; log: string }>,
+  allChecks: Check[]
+): InternalBuildInfo {
+  const info: InternalBuildInfo = {
+    status: 'unknown',
+    jobId: null,
+    runId: null,
+    pipelineUrl: null,
+    pipelineId: null,
+    projectPath: null,
+    branchRef: null,
+    headRef: null,
+    userLogin: null,
+  };
+
+  // Find internal-build check
+  const ibCheck = allChecks.find((c) => c.name === 'internal-build');
+  if (!ibCheck) {
+    info.status = 'absent';
+    return info;
+  }
+
+  info.status = ibCheck.status;
+  info.jobId = extractJobId(ibCheck.url);
+
+  const runMatch = ibCheck.url.match(/\/runs\/(\d+)/);
+  info.runId = runMatch ? runMatch[1] : null;
+
+  // If it failed, we already have the log in failureDetails
+  const ibFailure = failureDetails.find((f) => f.name === 'internal-build');
+  if (ibFailure?.log) {
+    Object.assign(info, parseInternalBuildLog(ibFailure.log));
+  }
+
+  return info;
+}
+
+function parseInternalBuildLog(log: string): Partial<InternalBuildInfo> {
+  const result: Partial<InternalBuildInfo> = {};
+
+  // Extract pipeline URL (only present on failure)
+  const pipelineMatch = log.match(
+    /Internal pipeline (?:failed|succeeded):\s*(https:\/\/gitlab\.cfdata\.org\/([^/]+(?:\/[^/]+)*)\/\-\/pipelines\/(\d+))/
+  );
+  if (pipelineMatch) {
+    result.pipelineUrl = pipelineMatch[1];
+    result.projectPath = pipelineMatch[2];
+    result.pipelineId = pipelineMatch[3];
+  }
+
+  // Extract branch ref
+  const headRefMatch = log.match(/HEAD_REF:\s*(\S+)/);
+  if (headRefMatch) result.headRef = headRefMatch[1];
+
+  const userMatch = log.match(/USER_LOGIN:\s*(\S+)/);
+  if (userMatch) result.userLogin = userMatch[1];
+
+  // Extract the actual ref used (could be direct or workerd-robot/ prefixed)
+  const refMatch = log.match(/REF="([^"]+)"/g);
+  if (refMatch) {
+    // Last REF= assignment is the one that's used (the else branch for non-forks)
+    const last = refMatch[refMatch.length - 1];
+    const m = last.match(/REF="([^"]+)"/);
+    if (m) result.branchRef = m[1];
+  }
+
+  return result;
+}


### PR DESCRIPTION
Teach opencode how to report on CI status, optionally with the ability to restart flaky failures.

Use: `/ci {PR number | URL | blank}` ... if the argument is not given, will check CI status for the local branch if a PR exists for it.