### PR TITLE
[build] Prepare workerd for explicit libc++ linkage

### DIFF
--- a/build/BUILD.sqlite3
+++ b/build/BUILD.sqlite3
@@ -42,10 +42,17 @@ GENERATED_SOURCES = []
 # We have not set SQLITE_SMALL_STACK, so this Bazel-build file does
 # not bother with tool/vdbe-compress.tcl.
 
+# The build tools below are C only, so they opt out of the extra library that the build links into
+# every binary (V8's libc++, in the edgeworker build). This is load bearing for mksourceid:
+# `sqlite3_h` copies it out of bazel-out before running it, which leaves an $ORIGIN-relative RUNPATH
+# pointing at nothing, so it must not acquire a dynamic dependency on a C++ runtime.
+LINK_EXTRA_LIB_NONE = "@bazel_tools//tools/cpp:empty_lib"
+
 cc_binary(
     name = "lemon",
     srcs = ["tool/lemon.c"],
     copts = ["-w"],
+    link_extra_lib = LINK_EXTRA_LIB_NONE,
 )
 
 # ========================================================================
@@ -199,6 +206,7 @@ cc_binary(
     name = "mkkeywordhash",
     srcs = ["tool/mkkeywordhash.c"],
     copts = ["-w"],
+    link_extra_lib = LINK_EXTRA_LIB_NONE,
 )
 
 genrule(
@@ -217,6 +225,7 @@ cc_binary(
     name = "mksourceid",
     srcs = ["tool/mksourceid.c"],
     copts = ["-w"],
+    link_extra_lib = LINK_EXTRA_LIB_NONE,
 )
 
 genrule(

--- a/src/rust/cxx/BUILD.bazel
+++ b/src/rust/cxx/BUILD.bazel
@@ -8,6 +8,7 @@ rust_library(
     link_deps = [
         ":core",
         "//src/rust/cxx/third-party:runtime",
+        "@@//deps:rust_runtime",
     ],
     proc_macro_deps = [
         ":cxxbridge-macro",
@@ -82,6 +83,7 @@ rust_binary(
     srcs = glob(["gen/cmd/src/*.rs"]),
     compile_data = ["include/cxx.h"],
     edition = "2024",
+    link_deps = ["@@//deps:rust_runtime"],
     target_compatible_with = select({
         "@//build/config:no_build": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/src/workerd/api/cache.c++
+++ b/src/workerd/api/cache.c++
@@ -342,18 +342,16 @@ jsg::Promise<void> Cache::put(jsg::Lock& js,
       traceContext.setTag("cache.request.payload.size"_kjc, static_cast<int64_t>(length));
     }
 
-    // Wait for output locks and cache put quota, trying to avoid returning to the KJ event loop
-    // in the common case where no waits are needed.
-    // TODO(later): With Cache streams no longer having a size limit enforced by the runtime,
-    // explore if we can clean up stream serialization too.
+    // Wait for output locks, trying to avoid returning to the KJ event loop in the common case
+    // where no waits are needed.
     jsg::Promise<IoOwn<kj::AsyncInputStream>> startStreamPromise = nullptr;
-    auto makeCachePutStream = [&context, stream = kj::mv(payload.stream)](jsg::Lock& js) mutable {
-      return context.makeCachePutStream(js, kj::mv(stream));
-    };
     KJ_IF_SOME(p, context.waitForOutputLocksIfNecessary()) {
-      startStreamPromise = context.awaitIo(js, kj::mv(p), kj::mv(makeCachePutStream));
+      startStreamPromise = context.awaitIo(
+          js, kj::mv(p), [&context, stream = kj::mv(payload.stream)](jsg::Lock&) mutable {
+        return context.addObject(kj::mv(stream));
+      });
     } else {
-      startStreamPromise = makeCachePutStream(js);
+      startStreamPromise = js.resolvedPromise(context.addObject(kj::mv(payload.stream)));
     }
 
     return startStreamPromise.then(js,

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -265,6 +265,14 @@ wd_test(
 )
 
 wd_test(
+    src = "cache-put-stream-test.wd-test",
+    data = [
+        "cache-mock.js",
+        "cache-put-stream-test.js",
+    ],
+)
+
+wd_test(
     src = "kv-test.wd-test",
     args = ["--experimental"],
     data = [

--- a/src/workerd/api/tests/cache-put-stream-test.js
+++ b/src/workerd/api/tests/cache-put-stream-test.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import assert from 'node:assert';
+
+export const concurrentClonePuts = {
+  async test() {
+    const { readable, writable } = new TransformStream();
+    const response = new Response(readable);
+    const clone = response.clone();
+
+    const puts = Promise.all([
+      caches.default.put('https://example.com/clone-1', response),
+      caches.default.put('https://example.com/clone-2', clone),
+    ]);
+
+    const writer = writable.getWriter();
+    const write = (async () => {
+      const chunk = new Uint8Array(64 * 1024);
+      for (let i = 0; i < 16; ++i) {
+        await writer.write(chunk);
+      }
+      await writer.close();
+    })();
+
+    const result = await Promise.race([
+      Promise.all([puts, write]).then(() => 'completed'),
+      scheduler.wait(5000).then(() => 'timed out'),
+    ]);
+    assert.strictEqual(result, 'completed');
+  },
+};

--- a/src/workerd/api/tests/cache-put-stream-test.wd-test
+++ b/src/workerd/api/tests/cache-put-stream-test.wd-test
@@ -1,0 +1,22 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "cache-test",
+      worker = (
+        modules = [
+          ( name = "worker", esModule = embed "cache-put-stream-test.js" )
+        ],
+        cacheApiOutbound = "cache-backend",
+        compatibilityFlags = ["nodejs_compat"],
+      )
+    ),
+    ( name = "cache-backend",
+      worker = (
+        modules = [
+          ( name = "worker", esModule = embed "cache-mock.js" )
+        ],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -161,7 +161,6 @@ IoContext::IoContext(ThreadContext& thread,
       threadId(getThreadId()),
       deleteQueue(kj::arc<DeleteQueue>()),
       reverseIoOwnValidity(kj::arc<ReverseIoOwnValidity>()),
-      cachePutSerializer(kj::READY_NOW),
       timeoutManager(kj::heap<TimeoutManagerImpl>()),
       waitUntilTasks(*this),
       tasks(*this),
@@ -1592,64 +1591,6 @@ void IoContext::abortFromHang(Worker::AsyncLock& asyncLock) {
         "had hung and would never generate a response. Refer to: "
         "https://developers.cloudflare.com/workers/observability/errors/"));
   }
-}
-
-namespace {
-
-class CacheSerializedInputStream final: public kj::AsyncInputStream {
- public:
-  CacheSerializedInputStream(
-      kj::Own<kj::AsyncInputStream> inner, kj::Own<kj::PromiseFulfiller<void>> fulfiller)
-      : inner(kj::mv(inner)),
-        fulfiller(kj::mv(fulfiller)) {}
-
-  ~CacheSerializedInputStream() noexcept(false) {
-    fulfiller->fulfill();
-  }
-
-  kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
-    return inner->tryRead(buffer, minBytes, maxBytes);
-  }
-
-  kj::Maybe<uint64_t> tryGetLength() override {
-    return inner->tryGetLength();
-  }
-
-  kj::Promise<uint64_t> pumpTo(kj::AsyncOutputStream& output, uint64_t amount) override {
-    return inner->pumpTo(output, amount);
-  }
-
- private:
-  kj::Own<kj::AsyncInputStream> inner;
-  kj::Own<kj::PromiseFulfiller<void>> fulfiller;
-};
-
-}  // namespace
-
-jsg::Promise<IoOwn<kj::AsyncInputStream>> IoContext::makeCachePutStream(
-    jsg::Lock& js, kj::Own<kj::AsyncInputStream> stream) {
-  auto paf = kj::newPromiseAndFulfiller<void>();
-
-  KJ_DEFER(cachePutSerializer = kj::mv(paf.promise));
-
-  return awaitIo(js,
-      cachePutSerializer.then(
-          [fulfiller = kj::mv(paf.fulfiller),
-              stream = kj::mv(stream)]() mutable -> kj::Own<kj::AsyncInputStream> {
-    if (stream->tryGetLength() != kj::none) {
-      // PUT with Content-Length. We can just return immediately, allowing the next PUT to start.
-      KJ_DEFER(fulfiller->fulfill());
-      return kj::mv(stream);
-    } else {
-      // TODO(later): With Cache streams no longer having a size limit enforced by the runtime,
-      // explore if we can clean up stream serialization too.
-      // PUT with Transfer-Encoding: chunked. We have no idea how big this request body is going to
-      // be, so wrap the stream that only unblocks the next PUT after this one is complete.
-      return kj::heap<CacheSerializedInputStream>(kj::mv(stream), kj::mv(fulfiller));
-    }
-  }),
-      [this](
-          jsg::Lock&, kj::Own<kj::AsyncInputStream> result) { return addObject(kj::mv(result)); });
 }
 
 void IoContext::writeLogfwdr(

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -1076,15 +1076,6 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   // available in internal tracing.
   [[nodiscard]] TraceContext makeUserTraceSpan(kj::ConstString operationName);
 
-  // Implement per-IoContext rate limiting for Cache.put(). Pass the body of a Cache API PUT
-  // request and get a possibly wrapped stream back.
-  //
-  // If the stream has an unknown length, you will get a wrapped stream back that is used to
-  // serialize PUT requests.
-  jsg::Promise<IoOwn<kj::AsyncInputStream>> makeCachePutStream(
-      jsg::Lock& js, kj::Own<kj::AsyncInputStream> stream);
-  // TODO(cleanup): Factor this into getCacheClient() somehow so it's not opt-in.
-
   // Gets a CapabilityServerSet representing the capnp capabilities hosted by this request or
   // actor context. This allows us to implement the CapnpCapability::unwrap() method on
   // capabilities which allows the application to get at the underlying server object, when the
@@ -1161,11 +1152,6 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   OwnedObjectList ownedObjects;
 
   kj::Maybe<kj::Rc<ExternalPusherImpl>> externalPusher;
-
-  // Implementation detail of makeCachePutStream().
-
-  // TODO: Used for Cache PUT serialization.
-  kj::Promise<void> cachePutSerializer;
 
   // The timeout manager needs to live below `deleteQueue` because the promises may refer to
   // objects in the queue.

--- a/src/workerd/server/tests/compile-tests/BUILD.bazel
+++ b/src/workerd/server/tests/compile-tests/BUILD.bazel
@@ -16,4 +16,5 @@ sh_test(
         "//src/workerd/server:workerd",
     ],
     tags = ["no-qemu"],
+    target_compatible_with = ["@//build/platforms:compilation_mode_release"],
 )


### PR DESCRIPTION
Edgeworker now supplies libc++ globally through link_extra_libs rather
than toolchain linker flags. Fix the workerd targets that cannot use
this dependency directly.

Release note: None