### PR TITLE
[build] Prepare workerd for explicit libc++ linkage

### DIFF
--- a/src/rust/cxx/BUILD.bazel
+++ b/src/rust/cxx/BUILD.bazel
@@ -8,6 +8,7 @@ rust_library(
     link_deps = [
         ":core",
         "//src/rust/cxx/third-party:runtime",
+        "@@//deps:rust_runtime",
     ],
     proc_macro_deps = [
         ":cxxbridge-macro",
@@ -82,6 +83,11 @@ rust_binary(
     srcs = glob(["gen/cmd/src/*.rs"]),
     compile_data = ["include/cxx.h"],
     edition = "2024",
+    experimental_use_cc_common_link = select({
+        "@platforms//os:windows": 0,
+        "//conditions:default": 1,
+    }),
+    link_deps = ["@@//deps:rust_runtime"],
     target_compatible_with = select({
         "@//build/config:no_build": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/src/workerd/server/tests/compile-tests/compile-test.sh
+++ b/src/workerd/server/tests/compile-tests/compile-test.sh
@@ -11,6 +11,9 @@ EXPECTED=$3
 
 # Bazel creates a fresh, writable $TEST_TMPDIR for each test and cleans it up after the test finishes.
 CAPNP_BINARY=$TEST_TMPDIR/compiled-workerd
+# `workerd compile` preserves workerd's $ORIGIN-relative RUNPATH. Add a workerd.runfiles
+# link next to the generated executable so it can load debug shared libraries.
+ln -s "$TEST_SRCDIR" "$TEST_TMPDIR/workerd.runfiles"
 PORT_FILE=$TEST_TMPDIR/port
 
 # Compile the app


### PR DESCRIPTION
Edgeworker now supplies libc++ through link_extra_libs.
For "rust_" targets it is supplied via "@@//deps:rust_runtime".

Fix helloworld_compile_test to work with $ORIGIN relative RUNPATH.

Release note: None