### PR TITLE
properly allocate refcounted objects

### DIFF
--- a/src/workerd/api/base64-test.c++
+++ b/src/workerd/api/base64-test.c++
@@ -12,10 +12,10 @@ KJ_TEST("base64 encode") {
   TestFixture t;
 
   t.runInIoContext([](const workerd::TestFixture::Environment& env) {
-    auto b = Base64Module();
+    auto b = env.js.alloc<Base64Module>();
     auto ab = jsg::JsArrayBuffer::create(env.js, 1);
     ab.asArrayPtr().begin()[0] = 'A';
-    auto ret = b.encodeArray(env.js, jsg::JsBufferSource(ab));
+    auto ret = b->encodeArray(env.js, jsg::JsBufferSource(ab));
     KJ_ASSERT(ret.asArrayPtr() == "QQ=="_kjb);
   });
 }
@@ -24,10 +24,10 @@ KJ_TEST("base64 valid decode") {
   TestFixture t;
 
   t.runInIoContext([](const workerd::TestFixture::Environment& env) {
-    auto b = Base64Module();
+    auto b = env.js.alloc<Base64Module>();
     auto ab = jsg::JsArrayBuffer::create(env.js, 4);
     ab.asArrayPtr().copyFrom("QQ=="_kjb);
-    auto ret = b.decodeArray(env.js, jsg::JsBufferSource(ab));
+    auto ret = b->decodeArray(env.js, jsg::JsBufferSource(ab));
     KJ_ASSERT(ret.asArrayPtr() == "A"_kjb);
   });
 }
@@ -36,11 +36,11 @@ KJ_TEST("base64 invalid decode") {
   TestFixture t;
 
   t.runInIoContext([](const workerd::TestFixture::Environment& env) {
-    auto b = Base64Module();
+    auto b = env.js.alloc<Base64Module>();
     auto ab = jsg::JsArrayBuffer::create(env.js, 14);
     ab.asArrayPtr().copyFrom("INVALID BASE64"_kjb);
     try {
-      b.decodeArray(env.js, jsg::JsBufferSource(ab));
+      b->decodeArray(env.js, jsg::JsBufferSource(ab));
       KJ_UNREACHABLE;
     } catch (kj::Exception& e) {
       KJ_EXPECT(e.getDescription().contains("jsg.DOMException(SyntaxError): Invalid base64"_kj));
@@ -52,10 +52,10 @@ KJ_TEST("base64 decode as string") {
   TestFixture t;
 
   t.runInIoContext([](const workerd::TestFixture::Environment& env) {
-    auto b = Base64Module();
+    auto b = env.js.alloc<Base64Module>();
     auto ab = jsg::JsArrayBuffer::create(env.js, 1);
     ab.asArrayPtr().begin()[0] = 'A';
-    KJ_ASSERT(b.encodeArrayToString(env.js, jsg::JsBufferSource(ab)) == env.js.str("QQ=="_kj));
+    KJ_ASSERT(b->encodeArrayToString(env.js, jsg::JsBufferSource(ab)) == env.js.str("QQ=="_kj));
   });
 }
 }  // namespace

--- a/src/workerd/api/container-test.c++
+++ b/src/workerd/api/container-test.c++
@@ -595,8 +595,8 @@ KJ_TEST("Container::start monitors a container that exits immediately") {
   auto fixture = makeFixture();
   fixture.runInIoContext([](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto weakContext = env.context.getWeakRef();
-    auto container = kj::heap<Container>(
-        rpc::Container::Client(kj::heap<ImmediateExitContainerServer>()), false);
+    auto container =
+        kj::rc<Container>(rpc::Container::Client(kj::heap<ImmediateExitContainerServer>()), false);
 
     container->start(env.js, kj::none);
     KJ_EXPECT(container->getRunning());
@@ -642,7 +642,7 @@ KJ_TEST("Container::start forwards a named instance type") {
 
   fixture.runInIoContext([promise = kj::mv(promise), fulfiller = kj::mv(paf.fulfiller)](
                              const TestFixture::Environment& env) mutable {
-    auto container = kj::heap<Container>(
+    auto container = kj::rc<Container>(
         rpc::Container::Client(kj::heap<MockContainerServer>(kj::mv(fulfiller))), false);
     container->start(env.js,
         Container::StartupOptions{
@@ -666,7 +666,7 @@ KJ_TEST("Container::start forwards custom instance resources") {
 
   fixture.runInIoContext([promise = kj::mv(promise), fulfiller = kj::mv(paf.fulfiller)](
                              const TestFixture::Environment& env) mutable {
-    auto container = kj::heap<Container>(
+    auto container = kj::rc<Container>(
         rpc::Container::Client(kj::heap<MockContainerServer>(kj::mv(fulfiller))), false);
     container->start(env.js,
         Container::StartupOptions{
@@ -693,7 +693,7 @@ KJ_TEST("Container::snapshotDirectory propagates the current span context") {
   auto fixture = makeFixture();
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    auto container = kj::heap<Container>(
+    auto container = kj::rc<Container>(
         rpc::Container::Client(kj::heap<MockContainerServer>(directoryCalled, containerCalled)),
         true);
     auto promise = container->snapshotDirectory(env.js,
@@ -714,7 +714,7 @@ KJ_TEST("Container::snapshotContainer propagates the current span context") {
   auto fixture = makeFixture();
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    auto container = kj::heap<Container>(
+    auto container = kj::rc<Container>(
         rpc::Container::Client(kj::heap<MockContainerServer>(directoryCalled, containerCalled)),
         true);
     auto promise = container->snapshotContainer(env.js,
@@ -735,7 +735,7 @@ KJ_TEST("Container::exec forwards pty options and resize() sends a resize RPC") 
   auto paf = kj::newPromiseAndFulfiller<void>();
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
-    auto container = kj::heap<Container>(
+    auto container = kj::rc<Container>(
         rpc::Container::Client(kj::heap<MockExecContainerServer>(
             env.context.getByteStreamFactory(), observations, kj::mv(paf.fulfiller))),
         true);
@@ -770,8 +770,8 @@ KJ_TEST("Container::exec without pty leaves the process non-pty and rejects resi
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto container =
-        kj::heap<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
-                                env.context.getByteStreamFactory(), observations, kj::none)),
+        kj::rc<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
+                              env.context.getByteStreamFactory(), observations, kj::none)),
             true);
 
     auto jsPromise = container->exec(env.js, kj::arr(kj::str("/bin/sh")), kj::none)
@@ -801,8 +801,8 @@ KJ_TEST("Container::exec with pty: true boolean shorthand enables PTY with defau
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto container =
-        kj::heap<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
-                                env.context.getByteStreamFactory(), observations, kj::none)),
+        kj::rc<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
+                              env.context.getByteStreamFactory(), observations, kj::none)),
             true);
 
     ExecOptions options;
@@ -829,8 +829,8 @@ KJ_TEST("Container::exec with pty: {} empty object enables PTY with server defau
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto container =
-        kj::heap<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
-                                env.context.getByteStreamFactory(), observations, kj::none)),
+        kj::rc<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
+                              env.context.getByteStreamFactory(), observations, kj::none)),
             true);
 
     ExecOptions options;
@@ -857,8 +857,8 @@ KJ_TEST("Container::exec with pty rejects explicit stderr: \"pipe\"") {
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto container =
-        kj::heap<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
-                                env.context.getByteStreamFactory(), observations, kj::none)),
+        kj::rc<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
+                              env.context.getByteStreamFactory(), observations, kj::none)),
             true);
 
     ExecOptions options;
@@ -884,8 +884,8 @@ KJ_TEST("Container::exec resize() rejects zero dimensions") {
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto container =
-        kj::heap<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
-                                env.context.getByteStreamFactory(), observations, kj::none)),
+        kj::rc<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
+                              env.context.getByteStreamFactory(), observations, kj::none)),
             true);
 
     ExecOptions options;
@@ -924,8 +924,8 @@ KJ_TEST("Container::exec resize() rejects out-of-range dimensions") {
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto container =
-        kj::heap<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
-                                env.context.getByteStreamFactory(), observations, kj::none)),
+        kj::rc<Container>(rpc::Container::Client(kj::heap<MockExecContainerServer>(
+                              env.context.getByteStreamFactory(), observations, kj::none)),
             true);
 
     ExecOptions options;
@@ -1249,8 +1249,8 @@ KJ_TEST("Container TCP port fetcher keeps pooled state alive") {
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
     auto container =
-        kj::heap<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
-                                byteStreamFactory, ResponseMode::KEEP_ALIVE, connectCount)),
+        kj::rc<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
+                              byteStreamFactory, ResponseMode::KEEP_ALIVE, connectCount)),
             true);
     auto fetcher = container->getTcpPort(env.js, 8080);
     container = nullptr;

--- a/src/workerd/api/crypto/aes-test.c++
+++ b/src/workerd/api/crypto/aes-test.c++
@@ -105,7 +105,7 @@ KJ_TEST("AES-CTR key wrap") {
 
   static constexpr kj::ArrayPtr<const kj::byte> KEY_DATA(RAW_KEY_DATA, 32);
 
-  SubtleCrypto subtle;
+  auto subtle = kj::rc<SubtleCrypto>();
 
   static constexpr auto getWrappingKey = [](jsg::Lock& js, SubtleCrypto& subtle) {
     auto keyData = jsg::JsBufferSource(jsg::JsUint8Array::create(js, KEY_DATA));
@@ -139,23 +139,23 @@ KJ_TEST("AES-CTR key wrap") {
   e.getIsolate().runInLockScope([&](CryptoIsolate::Lock& isolateLock) {
     JSG_WITHIN_CONTEXT_SCOPE(isolateLock,
         isolateLock.newContext<CryptoContext>().getHandle(isolateLock), [&](jsg::Lock& js) {
-      auto wrappingKey = getWrappingKey(js, subtle);
+      auto wrappingKey = getWrappingKey(js, *subtle);
       auto keyData = jsg::JsBufferSource(jsg::JsUint8Array::create(js, KEY_DATA));
       subtle
-          .importKey(js, kj::str("raw"), keyData.addRef(js), getImportKeyAlg(), true,
+          ->importKey(js, kj::str("raw"), keyData.addRef(js), getImportKeyAlg(), true,
               kj::arr(kj::str("decrypt")))
           .then(js,
               [&](jsg::Lock&, jsg::Ref<CryptoKey> toWrap) {
-        return subtle.wrapKey(js, kj::str("raw"), *toWrap, *wrappingKey, getEnc(js), *jwkHandler);
+        return subtle->wrapKey(js, kj::str("raw"), *toWrap, *wrappingKey, getEnc(js), *jwkHandler);
       })
           .then(js,
               [&](jsg::Lock& js, jsg::JsRef<jsg::JsArrayBuffer> wrapped) {
         auto data = jsg::JsBufferSource(wrapped.getHandle(js));
-        return subtle.unwrapKey(js, kj::str("raw"), data, *wrappingKey, getEnc(js),
+        return subtle->unwrapKey(js, kj::str("raw"), data, *wrappingKey, getEnc(js),
             getImportKeyAlg(), true, kj::arr(kj::str("encrypt")), *jwkHandler);
       })
           .then(js, [&](jsg::Lock& js, jsg::Ref<CryptoKey> unwrapped) {
-        return subtle.exportKey(js, kj::str("raw"), *unwrapped);
+        return subtle->exportKey(js, kj::str("raw"), *unwrapped);
       }).then(js, [&](jsg::Lock& js, api::SubtleCrypto::ExportKeyData roundTrippedKeyMaterial) {
         auto& buf = roundTrippedKeyMaterial.get<jsg::JsRef<jsg::JsArrayBuffer>>();
         KJ_ASSERT(buf.getHandle(js).asArrayPtr() == KEY_DATA);

--- a/src/workerd/api/fetch-body-rewindable-test.c++
+++ b/src/workerd/api/fetch-body-rewindable-test.c++
@@ -310,12 +310,12 @@ KJ_TEST("Fetcher dispatches actor retry metadata through the metadata-aware fact
   TestFixture fixture;
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    Fetcher fetcher(
+    auto fetcher = env.js.alloc<Fetcher>(
         env.context.addObject<Fetcher::OutgoingFactory>(
             kj::heap<RetryMetadataOutgoingFactory>(ordinaryDispatchCalled, capturedMetadata)),
         Fetcher::RequiresHostAndProtocol::YES);
 
-    auto client = fetcher.getClientWithTracing(env.context, kj::none, "fetch"_kjc,
+    auto client = fetcher->getClientWithTracing(env.context, kj::none, "fetch"_kjc,
         IoChannelFactory::ActorRetryRequestMetadata{
           .nonce = 0x123456789abcdef0,
           .createdAt = kj::UNIX_EPOCH + 123 * kj::MILLISECONDS,
@@ -339,12 +339,12 @@ KJ_TEST("Fetcher rejects actor retry metadata instead of using ordinary factory 
   TestFixture fixture;
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    Fetcher fetcher(env.context.addObject<Fetcher::OutgoingFactory>(
-                        kj::heap<UnsupportedOutgoingFactory>(called)),
+    auto fetcher = env.js.alloc<Fetcher>(env.context.addObject<Fetcher::OutgoingFactory>(
+                                             kj::heap<UnsupportedOutgoingFactory>(called)),
         Fetcher::RequiresHostAndProtocol::YES);
 
     KJ_EXPECT_THROW_MESSAGE("actor retry metadata supplied to an unsupported Fetcher",
-        fetcher.getClientWithTracing(env.context, kj::none, "fetch"_kjc,
+        fetcher->getClientWithTracing(env.context, kj::none, "fetch"_kjc,
             IoChannelFactory::ActorRetryRequestMetadata{
               .nonce = 1,
               .createdAt = kj::UNIX_EPOCH,
@@ -360,10 +360,11 @@ KJ_TEST("Fetcher rejects actor retry metadata before numeric subrequest-channel 
   TestFixture fixture;
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
-    Fetcher fetcher(static_cast<uint>(1), Fetcher::RequiresHostAndProtocol::YES);
+    auto fetcher =
+        env.js.alloc<Fetcher>(static_cast<uint>(1), Fetcher::RequiresHostAndProtocol::YES);
 
     KJ_EXPECT_THROW_MESSAGE("actor retry metadata supplied to an unsupported Fetcher",
-        fetcher.getClientWithTracing(env.context, kj::none, "fetch"_kjc,
+        fetcher->getClientWithTracing(env.context, kj::none, "fetch"_kjc,
             IoChannelFactory::ActorRetryRequestMetadata{
               .nonce = 1,
               .createdAt = kj::UNIX_EPOCH,

--- a/src/workerd/api/streams-test.c++
+++ b/src/workerd/api/streams-test.c++
@@ -33,8 +33,8 @@ KJ_TEST("Streams tee stack overflow regression") {
   TestFixture testFixture;
   testFixture.runInIoContext([](const TestFixture::Environment& env) {
     auto& js = jsg::Lock::from(env.isolate);
-    ReadableStream s(env.context, kj::heap<FakeStreamSource>(10 * 1024 * 1024));
-    auto readableStreams = s.tee(js);
+    auto s = js.alloc<ReadableStream>(env.context, kj::heap<FakeStreamSource>(10 * 1024 * 1024));
+    auto readableStreams = s->tee(js);
     for (size_t i = 0; i < teeDepth; i++) {
       readableStreams = readableStreams[0]->tee(js);
     }

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1437,6 +1437,10 @@ class Object: private Wrappable {
   friend kj::Own<T> kj::addRef(T& object);
   template <typename T, typename... Params>
   friend kj::Own<T> kj::refcounted(Params&&... params);
+  template <typename T, typename... Params>
+  friend kj::Rc<T> kj::rc(Params&&... params);
+  template <typename T, typename U>
+  friend constexpr bool kj::canConvert();
   friend class GcVisitor;
   template <typename, typename...>
   friend class TypeWrapper;

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -349,65 +349,65 @@ KJ_TEST("runTunnelingExceptions") {
 }
 
 KJ_TEST("isTunneledException") {
-  TunneledContext context;
+  auto context = kj::rc<TunneledContext>();
   try {
-    context.throwTunneledTypeError();
+    context->throwTunneledTypeError();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
-    context.throwTunneledTypeErrorWithoutMessage();
+    context->throwTunneledTypeErrorWithoutMessage();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
-    context.throwTunneledTypeErrorLateColon();
+    context->throwTunneledTypeErrorLateColon();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
-    context.throwTunneledTypeErrorWithExpectation();
+    context->throwTunneledTypeErrorWithExpectation();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
-    context.throwTunneledOperationError();
+    context->throwTunneledOperationError();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
-    context.throwTunneledOperationErrorLateColon();
+    context->throwTunneledOperationErrorLateColon();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
-    context.throwTunneledOperationErrorWithExpectation();
+    context->throwTunneledOperationErrorWithExpectation();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(isTunneledException(e.getDescription()), e.getDescription());
   }
 
   try {
-    context.throwBadTunneledError();
+    context->throwBadTunneledError();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(!isTunneledException(e.getDescription()), e.getDescription());
   }
   try {
-    context.throwBadTunneledErrorWithExpectation();
+    context->throwBadTunneledErrorWithExpectation();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(!isTunneledException(e.getDescription()), e.getDescription());
   }
 
   try {
-    context.throwRemoteCpuExceededError();
+    context->throwRemoteCpuExceededError();
     KJ_UNREACHABLE;
   } catch (kj::Exception& e) {
     KJ_EXPECT(!isTunneledException(e.getDescription()), e.getDescription());

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -636,7 +636,7 @@ static v8::Local<v8::Value> createBindingValue(JsgWorkerdIsolate::Lock& lock,
           lock.unwrap<kj::OneOf<kj::String, api::SubtleCrypto::ImportKeyAlgorithm>>(context, algo);
 
       jsg::Ref<api::CryptoKey> importedKey =
-          api::SubtleCrypto().importKeySync(lock, key.format, kj::mv(keyData),
+          lock.alloc<api::SubtleCrypto>()->importKeySync(lock, key.format, kj::mv(keyData),
               api::interpretAlgorithmParam(kj::mv(importKeyAlgo)), key.extractable, key.usages);
 
       value = lock.wrap(context, kj::mv(importedKey));


### PR DESCRIPTION
New capnproto prohibits on-the-stack creation of Refcounted objects.