### PR TITLE
CC-8419: make directory snapshot id optional

### DIFF
--- a/src/workerd/api/container-test.c++
+++ b/src/workerd/api/container-test.c++
@@ -231,6 +231,47 @@ class MockExecContainerServer final: public rpc::Container::Server {
   kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> resizeFulfiller;
 };
 
+struct CapturedDirectorySnapshot {
+  bool hasSnapshotId = false;
+  kj::String snapshotId;
+  kj::String restorePath;
+};
+
+// Captures the directorySnapshots forwarded by Container::start() so tests can assert how each
+// DirectorySnapshotRestoreParams is translated into the RPC request.
+class DirectorySnapshotStartServer final: public rpc::Container::Server {
+ public:
+  explicit DirectorySnapshotStartServer(kj::Vector<CapturedDirectorySnapshot>& captured)
+      : captured(captured) {}
+
+  kj::Promise<void> start(StartContext context) override {
+    for (auto entry: context.getParams().getDirectorySnapshots()) {
+      captured.add(CapturedDirectorySnapshot{
+        .hasSnapshotId = entry.hasSnapshotId(),
+        .snapshotId = kj::str(entry.getSnapshotId()),
+        .restorePath = kj::str(entry.getRestorePath()),
+      });
+    }
+    return kj::READY_NOW;
+  }
+
+  kj::Promise<void> monitor(MonitorContext context) override {
+    return kj::NEVER_DONE;
+  }
+
+ private:
+  kj::Vector<CapturedDirectorySnapshot>& captured;
+};
+
+Container::DirectorySnapshot makeDirectorySnapshot(kj::StringPtr id, kj::StringPtr dir) {
+  return Container::DirectorySnapshot{
+    .id = kj::str(id),
+    .size = 0,
+    .dir = kj::str(dir),
+    .name = kj::none,
+  };
+}
+
 enum class TunnelReuseGate { DISABLED, ENABLED };
 
 class AutogateScope {
@@ -746,6 +787,126 @@ KJ_TEST("Container::snapshotContainer propagates the current span context") {
 
   KJ_EXPECT(!directoryCalled);
   KJ_EXPECT(containerCalled);
+}
+
+KJ_TEST("Container::start restores a directory snapshot using the snapshot's own dir") {
+  kj::Vector<CapturedDirectorySnapshot> captured;
+  auto fixture = makeFixture();
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = kj::heap<Container>(
+        rpc::Container::Client(kj::heap<DirectorySnapshotStartServer>(captured)), false);
+
+    auto snapshots = kj::heapArrayBuilder<Container::DirectorySnapshotRestoreParams>(1);
+    snapshots.add(Container::DirectorySnapshotRestoreParams{
+      .snapshot = makeDirectorySnapshot("snap-id"_kj, "/data"_kj),
+      .mountPoint = kj::none,
+    });
+    container->start(env.js,
+        Container::StartupOptions{
+          .directorySnapshots = snapshots.finish(),
+        });
+
+    // Give the queued start RPC bounded time to run.
+    for (auto i = 0; i < 10; ++i) {
+      co_await kj::yield();
+    }
+  });
+
+  KJ_ASSERT(captured.size() == 1);
+  KJ_EXPECT(captured[0].hasSnapshotId);
+  KJ_EXPECT(captured[0].snapshotId == "snap-id");
+  KJ_EXPECT(captured[0].restorePath == "/data");
+}
+
+KJ_TEST("Container::start lets mountPoint override the snapshot's dir as the restore path") {
+  kj::Vector<CapturedDirectorySnapshot> captured;
+  auto fixture = makeFixture();
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = kj::heap<Container>(
+        rpc::Container::Client(kj::heap<DirectorySnapshotStartServer>(captured)), false);
+
+    auto snapshots = kj::heapArrayBuilder<Container::DirectorySnapshotRestoreParams>(1);
+    snapshots.add(Container::DirectorySnapshotRestoreParams{
+      .snapshot = makeDirectorySnapshot("snap-id"_kj, "/data"_kj),
+      .mountPoint = kj::str("/mnt/elsewhere"),
+    });
+    container->start(env.js,
+        Container::StartupOptions{
+          .directorySnapshots = snapshots.finish(),
+        });
+
+    for (auto i = 0; i < 10; ++i) {
+      co_await kj::evalLater([]() {});
+    }
+  });
+
+  KJ_ASSERT(captured.size() == 1);
+  KJ_EXPECT(captured[0].hasSnapshotId);
+  KJ_EXPECT(captured[0].snapshotId == "snap-id");
+  KJ_EXPECT(captured[0].restorePath == "/mnt/elsewhere");
+}
+
+KJ_TEST("Container::start restores to mountPoint when no snapshot is given") {
+  kj::Vector<CapturedDirectorySnapshot> captured;
+  auto fixture = makeFixture();
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = kj::heap<Container>(
+        rpc::Container::Client(kj::heap<DirectorySnapshotStartServer>(captured)), false);
+
+    auto snapshots = kj::heapArrayBuilder<Container::DirectorySnapshotRestoreParams>(1);
+    snapshots.add(Container::DirectorySnapshotRestoreParams{
+      .snapshot = kj::none,
+      .mountPoint = kj::str("/mnt/data"),
+    });
+    container->start(env.js,
+        Container::StartupOptions{
+          .directorySnapshots = snapshots.finish(),
+        });
+
+    for (auto i = 0; i < 10; ++i) {
+      co_await kj::evalLater([]() {});
+    }
+  });
+
+  KJ_ASSERT(captured.size() == 1);
+  KJ_EXPECT(!captured[0].hasSnapshotId);
+  KJ_EXPECT(captured[0].snapshotId == "");
+  KJ_EXPECT(captured[0].restorePath == "/mnt/data");
+}
+
+KJ_TEST("Container::start requires mountPoint when no snapshot is given") {
+  kj::Vector<CapturedDirectorySnapshot> captured;
+  auto fixture = makeFixture();
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = kj::heap<Container>(
+        rpc::Container::Client(kj::heap<DirectorySnapshotStartServer>(captured)), false);
+
+    auto snapshots = kj::heapArrayBuilder<Container::DirectorySnapshotRestoreParams>(1);
+    snapshots.add(Container::DirectorySnapshotRestoreParams{
+      .snapshot = kj::none,
+      .mountPoint = kj::none,
+    });
+
+    bool threw = false;
+    JSG_TRY(env.js) {
+      container->start(env.js,
+          Container::StartupOptions{
+            .directorySnapshots = snapshots.finish(),
+          });
+    }
+    JSG_CATCH(exception KJ_UNUSED) {
+      threw = true;
+    }
+    KJ_EXPECT(threw, "start() should throw when neither snapshot nor mountPoint is given");
+
+    return kj::READY_NOW;
+  });
+
+  KJ_EXPECT(captured.size() == 0);
 }
 
 KJ_TEST("Container::exec forwards pty options and resize() sends a resize RPC") {

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -420,17 +420,25 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
     for (auto i: kj::indices(directorySnapshots)) {
       auto entry = list[i];
       auto& restore = directorySnapshots[i];
-      auto& snap = restore.snapshot;
-      auto effectiveRestorePath = snap.dir.asPtr();
+
+      kj::Maybe<kj::StringPtr> effectiveRestorePath;
+      KJ_IF_SOME(snap, restore.snapshot) {
+        effectiveRestorePath = snap.dir.asPtr();
+      }
       KJ_IF_SOME(mp, restore.mountPoint) {
         effectiveRestorePath = mp.asPtr();
       }
 
-      JSG_REQUIRE_NONNULL(parseRestorePath(effectiveRestorePath), Error,
+      auto restorePath = JSG_REQUIRE_NONNULL(effectiveRestorePath, Error,
+          "Directory snapshot restore requires a mountPoint when no snapshot is given.");
+
+      JSG_REQUIRE_NONNULL(parseRestorePath(restorePath), Error,
           "Directory snapshot cannot be restored to root directory.");
 
-      entry.setSnapshotId(snap.id);
-      entry.setRestorePath(effectiveRestorePath);
+      KJ_IF_SOME(snap, restore.snapshot) {
+        entry.setSnapshotId(snap.id);
+      }
+      entry.setRestorePath(restorePath);
     }
   }
 

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -215,10 +215,14 @@ class Container: public jsg::Object {
   };
 
   struct DirectorySnapshotRestoreParams {
-    DirectorySnapshot snapshot;
+    jsg::Optional<DirectorySnapshot> snapshot;
     jsg::Optional<kj::String> mountPoint;
 
     JSG_STRUCT(snapshot, mountPoint);
+    JSG_STRUCT_TS_OVERRIDE(type ContainerDirectorySnapshotRestoreParams =
+      | { snapshot: ContainerDirectorySnapshot; mountPoint?: string }
+      | { snapshot?: undefined; mountPoint: string }
+    );
   };
 
   struct Snapshot {

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4081,10 +4081,15 @@ interface ContainerDirectorySnapshotOptions {
   dir: string;
   name?: string;
 }
-interface ContainerDirectorySnapshotRestoreParams {
-  snapshot: ContainerDirectorySnapshot;
-  mountPoint?: string;
-}
+type ContainerDirectorySnapshotRestoreParams =
+  | {
+      snapshot: ContainerDirectorySnapshot;
+      mountPoint?: string;
+    }
+  | {
+      snapshot?: undefined;
+      mountPoint: string;
+    };
 interface ContainerSnapshot {
   id: string;
   size: number;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4090,10 +4090,15 @@ export interface ContainerDirectorySnapshotOptions {
   dir: string;
   name?: string;
 }
-export interface ContainerDirectorySnapshotRestoreParams {
-  snapshot: ContainerDirectorySnapshot;
-  mountPoint?: string;
-}
+export type ContainerDirectorySnapshotRestoreParams =
+  | {
+      snapshot: ContainerDirectorySnapshot;
+      mountPoint?: string;
+    }
+  | {
+      snapshot?: undefined;
+      mountPoint: string;
+    };
 export interface ContainerSnapshot {
   id: string;
   size: number;

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -3991,10 +3991,15 @@ interface ContainerDirectorySnapshotOptions {
   dir: string;
   name?: string;
 }
-interface ContainerDirectorySnapshotRestoreParams {
-  snapshot: ContainerDirectorySnapshot;
-  mountPoint?: string;
-}
+type ContainerDirectorySnapshotRestoreParams =
+  | {
+      snapshot: ContainerDirectorySnapshot;
+      mountPoint?: string;
+    }
+  | {
+      snapshot?: undefined;
+      mountPoint: string;
+    };
 interface ContainerSnapshot {
   id: string;
   size: number;

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -4000,10 +4000,15 @@ export interface ContainerDirectorySnapshotOptions {
   dir: string;
   name?: string;
 }
-export interface ContainerDirectorySnapshotRestoreParams {
-  snapshot: ContainerDirectorySnapshot;
-  mountPoint?: string;
-}
+export type ContainerDirectorySnapshotRestoreParams =
+  | {
+      snapshot: ContainerDirectorySnapshot;
+      mountPoint?: string;
+    }
+  | {
+      snapshot?: undefined;
+      mountPoint: string;
+    };
 export interface ContainerSnapshot {
   id: string;
   size: number;


### PR DESCRIPTION
If snapshot is empty, directory will just be prepared to be snapshotted upfront

Draft until internal mr merged

cc @spahl @rushilmehra 