### PR TITLE
Fix incorrect error message for workers-py version requirement

### DIFF
--- a/src/pyodide/python-entrypoint-helper.ts
+++ b/src/pyodide/python-entrypoint-helper.ts
@@ -192,7 +192,7 @@ async function injectWorkersApi(pyodide: Pyodide): Promise<void> {
     pyodide.FS.mkdir(`${pyodide.FS.sitePackages}/workers`);
     const template = [
       `err = ModuleNotFoundError("No module named '$MODNAME'", name="$MODNAME")`,
-      `err.add_note("You need to update to workers-py >= 1.90 or to pass disable_python_external_sdk")`,
+      `err.add_note("You need to update to workers-py >= 1.9 or to pass disable_python_external_sdk")`,
       `raise err`,
     ].join('\n');
     pyodide.FS.writeFile(


### PR DESCRIPTION
I thought we fixed this a long ago but we didn't. 