### PR TITLE
Name the warning level `warn` in structured logs

### DIFF
--- a/src/workerd/server/json-logger-test.c++
+++ b/src/workerd/server/json-logger-test.c++
@@ -2,25 +2,47 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-#if __linux__
 #include "json-logger.h"
 
 #include <workerd/server/log-schema.capnp.h>
 
+#if __linux__
 #include <fcntl.h>
 #include <unistd.h>
 
-#include <capnp/compat/json.h>
-#include <capnp/message.h>
 #include <kj/async-unix.h>
 #include <kj/io.h>
 
 #include <cstdio>
 #endif  // __linux__
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
 #include <kj/test.h>
 
 namespace workerd::server {
 namespace {
+
+// The level names are a contract with consumers of workerd's structured output, so pin the encoded
+// strings rather than round-tripping them through the codec that produced them.
+KJ_TEST("JSON log level names") {
+  capnp::JsonCodec codec;
+  codec.handleByAnnotation<log_schema::LogEntry>();
+
+  auto expectLevelName = [&](log_schema::LogEntry::LogLevel level, kj::StringPtr expected) {
+    capnp::MallocMessageBuilder message;
+    auto entry = message.initRoot<log_schema::LogEntry>();
+    entry.setLevel(level);
+    auto json = codec.encode(entry);
+    KJ_EXPECT(json.contains(kj::str("\"level\":\"", expected, "\"")), json, expected);
+  };
+
+  expectLevelName(log_schema::LogEntry::LogLevel::DEBUG_, "debug");
+  expectLevelName(log_schema::LogEntry::LogLevel::INFO, "info");
+  expectLevelName(log_schema::LogEntry::LogLevel::WARNING, "warn");
+  expectLevelName(log_schema::LogEntry::LogLevel::ERROR, "error");
+  expectLevelName(log_schema::LogEntry::LogLevel::FATAL, "fatal");
+}
+
 #if __linux__
 // This test uses pipe2 and dup2 to capture stdout which is far easier on linux.
 
@@ -153,6 +175,7 @@ KJ_TEST("StructuredLoggingProcessContext - structured logging mode") {
   auto jsonEntry = KJ_ASSERT_NONNULL(findJsonEntryContaining(output, "Test structured warning"));
   validateJsonLogEntry(
       jsonEntry, log_schema::LogEntry::LogLevel::WARNING, "Test structured warning");
+  KJ_EXPECT(jsonEntry.contains("\"level\":\"warn\""), jsonEntry);
 }
 
 KJ_TEST("StructuredLoggingProcessContext - error handling in structured mode") {
@@ -168,8 +191,6 @@ KJ_TEST("StructuredLoggingProcessContext - error handling in structured mode") {
 }
 
 #endif  // __linux__
-
-KJ_TEST("Blank test because KJ fails when 0 tests are enabled") {}
 
 }  // namespace
 }  // namespace workerd::server

--- a/src/workerd/server/log-schema.capnp
+++ b/src/workerd/server/log-schema.capnp
@@ -28,10 +28,16 @@ struct LogEntry {
   # Context depth for nested operations (optional, only included if > 0)
 
   enum LogLevel {
+    # The JSON names are a contract with whoever consumes workerd's structured output, and match the
+    # names used by JS console logs (`logLevelToString()` in io/worker.c++), so that a single set of
+    # level names covers everything workerd emits. `warning` is spelled `warn` for that reason.
+    # `log` appears only in console output and `fatal` only here, neither having a counterpart in
+    # the other.
+
     debug @0 $Cxx.name("debug_") $Json.name("debug");
     # in C++, the constant will be DEBUG_ to avoid clashing with the DEBUG macro
     info @1 $Json.name("info");
-    warning @2 $Json.name("warning");
+    warning @2 $Json.name("warn");
     error @3 $Json.name("error");
     fatal @4 $Json.name("fatal");
   }


### PR DESCRIPTION
## Problem

workerd emits structured JSON logs from two places, with two different sets of level names:

| Producer | Level names |
| --- | --- |
| JS console logs — `logLevelToString()` in `io/worker.c++`, via `formatLog()` in `src/node/internal/internal_inspect.ts` | `debug` `info` `log` `warn` `error` |
| Process-level logs — `context.warning()` / `KJ_LOG`, via `log-schema.capnp` in `server/json-logger.c++` | `debug` `info` `warning` `error` `fatal` |

`debug`, `info` and `error` agree. `warning` was the lone outlier, so a consumer keying on `warn`
picks up a Worker's `console.warn()` but silently demotes workerd's own warnings to whatever it does
with unrecognised levels:

- Miniflare's `defaultStructuredLogsHandler` tests `level === "error" || level === "warn"`, so a
  process warning goes to `console.log` instead of red `console.error`.
- wrangler's `handleStructuredLogs` tests `warn`/`info`/`debug`/`error` and falls through to
  `logger.log`, which is below the `warn` threshold — so `--log-level=warn` hides warnings entirely.
- The Vite plugin's handler tests `warn`/`error` and falls through to `logger.info`.

## Change

Spell the level `warn` on the wire. The Cap'n Proto enumerant keeps mirroring
`kj::LogSeverity::WARNING`; only the `$Json.name` annotation changes, so no C++ is affected —
`capnp`'s `AnnotatedEnumHandler` applies the annotation to both encode and decode, and
`json-logger.c++` already installs it via `handleByAnnotation`.

This fixes **already-released** wrangler, Vite plugin and Miniflare versions on the next workerd
bump, with no changes needed on their side.

`log-schema.capnp` is consumed only by `json-logger.{h,c++}` and its test, and lives under
`server/`, so this doesn't reach the production runtime. No compatibility flag applies: this is
process-level CLI output, not per-Worker behaviour.

## Testing

The level names had no coverage: `json-logger-test` decoded each entry with the same annotated codec
that encoded it, which round-trips whatever the schema says. That's why the mismatch went unnoticed.

- New `JSON log level names` test pins the encoded string for all five levels. It needs no captured
  file descriptor, unlike the rest of that file, so it runs on macOS and Windows too — which lets
  the file drop its `Blank test because KJ fails when 0 tests are enabled` placeholder.
- One literal `"level":"warn"` assertion in the existing structured-mode test, so the real
  `context.warning()` path is pinned rather than just the codec.
- Confirmed red first: `{"timestamp":"0","level":"warning","context_depth":0}` failed the `WARNING`
  case while `debug`/`info`/`error`/`fatal` passed, confirming `warning` was the only outlier.
- Verified end to end by running `workerd serve` on a config with `structuredLogging = true` and a
  redundant compatibility flag (stacking #6980 locally so the diagnostic is a warning rather than a
  fatal error):

  ```json
  {"timestamp":"1787059251355","level":"warn","source":"src/workerd/server/json-logger.c++:109","message":"service main: The compatibility flag global_navigator became the default as of 2022-03-21 so does not need to be specified anymore.","context_depth":0}
  ```

- Full suite: 1635/1635 pass, 6 skipped.

## Noticed, not addressed

- `log-schema.capnp` claims `contextDepth` is "only included if > 0" and `buildJsonLogMessage`
  guards on that, but the codec emits default primitives regardless, so every entry carries
  `"context_depth":0`.
- `source` on process-level entries is always `json-logger.c++:109` or `:127` — the wrapper's own
  `__FILE__`/`__LINE__`, not the origin. Only `KJ_LOG` entries get a useful value.
- `fatal` has no counterpart in the console vocabulary, so it still lands at plain log level in
  workers-sdk. It can't be aliased to `error` here: duplicate `$Json.name` values would break
  `AnnotatedEnumHandler`, which inserts them into a `kj::HashMap`. That fix belongs on the consumer
  side, along with optionally accepting `"warning"` so older workerd binaries stay correctly levelled.
