### PR TITLE
[diagnostic] Restore Bonk with the proven Cloudflare AI Gateway route

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -36,9 +36,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-sol'
           mentions: '/bigbonk'
-          variant: 'high'
+          variant: 'max'
           permissions: write
           # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
           # third-party providers. Stay on the known-working release until the

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -36,13 +36,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
           mentions: '/bigbonk'
-          variant: 'max'
+          variant: 'high'
           permissions: write
-          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
-          # upstream Anthropic key. Stay on the known-working release until
-          # the native Cloudflare AI Gateway passthrough fix is released.
+          # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
+          # third-party providers. Stay on the known-working release until the
+          # native Cloudflare AI Gateway passthrough fix is released.
           opencode_version: "1.15.13"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -36,11 +36,14 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
           mentions: '/bigbonk'
           variant: 'max'
           permissions: write
-          opencode_version: "1.18.18"
+          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
+          # upstream Anthropic key. Stay on the known-working release until
+          # the native Cloudflare AI Gateway passthrough fix is released.
+          opencode_version: "1.15.13"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk
           # to update their PR via /bigbonk.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -36,10 +36,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
           mentions: '/bonk,@ask-bonk'
           permissions: write
-          opencode_version: "1.18.18"
+          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
+          # upstream Anthropic key. Stay on the known-working release until
+          # the native Cloudflare AI Gateway passthrough fix is released.
+          opencode_version: "1.15.13"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk
           # to update their PR via /bonk.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -36,12 +36,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
           mentions: '/bonk,@ask-bonk'
           permissions: write
-          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
-          # upstream Anthropic key. Stay on the known-working release until
-          # the native Cloudflare AI Gateway passthrough fix is released.
+          # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
+          # third-party providers. Stay on the known-working release until the
+          # native Cloudflare AI Gateway passthrough fix is released.
           opencode_version: "1.15.13"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -36,8 +36,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-terra'
           mentions: '/bonk,@ask-bonk'
+          variant: 'high'
           permissions: write
           # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
           # third-party providers. Stay on the known-working release until the

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -42,12 +42,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
           forks: 'false'
           permissions: write
-          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
-          # upstream Anthropic key. Stay on the known-working release until
-          # the native Cloudflare AI Gateway passthrough fix is released.
+          # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
+          # third-party providers. Stay on the known-working release until the
+          # native Cloudflare AI Gateway passthrough fix is released.
           opencode_version: "1.15.13"
           # The auto-reviewer must never push to PR branches. Its prompt
           # (bonk_reviewer.md) already forbids git write ops, but NO_PUSH

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -42,10 +42,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
           forks: 'false'
           permissions: write
-          opencode_version: "1.18.18"
+          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
+          # upstream Anthropic key. Stay on the known-working release until
+          # the native Cloudflare AI Gateway passthrough fix is released.
+          opencode_version: "1.15.13"
           # The auto-reviewer must never push to PR branches. Its prompt
           # (bonk_reviewer.md) already forbids git write ops, but NO_PUSH
           # enforces that at the token level so it holds even if the model

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -42,7 +42,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-terra'
+          variant: 'high'
           forks: 'false'
           permissions: write
           # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for


### PR DESCRIPTION
## Summary

- switch the automatic reviewer, `/bonk`, and `/bigbonk` to the GPT-5.5 Cloudflare AI Gateway route already working in Vinext
- pin OpenCode to the known-working `1.15.13` release
- use `high` for `/bigbonk`, since GPT-5.5 does not expose the Anthropic-only `max` variant

## What broke

Two independent compatibility problems are stacked together:

1. Workerd's Anthropic model ID stopped resolving in OpenCode after models.dev changed the relay catalog from `claude-opus-4-6` to `claude-opus-4.6`.
2. OpenCode 1.18.x changed Cloudflare AI Gateway handling and can send the gateway token as an upstream Anthropic key, producing `Invalid Anthropic API Key`. The native passthrough/token-scoping fix exists upstream, but has not shipped in an OpenCode release yet.

I initially tried the catalog's dotted Anthropic ID with OpenCode 1.15.13. The PR's automatic review run proved that this is not sufficient: OpenCode accepted `claude-opus-4.6`, but the live `/v1/compat` gateway rejected it and suggested the old hyphenated spelling. The catalog and live gateway currently disagree, leaving no Anthropic spelling that works end to end with a released OpenCode version.

This PR therefore uses `cloudflare-ai-gateway/openai/gpt-5.5` with OpenCode `1.15.13`, matching the combination already running successfully in Vinext.

## Evidence

- this PR's dotted-ID test, rejected by the live gateway: https://github.com/cloudflare/workerd/actions/runs/32174096175
- current Workerd model lookup failure: https://github.com/cloudflare/workerd/actions/runs/32147099120
- earlier Workerd `Invalid Anthropic API Key` failure: https://github.com/cloudflare/workerd/actions/runs/31437940592
- models.dev relay-ID change: https://github.com/anomalyco/models.dev/commit/3d5735ec1b666cc55b4cbba965fb755e70bf3309
- upstream OpenCode passthrough/token-scoping fix: https://github.com/anomalyco/opencode/commit/cba6b5f2f74080239cdc7405efcb83219c980136

## Validation

- parsed all three changed workflow files as YAML
- `git diff --check`
- confirmed all three workflows use GPT-5.5 and OpenCode 1.15.13

The automatic `pull_request` reviewer can load workflow changes from the PR branch before merge. The comment-triggered `/bonk` workflow is expected to load its workflow from the default branch, so the test comment below should demonstrate whether merging is required before slash-command Bonk uses this fix.