### PR TITLE
[staged] Restore Bonk with GPT-5.6 Terra and Sol

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -36,9 +36,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-sol'
           mentions: '/bigbonk'
-          variant: 'high'
+          variant: 'max'
           permissions: write
           # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
           # third-party providers. Stay on the known-working release until the

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -36,13 +36,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
           mentions: '/bigbonk'
-          variant: 'max'
+          variant: 'high'
           permissions: write
-          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
-          # upstream Anthropic key. Stay on the known-working release until
-          # the native Cloudflare AI Gateway passthrough fix is released.
+          # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
+          # third-party providers. Stay on the known-working release until the
+          # native Cloudflare AI Gateway passthrough fix is released.
           opencode_version: "1.15.13"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -36,11 +36,14 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
           mentions: '/bigbonk'
           variant: 'max'
           permissions: write
-          opencode_version: "1.18.18"
+          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
+          # upstream Anthropic key. Stay on the known-working release until
+          # the native Cloudflare AI Gateway passthrough fix is released.
+          opencode_version: "1.15.13"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk
           # to update their PR via /bigbonk.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -36,10 +36,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
           mentions: '/bonk,@ask-bonk'
           permissions: write
-          opencode_version: "1.18.18"
+          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
+          # upstream Anthropic key. Stay on the known-working release until
+          # the native Cloudflare AI Gateway passthrough fix is released.
+          opencode_version: "1.15.13"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk
           # to update their PR via /bonk.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -36,12 +36,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
           mentions: '/bonk,@ask-bonk'
           permissions: write
-          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
-          # upstream Anthropic key. Stay on the known-working release until
-          # the native Cloudflare AI Gateway passthrough fix is released.
+          # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
+          # third-party providers. Stay on the known-working release until the
+          # native Cloudflare AI Gateway passthrough fix is released.
           opencode_version: "1.15.13"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -36,8 +36,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-terra'
           mentions: '/bonk,@ask-bonk'
+          variant: 'high'
           permissions: write
           # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
           # third-party providers. Stay on the known-working release until the

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -42,12 +42,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
           forks: 'false'
           permissions: write
-          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
-          # upstream Anthropic key. Stay on the known-working release until
-          # the native Cloudflare AI Gateway passthrough fix is released.
+          # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for
+          # third-party providers. Stay on the known-working release until the
+          # native Cloudflare AI Gateway passthrough fix is released.
           opencode_version: "1.15.13"
           # The auto-reviewer must never push to PR branches. Its prompt
           # (bonk_reviewer.md) already forbids git write ops, but NO_PUSH

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -42,10 +42,13 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4.6'
           forks: 'false'
           permissions: write
-          opencode_version: "1.18.18"
+          # OpenCode 1.18.x forwards the Cloudflare gateway token as the
+          # upstream Anthropic key. Stay on the known-working release until
+          # the native Cloudflare AI Gateway passthrough fix is released.
+          opencode_version: "1.15.13"
           # The auto-reviewer must never push to PR branches. Its prompt
           # (bonk_reviewer.md) already forbids git write ops, but NO_PUSH
           # enforces that at the token level so it holds even if the model

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -42,7 +42,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/openai/gpt-5.5'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-terra'
+          variant: 'high'
           forks: 'false'
           permissions: write
           # OpenCode 1.18.x incorrectly scopes the Cloudflare gateway token for


### PR DESCRIPTION
## Summary

- use GPT-5.6 Terra with `high` reasoning for the automatic reviewer and normal `/bonk`
- use GPT-5.6 Sol with `max` reasoning for explicit `/bigbonk` requests
- pin OpenCode to `1.15.13` until its Cloudflare AI Gateway token passthrough fix ships in a release

## Model choice

Terra is the balanced default for frequent code review and interactive repo work. Sol is the higher-cost flagship model, so it remains behind `/bigbonk`, where users explicitly request the most capable path. This keeps the existing regular/Big Bonk distinction while moving both workflows onto the same current model family.

## What broke

Two independent compatibility problems broke the old Anthropic configuration:

1. models.dev changed the Cloudflare AI Gateway Anthropic relay ID from `claude-opus-4-6` to `claude-opus-4.6`, so Workerd's old ID no longer resolves in OpenCode.
2. OpenCode 1.18.x changed Cloudflare AI Gateway handling and can send the gateway token as an upstream Anthropic key, producing `Invalid Anthropic API Key`. The native passthrough/token-scoping fix exists upstream but has not shipped in an OpenCode release yet.

The diagnostic PR also tested the dotted Anthropic ID with OpenCode 1.15.13. OpenCode accepted the catalog entry, but the live `/v1/compat` gateway rejected it and suggested the old hyphenated spelling. The catalog and gateway currently disagree, leaving no Anthropic spelling that works end to end with a released OpenCode version.

## Evidence

- diagnostic PR and merge-behavior test: https://github.com/cloudflare/workerd/pull/7047
- dotted Anthropic ID rejected by the live gateway: https://github.com/cloudflare/workerd/actions/runs/32174096175
- `/bonk` loaded its workflow from `main`, proving slash-command changes require merge: https://github.com/cloudflare/workerd/actions/runs/32174438684
- current Workerd model lookup failure: https://github.com/cloudflare/workerd/actions/runs/32147099120
- earlier Workerd `Invalid Anthropic API Key` failure: https://github.com/cloudflare/workerd/actions/runs/31437940592
- models.dev relay-ID change: https://github.com/anomalyco/models.dev/commit/3d5735ec1b666cc55b4cbba965fb755e70bf3309
- upstream OpenCode passthrough/token-scoping fix: https://github.com/anomalyco/opencode/commit/cba6b5f2f74080239cdc7405efcb83219c980136

## Validation

- parsed all three changed workflow files as YAML
- `git diff --check`
- this newly opened PR should exercise GPT-5.6 Terra through the automatic reviewer before merge

The automatic `pull_request` reviewer loads the workflow from this PR branch. Comment-triggered `/bonk` and `/bigbonk` load their workflows from the default branch, so those commands will use this configuration only after merge.