### PR TITLE
Use validated GPT-5.6 Bonk configuration

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -34,6 +34,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          OPENCODE_CONFIG_CONTENT: '{"permission":{"external_directory":{"/home/runner/work/**":"allow"},"question":"deny","doom_loop":"deny"}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: 'cloudflare-ai-gateway/openai/gpt-5.6-sol'

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -29,18 +29,19 @@ jobs:
           fetch-depth: 1
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@main
+        uses: ask-bonk/ask-bonk/github@d00cbcf581a5463f7adc2d81e470234b1727f8dd # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-sol'
           mentions: '/bigbonk'
           variant: 'max'
           permissions: write
-          opencode_version: "1.18.18"
+          opencode_dev: true
+          opencode_version: "latest"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk
           # to update their PR via /bigbonk.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -29,17 +29,19 @@ jobs:
           fetch-depth: 1
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@main
+        uses: ask-bonk/ask-bonk/github@d00cbcf581a5463f7adc2d81e470234b1727f8dd # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-terra'
           mentions: '/bonk,@ask-bonk'
+          variant: 'high'
           permissions: write
-          opencode_version: "1.18.18"
+          opencode_dev: true
+          opencode_version: "latest"
           # token_permissions defaults to WRITE (i.e. Bonk can push commits).
           # We intentionally leave it that way here because users may ask Bonk
           # to update their PR via /bonk.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -34,6 +34,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          OPENCODE_CONFIG_CONTENT: '{"permission":{"external_directory":{"/home/runner/work/**":"allow"},"question":"deny","doom_loop":"deny"}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: 'cloudflare-ai-gateway/openai/gpt-5.6-terra'

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -2,7 +2,7 @@ name: New PR Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   review:
@@ -40,6 +40,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          OPENCODE_CONFIG_CONTENT: '{"permission":{"external_directory":{"/home/runner/work/**":"allow"},"edit":"deny","question":"deny","doom_loop":"deny"}}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: 'cloudflare-ai-gateway/openai/gpt-5.6-terra'

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -35,17 +35,19 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@main
+        uses: ask-bonk/ask-bonk/github@d00cbcf581a5463f7adc2d81e470234b1727f8dd # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          model: 'cloudflare-ai-gateway/openai/gpt-5.6-terra'
+          variant: 'high'
           forks: 'false'
           permissions: write
-          opencode_version: "1.18.18"
+          opencode_dev: true
+          opencode_version: "latest"
           # The auto-reviewer must never push to PR branches. Its prompt
           # (bonk_reviewer.md) already forbids git write ops, but NO_PUSH
           # enforces that at the token level so it holds even if the model

--- a/.github/workflows/new-pr-review.yml
+++ b/.github/workflows/new-pr-review.yml
@@ -2,7 +2,7 @@ name: New PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   review:


### PR DESCRIPTION
## Summary

- use GPT-5.6 Terra with `high` reasoning for automatic reviews and `/bonk`
- use GPT-5.6 Sol with `max` reasoning for `/bigbonk`
- pin Bonk to `d00cbcf581a5463f7adc2d81e470234b1727f8dd`
- temporarily install OpenCode from its `dev` channel
- make OpenCode permissions non-interactive in GitHub Actions

## Why

Workerd's Anthropic route is broken by a combination of model-ID drift and OpenCode's Cloudflare AI Gateway token handling.

Moving straight to OpenCode `1.18.18` does not fix it: that release can forward the Cloudflare gateway token as an upstream OpenAI key and receives a 401.

The current OpenCode dev build contains the upstream AI Gateway fix. Bonk cannot pin the exact npm build `0.0.0-dev-202608181849` because its version validator rejects the second hyphen, so this uses Bonk's explicit `opencode_dev: true` path until the fix reaches a stable OpenCode release.

OpenCode also defaults `external_directory`, `question`, and `doom_loop` permissions to interactive prompts. Workerd's review agent searches the parent GitHub runner workspace while loading repository guidance, so an unattended run can wait forever for approval. These workflows now allow the trusted runner workspace and deny interactive question/loop prompts. The automatic reviewer also denies file edits.

## Validation

This is copied from the configuration validated in Vinext:

- Vinext PR: https://github.com/cloudflare/vinext/pull/2987
- passing Terra/high and Sol/max smoke run: https://github.com/cloudflare/vinext/actions/runs/32176160708
- installed OpenCode build: `0.0.0-dev-202608181849`

The Workerd automatic reviewer also exercised the full repository-review path:

- first run identified the unattended permission prompt and timed out: https://github.com/cloudflare/workerd/actions/runs/32176642011
- second run completed in 2m59s and posted a Bonk review: https://github.com/cloudflare/workerd/actions/runs/32179760200

Bonk's only finding concerned the temporary `synchronize` trigger used to run the second test. That trigger has been removed, restoring the original opened-only behavior.

The `/bonk` and `/bigbonk` workflows use `issue_comment`, which GitHub loads from the default branch. Those command paths will use this configuration only after merge.

## Follow-up

Once OpenCode publishes a stable release containing the gateway fix, replace `opencode_dev: true` with a stable version pin.
