### PR TITLE
[build] Add misc-include-cleaner clang-tidy check for headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,7 @@ Checks: >
   google-readability-casting,
   misc-confusable-identifiers,
   misc-header-include-cycle,
+  misc-include-cleaner,
   misc-redundant-expression,
   misc-throw-by-value-catch-by-reference,
   misc-unused-alias-decls,
@@ -96,6 +97,11 @@ CheckOptions:
     value: "jsg/jsg.h|jsg/dom-exception.h"
   - key: cppcoreguidelines-missing-std-forward.ForwardFunction
     value: "kj::fwd"
+  - key: misc-include-cleaner.MissingIncludes
+    value: False
+  # Ignore KJ headers (too many to clean up for now) and some JSG headers where misc-include-cleaner reports false positives
+  - key: misc-include-cleaner.IgnoreHeaders
+    value: "jsg.h|function.h|kj/.*"
 
 ####
 # Custom checks.

--- a/build/tools/clang_tidy/check_path_filters.bzl
+++ b/build/tools/clang_tidy/check_path_filters.bzl
@@ -23,3 +23,9 @@ CHECK_PATH_FILTERS = {
         # "src/workerd/api",
     ],
 }
+
+HEADER_ONLY_CHECKS = [
+    # Enabling misc-include-cleaner on headers means having to clean up much
+    # fewer includes while still getting rid of superfluous transitive includes.
+    "misc-include-cleaner",
+]

--- a/build/tools/clang_tidy/clang_tidy.bzl
+++ b/build/tools/clang_tidy/clang_tidy.bzl
@@ -7,13 +7,15 @@ load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load("//build/tools/clang_tidy:check_path_filters.bzl", "CHECK_PATH_FILTERS")
+load("//build/tools/clang_tidy:check_path_filters.bzl", "CHECK_PATH_FILTERS", "HEADER_ONLY_CHECKS")
 
 def _get_disabled_checks_for_file(file_path):
     """Returns checks that should be disabled for this file.
 
     Checks listed in CHECK_PATH_FILTERS are only enabled for files under their
     allowed paths. For files not under any allowed path, the check is disabled.
+    Checks listed in HEADER_ONLY_CHECKS are only enabled for header files and
+    disabled otherwise.
     """
     disabled = []
     for check, allowed_paths in CHECK_PATH_FILTERS.items():
@@ -30,6 +32,11 @@ def _get_disabled_checks_for_file(file_path):
                 break
         if not enabled:
             disabled.append(check)
+
+    for check in HEADER_ONLY_CHECKS:
+        if not file_path.endswith(".h"):
+            disabled.append(check)
+
     return disabled
 
 def _clang_tidy_aspect_impl(target, ctx):
@@ -60,6 +67,12 @@ def _clang_tidy_aspect_impl(target, ctx):
     # we use $location in our copts, expand it
     rule_copts = [ctx.expand_location(opt) for opt in rule_copts]
 
+    # disable clang tidy if no-clang-tidy tag is defined. For no-clang-tidy-
+    # headers, we only disable it on header files.
+    # todo: figure out a better way to control clang tidy on a per-target basis.
+    if "no-clang-tidy" in ctx.rule.attr.tags:
+        return []
+
     srcs = []
     if hasattr(ctx.rule.attr, "srcs"):
         for src in ctx.rule.attr.srcs:
@@ -68,7 +81,7 @@ def _clang_tidy_aspect_impl(target, ctx):
                 for src in src.files.to_list()
                 if src.is_source and src.short_path.endswith((".c++", ".c", ".h"))
             ]
-    if hasattr(ctx.rule.attr, "hdrs"):
+    if hasattr(ctx.rule.attr, "hdrs") and not "no-clang-tidy-headers" in ctx.rule.attr.tags:
         for src in ctx.rule.attr.hdrs:
             srcs += [
                 src
@@ -83,11 +96,6 @@ def _clang_tidy_aspect_impl(target, ctx):
     system_includes = compilation_context.system_includes.to_list()
     external_includes = compilation_context.external_includes.to_list()
     headers = compilation_context.headers
-
-    # disable clang tidy if no-clang-tidy tag is defined.
-    # todo: figure out a better way to control clang tidy on a per-target basis.
-    if "no-clang-tidy" in ctx.rule.attr.tags:
-        return []
 
     # bazel doesn't expose implementation deps through compilation context
     # https://github.com/bazelbuild/bazel/issues/19663

--- a/src/rust/cxx/include/cxx.h
+++ b/src/rust/cxx/include/cxx.h
@@ -8,12 +8,10 @@
 #include <initializer_list>
 #include <iosfwd>
 #include <iterator>
-#include <new>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
-#include <vector>
 #ifdef _WIN32
 #include <basetsd.h>
 #else

--- a/src/rust/cxx/kj-rs/future.h
+++ b/src/rust/cxx/kj-rs/future.h
@@ -5,7 +5,6 @@
 
 #include <kj/debug.h>
 
-#include <concepts>
 #include <cstdint>
 
 namespace kj_rs {

--- a/src/rust/cxx/kj-rs/kj-rs.h
+++ b/src/rust/cxx/kj-rs/kj-rs.h
@@ -1,8 +1,11 @@
 #pragma once
 
+// This file is intentionally used as a catchall kj-rs header
+// NOLINTBEGIN(misc-include-cleaner)
 // KJ-C++ conversion utilities
 #include "kj-rs/convert.h"
 // Rust futures support
 #include "kj-rs/future.h"
 // KJ promises support
 #include "kj-rs/promise.h"
+// NOLINTEND(misc-include-cleaner)

--- a/src/rust/cxx/src/cxx.cc
+++ b/src/rust/cxx/src/cxx.cc
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <vector>
 
 extern "C" {
 void cxxbridge1$cxx_string$init(std::string *s, const std::uint8_t *ptr,

--- a/src/rust/cxx/tests/ffi/tests.h
+++ b/src/rust/cxx/tests/ffi/tests.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace A {
 struct AShared;

--- a/src/rust/jsg-test/ffi.h
+++ b/src/rust/jsg-test/ffi.h
@@ -8,9 +8,8 @@
 #include <workerd/rust/jsg/ffi.h>
 #include <workerd/rust/jsg/v8.rs.h>
 
-#include <kj-rs/kj-rs.h>
 #include <rust/cxx.h>
-#include <v8.h>
+#include <v8-isolate.h>
 
 #include <kj/function.h>
 #include <kj/memory.h>

--- a/src/rust/jsg/BUILD.bazel
+++ b/src/rust/jsg/BUILD.bazel
@@ -26,7 +26,6 @@ wd_cc_library(
     srcs = [],
     hdrs = ["jsg.h"],
     local_defines = ["JSG_IMPLEMENTATION"],
-    tags = ["no-clang-tidy"],
     visibility = ["//visibility:public"],
     deps = [":jsg"],
 )
@@ -38,7 +37,6 @@ wd_cc_library(
         "ffi.h",
     ],
     local_defines = ["JSG_IMPLEMENTATION"],
-    tags = ["no-clang-tidy"],
     textual_hdrs = [
         "ffi-inl.h",
     ],

--- a/src/rust/jsg/ffi.c++
+++ b/src/rust/jsg/ffi.c++
@@ -78,7 +78,7 @@ static v8::Local<v8::String> makeInternedStr(v8::Isolate* isolate, const Name& n
 }
 
 // Wrappable implementation - calls into Rust via CXX bridge
-Wrappable::~Wrappable() {
+Wrappable::~Wrappable() noexcept(false) {
   wrappable_invoke_drop(*this);
 }
 

--- a/src/rust/jsg/ffi.h
+++ b/src/rust/jsg/ffi.h
@@ -4,12 +4,10 @@
 
 #pragma once
 
-#include <workerd/jsg/modules.capnp.h>
 #include <workerd/jsg/wrappable.h>
 
-#include <kj-rs/kj-rs.h>
 #include <rust/cxx.h>
-#include <v8.h>
+#include <v8-isolate.h>
 
 #include <kj/function.h>
 #include <kj/memory.h>
@@ -56,7 +54,7 @@ struct TraitObjectPtr {
 // and destruction without knowing the concrete type at compile time.
 class Wrappable: public ::workerd::jsg::Wrappable {
  public:
-  ~Wrappable();
+  ~Wrappable() noexcept(false);
   void jsgVisitForGc(::workerd::jsg::GcVisitor& visitor) override;
   kj::StringPtr jsgGetMemoryName() const override;
   size_t jsgGetMemorySelfSize() const override;

--- a/src/rust/jsg/jsg.h
+++ b/src/rust/jsg/jsg.h
@@ -11,7 +11,6 @@
 #include <workerd/rust/jsg/ffi.h>
 #include <workerd/rust/jsg/v8.rs.h>
 
-#include <kj-rs/kj-rs.h>
 #include <rust/cxx.h>
 
 #include <kj/function.h>

--- a/src/rust/worker/bridge.h
+++ b/src/rust/worker/bridge.h
@@ -6,8 +6,6 @@
 
 #include <workerd/rust/worker/ffi.rs.h>
 
-#include <kj-rs/kj-rs.h>
-
 namespace workerd::rust::worker {
 
 inline workerd::EventOutcome fromImpl(kj_rs::Rust*, workerd::rust::worker::EventOutcome outcome) {

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -8,7 +8,7 @@
 #include <workerd/api/basics.h>
 #include <workerd/api/js-readable-stream.h>
 #include <workerd/api/js-writable-stream.h>
-#include <workerd/io/compatibility-date.h>
+#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/container.capnp.h>
 #include <workerd/io/io-own.h>
 #include <workerd/jsg/jsg.h>

--- a/src/workerd/api/crypto/impl.h
+++ b/src/workerd/api/crypto/impl.h
@@ -9,6 +9,8 @@
 
 #include "crypto.h"
 
+// For fastEncodeBase64Url, widely used in crypto implementation
+// NOLINTNEXTLINE(misc-include-cleaner)
 #include <workerd/api/util.h>
 #include <workerd/jsg/jsvalue.h>
 

--- a/src/workerd/api/data-url.c++
+++ b/src/workerd/api/data-url.c++
@@ -4,6 +4,7 @@
 
 #include <workerd/util/strings.h>
 
+#include <kj/debug.h>
 #include <kj/vector.h>
 
 namespace workerd::api {

--- a/src/workerd/api/eventsource.c++
+++ b/src/workerd/api/eventsource.c++
@@ -4,8 +4,8 @@
 
 #include "eventsource.h"
 
+#include "events.h"
 #include "http.h"
-#include "messagechannel.h"
 #include "streams/common.h"
 
 #include <workerd/io/features.h>

--- a/src/workerd/api/eventsource.h
+++ b/src/workerd/api/eventsource.h
@@ -4,7 +4,6 @@
 
 #pragma once
 #include "basics.h"
-#include "events.h"
 #include "http.h"
 
 #include <workerd/jsg/jsg.h>

--- a/src/workerd/api/fuzzilli.c++
+++ b/src/workerd/api/fuzzilli.c++
@@ -6,7 +6,12 @@
 #include <workerd/util/immediate-crash.h>
 
 #include <errno.h>
+#include <fcntl.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <kj/common.h>
 #include <kj/debug.h>

--- a/src/workerd/api/fuzzilli.h
+++ b/src/workerd/api/fuzzilli.h
@@ -4,13 +4,8 @@
 #include <workerd/jsg/jsg.h>
 
 #include <assert.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include <cstdint>
 

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "basics.h"
+#include "events.h"
 #include "filesystem.h"
 #include "http.h"
 #include "messagechannel.h"

--- a/src/workerd/api/html-rewriter.h
+++ b/src/workerd/api/html-rewriter.h
@@ -7,7 +7,7 @@
 #include <workerd/api/http.h>
 #include <workerd/jsg/jsg.h>
 
-#include <v8.h>
+#include <v8-template.h>
 
 struct lol_html_HtmlRewriterBuilder;
 struct lol_html_HtmlRewriter;

--- a/src/workerd/api/messagechannel.h
+++ b/src/workerd/api/messagechannel.h
@@ -1,10 +1,8 @@
 #pragma once
 
 #include <workerd/api/basics.h>
-#include <workerd/io/io-context.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules-new.h>
-#include <workerd/jsg/ser.h>
 #include <workerd/jsg/url.h>
 
 namespace workerd::api {

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -8,7 +8,6 @@
 #include <workerd/api/filesystem.h>
 #include <workerd/api/messagechannel.h>
 #include <workerd/api/node/node.h>
-#include <workerd/api/pyodide/pyodide.h>
 #include <workerd/api/rtti.h>
 #include <workerd/api/sockets.h>
 #include <workerd/api/tracing.h>

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -13,7 +13,6 @@
 #include <workerd/api/node/timers.h>
 #include <workerd/api/node/url.h>
 #include <workerd/api/node/util.h>
-#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/url.h>
@@ -22,8 +21,6 @@
 #include <workerd/util/autogate.h>
 
 #include <node/node.capnp.h>
-
-#include <capnp/dynamic.h>
 
 namespace workerd::api::node {
 

--- a/src/workerd/api/node/process.c++
+++ b/src/workerd/api/node/process.c++
@@ -3,6 +3,8 @@
 //     https://opensource.org/licenses/Apache-2.0
 #include "process.h"
 
+#include "node-version.h"
+
 #include <workerd/api/filesystem.h>
 #include <workerd/api/node/exceptions.h>
 #include <workerd/io/features.h>

--- a/src/workerd/api/node/process.h
+++ b/src/workerd/api/node/process.h
@@ -3,9 +3,6 @@
 //     https://opensource.org/licenses/Apache-2.0
 #pragma once
 
-#include <workerd/api/node/i18n.h>
-#include <workerd/api/node/node-version.h>
-#include <workerd/io/worker-fs.h>
 #include <workerd/jsg/jsg.h>
 
 namespace workerd::api::node {

--- a/src/workerd/api/pyodide/pyodide.h
+++ b/src/workerd/api/pyodide/pyodide.h
@@ -5,11 +5,9 @@
 
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
-#include <workerd/jsg/modules-new.h>
 #include <workerd/util/strong-bool.h>
 
 #include <pyodide/generated/pyodide_extra.capnp.h>
-#include <pyodide/pyodide_static.capnp.h>
 #include <pyodide/python_packages.capnp.h>
 
 #include <capnp/serialize.h>

--- a/src/workerd/api/r2-bucket.h
+++ b/src/workerd/api/r2-bucket.h
@@ -6,7 +6,7 @@
 
 #include "r2-rpc.h"
 
-#include <workerd/api/streams/readable.h>
+#include <workerd/api/js-readable-stream.h>
 #include <workerd/jsg/jsg.h>
 
 namespace workerd::api {

--- a/src/workerd/api/r2.h
+++ b/src/workerd/api/r2.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+// NOLINTNEXTLINE(misc-include-cleaner)
 #include "r2-bucket.h"
+// NOLINTNEXTLINE(misc-include-cleaner)
 #include "r2-multipart.h"
 
 namespace workerd::api::public_beta {

--- a/src/workerd/api/streams.h
+++ b/src/workerd/api/streams.h
@@ -7,6 +7,9 @@
 //
 // This is the most over-engineered spec...
 
+// This header is intentionally used to include the entire streams API – include it only when
+// strictly necessary
+// NOLINTBEGIN(misc-include-cleaner)
 #include <workerd/api/js-readable-stream.h>
 #include <workerd/api/js-writable-stream.h>
 #include <workerd/api/streams/compression.h>
@@ -16,6 +19,7 @@
 #include <workerd/api/streams/standard.h>
 #include <workerd/api/streams/transform.h>
 #include <workerd/api/streams/writable.h>
+// NOLINTEND(misc-include-cleaner)
 
 namespace workerd::api {
 

--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -12,6 +12,8 @@
 #include <workerd/util/ring-buffer.h>
 #include <workerd/util/state-machine.h>
 
+#include <zlib.h>
+
 namespace workerd::api {
 CompressionAllocator::CompressionAllocator(
     kj::Arc<const jsg::ExternalMemoryTarget>&& externalMemoryTarget)

--- a/src/workerd/api/streams/compression.h
+++ b/src/workerd/api/streams/compression.h
@@ -7,8 +7,6 @@
 #include <workerd/api/streams/transform.h>
 #include <workerd/jsg/jsg.h>
 
-#include <zlib.h>
-
 namespace workerd::api {
 
 // A custom allocator to be used by the zlib and brotli libraries.
@@ -19,7 +17,7 @@ class CompressionAllocator final {
  public:
   CompressionAllocator(kj::Arc<const jsg::ExternalMemoryTarget>&& externalMemoryTarget);
 
-  static void* AllocForZlib(void* data, uInt items, uInt size);
+  static void* AllocForZlib(void* data, uint items, uint size);
   static void* AllocForBrotli(void* data, size_t size);
   static void FreeForZlib(void* data, void* pointer);
 

--- a/src/workerd/api/streams/writable.h
+++ b/src/workerd/api/streams/writable.h
@@ -7,7 +7,6 @@
 #include "common.h"
 
 #include <workerd/util/state-machine.h>
-#include <workerd/util/weak-refs.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/unsafe.h
+++ b/src/workerd/api/unsafe.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <workerd/io/io-context.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/modules-new.h>
-#include <workerd/jsg/script.h>
 #include <workerd/jsg/url.h>
 
 #include <csignal>
@@ -11,11 +9,11 @@
 
 #ifdef _WIN32
 #include <io.h>
-#else
-#include <unistd.h>
 #endif
 
+#ifdef WORKERD_FUZZILLI
 #include <workerd/api/fuzzilli.h>
+#endif
 
 namespace workerd::api {
 

--- a/src/workerd/api/util.h
+++ b/src/workerd/api/util.h
@@ -6,8 +6,6 @@
 
 #include <workerd/jsg/jsg.h>
 
-#include <v8.h>
-
 #include <kj/async-io.h>
 #include <kj/compat/url.h>
 #include <kj/string.h>

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "basics.h"
-#include "events.h"
 
 #include <workerd/io/io-gate.h>
 #include <workerd/io/observer.h>
@@ -16,7 +15,6 @@
 #include <kj/compat/http.h>
 
 #include <cstdlib>
-#include <list>
 
 namespace workerd {
 class ActorObserver;

--- a/src/workerd/api/worker-loader.h
+++ b/src/workerd/api/worker-loader.h
@@ -5,7 +5,6 @@
 #include <workerd/io/io-channels.h>
 #include <workerd/io/io-own.h>
 #include <workerd/io/worker.h>
-#include <workerd/jsg/setup.h>
 
 namespace workerd::api {
 

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -18,9 +18,7 @@
 #include <workerd/io/trace.h>
 #include <workerd/io/worker-interface.capnp.h>
 #include <workerd/jsg/jsg.h>
-#include <workerd/jsg/modules-new.h>
 #include <workerd/jsg/ser.h>
-#include <workerd/jsg/url.h>
 
 namespace workerd::api {
 

--- a/src/workerd/io/limit-enforcer.h
+++ b/src/workerd/io/limit-enforcer.h
@@ -10,7 +10,6 @@
 #include <v8-isolate.h>
 
 #include <kj/async.h>   // For Promise
-#include <kj/debug.h>   // For KJ_REQUIRE
 #include <kj/memory.h>  // for Own
 #include <kj/one-of.h>  // for OneOf
 #include <kj/time.h>    // for Duration

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -18,7 +18,6 @@
 #include <kj/time.h>
 #include <kj/vector.h>
 
-#include <concepts>
 #include <initializer_list>
 
 namespace kj {

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -7,7 +7,6 @@
 #include <workerd/io/outcome.capnp.h>
 #include <workerd/io/trace.h>
 #include <workerd/io/worker-interface.capnp.h>
-#include <workerd/util/http-util.h>
 
 #include <capnp/compat/http-over-capnp.h>
 #include <kj/compat/http.h>

--- a/src/workerd/io/worker-modules.h
+++ b/src/workerd/io/worker-modules.h
@@ -2,11 +2,13 @@
 
 #include <workerd/api/commonjs.h>
 #include <workerd/api/modules.h>
+#include <workerd/api/pyodide/pyodide.h>
 #include <workerd/io/io-context.h>
 #include <workerd/io/worker.h>
 #include <workerd/jsg/modules-new.h>
 #include <workerd/util/strong-bool.h>
 
+#include <pyodide/pyodide_static.capnp.h>
 #include <pyodide/python-entrypoint.embed.h>
 
 #include <capnp/blob.h>

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -116,7 +116,7 @@ wd_cc_library(
         "@ssl",
     ],
     local_defines = ["JSG_IMPLEMENTATION"],
-    tags = ["no-clang-tidy"],
+    tags = ["no-clang-tidy-headers"],
     visibility = [
         "//src/rust/jsg:__pkg__",
         "//src/rust/jsg-test:__pkg__",

--- a/src/workerd/jsg/iterator.h
+++ b/src/workerd/jsg/iterator.h
@@ -6,6 +6,7 @@
 
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/memory.h>
+// NOLINTNEXTLINE(misc-include-cleaner)
 #include <workerd/jsg/struct.h>
 #include <workerd/util/weak-refs.h>
 

--- a/src/workerd/jsg/jsg-test.h
+++ b/src/workerd/jsg/jsg-test.h
@@ -8,6 +8,8 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/resource.h>
 #include <workerd/jsg/setup.h>
+// False negative
+// NOLINTNEXTLINE(misc-include-cleaner)
 #include <workerd/jsg/type-wrapper.h>
 
 #include <kj/test.h>

--- a/src/workerd/jsg/jsvalue.c++
+++ b/src/workerd/jsg/jsvalue.c++
@@ -466,7 +466,7 @@ kj::String JsDate::toISOString(jsg::Lock& js) const {
 }
 
 JsDate::operator kj::Date() const {
-  return kj::UNIX_EPOCH + (int64_t(inner->ValueOf()) * kj::MILLISECONDS);
+  return kj::UNIX_EPOCH + (static_cast<int64_t>(inner->ValueOf()) * kj::MILLISECONDS);
 }
 
 JsRegExp Lock::regexp(kj::StringPtr str, RegExpFlags flags, kj::Maybe<uint32_t> backtrackLimit) {
@@ -743,7 +743,7 @@ kj::ArrayPtr<const kj::byte> JsArrayBuffer::asArrayPtr() const {
 JsArrayBuffer JsArrayBuffer::slice(Lock& js, size_t newLength) const {
   JSG_REQUIRE(newLength <= size(), RangeError, "New length exceeds buffer length");
   auto dest = create(js, newLength);
-  dest.asArrayPtr().copyFrom(asArrayPtr().slice(0, newLength));
+  dest.asArrayPtr().copyFrom(asArrayPtr().first(newLength));
   return dest;
 }
 
@@ -933,7 +933,7 @@ kj::ArrayPtr<const kj::byte> JsSharedArrayBuffer::asArrayPtr() const {
 JsSharedArrayBuffer JsSharedArrayBuffer::slice(Lock& js, size_t newLength) const {
   JSG_REQUIRE(newLength <= size(), RangeError, "New length exceeds buffer length");
   auto dest = create(js, newLength);
-  dest.asArrayPtr().copyFrom(asArrayPtr().slice(0, newLength));
+  dest.asArrayPtr().copyFrom(asArrayPtr().first(newLength));
   return dest;
 }
 

--- a/src/workerd/jsg/memory.h
+++ b/src/workerd/jsg/memory.h
@@ -13,9 +13,7 @@
 #include <v8-profiler.h>
 
 #include <kj/common.h>
-#include <kj/debug.h>
 #include <kj/exception.h>
-#include <kj/hash.h>
 #include <kj/map.h>
 #include <kj/refcount.h>
 #include <kj/string.h>

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -1140,7 +1140,7 @@ class IsolateModuleRegistry final {
   };
 
   struct InstanceCallbacks final {
-    const Entry& keyForRow(const Entry& entry) const {
+    const Entry& keyForRow(const Entry& entry KJ_LIFETIMEBOUND) const {
       return entry;
     }
     bool matches(const Entry& entry, const Url& id, const Module* def) const {

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -8,8 +8,6 @@
 
 #include <v8-wasm.h>
 
-#include <kj/mutex.h>
-
 #include <span>
 
 namespace workerd::jsg {

--- a/src/workerd/jsg/struct.h
+++ b/src/workerd/jsg/struct.h
@@ -9,10 +9,8 @@
 // struct is translated to/from a native JS object with the same field names.
 
 #include <workerd/jsg/util.h>
-#include <workerd/jsg/value.h>
 #include <workerd/jsg/web-idl.h>
 
-#include <concepts>
 #include <type_traits>
 
 namespace workerd::jsg {

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -7,6 +7,7 @@
 //
 // The TypeWrapper knows how to convert a variety of types between C++ and JavaScript.
 
+// NOLINTNEXTLINE(misc-include-cleaner)
 #include <workerd/jsg/dom-exception.h>
 #include <workerd/jsg/function.h>
 #include <workerd/jsg/iterator.h>

--- a/src/workerd/jsg/url-test.c++
+++ b/src/workerd/jsg/url-test.c++
@@ -7,8 +7,6 @@
 #include <kj/table.h>
 #include <kj/test.h>
 
-#include <regex>
-
 namespace workerd::jsg::test {
 namespace {
 

--- a/src/workerd/jsg/v8-platform-wrapper.c++
+++ b/src/workerd/jsg/v8-platform-wrapper.c++
@@ -6,7 +6,7 @@
 
 #include "jsg.h"
 
-#include <v8-isolate.h>
+#include <v8-platform.h>
 
 namespace workerd::jsg {
 

--- a/src/workerd/server/pyodide.h
+++ b/src/workerd/server/pyodide.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <workerd/api/pyodide/pyodide.h>
-#include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/jsg/jsg.h>
 
 #include <kj/array.h>

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <workerd/api/pyodide/pyodide.h>
-#include <workerd/io/worker-fs.h>
 #include <workerd/io/worker.h>
 #include <workerd/server/workerd.capnp.h>
 

--- a/src/workerd/server/workerd-debug-port-client.h
+++ b/src/workerd/server/workerd-debug-port-client.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <workerd/io/io-channels.h>
 #include <workerd/io/io-own.h>
 #include <workerd/io/worker-interface.capnp.h>
 #include <workerd/jsg/jsg.h>

--- a/src/workerd/util/checked-queue.h
+++ b/src/workerd/util/checked-queue.h
@@ -2,9 +2,7 @@
 
 #include <kj/common.h>
 #include <kj/debug.h>
-#include <kj/exception.h>
 
-#include <concepts>
 #include <list>
 
 namespace workerd::util {

--- a/src/workerd/util/mimetype.h
+++ b/src/workerd/util/mimetype.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <workerd/jsg/memory.h>
-#include <workerd/util/strings.h>
 
 #include <kj/common.h>
 #include <kj/map.h>

--- a/src/workerd/util/sentry.h
+++ b/src/workerd/util/sentry.h
@@ -12,8 +12,6 @@
 #include <kj/string.h>
 #include <kj/time.h>
 
-#include <cstdint>
-
 namespace workerd {
 
 // For internal errors, we generate an ID to include when rendering user-facing "internal error"

--- a/src/workerd/util/strong-bool.h
+++ b/src/workerd/util/strong-bool.h
@@ -5,8 +5,12 @@
 
 #include <kj/string.h>
 
-#include <compare>
-#include <cstdint>
+// This header does not use the given includes directly, but any source file that uses
+// WD_STRONG_BOOL will need them.
+// NOLINTBEGIN(misc-include-cleaner)
+#include <compare>  // For operator<=>
+#include <cstdint>  // For std::uint8_t
+// NOLINTEND(misc-include-cleaner)
 
 namespace workerd {
 

--- a/src/workerd/util/thread-scopes.h
+++ b/src/workerd/util/thread-scopes.h
@@ -22,7 +22,7 @@
 #define WORKERD_ASAN 1
 #endif
 
-#include <cinttypes>
+#include <cstdint>
 
 namespace workerd {
 

--- a/src/workerd/util/use-perfetto-categories.h
+++ b/src/workerd/util/use-perfetto-categories.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// This file is widely used to enable perfetto
+// NOLINTNEXTLINE(misc-include-cleaner)
 #include <workerd/util/perfetto-tracing.h>
 
 // This header is to be imported by any translation unit (c++ file) that


### PR DESCRIPTION
Reduces transitive include bloat by enforcing that no unused headers are being added.

This only covers header files for now and does not include KJ includes, otherwise the PR would need to be much larger and people would get linter errors more frequently.

Deployment plan: This will require some downstream changes to land, a PR for that will follow soon. I plan to only enable this check for workerd for now and see how things go with that, if people find that it is too much of an annoyance to sometimes be told that they have superfluous headers we can disable it again. But I hope that the check makes sense to developers for the most part and that we can benefit from having includes that make sense and slightly faster compile times (fewer includes means less time spent parsing headers).
If feedback is mostly positive a couple weeks in, we may want to extend this to the downstream repo and to capnproto.