### PR TITLE
[build] Fall back to scalar zlib on CPUs without SIMD ports

### DIFF
--- a/build/BUILD.zlib
+++ b/build/BUILD.zlib
@@ -92,6 +92,7 @@ cc_library(
     local_defines = ["ZLIB_IMPLEMENTATION"] + select({
         "@platforms//cpu:x86_64": ["ADLER32_SIMD_SSSE3"],
         "@platforms//cpu:aarch64": ["ADLER32_SIMD_NEON"],
+        "//conditions:default": [],
     }) + select({
         ":x86_linux": ["X86_NOT_WINDOWS"],
         ":x86_macos": ["X86_NOT_WINDOWS"],
@@ -149,6 +150,7 @@ cc_library(
         "@platforms//cpu:aarch64": [
             "INFLATE_CHUNK_SIMD_NEON",
         ],
+        "//conditions:default": [],
     }),
     deps = [":zlib_common_headers"],
 )
@@ -185,6 +187,7 @@ cc_library(
     local_defines = ["ZLIB_IMPLEMENTATION"] + select({
         "@platforms//cpu:x86_64": ["DEFLATE_SLIDE_HASH_SSE2"],
         "@platforms//cpu:aarch64": ["DEFLATE_SLIDE_HASH_NEON"],
+        "//conditions:default": [],
     }),
     deps = [":zlib_common_headers"],
 )
@@ -242,6 +245,7 @@ cc_library(
             "CRC32_ARMV8_CRC32",
             "DEFLATE_SLIDE_HASH_NEON",
         ],
+        "//conditions:default": [],
     }) + select({
         ":x86_linux": ["X86_NOT_WINDOWS"],
         ":x86_macos": ["X86_NOT_WINDOWS"],
@@ -259,6 +263,7 @@ cc_library(
     ] + select({
         "@platforms//cpu:x86_64": [":zlib_crc32_simd"],
         "@platforms//cpu:aarch64": [":zlib_arm_crc32"],
+        "//conditions:default": [],
     }),
 )
 


### PR DESCRIPTION
build/BUILD.zlib overlays Chromium zlib with ISA-specific SIMD defines and deps, but several select()s only list x86_64 and aarch64. Bazel analysis then fails on any other CPU because those configurable attributes have no matching condition.

The SIMD libraries already no-op when their ADLER32_SIMD_*, INFLATE_CHUNK_SIMD_*, CRC32_* and DEFLATE_SLIDE_HASH_* defines are unset: the corresponding C files are empty translation units or the generic zlib sources are used instead. Add "//conditions:default": [] so those selects resolve, and skip the x86/ARM-only CRC SIMD deps on other CPUs.

This does not enable RISC-V Vector (or other) zlib optimizations; it only unblocks a portable scalar build.