### PR TITLE
Keep subject prefixes when applying V8 patches

### DIFF
--- a/.opencode/skills/update-v8/SKILL.md
+++ b/.opencode/skills/update-v8/SKILL.md
@@ -48,7 +48,7 @@ gclient sync
 
 ```sh
 git checkout -b workerd-patches
-git am <path_to_workerd>/patches/v8/*
+git am --keep-non-patch <path_to_workerd>/patches/v8/*
 ```
 
 There are multiple patches in `patches/v8/`. These include workerd-specific customizations:

--- a/ci/v8_update.py
+++ b/ci/v8_update.py
@@ -156,10 +156,13 @@ def prepare_update(target):
         "GIT_COMMITTER_EMAIL": "ew-v8-patches@cloudflare.com",
     }
 
+    # --keep-non-patch is the counterpart of the -k that finish_update passes to
+    # format-patch.
     v8_nightly_shared.run(
         [
             "git",
             "am",
+            "--keep-non-patch",
             "--3way",
             "--committer-date-is-author-date",
             *patch_files,

--- a/docs/v8-updates.md
+++ b/docs/v8-updates.md
@@ -34,8 +34,12 @@ To update the version of V8 used by workerd, the steps are:
 
    ```sh
    git checkout -b workerd-patches
-   git am <path_to_workerd>/patches/v8/*
+   git am --keep-non-patch <path_to_workerd>/patches/v8/*
    ```
+
+   `--keep-non-patch` is the counterpart of the `-k` in step 7. It keeps subject
+   prefixes such as the `[wasm]` that upstream V8 commits carry, so the patches
+   regenerated in step 7 keep their existing filenames.
 
 6. Rebase the workerd V8 changes onto the new version of V8. For example, assuming
    we are updating to `<new_version>`, the command would be:


### PR DESCRIPTION
finish_update regenerates patches/v8 with format-patch -k, but the git am that applies them carried no matching flag, so mailinfo stripped bracketed prefixes from the subject. Upstream V8 commits routinely carry one, so the first roll after adding such a patch rewrote its subject and renamed the file, putting churn unrelated to the roll into the diff. Pairing the two flags makes the series a fixed point instead: applying it and regenerating it reproduces the same filenames and bytes.

--keep-non-patch rather than -k, because -k would keep mail cruft like [PATCH] and [PATCH v2] too, baking it into the commit subject and hence the filename.

docs/v8-updates.md walks through the same sequence by hand, so it needs the flag to stay in step. Verified with git mailinfo on patches/v8/0039, the one patch carrying a prefix today, and by regenerating the rest of the series unchanged.

Assisted-by: OpenCode:claude-opus-5