### PR TITLE
Fix workers-sdk Vitest fixture filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,7 +236,7 @@ jobs:
           MINIFLARE_WORKERD_PATH: /tmp/workerd
 
       - name: Run Vitest unit tests
-        run: pnpm test:ci --filter="./fixtures/vitest-pool-workers-examples"
+        run: pnpm test:ci --filter="./fixtures/vitest-plugin-examples"
         env:
           MINIFLARE_WORKERD_PATH: /tmp/workerd
 


### PR DESCRIPTION
## Summary

Update the workers-sdk Vitest fixture filter after the fixture workspace was renamed in cloudflare/workers-sdk#15074. The workers-sdk integration job checks out the moving default branch, where the old path no longer exists.

## Testing

Verified on workers-sdk `main` that `fixtures/vitest-plugin-examples` exists and exposes the `test:ci` script, while the old fixture path no longer exists.