### PR TITLE
Temporarily disable the per PR random number generator

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -23,6 +23,8 @@ permissions:
 
 jobs:
   benchmarks:
+    # Temporarily disabled until benchmark quality and accuracy can be improved.
+    if: false
     name: Run benchmarks
     runs-on: ubuntu-22.04-16core
     env:


### PR DESCRIPTION
Accurate benchmarks are helpful. Inaccurate random number generators are not. Disable codspeed for now.