### PR TITLE
WO-1582 Add span.recordException

### DIFF
--- a/src/cloudflare/internal/test/tracing/tracing-log-attribution-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-log-attribution-instrumentation-test.js
@@ -166,6 +166,16 @@ function findLog(inv, substring) {
   return matches[0];
 }
 
+function findException(inv, message) {
+  const matches = inv.exceptions.filter((e) => e.message === message);
+  assert.strictEqual(
+    matches.length,
+    1,
+    `Expected exactly one exception with message "${message}" in invocation ${inv.invocationId}, got ${matches.length}`
+  );
+  return matches[0];
+}
+
 export const validate = {
   async test() {
     // Wait for every invocation's `outcome` event to arrive.
@@ -283,6 +293,44 @@ export const validate = {
         inv.topLevelSpanId,
         'diagnosticChannelEvent must NOT be attributed to the root'
       );
+    }
+
+    // recordException() targets the receiver span, even when a different span is active.
+    {
+      const { inv, span: active } = findInvocationBySpanName(
+        'record-exception-active'
+      );
+      const receiver = Array.from(inv.spans.values()).find(
+        (span) => span.name === 'record-exception-receiver'
+      );
+      assert.ok(receiver, 'expected the receiver span');
+
+      const error = findException(inv, 'recorded-error');
+      assert.strictEqual(error.name, 'Error');
+      assert.strictEqual(error.spanContextSpanId, receiver.spanId);
+      assert.notStrictEqual(error.spanContextSpanId, active.spanId);
+
+      const coded = findException(inv, 'recorded-code');
+      assert.strictEqual(coded.name, '42');
+      assert.strictEqual(coded.spanContextSpanId, receiver.spanId);
+
+      const string = findException(inv, 'recorded-string');
+      assert.strictEqual(string.name, '');
+      assert.strictEqual(string.spanContextSpanId, receiver.spanId);
+
+      const messageOnly = findException(inv, 'recorded-message');
+      assert.strictEqual(messageOnly.name, '');
+      assert.strictEqual(messageOnly.spanContextSpanId, receiver.spanId);
+
+      const zeroCode = findException(inv, 'recorded-zero-code');
+      assert.strictEqual(zeroCode.name, 'FallbackError');
+      assert.strictEqual(zeroCode.spanContextSpanId, receiver.spanId);
+    }
+
+    // Calls after end() must not emit an exception event.
+    {
+      const { inv } = findInvocationBySpanName('record-exception-ended');
+      assert.strictEqual(inv.exceptions.length, 0);
     }
 
     console.log('All tracing-log-attribution tests passed!');

--- a/src/cloudflare/internal/test/tracing/tracing-log-attribution-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-log-attribution-instrumentation-test.js
@@ -87,6 +87,7 @@ export default {
           break;
         case 'exception':
           inv.exceptions.push({
+            code: event.event.code,
             name: event.event.name,
             message: event.event.message,
             spanContextSpanId: currentSpanId,
@@ -172,6 +173,16 @@ function findException(inv, message) {
     matches.length,
     1,
     `Expected exactly one exception with message "${message}" in invocation ${inv.invocationId}, got ${matches.length}`
+  );
+  return matches[0];
+}
+
+function findExceptionByCode(inv, code) {
+  const matches = inv.exceptions.filter((e) => e.code === code);
+  assert.strictEqual(
+    matches.length,
+    1,
+    `Expected exactly one exception with code "${code}" in invocation ${inv.invocationId}, got ${matches.length}`
   );
   return matches[0];
 }
@@ -311,7 +322,8 @@ export const validate = {
       assert.notStrictEqual(error.spanContextSpanId, active.spanId);
 
       const coded = findException(inv, 'recorded-code');
-      assert.strictEqual(coded.name, '42');
+      assert.strictEqual(coded.code, 42);
+      assert.strictEqual(coded.name, '');
       assert.strictEqual(coded.spanContextSpanId, receiver.spanId);
 
       const string = findException(inv, 'recorded-string');
@@ -323,8 +335,20 @@ export const validate = {
       assert.strictEqual(messageOnly.spanContextSpanId, receiver.spanId);
 
       const zeroCode = findException(inv, 'recorded-zero-code');
+      assert.strictEqual(zeroCode.code, 0);
       assert.strictEqual(zeroCode.name, 'FallbackError');
       assert.strictEqual(zeroCode.spanContextSpanId, receiver.spanId);
+
+      const codeOnly = findExceptionByCode(inv, 'CODE_ONLY');
+      assert.strictEqual(codeOnly.name, '');
+      assert.strictEqual(codeOnly.message, '');
+      assert.strictEqual(codeOnly.spanContextSpanId, receiver.spanId);
+
+      assert.strictEqual(
+        inv.exceptions.length,
+        6,
+        'stack-only objects do not satisfy the Exception union'
+      );
     }
 
     // Calls after end() must not emit an exception event.

--- a/src/cloudflare/internal/test/tracing/tracing-log-attribution-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-log-attribution-test.js
@@ -81,3 +81,31 @@ export const diagnosticsChannelInsideEnterSpan = {
     });
   },
 };
+
+export const recordExceptionUsesReceiverSpan = {
+  async test(ctrl, env, ctx) {
+    const { withSpan } = env.tracingTest;
+    withSpan('record-exception-active', (active) => {
+      active.setAttribute('case', 'recordExceptionUsesReceiverSpan');
+      const detached = ctx.tracing.startSpan('record-exception-receiver');
+      detached.recordException(new Error('recorded-error'));
+      detached.recordException({ code: 42, message: 'recorded-code' });
+      detached.recordException('recorded-string');
+      detached.recordException({ message: 'recorded-message' });
+      detached.recordException({
+        code: 0,
+        name: 'FallbackError',
+        message: 'recorded-zero-code',
+      });
+      detached.end();
+    });
+  },
+};
+
+export const recordExceptionAfterEndIsIgnored = {
+  async test(ctrl, env, ctx) {
+    const span = ctx.tracing.startSpan('record-exception-ended');
+    span.end();
+    span.recordException('ignored-after-end');
+  },
+};

--- a/src/cloudflare/internal/test/tracing/tracing-log-attribution-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-log-attribution-test.js
@@ -97,6 +97,8 @@ export const recordExceptionUsesReceiverSpan = {
         name: 'FallbackError',
         message: 'recorded-zero-code',
       });
+      detached.recordException({ code: 'CODE_ONLY' });
+      detached.recordException({ stack: 'ignored-stack-only' });
       detached.end();
     });
   },

--- a/src/cloudflare/internal/tracing.d.ts
+++ b/src/cloudflare/internal/tracing.d.ts
@@ -9,26 +9,32 @@ interface SpanAttributes {
   [key: string]: SpanValue | undefined;
 }
 
-type SpanException =
-  | string
-  | {
-      code: string | number;
-      name?: string;
-      message?: string;
-      stack?: string;
-    }
-  | {
-      code?: string | number;
-      name: string;
-      message?: string;
-      stack?: string;
-    }
-  | {
-      code?: string | number;
-      name?: string;
-      message: string;
-      stack?: string;
-    };
+interface ExceptionWithCode {
+  code: string | number;
+  name?: string;
+  message?: string;
+  stack?: string;
+}
+
+interface ExceptionWithMessage {
+  code?: string | number;
+  message: string;
+  name?: string;
+  stack?: string;
+}
+
+interface ExceptionWithName {
+  code?: string | number;
+  message?: string;
+  name: string;
+  stack?: string;
+}
+
+type Exception =
+  | ExceptionWithCode
+  | ExceptionWithMessage
+  | ExceptionWithName
+  | string;
 
 declare class Span {
   // Returns true if this span will be recorded to the tracing system. False when the
@@ -43,7 +49,7 @@ declare class Span {
   setAttributes(attributes: SpanAttributes): this;
 
   // Records an exception event on the span. Calls after the span has ended are ignored.
-  recordException(exception: SpanException): void;
+  recordException(exception: Exception): void;
 
   // Ends the span and submits its attributes to the tracing system. Idempotent.
   end(): void;
@@ -88,4 +94,4 @@ export default tracing;
 // Re-export `Span` as a named type export for callers that prefer `import type { Span }`
 // over `InstanceType<typeof tracing.Span>`. The runtime module does not have a named
 // `Span` export - this is purely a type-level convenience.
-export type { Span };
+export type { Exception, Span };

--- a/src/cloudflare/internal/tracing.d.ts
+++ b/src/cloudflare/internal/tracing.d.ts
@@ -9,6 +9,27 @@ interface SpanAttributes {
   [key: string]: SpanValue | undefined;
 }
 
+type SpanException =
+  | string
+  | {
+      code: string | number;
+      name?: string;
+      message?: string;
+      stack?: string;
+    }
+  | {
+      code?: string | number;
+      name: string;
+      message?: string;
+      stack?: string;
+    }
+  | {
+      code?: string | number;
+      name?: string;
+      message: string;
+      stack?: string;
+    };
+
 declare class Span {
   // Returns true if this span will be recorded to the tracing system. False when the
   // current async context is not being traced, or when the span has already been submitted.
@@ -20,6 +41,9 @@ declare class Span {
 
   // Sets multiple attributes on the span. Attributes with undefined values are ignored.
   setAttributes(attributes: SpanAttributes): this;
+
+  // Records an exception event on the span. Calls after the span has ended are ignored.
+  recordException(exception: SpanException): void;
 
   // Ends the span and submits its attributes to the tracing system. Idempotent.
   end(): void;

--- a/src/cloudflare/internal/tracing.d.ts
+++ b/src/cloudflare/internal/tracing.d.ts
@@ -31,10 +31,7 @@ interface ExceptionWithName {
 }
 
 type Exception =
-  | ExceptionWithCode
-  | ExceptionWithMessage
-  | ExceptionWithName
-  | string;
+  ExceptionWithCode | ExceptionWithMessage | ExceptionWithName | string;
 
 declare class Span {
   // Returns true if this span will be recorded to the tracing system. False when the

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -72,6 +72,24 @@ void SpanState::setAttribute(kj::String key, kj::Maybe<TagValue> maybeValue) {
   // If value is kj::none the attribute is left unset (undefined on the JS side).
 }
 
+void SpanState::recordException(
+    kj::String name, kj::String message, kj::Maybe<kj::String> stack) {
+  if (!canRecordAttributes()) {
+    return;
+  }
+
+  size_t valueSize = name.size() + message.size();
+  KJ_IF_SOME(s, stack) {
+    valueSize += s.size();
+  }
+  bytesUsed += valueSize;
+  if (bytesUsed > MAX_SPAN_BYTES) {
+    recordSpanDataLimitError("exception", name, valueSize);
+    return;
+  }
+  recordExceptionImpl(kj::mv(name), kj::mv(message), kj::mv(stack));
+}
+
 class UserSpanState final: public SpanState {
  public:
   UserSpanState(kj::Rc<workerd::SpanObserver> observer, kj::ConstString operationName)
@@ -114,6 +132,11 @@ class UserSpanState final: public SpanState {
     }
   }
 
+  void recordExceptionImpl(
+      kj::String name, kj::String message, kj::Maybe<kj::String> stack) override {
+    builder.recordException(kj::mv(name), kj::mv(message), kj::mv(stack));
+  }
+
   void recordSpanDataLimitError(
       kj::StringPtr itemKind, kj::StringPtr name, size_t valueSize) override {
     if (!builder.isObserved()) {
@@ -154,6 +177,8 @@ class NoopSpanState final: public SpanState {
   }
 
   void recordAttribute(kj::String, TagValue) override {}
+
+  void recordExceptionImpl(kj::String, kj::String, kj::Maybe<kj::String>) override {}
 };
 
 // ======================================================================================
@@ -194,6 +219,63 @@ jsg::Ref<Span> Span::setAttributes(jsg::Lock& js, jsg::Dict<jsg::Optional<TagVal
     setAttribute(js, kj::mv(field.name), kj::mv(field.value));
   }
   return JSG_THIS;
+}
+
+void Span::recordException(
+    jsg::Lock& js, jsg::Value exception, const jsg::TypeHandler<ExceptionData>& exceptionHandler) {
+  if (!getIsTraced()) {
+    return;
+  }
+
+  kj::String name;
+  kj::String message;
+  kj::Maybe<kj::String> stack;
+  auto handle = exception.getHandle(js);
+  if (handle->IsString()) {
+    message = jsg::JsValue(handle).toString(js);
+  } else if (handle->IsObject()) {
+    auto data = KJ_REQUIRE_NONNULL(exceptionHandler.tryUnwrap(js, handle));
+    KJ_IF_SOME(code, data.code) {
+      KJ_SWITCH_ONEOF(code) {
+        KJ_CASE_ONEOF(s, kj::String) {
+          if (s.size() > 0) {
+            name = kj::mv(s);
+          }
+        }
+        KJ_CASE_ONEOF(n, double) {
+          if (n != 0 && n == n) {
+            name = kj::str(n);
+          }
+        }
+      }
+    }
+    if (name.size() == 0) {
+      KJ_IF_SOME(n, data.name) {
+        name = kj::mv(n);
+      }
+    }
+    KJ_IF_SOME(m, data.message) {
+      message = kj::mv(m);
+    }
+    KJ_IF_SOME(s, data.stack) {
+      stack = kj::mv(s);
+    }
+
+    if (name.size() == 0 && message.size() == 0) {
+      return;
+    }
+  } else {
+    return;
+  }
+
+  KJ_SWITCH_ONEOF(state) {
+    KJ_CASE_ONEOF(s, kj::Own<SpanState>) {
+      s->recordException(kj::mv(name), kj::mv(message), kj::mv(stack));
+    }
+    KJ_CASE_ONEOF(s, IoOwn<SpanState>) {
+      s->recordException(kj::mv(name), kj::mv(message), kj::mv(stack));
+    }
+  }
 }
 
 void Span::end() {

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -72,13 +72,25 @@ void SpanState::setAttribute(kj::String key, kj::Maybe<TagValue> maybeValue) {
   // If value is kj::none the attribute is left unset (undefined on the JS side).
 }
 
-void SpanState::recordException(
-    kj::String name, kj::String message, kj::Maybe<kj::String> stack) {
+void SpanState::recordException(kj::Maybe<tracing::Exception::Code> code,
+    kj::String name,
+    kj::String message,
+    kj::Maybe<kj::String> stack) {
   if (!canRecordAttributes()) {
     return;
   }
 
   size_t valueSize = name.size() + message.size();
+  KJ_IF_SOME(c, code) {
+    KJ_SWITCH_ONEOF(c) {
+      KJ_CASE_ONEOF(text, kj::String) {
+        valueSize += text.size();
+      }
+      KJ_CASE_ONEOF(_, double) {
+        valueSize += sizeof(double);
+      }
+    }
+  }
   KJ_IF_SOME(s, stack) {
     valueSize += s.size();
   }
@@ -87,7 +99,7 @@ void SpanState::recordException(
     recordSpanDataLimitError("exception", name, valueSize);
     return;
   }
-  recordExceptionImpl(kj::mv(name), kj::mv(message), kj::mv(stack));
+  recordExceptionImpl(kj::mv(code), kj::mv(name), kj::mv(message), kj::mv(stack));
 }
 
 class UserSpanState final: public SpanState {
@@ -132,9 +144,11 @@ class UserSpanState final: public SpanState {
     }
   }
 
-  void recordExceptionImpl(
-      kj::String name, kj::String message, kj::Maybe<kj::String> stack) override {
-    builder.recordException(kj::mv(name), kj::mv(message), kj::mv(stack));
+  void recordExceptionImpl(kj::Maybe<tracing::Exception::Code> code,
+    kj::String name,
+    kj::String message,
+    kj::Maybe<kj::String> stack) override {
+    builder.recordException(kj::mv(code), kj::mv(name), kj::mv(message), kj::mv(stack));
   }
 
   void recordSpanDataLimitError(
@@ -178,7 +192,10 @@ class NoopSpanState final: public SpanState {
 
   void recordAttribute(kj::String, TagValue) override {}
 
-  void recordExceptionImpl(kj::String, kj::String, kj::Maybe<kj::String>) override {}
+  void recordExceptionImpl(kj::Maybe<tracing::Exception::Code>,
+      kj::String,
+      kj::String,
+      kj::Maybe<kj::String>) override {}
 };
 
 // ======================================================================================
@@ -230,29 +247,29 @@ void Span::recordException(
   kj::String name;
   kj::String message;
   kj::Maybe<kj::String> stack;
+  kj::Maybe<tracing::Exception::Code> code;
   auto handle = exception.getHandle(js);
   if (handle->IsString()) {
     message = jsg::JsValue(handle).toString(js);
   } else if (handle->IsObject()) {
     auto data = KJ_REQUIRE_NONNULL(exceptionHandler.tryUnwrap(js, handle));
-    KJ_IF_SOME(code, data.code) {
-      KJ_SWITCH_ONEOF(code) {
+    bool hasRequiredField =
+        data.code != kj::none || data.name != kj::none || data.message != kj::none;
+    if (!hasRequiredField) {
+      return;
+    }
+    KJ_IF_SOME(c, data.code) {
+      KJ_SWITCH_ONEOF(c) {
         KJ_CASE_ONEOF(s, kj::String) {
-          if (s.size() > 0) {
-            name = kj::mv(s);
-          }
+          code = kj::mv(s);
         }
         KJ_CASE_ONEOF(n, double) {
-          if (n != 0 && n == n) {
-            name = kj::str(n);
-          }
+          code = n;
         }
       }
     }
-    if (name.size() == 0) {
-      KJ_IF_SOME(n, data.name) {
-        name = kj::mv(n);
-      }
+    KJ_IF_SOME(n, data.name) {
+      name = kj::mv(n);
     }
     KJ_IF_SOME(m, data.message) {
       message = kj::mv(m);
@@ -260,20 +277,16 @@ void Span::recordException(
     KJ_IF_SOME(s, data.stack) {
       stack = kj::mv(s);
     }
-
-    if (name.size() == 0 && message.size() == 0) {
-      return;
-    }
   } else {
     return;
   }
 
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(s, kj::Own<SpanState>) {
-      s->recordException(kj::mv(name), kj::mv(message), kj::mv(stack));
+      s->recordException(kj::mv(code), kj::mv(name), kj::mv(message), kj::mv(stack));
     }
     KJ_CASE_ONEOF(s, IoOwn<SpanState>) {
-      s->recordException(kj::mv(name), kj::mv(message), kj::mv(stack));
+      s->recordException(kj::mv(code), kj::mv(name), kj::mv(message), kj::mv(stack));
     }
   }
 }

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -145,9 +145,9 @@ class UserSpanState final: public SpanState {
   }
 
   void recordExceptionImpl(kj::Maybe<tracing::Exception::Code> code,
-    kj::String name,
-    kj::String message,
-    kj::Maybe<kj::String> stack) override {
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) override {
     builder.recordException(kj::mv(code), kj::mv(name), kj::mv(message), kj::mv(stack));
   }
 
@@ -192,10 +192,9 @@ class NoopSpanState final: public SpanState {
 
   void recordAttribute(kj::String, TagValue) override {}
 
-  void recordExceptionImpl(kj::Maybe<tracing::Exception::Code>,
-      kj::String,
-      kj::String,
-      kj::Maybe<kj::String>) override {}
+  void recordExceptionImpl(
+      kj::Maybe<tracing::Exception::Code>, kj::String, kj::String, kj::Maybe<kj::String>) override {
+  }
 };
 
 // ======================================================================================

--- a/src/workerd/api/tracing.h
+++ b/src/workerd/api/tracing.h
@@ -29,6 +29,8 @@ constexpr size_t MAX_USER_OPERATION_NAME_BYTES = 64;
 using TagValue = kj::OneOf<bool, double, kj::String>;
 
 struct ExceptionData {
+  // JSG dictionaries cannot express "at least one field is required". recordException()
+  // validates the OpenTelemetry Exception union after conversion.
   jsg::Optional<kj::OneOf<kj::String, double>> code;
   jsg::Optional<kj::String> name;
   jsg::Optional<kj::String> message;
@@ -57,14 +59,19 @@ class SpanState: public kj::Refcounted {
   // Sets a single attribute on the span. If value is kj::none, the attribute is not set.
   void setAttribute(kj::String key, kj::Maybe<TagValue> maybeValue);
 
-  void recordException(kj::String name, kj::String message, kj::Maybe<kj::String> stack);
+  void recordException(kj::Maybe<tracing::Exception::Code> code,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack);
 
  protected:
   SpanState() = default;
   virtual bool canRecordAttributes() = 0;
   virtual void recordAttribute(kj::String key, TagValue value) = 0;
-  virtual void recordExceptionImpl(
-      kj::String name, kj::String message, kj::Maybe<kj::String> stack) = 0;
+  virtual void recordExceptionImpl(kj::Maybe<tracing::Exception::Code> code,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) = 0;
   virtual void recordSpanDataLimitError(
       kj::StringPtr itemKind, kj::StringPtr name, size_t valueSize) {}
  private:

--- a/src/workerd/api/tracing.h
+++ b/src/workerd/api/tracing.h
@@ -74,6 +74,7 @@ class SpanState: public kj::Refcounted {
       kj::Maybe<kj::String> stack) = 0;
   virtual void recordSpanDataLimitError(
       kj::StringPtr itemKind, kj::StringPtr name, size_t valueSize) {}
+
  private:
   size_t bytesUsed = 0;
 };

--- a/src/workerd/api/tracing.h
+++ b/src/workerd/api/tracing.h
@@ -28,6 +28,15 @@ constexpr size_t MAX_USER_OPERATION_NAME_BYTES = 64;
 // The types allowed for tag and log values from JavaScript.
 using TagValue = kj::OneOf<bool, double, kj::String>;
 
+struct ExceptionData {
+  jsg::Optional<kj::OneOf<kj::String, double>> code;
+  jsg::Optional<kj::String> name;
+  jsg::Optional<kj::String> message;
+  jsg::Optional<kj::String> stack;
+
+  JSG_STRUCT(code, name, message, stack);
+};
+
 // Polymorphic state behind the JS Span wrapper. Concrete states represent recording user spans and
 // no-op spans, while sharing JS-side attribute byte-limit enforcement.
 class SpanState: public kj::Refcounted {
@@ -48,13 +57,16 @@ class SpanState: public kj::Refcounted {
   // Sets a single attribute on the span. If value is kj::none, the attribute is not set.
   void setAttribute(kj::String key, kj::Maybe<TagValue> maybeValue);
 
+  void recordException(kj::String name, kj::String message, kj::Maybe<kj::String> stack);
+
  protected:
   SpanState() = default;
   virtual bool canRecordAttributes() = 0;
   virtual void recordAttribute(kj::String key, TagValue value) = 0;
+  virtual void recordExceptionImpl(
+      kj::String name, kj::String message, kj::Maybe<kj::String> stack) = 0;
   virtual void recordSpanDataLimitError(
       kj::StringPtr itemKind, kj::StringPtr name, size_t valueSize) {}
-
  private:
   size_t bytesUsed = 0;
 };
@@ -83,6 +95,9 @@ class Span: public jsg::Object {
   // Sets each attribute in `attributes` as if by calling setAttribute().
   jsg::Ref<Span> setAttributes(jsg::Lock& js, jsg::Dict<jsg::Optional<TagValue>> attributes);
 
+  void recordException(
+      jsg::Lock& js, jsg::Value exception, const jsg::TypeHandler<ExceptionData>& exceptionHandler);
+
   // Ends the span and submits its content to the tracing system. Idempotent.
   void end();
 
@@ -91,6 +106,7 @@ class Span: public jsg::Object {
 
     JSG_METHOD(setAttribute);
     JSG_METHOD(setAttributes);
+    JSG_METHOD(recordException);
     JSG_METHOD(end);
 
     JSG_TS_OVERRIDE({
@@ -98,6 +114,10 @@ class Span: public jsg::Object {
       setAttributes(
         attributes: Record<string, boolean | number | string | undefined>
       ): this;
+      recordException(exception: string
+        | { code: string | number; name?: string; message?: string; stack?: string }
+        | { code?: string | number; name: string; message?: string; stack?: string }
+        | { code?: string | number; name?: string; message: string; stack?: string }): void;
     });
   }
 
@@ -205,4 +225,5 @@ kj::Own<jsg::modules::ModuleBundle> getInternalTracingModuleBundle(auto featureF
 
 }  // namespace workerd::api
 
-#define EW_TRACING_ISOLATE_TYPES api::Tracing, api::user_tracing::Span
+#define EW_TRACING_ISOLATE_TYPES                                                                   \
+  api::Tracing, api::user_tracing::Span, api::user_tracing::ExceptionData

--- a/src/workerd/io/trace-stream.c++
+++ b/src/workerd/io/trace-stream.c++
@@ -497,6 +497,16 @@ jsg::JsValue ToJs(jsg::Lock& js, const DiagnosticChannelEvent& dce, StringCache&
 jsg::JsValue ToJs(jsg::Lock& js, const Exception& ex, StringCache& cache) {
   auto obj = js.obj();
   obj.set(js, TYPE_STR, cache.get(js, EXCEPTION_STR));
+  KJ_IF_SOME(code, ex.code) {
+    KJ_SWITCH_ONEOF(code) {
+      KJ_CASE_ONEOF(text, kj::String) {
+        obj.set(js, CODE_STR, js.str(text));
+      }
+      KJ_CASE_ONEOF(number, double) {
+        obj.set(js, CODE_STR, js.num(number));
+      }
+    }
+  }
   obj.set(js, NAME_STR, cache.get(js, ex.name));
   obj.set(js, MESSAGE_STR, js.str(ex.message));
   KJ_IF_SOME(stack, ex.stack) {

--- a/src/workerd/io/trace-test.c++
+++ b/src/workerd/io/trace-test.c++
@@ -471,12 +471,29 @@ KJ_TEST("Read/Write Exception works") {
   KJ_ASSERT(info2.name == "foo"_kj);
   KJ_ASSERT(info2.message == "bar"_kj);
   KJ_ASSERT(info2.stack == kj::none);
+  KJ_ASSERT(info2.code == kj::none);
 
   Exception info3 = info.clone();
   KJ_ASSERT(info.timestamp == info3.timestamp);
   KJ_ASSERT(info3.name == "foo"_kj);
   KJ_ASSERT(info3.message == "bar"_kj);
   KJ_ASSERT(info3.stack == kj::none);
+  KJ_ASSERT(info3.code == kj::none);
+
+  capnp::MallocMessageBuilder stringCodeBuilder;
+  auto stringCodeRoot = stringCodeBuilder.initRoot<rpc::Trace::Exception>();
+  kj::Maybe<Exception::Code> stringCode = Exception::Code(kj::str("ERR_TEST"));
+  Exception stringCodeInfo(
+      kj::UNIX_EPOCH, kj::str("foo"), kj::str("bar"), kj::none, kj::mv(stringCode));
+  stringCodeInfo.copyTo(stringCodeRoot);
+  Exception stringCodeRoundTrip(stringCodeRoot.asReader());
+  KJ_ASSERT(KJ_ASSERT_NONNULL(stringCodeRoundTrip.code).get<kj::String>() == "ERR_TEST"_kj);
+
+  kj::Maybe<Exception::Code> numericCode = Exception::Code(42.0);
+  Exception numericCodeInfo(
+      kj::UNIX_EPOCH, kj::str("foo"), kj::str("bar"), kj::none, kj::mv(numericCode));
+  Exception numericCodeClone = numericCodeInfo.clone();
+  KJ_ASSERT(KJ_ASSERT_NONNULL(numericCodeClone.code).get<double>() == 42.0);
 }
 
 KJ_TEST("Read/Write StreamDiagnosticsEvent works") {

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -1923,6 +1923,15 @@ void SpanBuilder::addLog(kj::Date timestamp, kj::ConstString key, TagValue value
   }
 }
 
+void SpanBuilder::recordException(
+    kj::String name, kj::String message, kj::Maybe<kj::String> stack) {
+  if (span == kj::none) {
+    return;
+  }
+  observer->onException(
+      observer->getTime(), kj::mv(name), kj::mv(message), kj::mv(stack));
+}
+
 void TraceContext::setTag(kj::ConstString key, SpanBuilder::TagInitValue value) {
   if (!isObserved()) {
     return;

--- a/src/workerd/io/trace.c++
+++ b/src/workerd/io/trace.c++
@@ -862,12 +862,16 @@ Log Log::clone() const {
       timestamp, logLevel, kj::str(message), cloneLogErrorInfo(errorInfo), LogTruncated(truncated));
 }
 
-Exception::Exception(
-    kj::Date timestamp, kj::String name, kj::String message, kj::Maybe<kj::String> stack)
+Exception::Exception(kj::Date timestamp,
+    kj::String name,
+    kj::String message,
+    kj::Maybe<kj::String> stack,
+    kj::Maybe<Code> code)
     : timestamp(timestamp),
       name(kj::mv(name)),
       message(kj::mv(message)),
-      stack(kj::mv(stack)) {}
+      stack(kj::mv(stack)),
+      code(kj::mv(code)) {}
 
 Log::Log(rpc::Trace::Log::Reader reader)
     : timestamp(kj::UNIX_EPOCH + reader.getTimestampNs() * kj::NANOSECONDS),
@@ -899,6 +903,17 @@ Exception::Exception(rpc::Trace::Exception::Reader reader)
   if (reader.hasStack()) {
     stack = kj::str(reader.getStack());
   }
+  auto code = reader.getCode();
+  switch (code.which()) {
+    case rpc::Trace::Exception::Code::NONE:
+      break;
+    case rpc::Trace::Exception::Code::TEXT:
+      this->code = kj::str(code.getText());
+      break;
+    case rpc::Trace::Exception::Code::NUMBER:
+      this->code = code.getNumber();
+      break;
+  }
 }
 
 void Exception::copyTo(rpc::Trace::Exception::Builder builder) const {
@@ -908,10 +923,32 @@ void Exception::copyTo(rpc::Trace::Exception::Builder builder) const {
   KJ_IF_SOME(s, stack) {
     builder.setStack(s);
   }
+  KJ_IF_SOME(c, code) {
+    KJ_SWITCH_ONEOF(c) {
+      KJ_CASE_ONEOF(text, kj::String) {
+        builder.initCode().setText(text);
+      }
+      KJ_CASE_ONEOF(number, double) {
+        builder.initCode().setNumber(number);
+      }
+    }
+  }
 }
 
 Exception Exception::clone() const {
-  return Exception(timestamp, kj::str(name), kj::str(message), mapCopyString(stack));
+  kj::Maybe<Code> clonedCode;
+  KJ_IF_SOME(c, code) {
+    KJ_SWITCH_ONEOF(c) {
+      KJ_CASE_ONEOF(text, kj::String) {
+        clonedCode = kj::str(text);
+      }
+      KJ_CASE_ONEOF(number, double) {
+        clonedCode = number;
+      }
+    }
+  }
+  return Exception(
+      timestamp, kj::str(name), kj::str(message), mapCopyString(stack), kj::mv(clonedCode));
 }
 }  // namespace tracing
 
@@ -1923,13 +1960,15 @@ void SpanBuilder::addLog(kj::Date timestamp, kj::ConstString key, TagValue value
   }
 }
 
-void SpanBuilder::recordException(
-    kj::String name, kj::String message, kj::Maybe<kj::String> stack) {
+void SpanBuilder::recordException(kj::Maybe<tracing::Exception::Code> code,
+    kj::String name,
+    kj::String message,
+    kj::Maybe<kj::String> stack) {
   if (span == kj::none) {
     return;
   }
   observer->onException(
-      observer->getTime(), kj::mv(name), kj::mv(message), kj::mv(stack));
+      observer->getTime(), kj::mv(code), kj::mv(name), kj::mv(message), kj::mv(stack));
 }
 
 void TraceContext::setTag(kj::ConstString key, SpanBuilder::TagInitValue value) {

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -1256,6 +1256,9 @@ class SpanBuilder {
   // duplicate keys.
   void addLog(kj::Date timestamp, kj::ConstString key, TagValue value);
 
+  // Records an exception associated with this span. Calls after end() are ignored.
+  void recordException(kj::String name, kj::String message, kj::Maybe<kj::String> stack);
+
  private:
   kj::Rc<SpanObserver> observer;
   // The under-construction span, or null if the span has ended.
@@ -1293,6 +1296,9 @@ class SpanObserver: public kj::Refcounted {
   // Called exactly once per observer, after onOpen(). Tags and logs are moved from the span;
   // the observer takes ownership.
   virtual void onClose(kj::Date endTime, Span::TagMap&& tags, kj::Vector<Span::Log>&& logs) = 0;
+
+  virtual void onException(
+      kj::Date timestamp, kj::String name, kj::String message, kj::Maybe<kj::String> stack) {}
 
   // Called when the operation name is changed after the span was opened (via
   // SpanBuilder::setOperationName()). Observers that eagerly stream the open event should handle

--- a/src/workerd/io/trace.h
+++ b/src/workerd/io/trace.h
@@ -683,8 +683,13 @@ struct Log final {
 
 // Describes an exception event
 struct Exception final {
-  explicit Exception(
-      kj::Date timestamp, kj::String name, kj::String message, kj::Maybe<kj::String> stack);
+  using Code = kj::OneOf<kj::String, double>;
+
+  explicit Exception(kj::Date timestamp,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack,
+      kj::Maybe<Code> code = kj::none);
   Exception(rpc::Trace::Exception::Reader reader);
   Exception(Exception&&) noexcept = default;
   KJ_DISALLOW_COPY(Exception);
@@ -697,6 +702,7 @@ struct Exception final {
   kj::String message;
 
   kj::Maybe<kj::String> stack;
+  kj::Maybe<Code> code;
 
   void copyTo(rpc::Trace::Exception::Builder builder) const;
   Exception clone() const;
@@ -1257,7 +1263,10 @@ class SpanBuilder {
   void addLog(kj::Date timestamp, kj::ConstString key, TagValue value);
 
   // Records an exception associated with this span. Calls after end() are ignored.
-  void recordException(kj::String name, kj::String message, kj::Maybe<kj::String> stack);
+  void recordException(kj::Maybe<tracing::Exception::Code> code,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack);
 
  private:
   kj::Rc<SpanObserver> observer;
@@ -1297,8 +1306,11 @@ class SpanObserver: public kj::Refcounted {
   // the observer takes ownership.
   virtual void onClose(kj::Date endTime, Span::TagMap&& tags, kj::Vector<Span::Log>&& logs) = 0;
 
-  virtual void onException(
-      kj::Date timestamp, kj::String name, kj::String message, kj::Maybe<kj::String> stack) {}
+  virtual void onException(kj::Date timestamp,
+      kj::Maybe<tracing::Exception::Code> code,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) {}
 
   // Called when the operation name is changed after the span was opened (via
   // SpanBuilder::setOperationName()). Observers that eagerly stream the open event should handle

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -37,6 +37,28 @@ tracing::Attribute::Value cloneAttributeValue(const tracing::Attribute::Value& v
   }
   KJ_UNREACHABLE;
 }
+
+void reportExceptionToTailStream(tracing::TailStreamWriter& writer,
+    const tracing::InvocationSpanContext& context,
+    kj::Date timestamp,
+    kj::StringPtr name,
+    kj::StringPtr message,
+    kj::Maybe<kj::StringPtr> stack) {
+  auto truncatedName = name.first(kj::min(name.size(), MAX_TRACE_BYTES));
+  auto truncatedMessage =
+      message.first(kj::min(message.size(), MAX_TRACE_BYTES - truncatedName.size()));
+  kj::Maybe<kj::String> truncatedStack;
+  size_t truncatedStackSize = 0;
+  KJ_IF_SOME(s, stack) {
+    truncatedStackSize =
+        kj::min(s.size(), MAX_TRACE_BYTES - truncatedName.size() - truncatedMessage.size());
+    truncatedStack = kj::heapString(s.first(truncatedStackSize));
+  }
+  writer.report(context,
+      {tracing::Exception(
+          timestamp, kj::str(truncatedName), kj::str(truncatedMessage), kj::mv(truncatedStack))},
+      timestamp, truncatedName.size() + truncatedMessage.size() + truncatedStackSize);
+}
 }  // namespace
 
 kj::Promise<kj::Own<Trace>> WorkerTracer::onComplete() {
@@ -255,21 +277,11 @@ void WorkerTracer::addException(const tracing::InvocationSpanContext& context,
     messageSize += s.size();
   }
   KJ_IF_SOME(writer, maybeTailStreamWriter) {
-    auto maybeTruncatedName = name.first(kj::min(name.size(), MAX_TRACE_BYTES));
-    auto maybeTruncatedMessage =
-        message.first(kj::min(message.size(), MAX_TRACE_BYTES - maybeTruncatedName.size()));
-    kj::Maybe<kj::String> maybeTruncatedStack;
-    auto maybeTruncatedStackSize = 0;
+    kj::Maybe<kj::StringPtr> stackPtr;
     KJ_IF_SOME(s, stack) {
-      maybeTruncatedStackSize = kj::min(
-          s.size(), MAX_TRACE_BYTES - maybeTruncatedName.size() - maybeTruncatedMessage.size());
-      maybeTruncatedStack = kj::heapString(s.first(maybeTruncatedStackSize));
+      stackPtr = s;
     }
-    writer->report(context,
-        {tracing::Exception(timestamp, kj::str(maybeTruncatedName), kj::str(maybeTruncatedMessage),
-            kj::mv(maybeTruncatedStack))},
-        timestamp,
-        maybeTruncatedName.size() + maybeTruncatedMessage.size() + maybeTruncatedStackSize);
+    reportExceptionToTailStream(*writer, context, timestamp, name, message, stackPtr);
   }
 
   if (trace->exceededExceptionLimit) {
@@ -285,6 +297,27 @@ void WorkerTracer::addException(const tracing::InvocationSpanContext& context,
     trace->bytesUsed += messageSize;
     trace->exceptions.add(timestamp, kj::mv(name), kj::mv(message), kj::mv(stack));
   }
+}
+
+void WorkerTracer::addSpanException(tracing::SpanId spanId,
+    kj::Date timestamp,
+    kj::String name,
+    kj::String message,
+    kj::Maybe<kj::String> stack) {
+  if (pipelineLogLevel == PipelineLogLevel::NONE) {
+    return;
+  }
+
+  auto& writer = KJ_UNWRAP_OR_RETURN(maybeTailStreamWriter);
+  auto& topLevelContext = KJ_ASSERT_NONNULL(topLevelInvocationSpanContext);
+  auto context = tracing::InvocationSpanContext(topLevelContext.getTraceId(),
+      topLevelContext.getInvocationId(), spanId, topLevelContext.getTraceFlags());
+
+  kj::Maybe<kj::StringPtr> stackPtr;
+  KJ_IF_SOME(s, stack) {
+    stackPtr = s;
+  }
+  reportExceptionToTailStream(*writer, context, timestamp, name, message, stackPtr);
 }
 
 void WorkerTracer::addDiagnosticChannelEvent(const tracing::InvocationSpanContext& context,
@@ -618,6 +651,13 @@ void UserSpanObserver::onOpen(kj::ConstString operationName, kj::Date startTime)
         submitter->submitUserSpanOpen(spanId, parentSpanId, kj::mv(operationName), startTime);
   } else {
     wasAccepted = submitter->submitSpanOpen(spanId, parentSpanId, kj::mv(operationName), startTime);
+  }
+}
+
+void UserSpanObserver::onException(
+    kj::Date timestamp, kj::String name, kj::String message, kj::Maybe<kj::String> stack) {
+  if (wasAccepted) {
+    submitter->submitSpanException(spanId, timestamp, kj::mv(name), kj::mv(message), kj::mv(stack));
   }
 }
 

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -41,23 +41,38 @@ tracing::Attribute::Value cloneAttributeValue(const tracing::Attribute::Value& v
 void reportExceptionToTailStream(tracing::TailStreamWriter& writer,
     const tracing::InvocationSpanContext& context,
     kj::Date timestamp,
+    kj::Maybe<tracing::Exception::Code> code,
     kj::StringPtr name,
     kj::StringPtr message,
     kj::Maybe<kj::StringPtr> stack) {
-  auto truncatedName = name.first(kj::min(name.size(), MAX_TRACE_BYTES));
+  kj::Maybe<tracing::Exception::Code> truncatedCode;
+  size_t codeSize = 0;
+  KJ_IF_SOME(c, code) {
+    KJ_SWITCH_ONEOF(c) {
+      KJ_CASE_ONEOF(text, kj::String) {
+        codeSize = kj::min(text.size(), MAX_TRACE_BYTES);
+        truncatedCode = kj::str(text.first(codeSize));
+      }
+      KJ_CASE_ONEOF(number, double) {
+        codeSize = sizeof(double);
+        truncatedCode = number;
+      }
+    }
+  }
+  auto truncatedName = name.first(kj::min(name.size(), MAX_TRACE_BYTES - codeSize));
   auto truncatedMessage =
-      message.first(kj::min(message.size(), MAX_TRACE_BYTES - truncatedName.size()));
+      message.first(kj::min(message.size(), MAX_TRACE_BYTES - codeSize - truncatedName.size()));
   kj::Maybe<kj::String> truncatedStack;
   size_t truncatedStackSize = 0;
   KJ_IF_SOME(s, stack) {
-    truncatedStackSize =
-        kj::min(s.size(), MAX_TRACE_BYTES - truncatedName.size() - truncatedMessage.size());
+    truncatedStackSize = kj::min(
+        s.size(), MAX_TRACE_BYTES - codeSize - truncatedName.size() - truncatedMessage.size());
     truncatedStack = kj::heapString(s.first(truncatedStackSize));
   }
   writer.report(context,
-      {tracing::Exception(
-          timestamp, kj::str(truncatedName), kj::str(truncatedMessage), kj::mv(truncatedStack))},
-      timestamp, truncatedName.size() + truncatedMessage.size() + truncatedStackSize);
+      {tracing::Exception(timestamp, kj::str(truncatedName), kj::str(truncatedMessage),
+          kj::mv(truncatedStack), kj::mv(truncatedCode))},
+      timestamp, codeSize + truncatedName.size() + truncatedMessage.size() + truncatedStackSize);
 }
 }  // namespace
 
@@ -281,7 +296,7 @@ void WorkerTracer::addException(const tracing::InvocationSpanContext& context,
     KJ_IF_SOME(s, stack) {
       stackPtr = s;
     }
-    reportExceptionToTailStream(*writer, context, timestamp, name, message, stackPtr);
+    reportExceptionToTailStream(*writer, context, timestamp, kj::none, name, message, stackPtr);
   }
 
   if (trace->exceededExceptionLimit) {
@@ -301,6 +316,7 @@ void WorkerTracer::addException(const tracing::InvocationSpanContext& context,
 
 void WorkerTracer::addSpanException(tracing::SpanId spanId,
     kj::Date timestamp,
+    kj::Maybe<tracing::Exception::Code> code,
     kj::String name,
     kj::String message,
     kj::Maybe<kj::String> stack) {
@@ -317,7 +333,7 @@ void WorkerTracer::addSpanException(tracing::SpanId spanId,
   KJ_IF_SOME(s, stack) {
     stackPtr = s;
   }
-  reportExceptionToTailStream(*writer, context, timestamp, name, message, stackPtr);
+  reportExceptionToTailStream(*writer, context, timestamp, kj::mv(code), name, message, stackPtr);
 }
 
 void WorkerTracer::addDiagnosticChannelEvent(const tracing::InvocationSpanContext& context,
@@ -654,10 +670,14 @@ void UserSpanObserver::onOpen(kj::ConstString operationName, kj::Date startTime)
   }
 }
 
-void UserSpanObserver::onException(
-    kj::Date timestamp, kj::String name, kj::String message, kj::Maybe<kj::String> stack) {
+void UserSpanObserver::onException(kj::Date timestamp,
+    kj::Maybe<tracing::Exception::Code> code,
+    kj::String name,
+    kj::String message,
+    kj::Maybe<kj::String> stack) {
   if (wasAccepted) {
-    submitter->submitSpanException(spanId, timestamp, kj::mv(name), kj::mv(message), kj::mv(stack));
+    submitter->submitSpanException(
+        spanId, timestamp, kj::mv(code), kj::mv(name), kj::mv(message), kj::mv(stack));
   }
 }
 

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -65,6 +65,7 @@ class BaseTracer: public kj::Refcounted {
   // Records an exception event on a span without treating the invocation as having thrown.
   virtual void addSpanException(tracing::SpanId spanId,
       kj::Date timestamp,
+      kj::Maybe<tracing::Exception::Code> code,
       kj::String name,
       kj::String message,
       kj::Maybe<kj::String> stack) = 0;
@@ -174,6 +175,7 @@ class WorkerTracer final: public BaseTracer {
       kj::Maybe<kj::String> stack) override;
   void addSpanException(tracing::SpanId spanId,
       kj::Date timestamp,
+      kj::Maybe<tracing::Exception::Code> code,
       kj::String name,
       kj::String message,
       kj::Maybe<kj::String> stack) override;
@@ -249,6 +251,7 @@ class SpanSubmitter: public kj::Refcounted {
 
   virtual void submitSpanException(tracing::SpanId spanId,
       kj::Date timestamp,
+      kj::Maybe<tracing::Exception::Code> code,
       kj::String name,
       kj::String message,
       kj::Maybe<kj::String> stack) = 0;
@@ -295,6 +298,7 @@ class UserSpanObserver final: public SpanObserver {
   void onOpen(kj::ConstString operationName, kj::Date startTime) override;
   void onClose(kj::Date endTime, Span::TagMap&& tags, kj::Vector<Span::Log>&& logs) override;
   void onException(kj::Date timestamp,
+      kj::Maybe<tracing::Exception::Code> code,
       kj::String name,
       kj::String message,
       kj::Maybe<kj::String> stack) override;

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -62,6 +62,13 @@ class BaseTracer: public kj::Refcounted {
       kj::String message,
       kj::Maybe<kj::String> stack) = 0;
 
+  // Records an exception event on a span without treating the invocation as having thrown.
+  virtual void addSpanException(tracing::SpanId spanId,
+      kj::Date timestamp,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) = 0;
+
   virtual void addDiagnosticChannelEvent(const tracing::InvocationSpanContext& context,
       kj::Date timestamp,
       kj::String channel,
@@ -165,6 +172,11 @@ class WorkerTracer final: public BaseTracer {
       kj::String name,
       kj::String message,
       kj::Maybe<kj::String> stack) override;
+  void addSpanException(tracing::SpanId spanId,
+      kj::Date timestamp,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) override;
   void addDiagnosticChannelEvent(const tracing::InvocationSpanContext& context,
       kj::Date timestamp,
       kj::String channel,
@@ -235,6 +247,12 @@ class SpanSubmitter: public kj::Refcounted {
   virtual void submitSpanClose(
       tracing::SpanId spanId, kj::Date startTime, kj::Date endTime, Span::TagMap&& tags) = 0;
 
+  virtual void submitSpanException(tracing::SpanId spanId,
+      kj::Date timestamp,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) = 0;
+
   virtual tracing::SpanId makeSpanId() = 0;
 };
 
@@ -276,6 +294,10 @@ class UserSpanObserver final: public SpanObserver {
   kj::Rc<SpanObserver> newChildFromUserCode() override;
   void onOpen(kj::ConstString operationName, kj::Date startTime) override;
   void onClose(kj::Date endTime, Span::TagMap&& tags, kj::Vector<Span::Log>&& logs) override;
+  void onException(kj::Date timestamp,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) override;
   kj::Date getTime() override;
   kj::Maybe<tracing::SpanContext> toSpanContext() override;
   tracing::SpanId getSpanId() override;

--- a/src/workerd/io/worker-interface.capnp
+++ b/src/workerd/io/worker-interface.capnp
@@ -125,6 +125,11 @@ struct Trace @0x8e8d911203762d34 {
     name @1 :Text;
     message @2 :Text;
     stack @3 :Text;
+    code :union {
+      none @4 :Void;
+      text @5 :Text;
+      number @6 :Float64;
+    }
   }
 
   outcome @2 :EventOutcome;

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3215,6 +3215,19 @@ class SequentialSpanSubmitter final: public SpanSubmitter {
     });
   }
 
+  void submitSpanException(tracing::SpanId spanId,
+      kj::Date timestamp,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) override {
+    weakTracer->runIfAlive([&](BaseTracer& tracer) {
+      if (isPredictableModeForTest()) {
+        timestamp = kj::UNIX_EPOCH;
+      }
+      tracer.addSpanException(spanId, timestamp, kj::mv(name), kj::mv(message), kj::mv(stack));
+    });
+  }
+
   bool submitSpanOpen(tracing::SpanId spanId,
       tracing::SpanId parentSpanId,
       kj::ConstString operationName,

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3217,6 +3217,7 @@ class SequentialSpanSubmitter final: public SpanSubmitter {
 
   void submitSpanException(tracing::SpanId spanId,
       kj::Date timestamp,
+      kj::Maybe<tracing::Exception::Code> code,
       kj::String name,
       kj::String message,
       kj::Maybe<kj::String> stack) override {
@@ -3224,7 +3225,8 @@ class SequentialSpanSubmitter final: public SpanSubmitter {
       if (isPredictableModeForTest()) {
         timestamp = kj::UNIX_EPOCH;
       }
-      tracer.addSpanException(spanId, timestamp, kj::mv(name), kj::mv(message), kj::mv(stack));
+      tracer.addSpanException(
+          spanId, timestamp, kj::mv(code), kj::mv(name), kj::mv(message), kj::mv(stack));
     });
   }
 

--- a/types/defines/trace.d.ts
+++ b/types/defines/trace.d.ts
@@ -142,6 +142,7 @@ interface DiagnosticChannelEvent {
 
 interface Exception {
   readonly type: "exception";
+  readonly code?: string | number;
   readonly name: string;
   readonly message: string;
   readonly stack?: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4856,6 +4856,28 @@ declare abstract class Span {
   setAttributes(
     attributes: Record<string, boolean | number | string | undefined>,
   ): this;
+  recordException(
+    exception:
+      | string
+      | {
+          code: string | number;
+          name?: string;
+          message?: string;
+          stack?: string;
+        }
+      | {
+          code?: string | number;
+          name: string;
+          message?: string;
+          stack?: string;
+        }
+      | {
+          code?: string | number;
+          name?: string;
+          message: string;
+          stack?: string;
+        },
+  ): void;
   end(): void;
 }
 /**
@@ -17098,6 +17120,7 @@ declare namespace TailStream {
   }
   interface Exception {
     readonly type: "exception";
+    readonly code?: string | number;
     readonly name: string;
     readonly message: string;
     readonly stack?: string;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4865,6 +4865,28 @@ export declare abstract class Span {
   setAttributes(
     attributes: Record<string, boolean | number | string | undefined>,
   ): this;
+  recordException(
+    exception:
+      | string
+      | {
+          code: string | number;
+          name?: string;
+          message?: string;
+          stack?: string;
+        }
+      | {
+          code?: string | number;
+          name: string;
+          message?: string;
+          stack?: string;
+        }
+      | {
+          code?: string | number;
+          name?: string;
+          message: string;
+          stack?: string;
+        },
+  ): void;
   end(): void;
 }
 /**
@@ -17056,6 +17078,7 @@ export declare namespace TailStream {
   }
   interface Exception {
     readonly type: "exception";
+    readonly code?: string | number;
     readonly name: string;
     readonly message: string;
     readonly stack?: string;

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -4579,6 +4579,28 @@ declare abstract class Span {
   setAttributes(
     attributes: Record<string, boolean | number | string | undefined>,
   ): this;
+  recordException(
+    exception:
+      | string
+      | {
+          code: string | number;
+          name?: string;
+          message?: string;
+          stack?: string;
+        }
+      | {
+          code?: string | number;
+          name: string;
+          message?: string;
+          stack?: string;
+        }
+      | {
+          code?: string | number;
+          name?: string;
+          message: string;
+          stack?: string;
+        },
+  ): void;
   end(): void;
 }
 /**
@@ -16821,6 +16843,7 @@ declare namespace TailStream {
   }
   interface Exception {
     readonly type: "exception";
+    readonly code?: string | number;
     readonly name: string;
     readonly message: string;
     readonly stack?: string;

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -4588,6 +4588,28 @@ export declare abstract class Span {
   setAttributes(
     attributes: Record<string, boolean | number | string | undefined>,
   ): this;
+  recordException(
+    exception:
+      | string
+      | {
+          code: string | number;
+          name?: string;
+          message?: string;
+          stack?: string;
+        }
+      | {
+          code?: string | number;
+          name: string;
+          message?: string;
+          stack?: string;
+        }
+      | {
+          code?: string | number;
+          name?: string;
+          message: string;
+          stack?: string;
+        },
+  ): void;
   end(): void;
 }
 /**
@@ -16779,6 +16801,7 @@ export declare namespace TailStream {
   }
   interface Exception {
     readonly type: "exception";
+    readonly code?: string | number;
     readonly name: string;
     readonly message: string;
     readonly stack?: string;


### PR DESCRIPTION
We currently send uncaught exceptions to the tail worker, but this would allow us to capture them on the span where they were emitted

This adds `span.recordException`

```ts
 recordException(
    exception:
      | string
      | {
          code: string | number;
          name?: string;
          message?: string;
          stack?: string;
        }
      | {
          code?: string | number;
          name: string;
          message?: string;
          stack?: string;
        }
      | {
          code?: string | number;
          name?: string;
          message: string;
          stack?: string;
        },
  ): void;
```

The types here should match OpenTelemetry JS's `span.recordException`, though we don't yet support passing in your own timestamp:

https://github.com/open-telemetry/opentelemetry-js/blob/main/api/src/trace/span.ts#L144-L150
https://github.com/open-telemetry/opentelemetry-js/blob/main/api/src/common/Exception.ts#L6-L38

The STW interface already supports an `exception` event. This adds `code?: string | number` to the payload.