### PR TITLE
Fix wrong error message when trying to use alarms in facets.

### DIFF
--- a/src/workerd/io/actor-sqlite.c++
+++ b/src/workerd/io/actor-sqlite.c++
@@ -1213,7 +1213,7 @@ const ActorSqlite::Hooks ActorSqlite::Hooks::DEFAULT = ActorSqlite::Hooks{};
 
 kj::Promise<void> ActorSqlite::Hooks::scheduleRun(
     kj::Maybe<kj::Date> newAlarmTime, kj::Promise<void> priorTask) {
-  JSG_FAIL_REQUIRE(Error, "alarms are not yet implemented for SQLite-backed Durable Objects");
+  JSG_FAIL_REQUIRE(Error, "Alarms have not been configured for this Durable Object.");
 }
 
 kj::OneOf<kj::Maybe<ActorCacheOps::Value>, kj::Promise<kj::Maybe<ActorCacheOps::Value>>>

--- a/src/workerd/io/actor-sqlite.h
+++ b/src/workerd/io/actor-sqlite.h
@@ -30,6 +30,14 @@ class ActorSqlite final: public ActorCacheInterface, private kj::TaskSet::ErrorH
     // wait on prior to scheduling the new request, as of this writing, this would be the
     // alarmLaterInFlight promise, which tracks any in-flight request to move the alarm "later"
     // than is currently set.
+    //
+    // The default implementation throws, since there is no alarm manager to talk to. An embedder
+    // that constructs an ActorSqlite which can never schedule alarms should override this to
+    // throw a JSG error explaining why alarms aren't available in that context, since the default
+    // exception is an internal error, not something the application can act on.
+    //
+    // This may throw synchronously; the caller relies on that to roll back the write that
+    // requested the alarm. Don't return a rejected promise instead.
     virtual kj::Promise<void> scheduleRun(
         kj::Maybe<kj::Date> newAlarmTime, kj::Promise<void> priorTask);
 

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -6392,6 +6392,94 @@ KJ_TEST("Server: Durable Object facet limits") {
       "The maximum depth including the root Durable Object is 4.");
 }
 
+KJ_TEST("Server: Durable Object facets cannot set alarms") {
+  kj::StringPtr config = R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2025-04-01",
+          compatibilityFlags = ["experimental"],
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `import { DurableObject } from "cloudflare:workers";
+                `export default {
+                `  async fetch(request, env, ctx) {
+                `    let id = env.MY_ACTOR.idFromName("alarms");
+                `    let actor = env.MY_ACTOR.get(id);
+                `    return await actor.fetch(request);
+                `  }
+                `}
+                `export class MyActorClass extends DurableObject {
+                `  async fetch(request) {
+                `    if (request.url.endsWith("/root")) {
+                `      // The root object can set an alarm just fine.
+                `      let time = Date.now() + 3600000;
+                `      await this.ctx.storage.setAlarm(time);
+                `      return new Response(
+                `          "alarm set: " + ((await this.ctx.storage.getAlarm()) === time));
+                `    } else {
+                `      let facet = this.ctx.facets.get("child",
+                `          () => ({class: this.env.CHILD}));
+                `      try {
+                `        await facet.setAlarm();
+                `        return new Response("no error, unexpected");
+                `      } catch (e) {
+                `        return new Response(e.name + ": " + e.message);
+                `      }
+                `    }
+                `  }
+                `  async alarm() {}
+                `}
+                `export class ChildFacet extends DurableObject {
+                `  async setAlarm() {
+                `    await this.ctx.storage.setAlarm(Date.now() + 3600000);
+                `  }
+                `  async alarm() {}
+                `}
+            )
+          ],
+          bindings = [
+            (name = "MY_ACTOR", durableObjectNamespace = "MyActorClass"),
+            (name = "CHILD", durableObjectClass = (name = "hello", entrypoint = "ChildFacet"))
+          ],
+          durableObjectNamespaces = [
+            ( className = "MyActorClass",
+              uniqueKey = "mykey",
+            )
+          ],
+          durableObjectStorage = (localDisk = "my-disk")
+        )
+      ),
+      ( name = "my-disk",
+        disk = (
+          path = "../../do-storage",
+          writable = true,
+        )
+      ),
+    ],
+    sockets = [
+      ( name = "main",
+        address = "test-addr",
+        service = "hello"
+      )
+    ]
+  ))"_kj;
+
+  TestServer test(config);
+  test.root->openSubdir(kj::Path({"do-storage"_kj}), kj::WriteMode::CREATE);
+  test.server.allowExperimental();
+  test.start();
+  auto conn = test.connect("test-addr");
+
+  // SQLite-backed Durable Objects do support alarms...
+  conn.httpGet200("/root", "alarm set: true");
+
+  // ... but facets don't. The attempt breaks the facet's output gate, so the error surfaces to the
+  // parent in place of the RPC response.
+  conn.httpGet200("/facet", "Error: Facets currently cannot set alarms.");
+}
+
 KJ_TEST("Server: Pass service stubs in ctx.props.") {
   TestServer test(R"((
     services = [

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1256,8 +1256,8 @@ class Server::ActorNamespace final {
                 sqliteHooks = fakeOwn(ActorSqlite::Hooks::getDefaultHooks());
               }
             } else {
-              // TODO(someday): Support alarms in facets, somehow.
-              sqliteHooks = fakeOwn(ActorSqlite::Hooks::getDefaultHooks());
+              // A non-null `parent` means this is a facet, which has no alarm scheduler.
+              sqliteHooks = kj::heap<FacetAlarmHooks>();
             }
 
             uint selfId = getFacetId();
@@ -1732,6 +1732,20 @@ class Server::ActorNamespace final {
    private:
     AlarmScheduler& alarmScheduler;
     kj::Own<ActorKey> actor;
+  };
+
+  // Hooks used by facets, which have their own storage but no way to schedule alarms: the alarm
+  // scheduler only knows how to deliver alarms to the root actor of a namespace.
+  //
+  // TODO(someday): Support alarms in facets, somehow.
+  class FacetAlarmHooks final: public ActorSqlite::Hooks {
+   public:
+    kj::Promise<void> scheduleRun(
+        kj::Maybe<kj::Date> newAlarmTime, kj::Promise<void> priorTask) override {
+      // Keep this message in sync with the equivalent error produced in actor-storage-factory.c++
+      // in the internal codebase.
+      JSG_FAIL_REQUIRE(Error, "Facets currently cannot set alarms.");
+    }
   };
 };
 


### PR DESCRIPTION
Trying to set an alarm in a facet was incorrectly giving the error: "alarms are not yet implemented for SQLite-backed Durable Objects"

This was the default error message thrown when an alarm implementation isn't provided. The text has been wrong for years, but has been dormant since actual alarm implementations were being provided in all cases. That is, until facets came about and didn't implement it. Then the error was wrong.

This only applies to stand-alone workerd. In production an appropriate error has been thrown all along.