### PR TITLE
Add ioContext.createObject

### DIFF
--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -1148,7 +1148,7 @@ void AbortSignal::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
   // Keep track of every AbortSignal cloned from this one.
   // If this->triggerAbort(...) is called, each clone will be informed.
   rpcRegistrations.add(kj::arc<RpcRegistration>(ioContext.getCrossContextExecutor(),
-      ioContext.addObject(kj::heap<AbortTriggerRpcClient>(kj::mv(triggerCap)))));
+      ioContext.createObject<AbortTriggerRpcClient>(kj::mv(triggerCap))));
 }
 
 jsg::Ref<AbortSignal> AbortSignal::deserialize(

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -460,7 +460,7 @@ void Container::startMonitor() {
   }).fork();
 
   currentMonitor =
-      IoContext::current().addObject(kj::heap<Monitor>(kj::mv(monitor), ++nextMonitorGeneration));
+      IoContext::current().createObject<Monitor>(kj::mv(monitor), ++nextMonitorGeneration);
 }
 
 jsg::Promise<void> Container::setLabels(jsg::Lock& js, jsg::Dict<kj::String> labels) {
@@ -1481,7 +1481,7 @@ jsg::Ref<Fetcher> Container::getTcpPort(jsg::Lock& js, int port) {
   auto portState = [&]() -> kj::Rc<TcpPortState> {
     if (util::Autogate::isEnabled(util::AutogateKey::CONTAINER_TUNNEL_REUSE)) {
       if (tcpPortStates == kj::none) {
-        tcpPortStates = ioctx.addObject(kj::heap<kj::HashMap<int, kj::Rc<TcpPortState>>>());
+        tcpPortStates = ioctx.createObject<kj::HashMap<int, kj::Rc<TcpPortState>>>();
       }
       auto& states = *KJ_ASSERT_NONNULL(tcpPortStates);
 

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -1009,7 +1009,7 @@ jsg::Ref<Socket> hydrateRpcSocket(jsg::Lock& js,
   // socket is being torn down, so there is nothing to wire up). The wiring runs JS that can throw
   // with no user code on the stack, so each body is wrapped in JSG_TRY/JSG_CATCH and reports via
   // js.reportError() (matching the queueMicrotask() pattern in global-scope.c++).
-  auto disconnectedOwn = ioContext.addObject(kj::heap<kj::Promise<bool>>(kj::mv(disconnected)));
+  auto disconnectedOwn = ioContext.createObject<kj::Promise<bool>>(kj::mv(disconnected));
   js.v8Context()->GetMicrotaskQueue()->EnqueueMicrotask(js.v8Isolate,
       js.wrapSimpleFunction(js.v8Context(),
           JSG_VISITABLE_LAMBDA((self = socket.addRef(), disconnected = kj::mv(disconnectedOwn)),

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -75,8 +75,8 @@ class Socket: public jsg::Object {
       kj::Maybe<kj::String> domain,
       bool isDefaultFetchPort,
       jsg::PromiseResolverPair<SocketInfo> openedPrPair)
-      : connectionData(context.addObject(kj::heap<ConnectionData>(
-            kj::mv(tlsStarter), kj::mv(connectionStream), kj::mv(watchForDisconnectTask)))),
+      : connectionData(context.createObject<ConnectionData>(
+            kj::mv(tlsStarter), kj::mv(connectionStream), kj::mv(watchForDisconnectTask))),
         readable(kj::mv(readableParam)),
         writable(kj::mv(writable)),
         closedResolver(kj::mv(closedPrPair.resolver)),

--- a/src/workerd/api/sql.c++
+++ b/src/workerd/api/sql.c++
@@ -25,7 +25,7 @@ static constexpr uint SQL_STATEMENT_CACHE_MAX_SIZE = 1024 * 1024;
 
 SqlStorage::SqlStorage(jsg::Ref<DurableObjectStorage> storage)
     : storage(kj::mv(storage)),
-      statementCache(IoContext::current().addObject(kj::heap<StatementCache>())) {}
+      statementCache(IoContext::current().createObject<StatementCache>()) {}
 
 SqlStorage::~SqlStorage() {}
 

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -210,7 +210,7 @@ class WritableStreamInternalController: public WritableStreamController {
       kj::Maybe<uint64_t> maybeHighWaterMark = kj::none,
       kj::Maybe<jsg::Promise<void>> maybeClosureWaitable = kj::none)
       : state(State::create<IoOwn<Writable>>(
-            IoContext::current().addObject(kj::heap<Writable>(kj::mv(writable))))),
+            IoContext::current().createObject<Writable>(kj::mv(writable)))),
         observer(kj::mv(observer)),
         maybeHighWaterMark(maybeHighWaterMark),
         maybeClosureWaitable(kj::mv(maybeClosureWaitable)) {}

--- a/src/workerd/api/sync-kv.c++
+++ b/src/workerd/api/sync-kv.c++
@@ -77,7 +77,7 @@ jsg::Ref<SyncKvStorage::ListIterator> SyncKvStorage::list(
       KJ_UNWRAP_OR(DurableObjectStorageOperations::compileListOptions(asyncOptions), {
         // Key range is empty. Return empty map.
         return js.alloc<SyncKvStorage::ListIterator>(
-            IoContext::current().addObject(kj::heap<SqliteKv::ListCursor>(nullptr)));
+            IoContext::current().createObject<SqliteKv::ListCursor>(nullptr));
       });
 
   auto cursor = sqliteKv.list(start, end, limit, reverse ? SqliteKv::REVERSE : SqliteKv::FORWARD)

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -307,11 +307,12 @@ LegacyWebSocketAdapter::LegacyWebSocketAdapter(jsg::Lock& js,
           ws,
           kj::mv(KJ_REQUIRE_NONNULL(package.maybeTags)),
           package.closedOutgoingConnection)),
-      outgoingMessages(IoContext::current().addObject(kj::heap<OutgoingMessagesMap>())),
-      autoResponseStatusOwner(ioContext.addObject(kj::heap<AutoResponse>())),
+      outgoingMessages(ioContext.createObject<OutgoingMessagesMap>()),
+      autoResponseStatusOwner(ioContext.createObject<AutoResponse>()),
       autoResponseStatus(*autoResponseStatusOwner) {
   autoResponseStatus.isClosed = farNative->closedOutgoing;
 }
+
 // This constructor is used when reinstantiating a websocket that had been hibernating, which is
 // why we can go straight to the Accepted state. However, note that we are actually in the
 // `Hibernatable` "sub-state"!
@@ -324,8 +325,8 @@ LegacyWebSocketAdapter::LegacyWebSocketAdapter(
                                                                         : BinaryType::ARRAYBUFFER),
       allowHalfOpen(!FeatureFlags::get(js).getWebSocketAutoReplyToClose()),
       farNative(nullptr),
-      outgoingMessages(IoContext::current().addObject(kj::heap<OutgoingMessagesMap>())),
-      autoResponseStatusOwner(IoContext::current().addObject(kj::heap<AutoResponse>())),
+      outgoingMessages(IoContext::current().createObject<OutgoingMessagesMap>()),
+      autoResponseStatusOwner(IoContext::current().createObject<AutoResponse>()),
       autoResponseStatus(*autoResponseStatusOwner) {
   auto nativeObj = kj::heap<Native>();
   nativeObj->state.init<AwaitingAcceptanceOrCoupling>(kj::mv(native));
@@ -339,8 +340,8 @@ LegacyWebSocketAdapter::LegacyWebSocketAdapter(jsg::Lock& js, WebSocket& shell, 
                                                                         : BinaryType::ARRAYBUFFER),
       allowHalfOpen(!FeatureFlags::get(js).getWebSocketAutoReplyToClose()),
       farNative(nullptr),
-      outgoingMessages(IoContext::current().addObject(kj::heap<OutgoingMessagesMap>())),
-      autoResponseStatusOwner(IoContext::current().addObject(kj::heap<AutoResponse>())),
+      outgoingMessages(IoContext::current().createObject<OutgoingMessagesMap>()),
+      autoResponseStatusOwner(IoContext::current().createObject<AutoResponse>()),
       autoResponseStatus(*autoResponseStatusOwner) {
   auto nativeObj = kj::heap<Native>();
   nativeObj->state.init<AwaitingConnection>();

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -764,6 +764,12 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   template <typename T>
   IoOwn<T> addObject(kj::Rc<T> obj);
 
+  // Shortcut for addObject(kj::heap(...)) to avoid having to write kj::heap() in every call site.
+  template <typename T, typename... Params>
+  IoOwn<T> createObject(Params&&... params) {
+    return addObject(kj::heap<T>(kj::fwd<Params>(params)...));
+  }
+
   // Like addObject() but takes a functor, returning a functor which holds the original functor
   // under an `IoOwn`, and so will stop working if the IoContext is no longer valid. This is
   // particularly useful for passing to `jsg::Promise::then()` when you need the continuation to


### PR DESCRIPTION
Minor quality of life improvement... since `ioContext.addObject(kj::heap<T>(...))` is rather common, save ourselves some extra steps with a `ioContext.createObject<T>(...)` shortcut.