### PR TITLE
workflows: add experimental subscribe support

### DIFF
--- a/src/cloudflare/internal/test/workflows/workflows-api-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-api-test.js
@@ -17,6 +17,14 @@ async function getLastRestartBody(env, id) {
   return (await res.json()).result;
 }
 
+async function getLastSubscribeOptions(env, id) {
+  const res = await env.mock.fetch('http://placeholder/last-subscribe', {
+    method: 'POST',
+    body: JSON.stringify({ id }),
+  });
+  return (await res.json()).result;
+}
+
 export const workflowsApi = {
   async test(_, env) {
     {
@@ -108,6 +116,7 @@ export const workflowsApi = {
         'delete',
         'status',
         'sendEvent',
+        'subscribe',
       ]) {
         assert.strictEqual(typeof fromGet[method], 'function');
       }
@@ -125,6 +134,46 @@ export const workflowsApi = {
         message: 'workflow instance not found',
       });
     }
+  },
+};
+
+export const subscribeNoOptions = {
+  async test(_, env) {
+    const instance = await env.workflow.get('subscribe-basic');
+    using subscription = await instance.subscribe();
+
+    assert.deepStrictEqual(await subscription.next(), {
+      done: false,
+      value: {
+        instanceId: 'subscribe-basic',
+        eventId: 0,
+        timestamp: 0,
+        type: 'workflow_completed',
+        output: 'done',
+      },
+    });
+    assert.deepStrictEqual(await subscription.next(), {
+      done: true,
+      value: undefined,
+    });
+    assert.strictEqual(
+      await getLastSubscribeOptions(env, 'subscribe-basic'),
+      null
+    );
+  },
+};
+
+export const subscribeAllOptions = {
+  async test(_, env) {
+    const instance = await env.workflow.get('subscribe-full');
+    using _subscription = await instance.subscribe({
+      cursor: 1,
+      filter: ['workflow_queued', 'workflow_completed'],
+    });
+    assert.deepStrictEqual(
+      await getLastSubscribeOptions(env, 'subscribe-full'),
+      { cursor: 1, filter: ['workflow_queued', 'workflow_completed'] }
+    );
   },
 };
 

--- a/src/cloudflare/internal/test/workflows/workflows-mock.js
+++ b/src/cloudflare/internal/test/workflows/workflows-mock.js
@@ -2,12 +2,31 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-import { WorkerEntrypoint } from 'cloudflare:workers';
+import { RpcTarget, WorkerEntrypoint } from 'cloudflare:workers';
 
 const restartBodies = new Map();
+const subscribeOptions = new Map();
 
 const THROW_ID = 'throw';
 const MISSING_DELETE_ID = 'missing-delete';
+
+class SubscriptionMock extends RpcTarget {
+  #events;
+  #closed = false;
+
+  constructor(events) {
+    super();
+    this.#events = events;
+  }
+
+  async next() {
+    if (this.#closed || this.#events.length === 0) {
+      this.#closed = true;
+      return { done: true, value: undefined };
+    }
+    return { done: false, value: this.#events.shift() };
+  }
+}
 
 export default class WorkflowsMock extends WorkerEntrypoint {
   async getInstance(id) {
@@ -58,6 +77,20 @@ export default class WorkflowsMock extends WorkerEntrypoint {
 
   async sendEvent(_id, _event) {}
 
+  async subscribe(id, options) {
+    subscribeOptions.set(id, options ?? null);
+
+    return new SubscriptionMock([
+      {
+        instanceId: id,
+        eventId: 0,
+        timestamp: 0,
+        type: 'workflow_completed',
+        output: 'done',
+      },
+    ]);
+  }
+
   // Introspection only. The binding itself never uses fetch(), but the test worker's own compat
   // date leaves RPC gated on `env.mock`, so it reaches these records over HTTP instead.
   async fetch(request) {
@@ -67,6 +100,8 @@ export default class WorkflowsMock extends WorkerEntrypoint {
     switch (pathname) {
       case '/last-restart':
         return Response.json({ result: restartBodies.get(data.id) ?? null });
+      case '/last-subscribe':
+        return Response.json({ result: subscribeOptions.get(data.id) ?? null });
       default:
         throw new Error(
           `unexpected HTTP request to the workflows mock: ${pathname}`

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -39,6 +39,10 @@ interface Fetcher {
     id: string,
     event: { type: string; payload: unknown }
   ): Promise<void>;
+  subscribe(
+    id: string,
+    options?: WorkflowInstanceSubscribeOptions
+  ): Promise<WorkflowInstanceSubscription>;
 }
 
 class InstanceImpl implements WorkflowInstance {
@@ -84,6 +88,12 @@ class InstanceImpl implements WorkflowInstance {
     payload: unknown;
   }): Promise<void> {
     await this.#fetcher.sendEvent(this.id, { type, payload });
+  }
+
+  async subscribe(
+    options?: WorkflowInstanceSubscribeOptions
+  ): Promise<WorkflowInstanceSubscription> {
+    return await this.#fetcher.subscribe(this.id, options);
   }
 }
 

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -149,6 +149,68 @@ interface WorkflowInstanceRestartOptions {
   };
 }
 
+type WorkflowInstanceEventCommon = {
+  instanceId: string;
+  eventId: number;
+  timestamp: number;
+};
+
+type WorkflowInstanceEvent = WorkflowInstanceEventCommon &
+  (
+    | { type: 'workflow_queued' }
+    | { type: 'workflow_started'; params?: unknown }
+    | { type: 'workflow_completed'; output?: unknown }
+    | { type: 'workflow_failed'; error: { name: string; message: string } }
+    | { type: 'workflow_terminated' }
+    | { type: 'step_started'; stepName: string }
+    | { type: 'step_completed'; stepName: string; output?: unknown }
+    | { type: 'step_failed'; stepName: string }
+    | { type: 'attempt_started'; stepName: string; attempt: number }
+    | { type: 'attempt_completed'; stepName: string; attempt: number }
+    | {
+        type: 'attempt_failed';
+        stepName: string;
+        attempt: number;
+        retryDelayMs?: number;
+        error: { name: string; message: string };
+      }
+    | { type: 'sleep_started'; stepName: string; durationMs: number }
+    | { type: 'sleep_completed'; stepName: string }
+    | { type: 'wait_started'; stepName: string; eventType: string }
+    | { type: 'wait_completed'; stepName: string }
+    | { type: 'wait_timed_out'; stepName: string }
+    | { type: 'rollback_started' }
+    | { type: 'rollback_step_started'; stepName: string }
+    | { type: 'rollback_step_completed'; stepName: string }
+    | {
+        type: 'rollback_step_failed';
+        stepName: string;
+        error: { name: string; message: string };
+      }
+    | { type: 'rollback_attempt_started'; stepName: string; attempt: number }
+    | { type: 'rollback_attempt_completed'; stepName: string; attempt: number }
+    | {
+        type: 'rollback_attempt_failed';
+        stepName: string;
+        attempt: number;
+        retryDelayMs?: number;
+        error: { name: string; message: string };
+      }
+    | { type: 'rollback_completed' }
+    | { type: 'rollback_failed' }
+  );
+
+type WorkflowInstanceEventType = WorkflowInstanceEvent['type'];
+
+type WorkflowInstanceSubscribeOptions = {
+  cursor?: number;
+  filter?: WorkflowInstanceEventType[];
+};
+
+interface WorkflowInstanceSubscription extends Disposable {
+  next(): Promise<IteratorResult<WorkflowInstanceEvent, undefined>>;
+}
+
 declare abstract class WorkflowInstance {
   id: string;
 
@@ -190,4 +252,8 @@ declare abstract class WorkflowInstance {
     type: string;
     payload: unknown;
   }): Promise<void>;
+
+  subscribe(
+    options?: WorkflowInstanceSubscribeOptions
+  ): Promise<WorkflowInstanceSubscription>;
 }


### PR DESCRIPTION
This PR adds the experimental `workflows_instance_subscribe` compatibility flag to gate the new workflows event subscription feature. It also adds the required api fetcher implementation.

This intentionally does not update public types since the feature is behind a experimental compat flag, public types will be deferred to a later PR enabling the feature publicly