### PR TITLE
Fix node:fs cp to handle symlinks when copying into subdirectories

### DIFF
--- a/src/workerd/api/filesystem.c++
+++ b/src/workerd/api/filesystem.c++
@@ -1239,6 +1239,11 @@ namespace {
 using MaybeFsNode = kj::Maybe<
     kj::OneOf<kj::Rc<workerd::Directory>, kj::Rc<workerd::File>, kj::Rc<workerd::SymbolicLink>>>;
 
+struct CopyEntry final {
+  kj::String name;
+  workerd::Directory::Item item;
+};
+
 MaybeFsNode getNodeOrError(jsg::Lock& js,
     const workerd::VirtualFileSystem& vfs,
     const jsg::Url& url,
@@ -1422,11 +1427,32 @@ void handleCpDir(jsg::Lock& js,
     node::THROW_ERR_UV_EINVAL(js, "cp"_kj, "Source and destination directories are the same"_kj);
   }
 
+  // entries store the reference to the node and the name of the entry
+  // of all the entries in the source directory, to ensure they remain valid
+  // even if the source directory is mutated during copying.
+  // this can happen when the destination directory contains a
+  // symbolic link that points to the source directory.
+  kj::Vector<CopyEntry> entries;
+  entries.reserve(src->count(js));
+  for (auto& entry: *src) {
+    KJ_SWITCH_ONEOF(entry.value) {
+      KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
+        entries.add(CopyEntry{.name = kj::str(entry.key), .item = file.addRef()});
+      }
+      KJ_CASE_ONEOF(dir, kj::Rc<workerd::Directory>) {
+        entries.add(CopyEntry{.name = kj::str(entry.key), .item = dir.addRef()});
+      }
+      KJ_CASE_ONEOF(link, kj::Rc<workerd::SymbolicLink>) {
+        entries.add(CopyEntry{.name = kj::str(entry.key), .item = link.addRef()});
+      }
+    }
+  }
+
   // Here, we iterate through each of the entries in the source directory,
   // recursively copying them to the destination directory.
-  for (auto& entry: *src) {
-    kj::StringPtr name = entry.key;
-    KJ_SWITCH_ONEOF(entry.value) {
+  for (auto& entry: entries) {
+    kj::StringPtr name = entry.name;
+    KJ_SWITCH_ONEOF(entry.item) {
       KJ_CASE_ONEOF(file, kj::Rc<workerd::File>) {
         // We have a file, we will copy it to the destination directory
         // unless errorOnExist is true, force is false, and the destination already exists.

--- a/src/workerd/api/node/tests/fs-cp-into-subdirectory-test.js
+++ b/src/workerd/api/node/tests/fs-cp-into-subdirectory-test.js
@@ -1,8 +1,15 @@
 // Copyright (c) 2026 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-import { cpSync, mkdirSync, writeFileSync } from 'node:fs';
-import { throws } from 'node:assert';
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { strictEqual, throws } from 'node:assert';
 
 export const FsCpIntoSubdirectory = {
   test() {
@@ -17,6 +24,33 @@ export const FsCpIntoSubdirectory = {
       {
         code: 'ERR_FS_CP_EINVAL',
       }
+    );
+  },
+};
+
+export const FsCpDestinationSymlinkToSource = {
+  test() {
+    const src = new URL('file:///tmp/src');
+    const dest = new URL('file:///tmp/dest');
+
+    mkdirSync(new URL('file:///tmp/src/child'), { recursive: true });
+    writeFileSync(new URL('file:///tmp/src/child/payload.txt'), 'payload');
+    writeFileSync(new URL('file:///tmp/src/a.txt'), 'a');
+    strictEqual(readdirSync(src).length, 2);
+
+    mkdirSync(dest);
+    // /tmp/dest/child --> /tmp/src
+    symlinkSync(src, new URL('file:///tmp/dest/child'));
+
+    cpSync(src, dest, { recursive: true, dereference: true });
+    strictEqual(readFileSync(new URL('file:///tmp/dest/a.txt'), 'utf8'), 'a');
+    strictEqual(
+      readFileSync(new URL('file:///tmp/src/payload.txt'), 'utf8'),
+      'payload'
+    );
+    strictEqual(
+      readFileSync(new URL('file:///tmp/src/child/payload.txt'), 'utf8'),
+      'payload'
     );
   },
 };


### PR DESCRIPTION
Fixes node:fs cp functions to handle subdirectories that contain symlink properly.

When the `dest` directory contains a symlink to the `src` directory, it could free up the memory of the `src` directory during the copy.

This fixes it by holding a refcount of all the entries in the src directory before performing the copy.