### PR TITLE
STOR-5489: Propagate actor retry gate state

### DIFF
--- a/src/workerd/api/actor-fetch-retry-test.c++
+++ b/src/workerd/api/actor-fetch-retry-test.c++
@@ -253,18 +253,13 @@ class ReplayOutgoingFactory final: public Fetcher::OutgoingFactory {
   ReplayState& state;
 };
 
-enum class RetryEnforcement {
-  DISABLED,
-  ENABLED,
-};
-
 enum class ActorFetchKind {
   HTTP,
   WEB_SOCKET,
 };
 
 kj::Maybe<kj::Exception> runActorFetch(ReplayState& state,
-    RetryEnforcement enforcement,
+    ActorRetryGateEnabled retryGateEnabled,
     kj::Maybe<kj::StringPtr> body,
     ActorFetchKind kind) {
   kj::TimerImpl timer(kj::origin<kj::TimePoint>());
@@ -277,7 +272,7 @@ kj::Maybe<kj::Exception> runActorFetch(ReplayState& state,
     return kj::rc<TestFixture::DummyIoChannelFactory>(timerChannel);
   }),
   });
-  if (enforcement == RetryEnforcement::ENABLED) {
+  if (retryGateEnabled.toBool()) {
     util::Autogate::initAutogateNamesForTest(
         {"durable-object-retries-fetch"_kj, "durable-object-retries-fetch-retry-requests"_kj},
         util::IgnoreAllAutogatesEnv::YES);
@@ -442,6 +437,8 @@ KJ_TEST("fetch generates actor retry metadata for a supported outgoing factory")
   kj::Date beforeFetch = kj::UNIX_EPOCH;
   kj::Date afterFetch = kj::UNIX_EPOCH;
   TestFixture fixture;
+  util::Autogate::initAutogateNamesForTest(
+      {"durable-object-retries-fetch"_kj}, util::IgnoreAllAutogatesEnv::YES);
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
     auto fetcher = env.js.alloc<Fetcher>(
@@ -459,6 +456,7 @@ KJ_TEST("fetch generates actor retry metadata for a supported outgoing factory")
     KJ_EXPECT(metadata.createdAt >= beforeFetch);
     KJ_EXPECT(metadata.createdAt <= afterFetch);
     KJ_EXPECT(metadata.isRetry == IsActorRetry::NO);
+    KJ_EXPECT(metadata.retryGateEnabled == ActorRetryGateEnabled::NO);
   } else {
     KJ_FAIL_EXPECT("supported fetch did not generate actor retry metadata");
   }
@@ -505,7 +503,7 @@ KJ_TEST("fetch omits actor retry metadata for an unsupported outgoing factory") 
 KJ_TEST("actor fetch updates retry metadata and rewinds the body") {
   ReplayState state{.failures = kj::arr(ReplayFailure::NOT_DELIVERED, ReplayFailure::AMBIGUOUS,
                         ReplayFailure::NOT_DELIVERED)};
-  KJ_EXPECT(runActorFetch(state, RetryEnforcement::ENABLED, "request body"_kj,
+  KJ_EXPECT(runActorFetch(state, ActorRetryGateEnabled::YES, "request body"_kj,
                 ActorFetchKind::HTTP) == kj::none);
 
   KJ_ASSERT(state.metadata.size() == 4);
@@ -518,26 +516,31 @@ KJ_TEST("actor fetch updates retry metadata and rewinds the body") {
   KJ_EXPECT(state.metadata[1].isRetry == IsActorRetry::NO);
   KJ_EXPECT(state.metadata[2].isRetry == IsActorRetry::YES);
   KJ_EXPECT(state.metadata[3].isRetry == IsActorRetry::YES);
+  for (auto& metadata: state.metadata) {
+    KJ_EXPECT(metadata.retryGateEnabled == ActorRetryGateEnabled::YES);
+  }
   KJ_ASSERT(state.requestBodies.size() == 4);
   for (auto& body: state.requestBodies) {
     KJ_EXPECT(body == "request body"_kj.asBytes());
   }
 }
 
-KJ_TEST("actor fetch does not retry when enforcement is disabled") {
+KJ_TEST("actor fetch does not retry when the enforce gate is disabled") {
   ReplayState state{.failures = kj::arr(ReplayFailure::AMBIGUOUS)};
 
   KJ_EXPECT(
-      runActorFetch(state, RetryEnforcement::DISABLED, kj::none, ActorFetchKind::HTTP) != kj::none);
+      runActorFetch(state, ActorRetryGateEnabled::NO, kj::none, ActorFetchKind::HTTP) != kj::none);
   KJ_EXPECT(state.requestCount == 1);
   KJ_EXPECT(state.retryCount == 0);
+  KJ_ASSERT(state.metadata.size() == 1);
+  KJ_EXPECT(state.metadata[0].retryGateEnabled == ActorRetryGateEnabled::NO);
 }
 
 KJ_TEST("actor fetch does not retry a delivered disconnect") {
   ReplayState state{.failures = kj::arr(ReplayFailure::DELIVERED)};
 
   KJ_EXPECT(
-      runActorFetch(state, RetryEnforcement::ENABLED, kj::none, ActorFetchKind::HTTP) != kj::none);
+      runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) != kj::none);
   KJ_EXPECT(state.requestCount == 1);
   KJ_EXPECT(state.retryCount == 0);
 }
@@ -547,7 +550,7 @@ KJ_TEST("actor fetch stops after a retry claim rejection") {
     .failures = kj::arr(ReplayFailure::AMBIGUOUS, ReplayFailure::CLAIM_REJECTED),
   };
   auto failure = KJ_REQUIRE_NONNULL(
-      runActorFetch(state, RetryEnforcement::ENABLED, kj::none, ActorFetchKind::HTTP));
+      runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP));
 
   KJ_EXPECT(failure.getType() == kj::Exception::Type::DISCONNECTED, failure);
   KJ_EXPECT(!failure.getDescription().contains("claim rejected"), failure);
@@ -558,7 +561,7 @@ KJ_TEST("actor fetch stops after a retry claim rejection") {
 KJ_TEST("actor fetch normalizes an initial retry claim rejection") {
   ReplayState state{.failures = kj::arr(ReplayFailure::CLAIM_REJECTED)};
   auto failure = KJ_REQUIRE_NONNULL(
-      runActorFetch(state, RetryEnforcement::ENABLED, kj::none, ActorFetchKind::HTTP));
+      runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP));
 
   KJ_EXPECT(failure.getType() == kj::Exception::Type::DISCONNECTED, failure);
   KJ_EXPECT(!failure.getDescription().contains("claim rejected"), failure);
@@ -572,8 +575,8 @@ KJ_TEST("actor WebSocket fetch retries a disconnected handshake") {
     .acceptWebSocket = true,
   };
 
-  KJ_EXPECT(runActorFetch(state, RetryEnforcement::ENABLED, kj::none, ActorFetchKind::WEB_SOCKET) ==
-      kj::none);
+  KJ_EXPECT(runActorFetch(state, ActorRetryGateEnabled::YES, kj::none,
+                ActorFetchKind::WEB_SOCKET) == kj::none);
   KJ_EXPECT(state.requestCount == 2);
   KJ_EXPECT(state.webSocketRequestCount == 2);
   KJ_EXPECT(state.retryCount == 1);
@@ -618,7 +621,7 @@ KJ_TEST("actor fetch stops after five attempts") {
   };
 
   KJ_EXPECT(
-      runActorFetch(state, RetryEnforcement::ENABLED, kj::none, ActorFetchKind::HTTP) != kj::none);
+      runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) != kj::none);
   KJ_EXPECT(state.requestCount == 5);
   KJ_EXPECT(state.retryCount == 4);
 }
@@ -629,7 +632,7 @@ KJ_TEST("actor fetch allows an in-flight retry to finish after the start budget"
   };
 
   KJ_EXPECT(
-      runActorFetch(state, RetryEnforcement::ENABLED, kj::none, ActorFetchKind::HTTP) == kj::none);
+      runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) == kj::none);
   KJ_EXPECT(state.requestCount == 2);
   KJ_EXPECT(state.retryCount == 1);
 }
@@ -640,7 +643,7 @@ KJ_TEST("actor fetch does not start a retry after the start budget") {
   };
 
   KJ_EXPECT(
-      runActorFetch(state, RetryEnforcement::ENABLED, kj::none, ActorFetchKind::HTTP) != kj::none);
+      runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) != kj::none);
   KJ_EXPECT(state.requestCount == 1);
   KJ_EXPECT(state.retryCount == 1);
 }
@@ -705,6 +708,7 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
           .nonce = 0x123456789abcdef0,
           .createdAt = kj::UNIX_EPOCH + 123 * kj::MILLISECONDS,
           .isRetry = IsActorRetry::YES,
+          .retryGateEnabled = ActorRetryGateEnabled::NO,
         },
         [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
 
@@ -722,6 +726,7 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
           .nonce = 0xfedcba9876543210,
           .createdAt = kj::UNIX_EPOCH + 456 * kj::MILLISECONDS,
           .isRetry = IsActorRetry::YES,
+          .retryGateEnabled = ActorRetryGateEnabled::NO,
         },
         [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
     KJ_EXPECT(checkedSubrequestCount == 2);

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1515,13 +1515,13 @@ template <typename T>
 using ActorFetchAttemptResult = kj::OneOf<T, ActorFetchFailure>;
 
 ActorFetchRetryState ActorFetchRetryState::create(TimerChannel& timer) {
-  auto metadata = generateActorRetryRequestMetadata(kj::systemCoarseCalendarClock().now());
+  bool retryGateEnabled = util::Autogate::isEnabled(
+      util::AutogateKey::DURABLE_OBJECT_RETRIES_FETCH_RETRY_REQUESTS);
+  auto metadata = generateActorRetryRequestMetadata(kj::systemCoarseCalendarClock().now(),
+      ActorRetryGateEnabled(retryGateEnabled));
   kj::Maybe<kj::TimePoint> deadline;
-  // TODO(STOR-5489): Keep sender-side retries disabled until retry-claim enforcement is deployed to
-  // every receiver. A mixed fleet can otherwise execute both an ambiguous request and its retry.
   if (util::Autogate::isEnabled(util::AutogateKey::DURABLE_OBJECT_RETRIES_FETCH) &&
-      util::Autogate::isEnabled(
-          util::AutogateKey::DURABLE_OBJECT_RETRIES_FETCH_RETRY_REQUESTS)) {
+      retryGateEnabled) {
     deadline = timer.nowForLimitTimeout() + RETRY_BUDGET;
   }
   return ActorFetchRetryState(kj::mv(metadata), kj::mv(deadline), timer);
@@ -1577,7 +1577,8 @@ kj::OneOf<kj::Duration, kj::Exception> ActorFetchRetryState::prepareRetry(
   if (exception.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) == kj::none) {
     metadata.isRetry = IsActorRetry::YES;
   } else if (metadata.isRetry == IsActorRetry::NO) {
-    metadata = generateActorRetryRequestMetadata(kj::systemCoarseCalendarClock().now());
+    metadata = generateActorRetryRequestMetadata(
+        kj::systemCoarseCalendarClock().now(), metadata.retryGateEnabled);
   }
 
   auto delay = retryDelay();

--- a/src/workerd/io/io-channels.c++
+++ b/src/workerd/io/io-channels.c++
@@ -8,7 +8,8 @@
 
 namespace workerd {
 
-IoChannelFactory::ActorRetryRequestMetadata generateActorRetryRequestMetadata(kj::Date createdAt) {
+IoChannelFactory::ActorRetryRequestMetadata generateActorRetryRequestMetadata(
+    kj::Date createdAt, ActorRetryGateEnabled retryGateEnabled) {
   static thread_local auto generator = [] {
     uint64_t seed;
     getEntropy(kj::asBytes(seed));
@@ -20,6 +21,7 @@ IoChannelFactory::ActorRetryRequestMetadata generateActorRetryRequestMetadata(kj
     .nonce = distribution(generator),
     .createdAt = createdAt,
     .isRetry = IsActorRetry::NO,
+    .retryGateEnabled = retryGateEnabled,
   };
 }
 

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -35,6 +35,9 @@ WD_STRONG_BOOL(Persistent);
 // Whether an actor request is a retry of an earlier attempt.
 WD_STRONG_BOOL(IsActorRetry);
 
+// Whether the sender's enforce gate is enabled for this logical call.
+WD_STRONG_BOOL(ActorRetryGateEnabled);
+
 // Interface for talking to the Cache API. Needs to be declared here so that IoContext can
 // contain it.
 class CacheClient {
@@ -138,6 +141,7 @@ class IoChannelFactory: public virtual kj::Refcounted {
     uint64_t nonce;
     kj::Date createdAt;
     IsActorRetry isRetry;
+    ActorRetryGateEnabled retryGateEnabled;
   };
 
   // Contains metadata attached to an outgoing subrequest from a worker, independent of the type
@@ -657,6 +661,7 @@ kj::Own<IoChannelFactory::RpcChannel> newPromisedChannel<IoChannelFactory::RpcCh
     kj::Promise<kj::Own<IoChannelFactory::RpcChannel>> promise);
 
 // Creates caller-owned metadata for the first attempt of a retry-eligible actor invocation.
-IoChannelFactory::ActorRetryRequestMetadata generateActorRetryRequestMetadata(kj::Date createdAt);
+IoChannelFactory::ActorRetryRequestMetadata generateActorRetryRequestMetadata(
+    kj::Date createdAt, ActorRetryGateEnabled retryGateEnabled);
 
 }  // namespace workerd

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -89,8 +89,9 @@ namespace workerd::util {
   /* Gate for the Durable Object fetch-retries feature, scoped to DO `fetch()`. Enables            \
     observe-only retry-token claim machinery. */                                                   \
   V(DURABLE_OBJECT_RETRIES_FETCH)                                                                  \
-  /* Enables Durable Object fetch retry requests and fail-closed receiver enforcement. The         \
-     observe-only DURABLE_OBJECT_RETRIES_FETCH gate is a prerequisite. */                          \
+  /* Enables Durable Object fetch retry requests. Enabled senders require receiver-side claim     \
+     enforcement on each request. The observe-only DURABLE_OBJECT_RETRIES_FETCH gate is a         \
+     prerequisite. */                                                                              \
   V(DURABLE_OBJECT_RETRIES_FETCH_RETRY_REQUESTS)                                                   \
   /* When enabled, the native `node-internal:url` module is provided by the Rust                   \
      implementation (api::node UrlUtil ported to src/rust/api) instead of the                      \


### PR DESCRIPTION
Attach the retry gate state to each logical actor call. Receivers can then enforce claims only for senders that retry.