### PR TITLE
STOR:5489: Retry replica actor fetches

### DIFF
--- a/src/workerd/api/actor-fetch-retry-test.c++
+++ b/src/workerd/api/actor-fetch-retry-test.c++
@@ -648,12 +648,18 @@ KJ_TEST("actor fetch does not start a retry after the start budget") {
   KJ_EXPECT(state.retryCount == 1);
 }
 
-KJ_TEST("replica actor fetch does not retry a disconnected primary channel") {
-  ReplayState state{.failures = kj::arr(ReplayFailure::NOT_DELIVERED)};
+KJ_TEST("replica actor fetch retries a request-level disconnect on its primary channel") {
+  ReplayState state{.failures = kj::arr(ReplayFailure::AMBIGUOUS)};
+  kj::TimerImpl timer(kj::origin<kj::TimePoint>());
+  DeterministicTimerChannel timerChannel(timer);
+  state.timerChannel = timerChannel;
   uint checkedSubrequestCount = 0;
-  kj::Maybe<kj::Exception> failure;
   TestFixture fixture(TestFixture::SetupParams{
-    .useRealTimers = true,
+    .useRealTimers = false,
+    .ioChannelFactory = kj::Function<kj::Rc<IoChannelFactory>(TimerChannel&)>(
+        [&](TimerChannel&) -> kj::Rc<IoChannelFactory> {
+    return kj::rc<TestFixture::DummyIoChannelFactory>(timerChannel);
+  }),
     .checkedSubrequestCount = checkedSubrequestCount,
   });
   util::Autogate::initAutogateNamesForTest(
@@ -666,17 +672,15 @@ KJ_TEST("replica actor fetch does not retry a disconnected primary channel") {
             kj::refcounted<ReplayActorChannel>(state), kj::str("actor-id"))),
         Fetcher::RequiresHostAndProtocol::YES);
     auto promise = fetcher->fetch(env.js, kj::str("http://example.com"), kj::none);
-    return env.context.awaitJs(env.js, kj::mv(promise))
-        .ignoreResult()
-        .catch_([&](kj::Exception&& exception) {
-      failure.emplace(kj::mv(exception));
-    }).attach(kj::mv(fetcher));
+    return env.context.awaitJs(env.js, kj::mv(promise)).ignoreResult().attach(kj::mv(fetcher));
   });
 
-  KJ_EXPECT(failure != kj::none);
-  KJ_EXPECT(state.requestCount == 1);
-  KJ_EXPECT(state.metadata.empty());
-  KJ_EXPECT(checkedSubrequestCount == 1);
+  KJ_EXPECT(state.requestCount == 2);
+  KJ_ASSERT(state.metadata.size() == 2);
+  KJ_EXPECT(state.metadata[0].nonce == state.metadata[1].nonce);
+  KJ_EXPECT(state.metadata[0].isRetry == IsActorRetry::NO);
+  KJ_EXPECT(state.metadata[1].isRetry == IsActorRetry::YES);
+  KJ_EXPECT(checkedSubrequestCount == 2);
 }
 
 KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for retries") {

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -150,10 +150,16 @@ kj::Own<IoChannelFactory::SubrequestChannel> GlobalActorOutgoingFactory::getSubr
 
 Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) {
+  return newSingleUseClientWithActorRetryMetadata(
+      kj::mv(cfStr), kj::none, kj::mv(makeUserSpanParent));
+}
+
+Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::
+    newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
+        kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+        MakeUserSpanParent makeUserSpanParent) {
   auto& context = IoContext::current();
 
-  // Replica-to-primary stubs hold a pre-resolved Pipeline and cannot reroute after it breaks, so
-  // they do not opt into actor fetch retries.
   kj::Maybe<TraceContextParent> spanParents;
   auto startRequest = [&](TraceContext& tracing, IoChannelFactory& ioChannelFactory) {
     tracing.setTag("objectId"_kjc, actorId.asPtr());
@@ -167,7 +173,8 @@ Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::newSingleUseClient
     // already open prior to this DO starting up.
     return actorChannel->startRequest({.cfBlobJson = kj::mv(cfStr),
       .parentSpan = tracing.getInternalSpanParent(),
-      .userSpanParent = kj::mv(userSpanParent)});
+      .userSpanParent = kj::mv(userSpanParent),
+      .actorRetryRequestMetadata = kj::mv(actorRetryRequestMetadata)});
   };
   auto client = startActorSubrequest(context, startRequest);
   return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -416,6 +416,16 @@ class ReplicaActorOutgoingFactory final: public Fetcher::OutgoingFactory {
 
   Result newSingleUseClient(
       kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) override;
+  bool supportsActorFetchRetries() const override {
+    return true;
+  }
+  void onActorFetchRetry() override {
+    // Keep the pre-resolved primary channel. Reconnecting a broken channel requires routing state
+    // that this factory does not own, but request-level disconnects can still succeed on retry.
+  }
+  Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
+      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+      MakeUserSpanParent makeUserSpanParent) override;
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() override;
 
  private:


### PR DESCRIPTION
Let replica-to-primary fetches use the actor replay loop while retaining their pre-resolved channel. Cover a request-level disconnect that succeeds on retry.