### PR TITLE
Skip writable abort task if no current request

### DIFF
--- a/src/workerd/api/js-writable-stream.c++
+++ b/src/workerd/api/js-writable-stream.c++
@@ -243,6 +243,10 @@ class TsWriterSink final: public WritableStreamSink {
   }
 
   void scheduleAbort(jsg::JsRef<jsg::JsObject> writer, kj::Exception reason) {
+    // Once the last IncomingRequest is gone the IoContext can no longer usefully run JavaScript:
+    // the task would be queued onto a task set that is already being torn down, so the app's
+    // abort algorithm would never observe it. Drop the writer rather than queue unrunnable work.
+    if (!context.hasCurrentIncomingRequest()) return;
     context.addTask(
         context.run([writer = kj::mv(writer), reason = kj::mv(reason)](Worker::Lock& lock) mutable {
       jsg::Lock& js = lock;

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -366,12 +366,7 @@ class WritableStreamJsRpcAdapter final: public capnp::ExplicitEndOutputStream {
     // hopefully improve the situation here.
     if (!ended) {
       KJ_IF_SOME(writer, this->writer) {
-        context.addTask(context.run([writer = kj::mv(writer), exception = cancellationException()](
-                                        Worker::Lock& lock) mutable {
-          jsg::Lock& js = lock;
-          auto ex = js.exceptionToJsValue(kj::mv(exception));
-          return IoContext::current().awaitJs(lock, writer->abort(lock, ex.getHandle(js)));
-        }));
+        scheduleAbort(kj::mv(writer));
       }
     }
   }
@@ -390,13 +385,7 @@ class WritableStreamJsRpcAdapter final: public capnp::ExplicitEndOutputStream {
         }
         auto w = kj::mv(obj.writer);
         KJ_IF_SOME(writer, w) {
-          obj.context.addTask(
-              obj.context.run([writer = kj::mv(writer), exception = cancellationException()](
-                                  Worker::Lock& lock) mutable {
-            jsg::Lock& js = lock;
-            auto ex = js.exceptionToJsValue(kj::mv(exception));
-            return IoContext::current().awaitJs(lock, writer->abort(lock, ex.getHandle(js)));
-          }));
+          obj.scheduleAbort(kj::mv(writer));
         }
       }
     }));
@@ -489,6 +478,21 @@ class WritableStreamJsRpcAdapter final: public capnp::ExplicitEndOutputStream {
       return *inner;
     }
     kj::throwFatalException(cancellationException());
+  }
+
+  // Runs the writer's abort algorithm on the isolate thread, reporting the generic cancellation
+  // reason (the peer's actual reason cannot be conveyed; see the destructor).
+  void scheduleAbort(jsg::Ref<WritableStreamDefaultWriter> writer) {
+    // Once the last IncomingRequest is gone the IoContext can no longer usefully run JavaScript:
+    // the task would be queued onto a task set that is already being torn down, so the abort
+    // algorithm would never observe it. Drop the writer rather than queue unrunnable work.
+    if (!context.hasCurrentIncomingRequest()) return;
+    context.addTask(context.run(
+        [writer = kj::mv(writer), exception = cancellationException()](Worker::Lock& lock) mutable {
+      jsg::Lock& js = lock;
+      auto ex = js.exceptionToJsValue(kj::mv(exception));
+      return IoContext::current().awaitJs(lock, writer->abort(lock, ex.getHandle(js)));
+    }));
   }
 
   static kj::Exception cancellationException() {

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -630,6 +630,18 @@ wd_test(
 )
 
 wd_test(
+    src = "js-rpc-writable-teardown-test.wd-test",
+    args = ["--experimental"],
+    data = ["js-rpc-writable-teardown-test.js"],
+)
+
+wd_test(
+    src = "js-rpc-writable-teardown-ts-test.wd-test",
+    args = ["--experimental"],
+    data = ["js-rpc-writable-teardown-test.js"],
+)
+
+wd_test(
     src = "js-rpc-params-ownership-test.wd-test",
     args = ["--experimental"],
     data = ["js-rpc-params-ownership-test.js"],

--- a/src/workerd/api/tests/js-rpc-writable-teardown-test.js
+++ b/src/workerd/api/tests/js-rpc-writable-teardown-test.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// A WritableStream transferred over JS RPC and then abandoned -- the peer writes into it but
+// never closes it, and the runner drops the stream -- leaves the RPC adapter holding a live
+// writer when it is dropped. Both the adapter's destructor and its revoke path then reach into
+// the IoContext to run the writer's abort algorithm, and that can happen after the last
+// IncomingRequest is gone (during TaskSet teardown). IoContext::run() requires a current
+// IncomingRequest, so the abort must be skipped in that window rather than attempted.
+//
+// Two configurations embed this file, so both writer-driven adapters are covered: without
+// typescript_implemented_streams the JS-backed sink below has no WritableStreamSink to detach
+// and serializes through the legacy adapter, and with the flag the same stream is a TypeScript
+// stream and serializes through the TypeScript writer sink.
+
+import { WorkerEntrypoint } from 'cloudflare:workers';
+import * as assert from 'node:assert';
+
+const enc = new TextEncoder();
+
+export class Peer extends WorkerEntrypoint {
+  // Writes into the received writable and returns without closing it, so the writer is still
+  // live when the runner drops the stream.
+  async writeAndAbandon(stream) {
+    assert.ok(stream instanceof WritableStream);
+    const writer = stream.getWriter();
+    await writer.write(enc.encode('partial'));
+  }
+}
+
+export default {
+  async test(controller, env) {
+    // Both services embed this file; only the runner has the binding.
+    if (env.PEER === undefined) return;
+
+    // A JS-backed sink accepts each chunk immediately, so the peer's write settles without
+    // anything draining the stream and the call returns with the writer still held.
+    const chunks = [];
+    const writable = new WritableStream({
+      write(chunk) {
+        chunks.push(chunk);
+      },
+    });
+
+    await env.PEER.writeAndAbandon(writable);
+    assert.strictEqual(chunks.length, 1);
+
+    // `writable` goes out of scope here, still unclosed and still holding the peer's writer.
+    // Its adapter is dropped during request teardown.
+  },
+};

--- a/src/workerd/api/tests/js-rpc-writable-teardown-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-writable-teardown-test.wd-test
@@ -1,0 +1,37 @@
+# A JS-backed WritableStream transferred over JS RPC and abandoned unclosed, so the RPC
+# adapter's destructor schedules the writer's abort during request teardown. Neither service
+# enables typescript_implemented_streams: this pins the writer-driven legacy adapter path.
+# See the header comment in the JS file.
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "runner",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "js-rpc-writable-teardown-test.js")
+        ],
+        compatibilityFlags = [
+          "nodejs_compat",
+          "streams_enable_constructors",
+          "rpc",
+        ],
+        bindings = [
+          (name = "PEER", service = (name = "peer", entrypoint = "Peer")),
+        ],
+      )
+    ),
+    ( name = "peer",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "js-rpc-writable-teardown-test.js")
+        ],
+        compatibilityFlags = [
+          "nodejs_compat",
+          "streams_enable_constructors",
+          "rpc",
+        ],
+      )
+    ),
+  ],
+);

--- a/src/workerd/api/tests/js-rpc-writable-teardown-ts-test.wd-test
+++ b/src/workerd/api/tests/js-rpc-writable-teardown-ts-test.wd-test
@@ -1,0 +1,44 @@
+# The abandoned-writable teardown test run with the TypeScript streams implementation enabled,
+# so both transferred writables serialize through the TypeScript writer sink rather than the
+# legacy adapters. See the header comment in the JS file.
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "runner",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "js-rpc-writable-teardown-test.js")
+        ],
+        compatibilityFlags = [
+          "nodejs_compat",
+          "experimental",
+          "streams_enable_constructors",
+          "rpc",
+          "typescript_implemented_streams",
+        ],
+        bindings = [
+          (name = "PEER", service = (name = "peer", entrypoint = "Peer")),
+        ],
+      )
+    ),
+    ( name = "peer",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "js-rpc-writable-teardown-test.js")
+        ],
+        compatibilityFlags = [
+          "nodejs_compat",
+          "experimental",
+          "streams_enable_constructors",
+          "rpc",
+          "typescript_implemented_streams",
+        ],
+      )
+    ),
+  ],
+  autogates = [
+    "workerd-autogate-per-isolate-javascript-bootstrap",
+    "workerd-autogate-rpc-externals-hydration",
+  ],
+);

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -520,7 +520,17 @@ void IoContext::addTask(kj::Promise<void> promise) {
     return;
   }
 
-  if (actor == kj::none) {
+  if (incomingRequests.empty()) {
+    // A task can be scheduled after the last IncomingRequest has been unlinked (see
+    // ~IoContext_IncomingRequest) while the IoContext itself is still alive -- an RPC stream
+    // adapter dropped during teardown, for instance, schedules the stream's abort algorithm from
+    // its destructor. There is no request to attribute the task to, so the metric below is
+    // skipped; the task is still queued, and runs if the IoContext gets far enough to run it.
+    // This is a state worth knowing about, hence the log, but it is recoverable and must not be
+    // treated as a precondition violation.
+    DEBUG_FATAL_RELEASE_LOG(WARNING, "Adding task to IoContext with no current IncomingRequest",
+        lastDeliveredLocation, kj::getStackTrace());
+  } else if (actor == kj::none) {
     // This metric won't work correctly in actors since it's being tracked per-request, but tasks
     // are not tied to requests in actors. So we just skip it in actors. (Actually this code path
     // is not even executed in the actor case but I'm leaving the check in just in case that ever
@@ -535,18 +545,18 @@ void IoContext::addTask(kj::Promise<void> promise) {
 }
 
 void IoContext::addWaitUntil(kj::Promise<void> promise) {
-  if (actor == kj::none) {
+  // The empty check comes first: getMetrics() requires a current IncomingRequest, so consulting
+  // it before checking would turn the recoverable no-request case into a fatal one. See addTask().
+  if (incomingRequests.empty()) {
+    DEBUG_FATAL_RELEASE_LOG(WARNING, "Adding task to IoContext with no current IncomingRequest",
+        lastDeliveredLocation, kj::getStackTrace());
+  } else if (actor == kj::none) {
     // This metric won't work correctly in actors since it's being tracked per-request, but tasks
     // are not tied to requests in actors. So we just skip it in actors.
     auto& metrics = getMetrics();
     if (metrics.getSpan().isObserved()) {
       promise = promise.attach(metrics.addedWaitUntilTask());
     }
-  }
-
-  if (incomingRequests.empty()) {
-    DEBUG_FATAL_RELEASE_LOG(WARNING, "Adding task to IoContext with no current IncomingRequest",
-        lastDeliveredLocation, kj::getStackTrace());
   }
 
   waitUntilTasks.add(kj::mv(promise));

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -424,6 +424,12 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   // The callback can accept either (Worker::Lock&) or (Worker::Lock&, IoContext&). When the
   // two-argument form is used, *this is passed as the second argument. Existing single-argument
   // call sites are unaffected.
+  //
+  // Requires a current IncomingRequest: the setup work reaches for per-request state (the
+  // IoChannelFactory's timer, the request's metrics) before the callback runs. An IoContext can
+  // outlive its last IncomingRequest, so callers reachable from teardown -- destructors and
+  // kj::defer cleanups in particular -- must check hasCurrentIncomingRequest() first and skip
+  // the work rather than call this and fault.
   template <typename Func>
   auto run(Func&& func, kj::Maybe<InputGate::Lock> inputLock = kj::none) KJ_WARN_UNUSED_RESULT {
     if constexpr (runFuncAcceptsIoContext<Func>) {


### PR DESCRIPTION
jsrpc WritableStream adapter tries to abort if it is destroyed without an explicit abort. If that happens during IoContext cleanup when there's no active request, getMetrics complains with a KJ_REQUIRE about the lack of a current request. Guard by checking first.