### PR TITLE
Implements resource name arg in jsg-test's eval

### DIFF
--- a/src/rust/jsg-test/ffi.c++
+++ b/src/rust/jsg-test/ffi.c++
@@ -74,17 +74,12 @@ void EvalContext::set_global(::rust::Str name, ::workerd::rust::jsg::Local value
   ::workerd::jsg::check(ctx->Global()->Set(ctx, key, v8Value));
 }
 
-EvalResult EvalContext::eval(::rust::Str code) const {
+namespace {
+EvalResult runScript(
+    v8::Isolate* v8Isolate, v8::Local<v8::Context> ctx, v8::Local<v8::Script> script) {
   EvalResult result;
   result.success = false;
 
-  v8::Local<v8::Context> ctx = v8Context.Get(v8Isolate);
-
-  v8::Local<v8::String> source = ::workerd::jsg::check(v8::String::NewFromUtf8(
-      v8Isolate, code.data(), v8::NewStringType::kNormal, static_cast<int>(code.size())));
-
-  v8::Local<v8::Script> script;
-  KJ_ASSERT(v8::Script::Compile(ctx, source).ToLocal(&script), "Failed to compile script");
   v8::TryCatch catcher(v8Isolate);
 
   v8::Local<v8::Value> value;
@@ -100,6 +95,27 @@ EvalResult EvalContext::eval(::rust::Str code) const {
   }
 
   return result;
+}
+}  // namespace
+
+EvalResult EvalContext::eval(::rust::Str code, kj::Maybe<::rust::Str> maybeResourceName) const {
+  v8::Local<v8::Context> ctx = v8Context.Get(v8Isolate);
+
+  v8::Local<v8::String> source = ::workerd::jsg::check(v8::String::NewFromUtf8(
+      v8Isolate, code.data(), v8::NewStringType::kNormal, static_cast<int>(code.size())));
+
+  v8::Local<v8::Script> script;
+  KJ_IF_SOME(resourceName, maybeResourceName) {
+    auto resourceNameStr = ::workerd::jsg::check(v8::String::NewFromUtf8(v8Isolate,
+        resourceName.data(), v8::NewStringType::kNormal, static_cast<int>(resourceName.size())));
+    v8::ScriptOrigin origin(resourceNameStr);
+    v8::ScriptCompiler::Source scriptSource(source, origin);
+    script = ::workerd::jsg::check(v8::ScriptCompiler::Compile(ctx, &scriptSource));
+  } else {
+    script = ::workerd::jsg::check(v8::Script::Compile(ctx, source));
+  }
+
+  return runScript(v8Isolate, ctx, script);
 }
 
 void TestHarness::run_in_context(

--- a/src/rust/jsg-test/ffi.h
+++ b/src/rust/jsg-test/ffi.h
@@ -28,7 +28,7 @@ class EvalContext {
  public:
   EvalContext(v8::Isolate* isolate, v8::Local<v8::Context> context);
 
-  EvalResult eval(::rust::Str code) const;
+  EvalResult eval(::rust::Str code, kj::Maybe<::rust::Str> resourceName) const;
   void set_global(::rust::Str name, ::workerd::rust::jsg::Local value) const;
 
   v8::Isolate* v8Isolate;

--- a/src/rust/jsg-test/lib.rs
+++ b/src/rust/jsg-test/lib.rs
@@ -45,7 +45,11 @@ mod ffi {
             callback: unsafe fn(usize /* callback */, *mut Isolate, Pin<&mut EvalContext>),
         );
 
-        pub unsafe fn eval(self: &EvalContext, code: &str) -> EvalResult;
+        pub unsafe fn eval(
+            self: &EvalContext,
+            code: &str,
+            resource_name: KjMaybe<&str>,
+        ) -> EvalResult;
         pub unsafe fn set_global(self: &EvalContext, name: &str, value: Local);
 
         /// Triggers garbage collection for testing purposes.
@@ -102,7 +106,7 @@ impl EvalContext<'_> {
         T: jsg::FromJS<ResultType = T>,
     {
         // SAFETY: self.inner is a valid EvalContext from C++; code is a valid str.
-        let result = unsafe { self.inner.eval(code) };
+        let result = unsafe { self.inner.eval(code, None.into()) };
         let opt_local: Option<v8::ffi::Local> = result.value.into();
 
         if result.success {
@@ -137,7 +141,26 @@ impl EvalContext<'_> {
     /// Useful for obtaining handles (e.g. functions) that aren't `FromJS` types.
     pub fn eval_raw(&self, code: &str) -> Result<v8::Local<'_, v8::Value>, EvalError<'_>> {
         // SAFETY: self.inner is a valid EvalContext from C++; code is a valid str.
-        let result = unsafe { self.inner.eval(code) };
+        let result = unsafe { self.inner.eval(code, None.into()) };
+        self.raw_result(result)
+    }
+
+    /// Like [`EvalContext::eval_raw`], but compiles the code with a `ScriptOrigin` whose resource
+    /// name is `resource_name`.
+    pub fn eval_raw_named(
+        &self,
+        code: &str,
+        resource_name: &str,
+    ) -> Result<v8::Local<'_, v8::Value>, EvalError<'_>> {
+        // SAFETY: self.inner is a valid EvalContext from C++; code and resource_name are valid strs.
+        let result = unsafe { self.inner.eval(code, Some(resource_name).into()) };
+        self.raw_result(result)
+    }
+
+    fn raw_result(
+        &self,
+        result: ffi::EvalResult,
+    ) -> Result<v8::Local<'_, v8::Value>, EvalError<'_>> {
         let opt_local: Option<v8::ffi::Local> = result.value.into();
 
         if result.success {


### PR DESCRIPTION
Need this for testing sourcemap support in profiler.