### PR TITLE
08-24-26 Build maintenance

### DIFF
--- a/build/BUILD.zlib
+++ b/build/BUILD.zlib
@@ -236,11 +236,13 @@ cc_library(
             "ADLER32_SIMD_SSSE3",
             "CRC32_SIMD_SSE42_PCLMUL",
             "DEFLATE_SLIDE_HASH_SSE2",
+            "DEFLATE_CHUNK_WRITE_64LE",
         ],
         "@platforms//cpu:aarch64": [
             "ADLER32_SIMD_NEON",
             "CRC32_ARMV8_CRC32",
             "DEFLATE_SLIDE_HASH_NEON",
+            "DEFLATE_CHUNK_WRITE_64LE",
         ],
     }) + select({
         ":x86_linux": ["X86_NOT_WINDOWS"],

--- a/build/deps/build_deps.jsonc
+++ b/build/deps/build_deps.jsonc
@@ -40,20 +40,15 @@
     // Node.js
     {
       "name": "aspect_rules_esbuild",
-      "type": "bazel_dep",
-      // Newer versions appear to break due to lack of sandboxing on Windows
-      "freeze_version": "0.26.0"
+      "type": "bazel_dep"
     },
     {
       "name": "aspect_rules_js",
-      "type": "bazel_dep",
-      "freeze_version": "3.1.1"
+      "type": "bazel_dep"
     },
     {
       "name": "aspect_rules_ts",
-      "type": "bazel_dep",
-      // Newer versions appear to break due to lack of sandboxing on Windows
-      "freeze_version": "3.8.11"
+      "type": "bazel_dep"
     },
     {
       "name": "rules_nodejs",

--- a/build/deps/gen/build_deps.MODULE.bazel
+++ b/build/deps/gen/build_deps.MODULE.bazel
@@ -5,19 +5,19 @@ http = use_extension("@//:build/exts/http.bzl", "http")
 git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 # abseil-cpp
-bazel_dep(name = "abseil-cpp", version = "20260526.0")
+bazel_dep(name = "abseil-cpp", version = "20260817.0")
 
 # apple_support
 bazel_dep(name = "apple_support", version = "2.8.0")
 
 # aspect_rules_esbuild
-bazel_dep(name = "aspect_rules_esbuild", version = "0.26.0")
+bazel_dep(name = "aspect_rules_esbuild", version = "0.27.0")
 
 # aspect_rules_js
-bazel_dep(name = "aspect_rules_js", version = "3.1.1")
+bazel_dep(name = "aspect_rules_js", version = "3.4.1")
 
 # aspect_rules_ts
-bazel_dep(name = "aspect_rules_ts", version = "3.8.11")
+bazel_dep(name = "aspect_rules_ts", version = "3.10.1")
 
 # bazel_lib
 bazel_dep(name = "bazel_lib", version = "3.7.1")

--- a/images/container-client-test/BUILD.bazel
+++ b/images/container-client-test/BUILD.bazel
@@ -14,6 +14,12 @@ js_image_layer(
     name = "layers",
     binary = ":app",
     root = "/",
+    # js_image_layer does not resolve runfiles symlinks properly on Windows, which makes this action
+    # fail. Since this target is only used for the Linux-only image target below, we can also
+    # constrain it to just Linux to address this.
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
 )
 
 oci_image(

--- a/src/rust/cxx/BUILD.bazel
+++ b/src/rust/cxx/BUILD.bazel
@@ -26,10 +26,7 @@ rust_library(
 rust_test(
     name = "cxx_tests",
     crate = ":cxx",
-    experimental_use_cc_common_link = select({
-        "@platforms//os:windows": 0,
-        "//conditions:default": 1,
-    }),
+    experimental_use_cc_common_link = 1,
     malloc = "//src/workerd/server:malloc",
     target_compatible_with = select({
         "@//build/config:no_build": ["@platforms//:incompatible"],
@@ -83,10 +80,7 @@ rust_binary(
     srcs = glob(["gen/cmd/src/*.rs"]),
     compile_data = ["include/cxx.h"],
     edition = "2024",
-    experimental_use_cc_common_link = select({
-        "@platforms//os:windows": 0,
-        "//conditions:default": 1,
-    }),
+    experimental_use_cc_common_link = 1,
     link_deps = ["@@//deps:rust_runtime"],
     target_compatible_with = select({
         "@//build/config:no_build": ["@platforms//:incompatible"],

--- a/src/rust/cxx/kj-rs/BUILD.bazel
+++ b/src/rust/cxx/kj-rs/BUILD.bazel
@@ -41,10 +41,7 @@ rust_test(
     name = "kj-rs_test",
     crate = "kj-rs",
     edition = "2024",
-    experimental_use_cc_common_link = select({
-        "@platforms//os:windows": 0,
-        "//conditions:default": 1,
-    }),
+    experimental_use_cc_common_link = 1,
     malloc = "//src/workerd/server:malloc",
     target_compatible_with = select({
         "@//build/config:no_build": ["@platforms//:incompatible"],

--- a/src/rust/cxx/kj-rs/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs/tests/BUILD.bazel
@@ -49,10 +49,7 @@ rust_unpretty(
 rust_test(
     name = "rust_tests",
     crate = "tests",
-    experimental_use_cc_common_link = select({
-        "@platforms//os:windows": 0,
-        "//conditions:default": 1,
-    }),
+    experimental_use_cc_common_link = 1,
     malloc = "//src/workerd/server:malloc",
     target_compatible_with = select({
         "@//build/config:no_build": ["@platforms//:incompatible"],

--- a/src/rust/cxx/tests/BUILD.bazel
+++ b/src/rust/cxx/tests/BUILD.bazel
@@ -7,10 +7,7 @@ rust_test(
     size = "small",
     srcs = ["test.rs"],
     edition = "2024",
-    experimental_use_cc_common_link = select({
-        "@platforms//os:windows": 0,
-        "//conditions:default": 1,
-    }),
+    experimental_use_cc_common_link = 1,
     malloc = "//src/workerd/server:malloc",
     target_compatible_with = select({
         "@//build/config:no_build": ["@platforms//:incompatible"],
@@ -27,10 +24,7 @@ rust_test(
     size = "small",
     srcs = ["cxx_gen.rs"],
     edition = "2024",
-    experimental_use_cc_common_link = select({
-        "@platforms//os:windows": 0,
-        "//conditions:default": 1,
-    }),
+    experimental_use_cc_common_link = 1,
     malloc = "//src/workerd/server:malloc",
     target_compatible_with = select({
         "@//build/config:no_build": ["@platforms//:incompatible"],


### PR DESCRIPTION
- Always use Rust cc_common_link
- Enable DEFLATE_CHUNK_WRITE_64LE for zlib to make compression slightly faster and match the downstream build
- Unfreeze dependencies, update non-automated protobuf

Credit for discovering that we were missing DEFLATE_CHUNK_WRITE_64LE goes to Bill Sobel. This optimization was only introduced after we started using Chromium zlib in workerd.