### PR TITLE
Honour the zstd dictionary option in node:zlib

### DIFF
--- a/src/node/internal/internal_zlib.ts
+++ b/src/node/internal/internal_zlib.ts
@@ -16,6 +16,7 @@ import {
   Zlib,
   Brotli,
   Zstd,
+  normalizeZstdOptions,
   zstdInitCParamsArray,
   zstdInitDParamsArray,
   kMaxZstdCParam,
@@ -345,26 +346,28 @@ export function zstdDecompressSync(
   data: ArrayBufferView | string,
   options: ZstdOptions = {}
 ): ZlibResult {
-  if (!options.info) {
+  const opts = normalizeZstdOptions(options);
+  if (!opts.info) {
     // Fast path, where we send the data directly to C++
-    return Buffer.from(zlibUtil.zstdDecompressSync(data, options));
+    return Buffer.from(zlibUtil.zstdDecompressSync(data, opts));
   }
 
   // Else, use the Engine class in sync mode
-  return processChunk(new ZstdDecompress(options), data);
+  return processChunk(new ZstdDecompress(opts), data);
 }
 
 export function zstdCompressSync(
   data: ArrayBufferView | string,
   options: ZstdOptions = {}
 ): ZlibResult {
-  if (!options.info) {
+  const opts = normalizeZstdOptions(options);
+  if (!opts.info) {
     // Fast path, where we send the data directly to C++
-    return Buffer.from(zlibUtil.zstdCompressSync(data, options));
+    return Buffer.from(zlibUtil.zstdCompressSync(data, opts));
   }
 
   // Else, use the Engine class in sync mode
-  return processChunk(new ZstdCompress(options), data);
+  return processChunk(new ZstdCompress(opts), data);
 }
 
 export function zstdDecompress(
@@ -376,10 +379,11 @@ export function zstdDecompress(
     optionsOrCallback,
     callbackOrUndefined
   );
+  const opts = normalizeZstdOptions(options);
 
-  if (!options.info) {
+  if (!opts.info) {
     // Fast path
-    zlibUtil.zstdDecompress(data, options, (res) => {
+    zlibUtil.zstdDecompress(data, opts, (res) => {
       queueMicrotask(() => {
         if (res instanceof Error) {
           callback(res);
@@ -392,7 +396,7 @@ export function zstdDecompress(
     return;
   }
 
-  processChunkCaptureError(new ZstdDecompress(options), data, callback);
+  processChunkCaptureError(new ZstdDecompress(opts), data, callback);
 }
 
 export function zstdCompress(
@@ -404,10 +408,11 @@ export function zstdCompress(
     optionsOrCallback,
     callbackOrUndefined
   );
+  const opts = normalizeZstdOptions(options);
 
-  if (!options.info) {
+  if (!opts.info) {
     // Fast path
-    zlibUtil.zstdCompress(data, options, (res) => {
+    zlibUtil.zstdCompress(data, opts, (res) => {
       queueMicrotask(() => {
         if (res instanceof Error) {
           callback(res);
@@ -420,7 +425,7 @@ export function zstdCompress(
     return;
   }
 
-  processChunkCaptureError(new ZstdCompress(options), data, callback);
+  processChunkCaptureError(new ZstdCompress(opts), data, callback);
 }
 export class Gzip extends Zlib {
   constructor(options: ZlibOptions) {

--- a/src/node/internal/internal_zlib_base.ts
+++ b/src/node/internal/internal_zlib_base.ts
@@ -826,6 +826,30 @@ export const kMaxZstdDParam = Math.max(
 );
 export const zstdInitDParamsArray = new Int32Array(kMaxZstdDParam + 1);
 
+// Node accepts a zstd `dictionary` as an ArrayBufferView or an ArrayBuffer, and quietly
+// ignores any other type rather than throwing (lib/zlib.js, class Zstd). Normalize here so
+// that both the stream path and the convenience functions' fast path behave the same way.
+export function normalizeZstdDictionary(
+  dictionary: ZstdOptions['dictionary']
+): ArrayBufferView | undefined {
+  if (dictionary === undefined || isArrayBufferView(dictionary)) {
+    return dictionary;
+  }
+  if (isAnyArrayBuffer(dictionary)) {
+    return new Uint8Array(dictionary);
+  }
+  return undefined;
+}
+
+// Returns `options` unchanged unless its dictionary needed normalizing, so the common case
+// allocates nothing.
+export function normalizeZstdOptions(options: ZstdOptions): ZstdOptions {
+  const dictionary = normalizeZstdDictionary(options.dictionary);
+  return dictionary === options.dictionary
+    ? options
+    : { ...options, dictionary };
+}
+
 const zstdDefaultOptions: ZlibDefaultOptions = {
   flush: CONST_ZSTD_e_continue,
   finishFlush: CONST_ZSTD_e_end,
@@ -883,7 +907,8 @@ export class Zstd extends ZlibBase {
         () => {
           queueMicrotask(processCallback.bind(handle));
         },
-        pledgedSrcSize
+        pledgedSrcSize,
+        normalizeZstdDictionary(options?.dictionary)
       )
     ) {
       throw new ERR_ZLIB_INITIALIZATION_FAILED();

--- a/src/node/internal/zlib.d.ts
+++ b/src/node/internal/zlib.d.ts
@@ -291,6 +291,10 @@ export interface ZstdOptions {
     | undefined;
   maxOutputLength?: number | undefined;
   pledgedSrcSize?: number | undefined;
+  // Declared as a view, like ZlibOptions above, though an ArrayBuffer is also accepted at
+  // runtime and any other type is ignored. See normalizeZstdDictionary() in
+  // internal_zlib_base.ts.
+  dictionary?: ArrayBufferView | undefined;
   // Not specified in NodeJS docs but the tests expect it
   info?: boolean | undefined;
 }
@@ -370,7 +374,8 @@ export class ZstdDecoder extends CompressionStream {
     params: Int32Array,
     writeResult: Uint32Array,
     writeCallback: () => void,
-    pledgedSrcSize?: number
+    pledgedSrcSize?: number,
+    dictionary?: ArrayBufferView
   ): boolean;
   params(): void;
 }
@@ -380,7 +385,8 @@ export class ZstdEncoder extends CompressionStream {
     params: Int32Array,
     writeResult: Uint32Array,
     writeCallback: () => void,
-    pledgedSrcSize?: number
+    pledgedSrcSize?: number,
+    dictionary?: ArrayBufferView
   ): boolean;
   params(): void;
 }

--- a/src/workerd/api/compression.c++
+++ b/src/workerd/api/compression.c++
@@ -603,10 +603,26 @@ ZstdEncoderContext::ZstdEncoderContext(ZlibMode _mode)
     : ZstdContext(_mode),
       cctx_(kj::disposeWith<zstdFreeCCtx>(ZSTD_createCCtx())) {}
 
-kj::Maybe<CompressionError> ZstdEncoderContext::initialize(uint64_t pledgedSrcSize) {
+kj::Maybe<CompressionError> ZstdEncoderContext::initialize(
+    uint64_t pledgedSrcSize, kj::ArrayPtr<const kj::byte> dictionary) {
   if (cctx_.get() == nullptr) {
     return CompressionError(
         "Could not initialize Zstd instance"_kj, "ERR_ZLIB_INITIALIZATION_FAILED"_kj, -1);
+  }
+
+  if (dictionary.size() > 0) {
+    // ZSTD_CCtx_loadDictionary() copies the dictionary into the context, so `dictionary` does
+    // not need to outlive this call. The content type is auto-detected: a buffer starting with
+    // the zstd dictionary magic is read as a trained dictionary, anything else as raw content.
+    // Loading is deferred until the first frame begins, so the parameters set by setParams()
+    // afterwards still apply to the dictionary's tables.
+    size_t result = ZSTD_CCtx_loadDictionary(cctx_.get(), dictionary.begin(), dictionary.size());
+    if (ZSTD_isError(result)) {
+      error_ = ZSTD_getErrorCode(result);
+      return CompressionError(
+          kj::str("Failed to load zstd dictionary: ", ZSTD_getErrorName(result)),
+          "ERR_ZLIB_DICTIONARY_LOAD_FAILED"_kj, -1);
+    }
   }
 
   if (pledgedSrcSize != ZSTD_CONTENTSIZE_UNKNOWN) {
@@ -674,12 +690,28 @@ ZstdDecoderContext::ZstdDecoderContext(ZlibMode _mode)
     : ZstdContext(_mode),
       dctx_(kj::disposeWith<zstdFreeDCtx>(ZSTD_createDCtx())) {}
 
-kj::Maybe<CompressionError> ZstdDecoderContext::initialize() {
+kj::Maybe<CompressionError> ZstdDecoderContext::initialize(
+    kj::ArrayPtr<const kj::byte> dictionary) {
   // dctx_ is created in the constructor. It can only be nullptr if ZSTD_createDCtx()
   // failed due to memory allocation failure.
   if (dctx_.get() == nullptr) {
     return CompressionError(
         "Could not initialize Zstd instance"_kj, "ERR_ZLIB_INITIALIZATION_FAILED"_kj, -1);
+  }
+
+  if (dictionary.size() > 0) {
+    // As with the encoder, the bytes are copied into the context and the content type is
+    // auto-detected. Note that a raw-content dictionary carries no dictionary ID, so reading a
+    // frame written against a different one is not rejected as ZSTD_error_dictionary_wrong: it
+    // fails as corrupt, or decodes to different bytes if the frame carries no checksum. That is
+    // zstd's behaviour and matches what Node does with the same calls.
+    size_t result = ZSTD_DCtx_loadDictionary(dctx_.get(), dictionary.begin(), dictionary.size());
+    if (ZSTD_isError(result)) {
+      error_ = ZSTD_getErrorCode(result);
+      return CompressionError(
+          kj::str("Failed to load zstd dictionary: ", ZSTD_getErrorName(result)),
+          "ERR_ZLIB_DICTIONARY_LOAD_FAILED"_kj, -1);
+    }
   }
 
   return kj::none;

--- a/src/workerd/api/compression.h
+++ b/src/workerd/api/compression.h
@@ -455,7 +455,8 @@ class ZstdContext {
     jsg::Optional<jsg::Dict<int>> params;
     jsg::Optional<kj::uint> maxOutputLength;
     jsg::Optional<uint64_t> pledgedSrcSize;
-    JSG_STRUCT(flush, finishFlush, chunkSize, params, maxOutputLength, pledgedSrcSize);
+    jsg::Optional<kj::Array<kj::byte>> dictionary;
+    JSG_STRUCT(flush, finishFlush, chunkSize, params, maxOutputLength, pledgedSrcSize, dictionary);
   };
 
  protected:
@@ -474,7 +475,11 @@ class ZstdEncoderContext final: public ZstdContext {
   KJ_DISALLOW_COPY_AND_MOVE(ZstdEncoderContext);
 
   void work();
-  kj::Maybe<CompressionError> initialize(uint64_t pledgedSrcSize);
+  // An empty `dictionary` means no dictionary, matching Node.js, which passes an empty
+  // std::string_view for the same case. The bytes are copied into the context, so the
+  // caller does not need to keep them alive.
+  kj::Maybe<CompressionError> initialize(
+      uint64_t pledgedSrcSize, kj::ArrayPtr<const kj::byte> dictionary = nullptr);
   kj::Maybe<CompressionError> resetStream();
   kj::Maybe<CompressionError> setParams(int key, int value);
   kj::Maybe<CompressionError> getError() const;
@@ -495,7 +500,8 @@ class ZstdDecoderContext final: public ZstdContext {
   KJ_DISALLOW_COPY_AND_MOVE(ZstdDecoderContext);
 
   void work();
-  kj::Maybe<CompressionError> initialize();
+  // See the note on ZstdEncoderContext::initialize() regarding `dictionary`.
+  kj::Maybe<CompressionError> initialize(kj::ArrayPtr<const kj::byte> dictionary = nullptr);
   kj::Maybe<CompressionError> resetStream();
   kj::Maybe<CompressionError> setParams(int key, int value);
   kj::Maybe<CompressionError> getError() const;

--- a/src/workerd/api/node/tests/zlib-zstd-nodejs-test.js
+++ b/src/workerd/api/node/tests/zlib-zstd-nodejs-test.js
@@ -446,3 +446,225 @@ export const zstdStreamLargeDecompressTest = {
     );
   },
 };
+
+// The dictionary tests below share this pair. `input` repeats phrases that appear in
+// `dictionary`, so a dictionary-aware encoder can reference them instead of emitting them,
+// which is what makes the size assertions meaningful.
+const DICTIONARY = Buffer.from(
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' +
+    'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ' +
+    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.'
+);
+
+const DICT_INPUT =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' +
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' +
+  'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ' +
+  'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum.';
+
+// A dictionary must shrink the output and must round-trip.
+export const zstdDictionarySyncTest = {
+  test() {
+    const input = Buffer.from(DICT_INPUT);
+    const plain = zlib.zstdCompressSync(input);
+    const withDict = zlib.zstdCompressSync(input, { dictionary: DICTIONARY });
+
+    assert(
+      withDict.length < plain.length,
+      `Dictionary should shrink the output, got ${withDict.length} with and ` +
+        `${plain.length} without`
+    );
+
+    const decompressed = zlib.zstdDecompressSync(withDict, {
+      dictionary: DICTIONARY,
+    });
+    assert.strictEqual(
+      decompressed.toString(),
+      input.toString(),
+      'Dictionary round-trip should match'
+    );
+  },
+};
+
+// Compressing a buffer against itself is the sharpest form of the size check: every byte of
+// the input is already in the dictionary, so the frame collapses to a few bytes. This is the
+// feature-detect that a caller has to resort to when the option is silently dropped.
+export const zstdDictionaryCollapseTest = {
+  test() {
+    const input = Buffer.from(
+      'the quick brown fox jumps over the lazy dog '.repeat(200)
+    );
+    const params = { [zlib.constants.ZSTD_c_compressionLevel]: 19 };
+
+    const none = zlib.zstdCompressSync(input, { params });
+    const good = zlib.zstdCompressSync(input, { dictionary: input, params });
+
+    assert(
+      good.length < none.length / 2,
+      `Self-dictionary should collapse the frame, got ${good.length} against ${none.length}`
+    );
+
+    // Parameters are applied after the dictionary is loaded, so this also proves the
+    // compression level still reaches the encoder.
+    const level1 = zlib.zstdCompressSync(input, {
+      dictionary: input,
+      params: { [zlib.constants.ZSTD_c_compressionLevel]: 1 },
+    });
+    assert.strictEqual(
+      zlib.zstdDecompressSync(good, { dictionary: input }).toString(),
+      input.toString(),
+      'Self-dictionary round-trip should match'
+    );
+    assert.strictEqual(
+      zlib.zstdDecompressSync(level1, { dictionary: input }).toString(),
+      input.toString(),
+      'Self-dictionary round-trip at level 1 should match'
+    );
+  },
+};
+
+// Buffer, TypedArray, DataView and ArrayBuffer all name the same bytes and must behave
+// identically. Mirrors Node's test/parallel/test-zlib-zstd-dictionary.js.
+export const zstdDictionaryTypesTest = {
+  test() {
+    const input = Buffer.from(DICT_INPUT);
+    const baseline = zlib.zstdCompressSync(input, {
+      dictionary: DICTIONARY,
+    }).length;
+
+    const arrayBuffer = DICTIONARY.buffer.slice(
+      DICTIONARY.byteOffset,
+      DICTIONARY.byteOffset + DICTIONARY.byteLength
+    );
+    const uint8 = new Uint8Array(arrayBuffer);
+    const dataView = new DataView(arrayBuffer);
+
+    for (const dictionary of [arrayBuffer, uint8, dataView]) {
+      const compressed = zlib.zstdCompressSync(input, { dictionary });
+      assert.strictEqual(
+        compressed.length,
+        baseline,
+        'Every dictionary representation should compress identically'
+      );
+      assert.strictEqual(
+        zlib.zstdDecompressSync(compressed, { dictionary }).toString(),
+        input.toString(),
+        'Every dictionary representation should decompress identically'
+      );
+    }
+  },
+};
+
+// Node ignores a dictionary that is neither an ArrayBufferView nor an ArrayBuffer rather
+// than throwing, on both the fast path and the stream path.
+export const zstdDictionaryIgnoredTypeTest = {
+  test() {
+    const input = Buffer.from(DICT_INPUT);
+    const plain = zlib.zstdCompressSync(input).length;
+
+    assert.strictEqual(
+      zlib.zstdCompressSync(input, { dictionary: 'not a buffer' }).length,
+      plain,
+      'A non-buffer dictionary should be ignored'
+    );
+    assert.strictEqual(
+      zlib.zstdCompressSync(input, { dictionary: 'not a buffer', info: true })
+        .buffer.length,
+      plain,
+      'A non-buffer dictionary should be ignored on the stream path too'
+    );
+  },
+};
+
+// A frame written with a dictionary cannot be read without it. The checksum is enabled so
+// that the mismatch is always detected rather than left to chance.
+export const zstdDictionaryMismatchTest = {
+  test() {
+    const input = Buffer.from(DICT_INPUT);
+    const other = Buffer.from('completely unrelated filler bytes '.repeat(20));
+    const compressed = zlib.zstdCompressSync(input, {
+      dictionary: DICTIONARY,
+      params: { [zlib.constants.ZSTD_c_checksumFlag]: 1 },
+    });
+
+    assert.throws(
+      () => zlib.zstdDecompressSync(compressed),
+      (err) => err instanceof Error,
+      'Decompressing without the dictionary should fail'
+    );
+    assert.throws(
+      () => zlib.zstdDecompressSync(compressed, { dictionary: other }),
+      (err) => err instanceof Error,
+      'Decompressing with the wrong dictionary should fail'
+    );
+  },
+};
+
+// The async convenience functions take the same option.
+export const zstdDictionaryAsyncTest = {
+  async test() {
+    const input = Buffer.from(DICT_INPUT);
+
+    const compressed = await new Promise((resolve, reject) => {
+      zlib.zstdCompress(input, { dictionary: DICTIONARY }, (err, res) => {
+        if (err) reject(err);
+        else resolve(res);
+      });
+    });
+
+    assert(
+      compressed.length < zlib.zstdCompressSync(input).length,
+      'Async compression should honour the dictionary'
+    );
+
+    const decompressed = await new Promise((resolve, reject) => {
+      zlib.zstdDecompress(
+        compressed,
+        { dictionary: DICTIONARY },
+        (err, res) => {
+          if (err) reject(err);
+          else resolve(res);
+        }
+      );
+    });
+
+    assert.strictEqual(
+      decompressed.toString(),
+      input.toString(),
+      'Async dictionary round-trip should match'
+    );
+  },
+};
+
+// And so do the streams, where the dictionary reaches the context through initialize().
+export const zstdDictionaryStreamTest = {
+  async test() {
+    const input = Buffer.from(DICT_INPUT);
+
+    const compress = zlib.createZstdCompress({ dictionary: DICTIONARY });
+    compress.end(input);
+    const compressedChunks = [];
+    for await (const chunk of compress) {
+      compressedChunks.push(chunk);
+    }
+    const compressed = Buffer.concat(compressedChunks);
+
+    assert(
+      compressed.length < zlib.zstdCompressSync(input).length,
+      'Stream compression should honour the dictionary'
+    );
+
+    const decompress = zlib.createZstdDecompress({ dictionary: DICTIONARY });
+    decompress.end(compressed);
+    const decompressedChunks = [];
+    for await (const chunk of decompress) {
+      decompressedChunks.push(chunk);
+    }
+
+    assert.strictEqual(
+      Buffer.concat(decompressedChunks).toString(),
+      input.toString(),
+      'Stream dictionary round-trip should match'
+    );
+  },
+};

--- a/src/workerd/api/node/zlib-util.c++
+++ b/src/workerd/api/node/zlib-util.c++
@@ -669,16 +669,21 @@ bool ZlibUtil::ZstdCompressionStream<CompressionContext>::initialize(jsg::Lock& 
     jsg::JsArrayBufferView params,
     jsg::JsArrayBufferView writeResult,
     jsg::Function<void()> writeCallback,
-    jsg::Optional<uint64_t> pledgedSrcSize) {
+    jsg::Optional<uint64_t> pledgedSrcSize,
+    jsg::Optional<kj::Array<kj::byte>> dictionary) {
   this->initializeStream(js, writeResult, kj::mv(writeCallback));
 
   uint64_t srcSize = pledgedSrcSize.orDefault(ZSTD_CONTENTSIZE_UNKNOWN);
+  kj::ArrayPtr<const kj::byte> dict = nullptr;
+  KJ_IF_SOME(d, dictionary) {
+    dict = d.asPtr();
+  }
 
   kj::Maybe<CompressionError> maybeError;
   if constexpr (CompressionContext::Mode == ZlibMode::ZSTD_ENCODE) {
-    maybeError = this->context()->initialize(srcSize);
+    maybeError = this->context()->initialize(srcSize, dict);
   } else {
-    maybeError = this->context()->initialize();
+    maybeError = this->context()->initialize(dict);
   }
 
   KJ_IF_SOME(err, maybeError) {
@@ -900,13 +905,18 @@ kj::Array<kj::byte> ZlibUtil::zstdSync(jsg::Lock& js, InputSource data, ZstdCont
   GrowableBuffer result(ZLIB_PERFORMANT_CHUNK_SIZE, maxOutputLength);
 
   // Initialize the context
+  kj::ArrayPtr<const kj::byte> dictionary = nullptr;
+  KJ_IF_SOME(d, opts.dictionary) {
+    dictionary = d.asPtr();
+  }
+
   if constexpr (Context::Mode == ZlibMode::ZSTD_ENCODE) {
     uint64_t pledgedSrcSize = opts.pledgedSrcSize.orDefault(ZSTD_CONTENTSIZE_UNKNOWN);
-    KJ_IF_SOME(err, ctx.initialize(pledgedSrcSize)) {
+    KJ_IF_SOME(err, ctx.initialize(pledgedSrcSize, dictionary)) {
       JSG_FAIL_REQUIRE(Error, err.message);
     }
   } else {
-    KJ_IF_SOME(err, ctx.initialize()) {
+    KJ_IF_SOME(err, ctx.initialize(dictionary)) {
       JSG_FAIL_REQUIRE(Error, err.message);
     }
   }

--- a/src/workerd/api/node/zlib-util.h
+++ b/src/workerd/api/node/zlib-util.h
@@ -333,7 +333,8 @@ class ZlibUtil final: public jsg::Object {
         jsg::JsArrayBufferView params,
         jsg::JsArrayBufferView writeResult,
         jsg::Function<void()> writeCallback,
-        jsg::Optional<uint64_t> pledgedSrcSize);
+        jsg::Optional<uint64_t> pledgedSrcSize,
+        jsg::Optional<kj::Array<kj::byte>> dictionary);
 
     void params() {
       // Currently a no-op, and not accessed from JS land.


### PR DESCRIPTION
Fixes #6967.

`node:zlib`'s zstd functions accept a `dictionary` option and drop it. On compress that is
silent, because a frame compressed without a dictionary decodes fine with one, so the only
signal is a byte count that never shrank. On decompress it surfaces as
`Zstd decompression failed: Data corruption detected` against bytes that are not corrupt.

This wires `ZSTD_CCtx_loadDictionary` / `ZSTD_DCtx_loadDictionary` into the bindings from
#6007, following Node's own implementation
([nodejs/node@201304537e](https://github.com/nodejs/node/commit/201304537e), nodejs/node#59240).

### What changed

**C++.** `ZstdContext::Options` gains `dictionary`, and both `initialize()` overloads take a
`kj::ArrayPtr<const kj::byte>` whose empty case means no dictionary, which is how Node passes
the same thing. A load failure returns `ERR_ZLIB_DICTIONARY_LOAD_FAILED`, matching Node's error
code. The option reaches the convenience functions through `zstdSync()` and the streams through
`ZstdCompressionStream::initialize()`.

**TypeScript.** One helper normalizes the option for both the stream class and the four
convenience functions, so the fast path and the `info: true` path agree.

### Three details worth a reviewer's eye

**Parameter order.** `ZSTD_CCtx_loadDictionary` defers building the dictionary's tables until
the first frame begins, so the `setParams` loop that runs after `initialize()` still applies to
them. Measured against zstd 1.5.7 with this exact call order (create, load dictionary, set
level, `ZSTD_compressStream2`) on the issue's 8800-byte input: 63 bytes with no dictionary, 19
with the right one, and 63 with a wrong one, which are the numbers Node produces.
`zstdDictionaryCollapseTest` pins it by round-tripping one dictionary at level 19 and again at
level 1.

**Dictionary content type.** Both calls auto-detect: a buffer starting with the zstd dictionary
magic is read as a trained dictionary and anything else as raw content. That is what lets a
Worker participate in [RFC 9842](https://www.rfc-editor.org/rfc/rfc9842.html) Compression
Dictionary Transport, whose dictionaries are raw bytes, and it is the behaviour Node has.

**Wrong types are ignored rather than rejected.** Node accepts an ArrayBufferView or an
ArrayBuffer for zstd and quietly ignores any other type, unlike its zlib and brotli paths which
throw `ERR_INVALID_ARG_TYPE` (`lib/zlib.js`, class `Zstd`). I matched Node rather than
tightening it, since the convenience functions hand the options object straight to JSG, which
would otherwise throw a `TypeError` on a value Node accepts silently. Say the word if you would
rather have `ERR_INVALID_ARG_TYPE` on both paths and I will change it.

### Tests

Seven cases added to `zlib-zstd-nodejs-test.js`:

- a dictionary shrinks the output and round-trips
- compressing a buffer against itself collapses the frame, at two compression levels
- Buffer, Uint8Array, DataView and ArrayBuffer all behave identically (mirrors Node's
  `test/parallel/test-zlib-zstd-dictionary.js`)
- a non-buffer dictionary is ignored on both paths (this one passes on `main` too, since the
  option is dropped there; it guards the behaviour rather than the fix)
- a frame written with a dictionary fails to decode without it, and with the wrong one
- the async convenience functions honour it
- `createZstdCompress` / `createZstdDecompress` honour it

The mismatch test sets `ZSTD_c_checksumFlag` deliberately. A raw-content dictionary carries no
dictionary ID, so without a checksum, decoding that frame against a different dictionary
returns 8800 bytes of wrong data rather than an error (measured). With the checksum it is
`Restored data doesn't match checksum`, and decoding with no dictionary at all is
`Data corruption detected` either way.

### What I ran, and what I could not

Ran and green: `//src/workerd/api:compression` (the C++ carrying the zstd calls),
`//src/node:node@tsproject`, `//src/workerd/api/node/tests:zlib-zstd-nodejs-test@eslint`, plus
the standalone zstd measurements above.

Could not run: the test target itself, and therefore the `zlib-util.c++` plumbing. My machine
only has the beta Xcode, and its `ld` produces Rust proc-macro dylibs that the same machine's
dyld refuses to load (`mis-aligned LINKEDIT string pool`), so every `[for tool]` Rust crate
fails and the capnp codegen those tools drive cannot run. That is an Apple toolchain problem
rather than anything in this branch, and neither `-ld_classic` nor re-signing the dylib got past
it. Flagging it rather than implying a full local run: if CI turns something up I will fix it
promptly.

### Not in this PR

`BrotliContext::Options` has no `dictionary` field either, and
`BrotliCompressionStream::initialize()` takes no dictionary argument, so brotli drops the option
the same way. Node supports it there through `BrotliEncoderAttachPreparedDictionary`. Happy to
follow up with that separately if you want it.
