### PR TITLE
Fix off-by-one and macro impls for TypedArray 

### DIFF
--- a/src/rust/jsg-test/tests/local_cast.rs
+++ b/src/rust/jsg-test/tests/local_cast.rs
@@ -444,3 +444,25 @@ fn array_object_roundtrip() {
         Ok(())
     });
 }
+
+/// A `DataView` is an `ArrayBufferView` but not a `TypedArray`; the downcast
+/// `From<Local<Value>> for Local<TypedArray>` should reject it.
+#[test]
+fn data_view_cannot_cast_to_typed_array() {
+    let harness = crate::Harness::new();
+    harness.run_in_context(|_lock, ctx| {
+        let val = ctx.eval_raw("new DataView(new ArrayBuffer(8))").unwrap();
+        assert!(val.is_array_buffer_view());
+        assert!(!val.is_typed_array());
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ta: v8::Local<v8::TypedArray> = val.clone().into();
+        }));
+        assert!(
+            result.is_err(),
+            "DataView must not cast to Local<TypedArray>"
+        );
+
+        Ok(())
+    });
+}

--- a/src/rust/jsg/ffi.c++
+++ b/src/rust/jsg/ffi.c++
@@ -238,6 +238,10 @@ bool local_is_uint8clamped_array(const Local& val) {
   return local_as_ref_from_ffi<v8::Value>(val)->IsUint8ClampedArray();
 }
 
+bool local_is_typed_array(const Local& val) {
+  return local_as_ref_from_ffi<v8::Value>(val)->IsTypedArray();
+}
+
 bool local_is_array_buffer(const Local& val) {
   return local_as_ref_from_ffi<v8::Value>(val)->IsArrayBuffer();
 }

--- a/src/rust/jsg/ffi.h
+++ b/src/rust/jsg/ffi.h
@@ -131,6 +131,7 @@ bool local_is_bigint64_array(const Local& val);
 bool local_is_biguint64_array(const Local& val);
 bool local_is_float16_array(const Local& val);
 bool local_is_uint8clamped_array(const Local& val);
+bool local_is_typed_array(const Local& val);
 bool local_is_array_buffer(const Local& val);
 bool local_is_array_buffer_view(const Local& val);
 bool local_is_shared_array_buffer(const Local& val);

--- a/src/rust/jsg/v8.rs
+++ b/src/rust/jsg/v8.rs
@@ -3144,7 +3144,7 @@ impl<'a> FunctionCallbackInfo<'a> {
     }
 
     pub fn get(&self, index: usize) -> Local<'a, Value> {
-        debug_assert!(index <= self.len(), "index out of bounds");
+        debug_assert!(index < self.len(), "index out of bounds");
         // SAFETY: self.0 is a valid FunctionCallbackInfo pointer (guaranteed by constructor).
         unsafe { Local::from_ffi(self.isolate(), ffi::fci_get_arg(self.0, index)) }
     }

--- a/src/rust/jsg/v8.rs
+++ b/src/rust/jsg/v8.rs
@@ -283,6 +283,7 @@ pub mod ffi {
         pub unsafe fn local_is_biguint64_array(value: &Local) -> bool;
         pub unsafe fn local_is_float16_array(value: &Local) -> bool;
         pub unsafe fn local_is_uint8clamped_array(value: &Local) -> bool;
+        pub unsafe fn local_is_typed_array(value: &Local) -> bool;
         pub unsafe fn local_is_array_buffer(value: &Local) -> bool;
         pub unsafe fn local_is_array_buffer_view(value: &Local) -> bool;
         pub unsafe fn local_is_shared_array_buffer(value: &Local) -> bool;
@@ -1320,6 +1321,12 @@ impl<'a, T> Local<'a, T> {
         unsafe { ffi::local_is_array_buffer_view(&self.handle) }
     }
 
+    /// Returns true if the value is a `TypedArray`
+    pub fn is_typed_array(&self) -> bool {
+        // SAFETY: handle is valid within the current HandleScope.
+        unsafe { ffi::local_is_typed_array(&self.handle) }
+    }
+
     /// Returns true if the value is a `SharedArrayBuffer`.
     pub fn is_shared_array_buffer(&self) -> bool {
         // SAFETY: handle is valid within the current HandleScope.
@@ -1536,11 +1543,7 @@ impl_local_cast!(Float64Array -> Value, is_float64_array);
 impl_local_cast!(BigInt64Array -> Value, is_bigint64_array);
 impl_local_cast!(BigUint64Array -> Value, is_biguint64_array);
 impl_local_cast!(Uint8ClampedArray -> Value, is_uint8clamped_array);
-
-// TypedArray base type to Value. Uses `is_array_buffer_view` which also matches
-// `DataView`, but this is acceptable because `TypedArray` is only constructed from
-// concrete typed array types (Uint8Array, etc.) that are always ArrayBufferViews.
-impl_local_cast!(TypedArray -> Value, is_array_buffer_view);
+impl_local_cast!(TypedArray -> Value, is_typed_array);
 
 // Concrete typed arrays to TypedArray base
 impl_local_cast!(Uint8Array -> TypedArray, is_uint8_array);
@@ -1558,7 +1561,7 @@ impl_local_cast!(Uint8ClampedArray -> TypedArray, is_uint8clamped_array);
 // Upcasts to Object (Function, Array, TypedArray are all Object subtypes in V8)
 impl_local_cast!(Function -> Object, is_function);
 impl_local_cast!(Array -> Object, is_array);
-impl_local_cast!(TypedArray -> Object, is_array_buffer_view);
+impl_local_cast!(TypedArray -> Object, is_typed_array);
 
 // ArrayBuffer <-> Value, ArrayBuffer <-> Object
 impl_local_cast!(ArrayBuffer -> Value, is_array_buffer);


### PR DESCRIPTION
Access beyond bounds is just undefined, but for both of the changes correctness is best.