### PR TITLE
WO-1582 Add tracing getActiveSpan

### DIFF
--- a/src/cloudflare/internal/test/instrumentation-test-helper.js
+++ b/src/cloudflare/internal/test/instrumentation-test-helper.js
@@ -16,11 +16,12 @@ import * as assert from 'node:assert';
 /**
  * Creates module-level state for instrumentation tests.
  * This mirrors the original test pattern with module-level variables.
- * @returns {Object} State object with invocationPromises and spans
+ * @returns {Object} State object with invocationPromises, invocations, and spans
  */
 export function createInstrumentationState() {
   return {
     invocationPromises: [],
+    invocations: new Map(),
     spans: new Map(),
   };
 }
@@ -31,7 +32,7 @@ export function createInstrumentationState() {
  * @returns {Function} The tailStream handler function
  */
 export function createTailStreamHandler(state) {
-  return (event, env, ctx) => {
+  return (onset, env, ctx) => {
     // For each "onset" event, store a promise which we will resolve when
     // we receive the equivalent "outcome" event
     let resolveFn;
@@ -40,6 +41,15 @@ export function createTailStreamHandler(state) {
         resolveFn = resolve;
       })
     );
+
+    const invocation = {
+      invocationId: onset.invocationId,
+      rootSpanId: onset.event.spanId,
+      onset: onset.event,
+      attributes: [],
+      attributeEvents: [],
+    };
+    state.invocations.set(onset.invocationId, invocation);
 
     // Accumulate the span info for easier testing
     return (event) => {
@@ -50,11 +60,23 @@ export function createTailStreamHandler(state) {
           state.spans.set(spanKey, { name: event.event.name });
           break;
         case 'attributes': {
-          let span = state.spans.get(spanKey);
-          for (let { name, value } of event.event.info) {
+          for (const { name, value } of event.event.info) {
+            invocation.attributeEvents.push({
+              spanId: event.spanContext.spanId,
+              name,
+              value,
+            });
+          }
+          if (event.spanContext.spanId === invocation.rootSpanId) {
+            invocation.attributes.push(...event.event.info);
+            break;
+          }
+
+          const span = state.spans.get(spanKey);
+          if (!span) break;
+          for (const { name, value } of event.event.info) {
             span[name] = value;
           }
-          state.spans.set(spanKey, span);
           break;
         }
         case 'spanClose': {
@@ -64,6 +86,7 @@ export function createTailStreamHandler(state) {
           break;
         }
         case 'outcome':
+          invocation.outcome = event.event;
           resolveFn();
           break;
       }
@@ -235,8 +258,9 @@ export function createTailStreamCollector() {
 
   const tailStream = createTailStreamHandler(state);
 
-  let spans = state.spans;
-  let invocationPromises = state.invocationPromises;
+  const spans = state.spans;
+  const invocations = state.invocations;
+  const invocationPromises = state.invocationPromises;
   const waitForCompletion = () => {
     return Promise.allSettled(invocationPromises);
   };
@@ -244,6 +268,7 @@ export function createTailStreamCollector() {
   return {
     tailStream,
     waitForCompletion,
+    invocations,
     spans,
   };
 }

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
@@ -21,6 +21,10 @@ export const validateSpans = {
     // Get all spans and prepare for validation
     const allSpans = collector.spans.values();
     const spansByTest = groupSpansBy(allSpans, 'test');
+    const invocations = [...collector.invocations.values()];
+    const rootAttributes = invocations.flatMap(
+      (invocation) => invocation.attributes
+    );
 
     // Core tests that validate withSpan produces a correctly-closed span of the given name.
     const testValidations = [
@@ -44,6 +48,7 @@ export const validateSpans = {
         test: 'publicImportStartSpan',
         expectedSpan: 'public-start-span-op',
       },
+      { test: 'getActiveSpan', expectedSpan: 'get-active-span-op' },
       { test: 'ctxTracing', expectedSpan: 'ctx-tracing-op' },
       {
         test: 'detachedSpanEndsAfterStreamDrain',
@@ -118,6 +123,30 @@ export const validateSpans = {
       assert(span, 'startActiveSpanSyncThrow: span present');
       assert.strictEqual(span['after.throw'], true);
       assert(span.closed, 'Manual throw span should be explicitly closed');
+    }
+
+    assert.deepStrictEqual(
+      rootAttributes.find(({ name }) => name === 'test'),
+      { name: 'test', value: 'getActiveSpanInvocation' }
+    );
+
+    for (const requestName of ['a', 'b']) {
+      const request = invocations.find(
+        (invocation) =>
+          invocation.onset.executionModel === 'durableObject' &&
+          invocation.onset.entrypoint === 'OverlappingRequestsObject' &&
+          new URL(invocation.onset.info.url).pathname === `/${requestName}`
+      );
+      assert(
+        request,
+        `Missing tail trace for overlapping request ${requestName}`
+      );
+      assert.deepStrictEqual(
+        request.attributeEvents
+          .filter(({ name }) => name === 'overlapping.request')
+          .map(({ spanId, value }) => ({ spanId, value })),
+        [{ spanId: request.rootSpanId, value: requestName }]
+      );
     }
 
     // setAttributes should record each supported value and ignore undefined values.

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
@@ -3,7 +3,75 @@
 //     https://opensource.org/licenses/Apache-2.0
 
 import assert from 'node:assert';
-import { tracing as publicTracing } from 'cloudflare:workers';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { DurableObject, tracing as publicTracing } from 'cloudflare:workers';
+
+assert.strictEqual(publicTracing.getActiveSpan(), undefined);
+const getActiveSpanOutsideInvocationContext = AsyncLocalStorage.bind(() =>
+  publicTracing.getActiveSpan()
+);
+
+// Overlapping Durable Object requests share an IoContext, but each async continuation must retain
+// its originating request's tracing state. This verifies that request A resuming while request B is
+// current cannot write A's invocation-span attributes into B's tail trace.
+export class OverlappingRequestsObject extends DurableObject {
+  constructor(ctx, env) {
+    super(ctx, env);
+    this.firstCanResume = new Promise((resolve) => {
+      this.resumeFirst = resolve;
+    });
+    this.firstAttributed = new Promise((resolve) => {
+      this.resolveFirstAttributed = resolve;
+    });
+  }
+
+  async fetch(request) {
+    const requestName = new URL(request.url).pathname.slice(1);
+
+    if (requestName === 'a') {
+      this.firstIsWaiting = true;
+      return new Response(
+        new ReadableStream({
+          pull: async (controller) => {
+            controller.enqueue(new TextEncoder().encode('ready'));
+            await this.firstCanResume;
+            const span = publicTracing.getActiveSpan();
+            assert(span);
+            assert.strictEqual(span.isTraced, true);
+            span.setAttribute('overlapping.request', 'a');
+            this.resolveFirstAttributed();
+            controller.close();
+          },
+        })
+      );
+    }
+
+    assert.strictEqual(this.firstIsWaiting, true);
+    const span = publicTracing.getActiveSpan();
+    assert(span);
+    assert.strictEqual(span.isTraced, true);
+    span.setAttribute('overlapping.request', 'b');
+    this.resumeFirst();
+    await this.firstAttributed;
+    return new Response('b');
+  }
+}
+
+export const overlappingDurableObjectRequests = {
+  async test(ctrl, env) {
+    const id = env.overlappingRequests.idFromName('test');
+    const stub = env.overlappingRequests.get(id);
+    const first = await stub.fetch('https://example.com/a');
+    const firstReader = first.body.getReader();
+    const ready = await firstReader.read();
+    assert.strictEqual(ready.done, false);
+    assert.strictEqual(new TextDecoder().decode(ready.value), 'ready');
+    const second = await stub.fetch('https://example.com/b');
+    const [firstEnd] = await Promise.all([firstReader.read(), second.text()]);
+    assert.strictEqual(firstEnd.done, true);
+    assert.deepStrictEqual([first.status, second.status], [200, 200]);
+  },
+};
 
 export const syncFunction = {
   async test(ctrl, env, ctx) {
@@ -248,6 +316,32 @@ export const publicImportStartSpan = {
     assert.strictEqual(span.isTraced, true);
     span.end();
     assert.strictEqual(span.isTraced, false);
+  },
+};
+
+export const getActiveSpan = {
+  async test(ctrl, env, ctx) {
+    const invocationSpan = publicTracing.getActiveSpan();
+    assert.ok(invocationSpan);
+    // All the ways to get the active span should return the same reference
+    assert.strictEqual(publicTracing.getActiveSpan(), invocationSpan);
+    assert.strictEqual(ctx.tracing.getActiveSpan(), invocationSpan);
+    assert.strictEqual(getActiveSpanOutsideInvocationContext(), undefined);
+    assert.strictEqual(invocationSpan.isTraced, true);
+    // This is ignored since we control the lifecycle
+    invocationSpan.end();
+    assert.strictEqual(invocationSpan.isTraced, true);
+    invocationSpan.setAttribute('test', 'getActiveSpanInvocation');
+
+    await ctx.tracing.startActiveSpan('get-active-span-op', async (span) => {
+      assert.strictEqual(publicTracing.getActiveSpan(), span);
+      await Promise.resolve();
+      assert.strictEqual(publicTracing.getActiveSpan(), span);
+      span.setAttribute('test', 'getActiveSpan');
+      span.end();
+    });
+
+    assert.strictEqual(publicTracing.getActiveSpan(), invocationSpan);
   },
 };
 

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.wd-test
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.wd-test
@@ -13,12 +13,23 @@ const unitTests :Workerd.Config = (
           "transformstream_enable_standard_constructor"
         ],
         streamingTails = ["tail"],
+        durableObjectNamespaces = [
+          (
+            className = "OverlappingRequestsObject",
+            uniqueKey = "tracing-helpers-overlapping-requests"
+          )
+        ],
+        durableObjectStorage = (inMemory = void),
         bindings = [
           (
             name = "tracingTest",
             wrapped = (
               moduleName = "cloudflare-internal:test-tracing-wrapper"
             )
+          ),
+          (
+            name = "overlappingRequests",
+            durableObjectNamespace = "OverlappingRequestsObject"
           )
         ],
       )

--- a/src/cloudflare/internal/tracing.d.ts
+++ b/src/cloudflare/internal/tracing.d.ts
@@ -82,6 +82,10 @@ declare const tracing: {
   // Callers must invoke `span.end()` explicitly.
   startSpan(name: string): Span;
 
+  // Returns the span associated with the current async context. Returns undefined
+  // outside an invocation or when execution is detached into the root async context.
+  getActiveSpan(): Span | undefined;
+
   // The `Span` class is exposed as a nested type so callers can reference the type via
   // `InstanceType<typeof tracing.Span>` (see `tracing-helpers.ts`).
   readonly Span: typeof Span;

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -173,6 +173,81 @@ class UserSpanState final: public SpanState {
   workerd::SpanBuilder builder;
 };
 
+class InvocationSpanState final: public SpanState {
+ public:
+  InvocationSpanState(workerd::SpanParent parent,
+      kj::Maybe<kj::Own<BaseTracer::WeakRef>> tracer,
+      kj::Maybe<tracing::InvocationSpanContext> context)
+      : parent(kj::mv(parent)),
+        tracer(kj::mv(tracer)),
+        context(kj::mv(context)) {}
+
+  // We should treat span.end() as a no-op for the invocation span because
+  // this lifecycle is controlled by the runtime.
+  void end() override {}
+
+  bool getIsTraced() override {
+    if (context != kj::none && parent.isObserved()) {
+      KJ_IF_SOME(value, tracer) {
+        return value->runIfAlive([](BaseTracer&) {});
+      }
+    }
+    return false;
+  }
+
+  workerd::SpanParent makeSpanParent() override {
+    return parent.addRef();
+  }
+
+ protected:
+  bool canRecordAttributes() override {
+    return getIsTraced();
+  }
+
+  void recordAttribute(kj::String key, TagValue value) override {
+    KJ_IF_SOME(valueContext, context) {
+      KJ_IF_SOME(valueTracer, tracer) {
+        valueTracer->runIfAlive([&](BaseTracer& tracer) {
+          KJ_SWITCH_ONEOF(value) {
+            KJ_CASE_ONEOF(b, bool) {
+              tracer.addSpanAttribute(valueContext, kj::ConstString(kj::mv(key)), b);
+            }
+            KJ_CASE_ONEOF(d, double) {
+              tracer.addSpanAttribute(valueContext, kj::ConstString(kj::mv(key)), d);
+            }
+            KJ_CASE_ONEOF(s, kj::String) {
+              tracer.addSpanAttribute(
+                  valueContext, kj::ConstString(kj::mv(key)), kj::ConstString(kj::mv(s)));
+            }
+          }
+        });
+      }
+    }
+  }
+
+  void recordExceptionImpl(kj::Maybe<tracing::Exception::Code> code,
+      kj::String name,
+      kj::String message,
+      kj::Maybe<kj::String> stack) override {
+    KJ_IF_SOME(valueContext, context) {
+      KJ_IF_SOME(observer, parent.getObserver()) {
+        auto timestamp = observer.getTime();
+        KJ_IF_SOME(valueTracer, tracer) {
+          valueTracer->runIfAlive([&](BaseTracer& tracer) {
+            tracer.addSpanException(valueContext.getSpanId(), timestamp, kj::mv(code), kj::mv(name),
+                kj::mv(message), kj::mv(stack));
+          });
+        }
+      }
+    }
+  }
+
+ private:
+  workerd::SpanParent parent;
+  kj::Maybe<kj::Own<BaseTracer::WeakRef>> tracer;
+  kj::Maybe<tracing::InvocationSpanContext> context;
+};
+
 class NoopSpanState final: public SpanState {
  public:
   void end() override {}
@@ -433,6 +508,13 @@ v8::Local<v8::Value> runSpan(jsg::Lock& js,
     });
   };
 
+  auto executeWithActiveSpan = [&]() -> v8::Local<v8::Value> {
+    auto activeSpan = spanHandler.wrap(js, jsSpan.addRef());
+    jsg::AsyncContextFrame::StorageScope activeSpanScope(js,
+        jsg::IsolateBase::from(js.v8Isolate).getActiveSpanAsyncContextKey(), js.v8Ref(activeSpan));
+    return executeCallback();
+  };
+
   // If we have an IoContext and an observed child span, push it onto the AsyncContextFrame
   // for the duration of the callback. The StorageScope RAII object restores the prior
   // async-context storage on scope exit; any async continuations captured during the
@@ -442,9 +524,9 @@ v8::Local<v8::Value> runSpan(jsg::Lock& js,
     auto& context = IoContext::current();
     jsg::AsyncContextFrame::StorageScope traceScope =
         context.makeUserAsyncTraceScope(context.getCurrentLock(), kj::mv(span));
-    return executeCallback();
+    return executeWithActiveSpan();
   } else {
-    return executeCallback();
+    return executeWithActiveSpan();
   }
 }
 
@@ -471,6 +553,61 @@ v8::Local<v8::Value> Tracing::startActiveSpan(jsg::Lock& js,
 
 jsg::Ref<user_tracing::Span> Tracing::startSpan(jsg::Lock& js, kj::String operationName) {
   return createSpan(js, kj::mv(operationName)).span;
+}
+
+jsg::Optional<jsg::Ref<user_tracing::Span>> Tracing::getActiveSpan(
+    jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler) {
+  // case: a user has an active span
+  //
+  // tracing.startActiveSpan('operation', async (span) => {
+  //   tracing.getActiveSpan() === span;
+  // });
+  KJ_IF_SOME(frame, jsg::AsyncContextFrame::current(js)) {
+    auto key = jsg::IsolateBase::from(js.v8Isolate).getActiveSpanAsyncContextKey();
+    KJ_IF_SOME(value, frame.get(*key)) {
+      KJ_IF_SOME(span, spanHandler.tryUnwrap(js, value.getHandle(js))) {
+        return kj::mv(span);
+      }
+    }
+  }
+
+  // case: outside an invocation
+  if (!IoContext::hasCurrent()) {
+    return kj::none;
+  }
+
+  // case: inside an invocation with no explicit child span set
+  // this is cached so that repeated calls return the same reference
+  auto& ioContext = IoContext::current();
+  KJ_IF_SOME(frame, jsg::AsyncContextFrame::current(js)) {
+    auto key = ioContext.getCurrentLock().getUserTraceAsyncContextKey();
+    KJ_IF_SOME(value, frame.get(*key)) {
+      auto holder = value.getHandle(js).As<v8::Object>();
+      auto& asyncContext = jsg::unwrapOpaqueRef<IoOwn<UserTraceAsyncContext>>(js.v8Isolate, holder);
+      auto cacheKey = v8::Private::ForApi(js.v8Isolate, js.strIntern("workerd.activeSpan"_kjc));
+      if (jsg::check(holder->HasPrivate(js.v8Context(), cacheKey))) {
+        auto cached = jsg::check(holder->GetPrivate(js.v8Context(), cacheKey));
+        KJ_IF_SOME(span, spanHandler.tryUnwrap(js, cached)) {
+          return kj::mv(span);
+        }
+      }
+
+      kj::Maybe<kj::Own<BaseTracer::WeakRef>> tracer;
+      KJ_IF_SOME(value, asyncContext->getTracer()) {
+        tracer = value.addRef();
+      }
+      kj::Own<user_tracing::SpanState> state =
+          kj::refcounted<user_tracing::InvocationSpanState>(asyncContext->getSpan(), kj::mv(tracer),
+              asyncContext->getInvocationSpanContext().map(
+                  [](auto& context) { return context.clone(); }));
+      auto span = js.alloc<user_tracing::Span>(ioContext.addObject(kj::mv(state)));
+      auto wrapped = spanHandler.wrap(js, span.addRef());
+      jsg::check(holder->SetPrivate(js.v8Context(), cacheKey, wrapped));
+      return span;
+    }
+  }
+
+  return kj::none;
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/tracing.h
+++ b/src/workerd/api/tracing.h
@@ -184,10 +184,17 @@ class Tracing: public jsg::Object {
   // must call span.end() explicitly. If no IoContext is available, returns a no-op span.
   jsg::Ref<user_tracing::Span> startSpan(jsg::Lock& js, kj::String operationName);
 
+  // Returns the span associated with the current async context, or the invocation span when no
+  // user-created span is active. Returns undefined outside an invocation or when execution is
+  // detached into the root async context.
+  jsg::Optional<jsg::Ref<user_tracing::Span>> getActiveSpan(
+      jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler);
+
   JSG_RESOURCE_TYPE(Tracing) {
     JSG_METHOD(enterSpan);
     JSG_METHOD(startActiveSpan);
     JSG_METHOD(startSpan);
+    JSG_METHOD(getActiveSpan);
 
     // Use the _NAMED variant so the property ends up as `tracing.Span` rather than
     // `tracing["user_tracing::Span"]`.
@@ -209,6 +216,7 @@ class Tracing: public jsg::Object {
         ...args: A
       ): T;
       startSpan(name: string): Span;
+      getActiveSpan(): Span | undefined;
     });
   }
 };

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1222,17 +1222,38 @@ jsg::AsyncContextFrame::StorageScope IoContext::makeAsyncTraceScope(
 
 jsg::AsyncContextFrame::StorageScope IoContext::makeUserAsyncTraceScope(
     Worker::Lock& lock, kj::Maybe<SpanParent> userSpanOverride) {
+  auto& ioContext = IoContext::current();
   jsg::Lock& js = lock;
-  kj::Own<SpanParent> userSpan;
+  SpanParent userSpan(nullptr);
   KJ_IF_SOME(sp, kj::mv(userSpanOverride)) {
-    userSpan = kj::heap(kj::mv(sp));
+    userSpan = kj::mv(sp);
   } else {
-    userSpan = kj::heap(getRootUserTraceSpan());
+    userSpan = getRootUserTraceSpan();
   }
-  auto ioOwnSpan = IoContext::current().addObject(kj::mv(userSpan));
-  auto spanHandle = jsg::wrapOpaque(js.v8Context(), kj::mv(ioOwnSpan));
+
+  kj::Maybe<tracing::InvocationSpanContext> invocationSpanContext;
+  if (userSpan.isObserved()) {
+    auto& baseContext = getCurrentIncomingRequest().getInvocationSpanContext();
+    auto spanId = userSpan.getSpanId();
+    if (spanId != tracing::SpanId::nullId) {
+      invocationSpanContext = tracing::InvocationSpanContext(baseContext.getTraceId(),
+          baseContext.getInvocationId(), spanId, baseContext.getTraceFlags());
+    } else {
+      invocationSpanContext = baseContext.clone();
+    }
+  }
+
+  kj::Maybe<kj::Own<workerd::WeakRef<BaseTracer>>> tracer;
+  KJ_IF_SOME(value, getWorkerTracer()) {
+    tracer = value.getWeakRef();
+  }
+
+  auto asyncContext = kj::heap<UserTraceAsyncContext>(
+      kj::mv(userSpan), kj::mv(tracer), kj::mv(invocationSpanContext));
+  auto ioOwnAsyncContext = ioContext.addObject(kj::mv(asyncContext));
+  auto contextHandle = jsg::wrapOpaque(js.v8Context(), kj::mv(ioOwnAsyncContext));
   return jsg::AsyncContextFrame::StorageScope(
-      js, lock.getUserTraceAsyncContextKey(), js.v8Ref(spanHandle));
+      js, lock.getUserTraceAsyncContextKey(), js.v8Ref(contextHandle));
 }
 
 SpanParent IoContext::getCurrentTraceSpan() {
@@ -1254,14 +1275,8 @@ SpanParent IoContext::getCurrentTraceSpan() {
 }
 
 SpanParent IoContext::getCurrentUserTraceSpan() {
-  // Skip the AsyncContextFrame probe when user tracing isn't wired up: an unobserved
-  // root means enterSpan can't have pushed anything (see Tracing::enterSpan).
   if (incomingRequests.empty()) {
     return SpanParent(nullptr);
-  }
-  SpanParent root = getCurrentIncomingRequest().getRootUserTraceSpan();
-  if (!root.isObserved()) {
-    return kj::mv(root);
   }
 
   // If called while lock is held, try to use the trace info stored in the async context.
@@ -1270,12 +1285,13 @@ SpanParent IoContext::getCurrentUserTraceSpan() {
       KJ_IF_SOME(value, frame.get(*lock.getUserTraceAsyncContextKey())) {
         auto handle = value.getHandle(lock);
         jsg::Lock& js = lock;
-        auto& userSpan = jsg::unwrapOpaqueRef<IoOwn<SpanParent>>(js.v8Isolate, handle);
-        return userSpan->addRef();
+        auto& asyncContext =
+            jsg::unwrapOpaqueRef<IoOwn<UserTraceAsyncContext>>(js.v8Isolate, handle);
+        return asyncContext->getSpan();
       }
     }
   }
-  return kj::mv(root);
+  return getCurrentIncomingRequest().getRootUserTraceSpan();
 }
 
 SpanBuilder IoContext::makeTraceSpan(kj::ConstString operationName) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -57,6 +57,40 @@ WD_STRONG_BOOL(IoContext_Runnable_Exceptional);
 
 class IoContext;
 
+// Request-specific user-tracing state captured in an AsyncContextFrame. Durable Object requests
+// share an IoContext and may overlap, so ambient IoContext state can refer to a newer request when
+// an older continuation resumes. Keeping the span, tracer, and invocation context together ensures
+// tracing events remain attributed to the request that created the async context.
+class UserTraceAsyncContext final {
+ public:
+  UserTraceAsyncContext(SpanParent span,
+      kj::Maybe<kj::Own<workerd::WeakRef<BaseTracer>>> tracer,
+      kj::Maybe<tracing::InvocationSpanContext> invocationSpanContext)
+      : span(kj::mv(span)),
+        tracer(kj::mv(tracer)),
+        invocationSpanContext(kj::mv(invocationSpanContext)) {}
+
+  SpanParent getSpan() {
+    return span.addRef();
+  }
+
+  kj::Maybe<workerd::WeakRef<BaseTracer>&> getTracer() {
+    KJ_IF_SOME(value, tracer) {
+      return *value;
+    }
+    return kj::none;
+  }
+
+  kj::Maybe<tracing::InvocationSpanContext&> getInvocationSpanContext() {
+    return invocationSpanContext;
+  }
+
+ private:
+  SpanParent span;
+  kj::Maybe<kj::Own<workerd::WeakRef<BaseTracer>>> tracer;
+  kj::Maybe<tracing::InvocationSpanContext> invocationSpanContext;
+};
+
 // Represents one incoming request being handled by a IoContext. In non-actor scenarios,
 // there is only ever one IncomingRequest per IoContext, but with actors there could be many.
 //
@@ -1069,10 +1103,10 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
 
   // Returns an object that ensures an async JS operation started in the current scope captures
   // the given user trace span, or the current incoming request's root user trace span if none is
-  // given. Storing the span in the AsyncContextFrame (which on actors outlives individual
-  // requests via the IoContext's delete queue) is safe because user-tracing SpanSubmitter
-  // implementations hold only a BaseTracer::WeakRef - stale references cannot extend tracer
-  // lifetime.
+  // given. The originating tracer and invocation context are captured with the span so that an
+  // actor continuation cannot pick up tracing state from a newer overlapping request. Storing this
+  // data in the AsyncContextFrame (which on actors outlives individual requests via the IoContext's
+  // delete queue) is safe because the tracer reference is weak.
   jsg::AsyncContextFrame::StorageScope makeUserAsyncTraceScope(
       Worker::Lock& lock, kj::Maybe<SpanParent> userSpan = kj::none) KJ_WARN_UNUSED_RESULT;
 

--- a/src/workerd/io/tracer.c++
+++ b/src/workerd/io/tracer.c++
@@ -603,6 +603,41 @@ void WorkerTracer::setWorkerAttribute(kj::ConstString key, Span::TagValue value)
   attributes.add(tracing::Attribute{kj::mv(key), kj::mv(value)});
 }
 
+void WorkerTracer::addSpanAttribute(const tracing::InvocationSpanContext& context,
+    kj::ConstString key,
+    tracing::Attribute::Value value) {
+  if (pipelineLogLevel == PipelineLogLevel::NONE || maybeTailStreamWriter == kj::none) {
+    return;
+  }
+  addSpanAttributeInternal(context, kj::mv(key), kj::mv(value), getTime());
+}
+
+void WorkerTracer::addSpanAttributeInternal(const tracing::InvocationSpanContext& context,
+    kj::ConstString key,
+    tracing::Attribute::Value value,
+    kj::Date timestamp) {
+  if (pipelineLogLevel == PipelineLogLevel::NONE) {
+    return;
+  }
+
+  auto& tailStreamWriter = KJ_UNWRAP_OR_RETURN(maybeTailStreamWriter);
+  size_t size = key.size();
+  KJ_SWITCH_ONEOF(value) {
+    KJ_CASE_ONEOF(string, kj::ConstString) {
+      size += string.size();
+    }
+    KJ_CASE_ONEOF_DEFAULT {
+      size += sizeof(double);
+    }
+  }
+  if (size > MAX_TRACE_BYTES) {
+    return;
+  }
+
+  tracing::CustomInfo attributes = kj::arr(tracing::Attribute(kj::mv(key), kj::mv(value)));
+  tailStreamWriter->report(context, kj::mv(attributes), timestamp, size);
+}
+
 SpanParent BaseTracer::makeUserRequestSpan(
     tracing::TraceId traceId, kj::Maybe<tracing::TraceFlags> traceFlags) {
   KJ_IF_SOME(func, makeUserRequestSpanFunc) {

--- a/src/workerd/io/tracer.h
+++ b/src/workerd/io/tracer.h
@@ -55,6 +55,9 @@ class BaseTracer: public kj::Refcounted {
       kj::Date startTime) = 0;
   // Add a span close event.
   virtual void addSpanClose(tracing::SpanEndData&& span, kj::Maybe<kj::Date> maybeStartTime) = 0;
+  virtual void addSpanAttribute(const tracing::InvocationSpanContext& context,
+      kj::ConstString key,
+      tracing::Attribute::Value value) = 0;
 
   virtual void addException(const tracing::InvocationSpanContext& context,
       kj::Date timestamp,
@@ -168,6 +171,14 @@ class WorkerTracer final: public BaseTracer {
       kj::ConstString operationName,
       kj::Date startTime) override;
   void addSpanClose(tracing::SpanEndData&& span, kj::Maybe<kj::Date> maybeStartTime) override;
+  void addSpanAttribute(const tracing::InvocationSpanContext& context,
+      kj::ConstString key,
+      tracing::Attribute::Value value) override;
+  // Variant for RPC-based tracing, where the caller supplies the timestamp from its IoContext.
+  void addSpanAttributeInternal(const tracing::InvocationSpanContext& context,
+      kj::ConstString key,
+      tracing::Attribute::Value value,
+      kj::Date timestamp);
   void addException(const tracing::InvocationSpanContext& context,
       kj::Date timestamp,
       kj::String name,

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -395,6 +395,7 @@ IsolateBase::IsolateBase(V8System& system,
       externalMemoryTarget(kj::arc<ExternalMemoryTarget>(ptr)),
       envAsyncContextKey(kj::arc<AsyncContextFrame::StorageKey>()),
       exportsAsyncContextKey(kj::arc<AsyncContextFrame::StorageKey>()),
+      activeSpanAsyncContextKey(kj::arc<AsyncContextFrame::StorageKey>()),
       heapTracer(ptr),
       observer(kj::mv(observer)),
       externalStringAllocator(kj::mv(externalStringAllocator)) {

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -339,6 +339,10 @@ class IsolateBase {
     return exportsAsyncContextKey.addRef();
   }
 
+  kj::Arc<AsyncContextFrame::StorageKey> getActiveSpanAsyncContextKey() {
+    return activeSpanAsyncContextKey.addRef();
+  }
+
   void setUsingNewModuleRegistry() {
     usingNewModuleRegistry = true;
   }
@@ -510,6 +514,9 @@ class IsolateBase {
 
   // A shared async context key for accessing exports
   kj::Arc<AsyncContextFrame::StorageKey> exportsAsyncContextKey;
+
+  // A shared async context key for accessing the active user tracing span.
+  kj::Arc<AsyncContextFrame::StorageKey> activeSpanAsyncContextKey;
 
   // We expect queues to remain relatively small -- 8 is the largest size I have observed from local
   // testing.

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4848,6 +4848,7 @@ interface Tracing {
     ...args: A
   ): T;
   startSpan(name: string): Span;
+  getActiveSpan(): Span | undefined;
   Span: typeof Span;
 }
 declare abstract class Span {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4857,6 +4857,7 @@ export interface Tracing {
     ...args: A
   ): T;
   startSpan(name: string): Span;
+  getActiveSpan(): Span | undefined;
   Span: typeof Span;
 }
 export declare abstract class Span {

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -4571,6 +4571,7 @@ interface Tracing {
     ...args: A
   ): T;
   startSpan(name: string): Span;
+  getActiveSpan(): Span | undefined;
   Span: typeof Span;
 }
 declare abstract class Span {

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -4580,6 +4580,7 @@ export interface Tracing {
     ...args: A
   ): T;
   startSpan(name: string): Span;
+  getActiveSpan(): Span | undefined;
   Span: typeof Span;
 }
 export declare abstract class Span {


### PR DESCRIPTION
 Adds `tracing.getActiveSpan()`

- `getActiveSpan()` returns the active user-created span when one exists.
- Otherwise, it returns a wrapper for the current invocation span.
- It returns `undefined` outside an invocation or in an async context detached from the invocation.
- Invocation-span wrappers are cached, so repeated calls return the same object.
- Calling `end()` on an invocation span is a no-op because the platform owns its lifecycle.

When you create your own spans, you get a reference to a `span` that you can add attributes to, but there is currently no way of getting a reference to this span if you are never passed it. This is important for middlewares, instrumentation, etc.

Additionally, we've had no way to get a reference to the root invocation span. This is where all of the interesting data lives! [Extending the attributes of this invocation span is an o11y best practice (IMO).](https://jeremymorrell.dev/blog/a-practitioners-guide-to-wide-events/).

Things like:
- this request was served on `/user/:id`
- this request was served for user 1234
- these are the active feature flags for this request

We currently have no internal `span` object that represents this invocation span. This adds `InvocationSpanState` to fill that role.

This should work exactly as a normal span except that it should treat `span.end()` as a no-op, since that lifecycle is owned by the platform. There is some precedent for this in the [`NonRecordingSpan`](https://github.com/open-telemetry/opentelemetry-js/blob/main/api/src/trace/NonRecordingSpan.ts#L66) in the otel-sdk.

There were some tricky bits for overlapping Durable Object requests. They share an `IoContext`: a continuation from request A must not emit attributes through request B’s tracer after B becomes the current request.