### PR TITLE
WO-1582 Add tracing getInvocationSpan

### DIFF
--- a/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-instrumentation-test.js
@@ -129,6 +129,10 @@ export const validateSpans = {
       rootAttributes.find(({ name }) => name === 'test'),
       { name: 'test', value: 'getActiveSpanInvocation' }
     );
+    assert.deepStrictEqual(
+      rootAttributes.find(({ name }) => name === 'user.id'),
+      { name: 'user.id', value: 'user-123' }
+    );
 
     for (const requestName of ['a', 'b']) {
       const request = invocations.find(

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
@@ -42,6 +42,7 @@ export class OverlappingRequestsObject extends DurableObject {
             await this.firstCanResume;
             const span = publicTracing.getActiveSpan();
             assert(span);
+            assert.strictEqual(publicTracing.getInvocationSpan(), span);
             assert.strictEqual(span.isTraced, true);
             span.setAttribute('overlapping.request', 'a');
             this.resolveFirstAttributed();
@@ -54,6 +55,7 @@ export class OverlappingRequestsObject extends DurableObject {
     assert.strictEqual(this.firstIsWaiting, true);
     const span = publicTracing.getActiveSpan();
     assert(span);
+    assert.strictEqual(publicTracing.getInvocationSpan(), span);
     assert.strictEqual(span.isTraced, true);
     span.setAttribute('overlapping.request', 'b');
     this.resumeFirst();

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
@@ -7,9 +7,14 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { DurableObject, tracing as publicTracing } from 'cloudflare:workers';
 
 assert.strictEqual(publicTracing.getActiveSpan(), undefined);
-const getActiveSpanOutsideInvocationContext = AsyncLocalStorage.bind(() =>
-  publicTracing.getActiveSpan()
-);
+assert.strictEqual(publicTracing.getInvocationSpan(), undefined);
+const getSpansOutsideInvocationContext = AsyncLocalStorage.bind(() => ({
+  active: [publicTracing.getActiveSpan(), publicTracing.getActiveSpan()],
+  invocation: [
+    publicTracing.getInvocationSpan(),
+    publicTracing.getInvocationSpan(),
+  ],
+}));
 
 // Overlapping Durable Object requests share an IoContext, but each async continuation must retain
 // its originating request's tracing state. This verifies that request A resuming while request B is
@@ -319,14 +324,19 @@ export const publicImportStartSpan = {
   },
 };
 
-export const getActiveSpan = {
+export const activeAndInvocationSpans = {
   async test(ctrl, env, ctx) {
     const invocationSpan = publicTracing.getActiveSpan();
     assert.ok(invocationSpan);
     // All the ways to get the active span should return the same reference
     assert.strictEqual(publicTracing.getActiveSpan(), invocationSpan);
     assert.strictEqual(ctx.tracing.getActiveSpan(), invocationSpan);
-    assert.strictEqual(getActiveSpanOutsideInvocationContext(), undefined);
+    assert.strictEqual(publicTracing.getInvocationSpan(), invocationSpan);
+    assert.strictEqual(ctx.tracing.getInvocationSpan(), invocationSpan);
+    const detachedSpans = getSpansOutsideInvocationContext();
+    assert.deepStrictEqual(detachedSpans.active, [undefined, undefined]);
+    assert.strictEqual(detachedSpans.invocation[0], invocationSpan);
+    assert.strictEqual(detachedSpans.invocation[1], invocationSpan);
     assert.strictEqual(invocationSpan.isTraced, true);
     // This is ignored since we control the lifecycle
     invocationSpan.end();
@@ -335,8 +345,11 @@ export const getActiveSpan = {
 
     await ctx.tracing.startActiveSpan('get-active-span-op', async (span) => {
       assert.strictEqual(publicTracing.getActiveSpan(), span);
+      assert.strictEqual(publicTracing.getInvocationSpan(), invocationSpan);
       await Promise.resolve();
       assert.strictEqual(publicTracing.getActiveSpan(), span);
+      assert.strictEqual(publicTracing.getInvocationSpan(), invocationSpan);
+      publicTracing.getInvocationSpan().setAttribute('user.id', 'user-123');
       span.setAttribute('test', 'getActiveSpan');
       span.end();
     });

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.js
@@ -4,7 +4,11 @@
 
 import assert from 'node:assert';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { DurableObject, tracing as publicTracing } from 'cloudflare:workers';
+import {
+  DurableObject,
+  WorkerEntrypoint,
+  tracing as publicTracing,
+} from 'cloudflare:workers';
 
 assert.strictEqual(publicTracing.getActiveSpan(), undefined);
 assert.strictEqual(publicTracing.getInvocationSpan(), undefined);
@@ -15,6 +19,33 @@ const getSpansOutsideInvocationContext = AsyncLocalStorage.bind(() => ({
     publicTracing.getInvocationSpan(),
   ],
 }));
+
+let getCrossContextInvocationSpan;
+
+export class CrossContextEntrypoint extends WorkerEntrypoint {
+  async fetch(request) {
+    const requestName = new URL(request.url).pathname.slice(1);
+
+    if (requestName === 'capture') {
+      const invocationSpan = publicTracing.getInvocationSpan();
+      assert(invocationSpan);
+      getCrossContextInvocationSpan = AsyncLocalStorage.bind(() =>
+        publicTracing.getInvocationSpan()
+      );
+      return new Response('captured');
+    }
+
+    try {
+      assert.strictEqual(getCrossContextInvocationSpan(), undefined);
+    } catch (error) {
+      assert.match(
+        error.message,
+        /Cannot call this AsyncLocalStorage bound function outside of the request/
+      );
+    }
+    return new Response('checked');
+  }
+}
 
 // Overlapping Durable Object requests share an IoContext, but each async continuation must retain
 // its originating request's tracing state. This verifies that request A resuming while request B is
@@ -33,7 +64,17 @@ export class OverlappingRequestsObject extends DurableObject {
   async fetch(request) {
     const requestName = new URL(request.url).pathname.slice(1);
 
+    if (requestName === 'stale') {
+      assert.strictEqual(this.getFirstInvocationSpan(), undefined);
+      return new Response('checked');
+    }
+
     if (requestName === 'a') {
+      const invocationSpan = publicTracing.getInvocationSpan();
+      assert(invocationSpan);
+      this.getFirstInvocationSpan = AsyncLocalStorage.bind(() =>
+        publicTracing.getInvocationSpan()
+      );
       this.firstIsWaiting = true;
       return new Response(
         new ReadableStream({
@@ -77,6 +118,25 @@ export const overlappingDurableObjectRequests = {
     const [firstEnd] = await Promise.all([firstReader.read(), second.text()]);
     assert.strictEqual(firstEnd.done, true);
     assert.deepStrictEqual([first.status, second.status], [200, 200]);
+    assert.strictEqual(
+      await (await stub.fetch('https://example.com/stale')).text(),
+      'checked'
+    );
+  },
+};
+
+export const crossIoContextInvocation = {
+  async test(ctrl, env) {
+    assert.strictEqual(
+      await (
+        await env.crossContext.fetch('https://example.com/capture')
+      ).text(),
+      'captured'
+    );
+    assert.strictEqual(
+      await (await env.crossContext.fetch('https://example.com/check')).text(),
+      'checked'
+    );
   },
 };
 

--- a/src/cloudflare/internal/test/tracing/tracing-helpers-test.wd-test
+++ b/src/cloudflare/internal/test/tracing/tracing-helpers-test.wd-test
@@ -30,6 +30,13 @@ const unitTests :Workerd.Config = (
           (
             name = "overlappingRequests",
             durableObjectNamespace = "OverlappingRequestsObject"
+          ),
+          (
+            name = "crossContext",
+            service = (
+              name = "tracing-helpers-test",
+              entrypoint = "CrossContextEntrypoint"
+            )
           )
         ],
       )

--- a/src/cloudflare/internal/tracing.d.ts
+++ b/src/cloudflare/internal/tracing.d.ts
@@ -48,7 +48,8 @@ declare class Span {
   // Records an exception event on the span. Calls after the span has ended are ignored.
   recordException(exception: Exception): void;
 
-  // Ends the span and submits its attributes to the tracing system. Idempotent.
+  // Ends the span and submits its attributes to the tracing system. Idempotent. This is a no-op
+  // for a runtime-owned invocation span, whose lifecycle is owned by the runtime.
   end(): void;
 }
 
@@ -85,6 +86,13 @@ declare const tracing: {
   // Returns the span associated with the current async context. Returns undefined
   // outside an invocation or when execution is detached into the root async context.
   getActiveSpan(): Span | undefined;
+
+  // Returns the runtime-owned invocation span regardless of which user-created span is active.
+  // Returns undefined outside an invocation. The returned span can record attributes, but end()
+  // is a no-op because the runtime owns its lifecycle. In root-detached actor execution, this
+  // follows the invocation currently selected by runtime attribution, which may differ from the
+  // callback's originating invocation.
+  getInvocationSpan(): Span | undefined;
 
   // The `Span` class is exposed as a nested type so callers can reference the type via
   // `InstanceType<typeof tracing.Span>` (see `tracing-helpers.ts`).

--- a/src/cloudflare/internal/tracing.d.ts
+++ b/src/cloudflare/internal/tracing.d.ts
@@ -88,10 +88,11 @@ declare const tracing: {
   getActiveSpan(): Span | undefined;
 
   // Returns the runtime-owned invocation span regardless of which user-created span is active.
-  // Returns undefined outside an invocation. The returned span can record attributes, but end()
-  // is a no-op because the runtime owns its lifecycle. In root-detached actor execution, this
-  // follows the invocation currently selected by runtime attribution, which may differ from the
-  // callback's originating invocation.
+  // Returns undefined outside an invocation, after the originating invocation has completed, or
+  // when the current async context originated in a different I/O context. The returned span can
+  // record attributes, but end() is a no-op because the runtime owns its lifecycle. In
+  // root-detached actor execution, this follows the invocation currently selected by runtime
+  // attribution, which may differ from the callback's originating invocation.
   getInvocationSpan(): Span | undefined;
 
   // The `Span` class is exposed as a nested type so callers can reference the type via

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -534,16 +534,17 @@ jsg::Optional<jsg::Ref<user_tracing::Span>> getInvocationSpanFromTag(jsg::Lock& 
     jsg::JsObject tag,
     const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler) {
   constexpr auto CACHE_KEY = "workerd.invocationSpan"_kj;
-  if (tag.hasPrivate(js, CACHE_KEY)) {
-    auto cached = tag.getPrivate(js, CACHE_KEY);
-    KJ_IF_SOME(span, spanHandler.tryUnwrap(js, cached)) {
-      return kj::mv(span);
-    }
-  }
-
   auto& state = jsg::unwrapOpaqueRef<IoOwn<UserTracingInvocationSpanTag>>(js.v8Isolate, tag);
   jsg::Optional<jsg::Ref<user_tracing::Span>> result;
   state->request->runIfAlive([&](IoContext::IncomingRequest& request) {
+    if (tag.hasPrivate(js, CACHE_KEY)) {
+      auto cached = tag.getPrivate(js, CACHE_KEY);
+      KJ_IF_SOME(span, spanHandler.tryUnwrap(js, cached)) {
+        result = kj::mv(span);
+        return;
+      }
+    }
+
     kj::Maybe<kj::Own<BaseTracer::WeakRef>> tracer;
     KJ_IF_SOME(value, request.getWorkerTracer()) {
       tracer = value.getWeakRef();

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -530,6 +530,33 @@ v8::Local<v8::Value> runSpan(jsg::Lock& js,
   }
 }
 
+jsg::Optional<jsg::Ref<user_tracing::Span>> getInvocationSpanFromTag(jsg::Lock& js,
+    jsg::JsObject tag,
+    const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler) {
+  constexpr auto CACHE_KEY = "workerd.invocationSpan"_kj;
+  if (tag.hasPrivate(js, CACHE_KEY)) {
+    auto cached = tag.getPrivate(js, CACHE_KEY);
+    KJ_IF_SOME(span, spanHandler.tryUnwrap(js, cached)) {
+      return kj::mv(span);
+    }
+  }
+
+  auto& state = jsg::unwrapOpaqueRef<IoOwn<UserTracingInvocationSpanTag>>(js.v8Isolate, tag);
+  jsg::Optional<jsg::Ref<user_tracing::Span>> result;
+  state->request->runIfAlive([&](IoContext::IncomingRequest& request) {
+    kj::Maybe<kj::Own<BaseTracer::WeakRef>> tracer;
+    KJ_IF_SOME(value, request.getWorkerTracer()) {
+      tracer = value.getWeakRef();
+    }
+    kj::Own<user_tracing::SpanState> spanState = kj::refcounted<user_tracing::InvocationSpanState>(
+        request.getRootUserTraceSpan(), kj::mv(tracer), request.getInvocationSpanContext().clone());
+    auto span = js.alloc<user_tracing::Span>(IoContext::current().addObject(kj::mv(spanState)));
+    tag.setPrivate(js, CACHE_KEY, jsg::JsValue(spanHandler.wrap(js, span.addRef())));
+    result = kj::mv(span);
+  });
+  return result;
+}
+
 }  // namespace
 
 v8::Local<v8::Value> Tracing::enterSpan(jsg::Lock& js,
@@ -577,36 +604,21 @@ jsg::Optional<jsg::Ref<user_tracing::Span>> Tracing::getActiveSpan(
   }
 
   // case: inside an invocation with no explicit child span set
-  // this is cached so that repeated calls return the same reference
-  auto& ioContext = IoContext::current();
-  KJ_IF_SOME(frame, jsg::AsyncContextFrame::current(js)) {
-    auto key = ioContext.getCurrentLock().getUserTraceAsyncContextKey();
-    KJ_IF_SOME(value, frame.get(*key)) {
-      auto holder = value.getHandle(js).As<v8::Object>();
-      auto& asyncContext = jsg::unwrapOpaqueRef<IoOwn<UserTraceAsyncContext>>(js.v8Isolate, holder);
-      auto cacheKey = v8::Private::ForApi(js.v8Isolate, js.strIntern("workerd.activeSpan"_kjc));
-      if (jsg::check(holder->HasPrivate(js.v8Context(), cacheKey))) {
-        auto cached = jsg::check(holder->GetPrivate(js.v8Context(), cacheKey));
-        KJ_IF_SOME(span, spanHandler.tryUnwrap(js, cached)) {
-          return kj::mv(span);
-        }
-      }
-
-      kj::Maybe<kj::Own<BaseTracer::WeakRef>> tracer;
-      KJ_IF_SOME(value, asyncContext->getTracer()) {
-        tracer = value.addRef();
-      }
-      kj::Own<user_tracing::SpanState> state =
-          kj::refcounted<user_tracing::InvocationSpanState>(asyncContext->getSpan(), kj::mv(tracer),
-              asyncContext->getInvocationSpanContext().map(
-                  [](auto& context) { return context.clone(); }));
-      auto span = js.alloc<user_tracing::Span>(ioContext.addObject(kj::mv(state)));
-      auto wrapped = spanHandler.wrap(js, span.addRef());
-      jsg::check(holder->SetPrivate(js.v8Context(), cacheKey, wrapped));
-      return span;
-    }
+  // The invocation tag caches the span so repeated calls return the same reference.
+  KJ_IF_SOME(tag, IoContext::current().getCurrentUserTracingInvocationTag(js)) {
+    return getInvocationSpanFromTag(js, kj::mv(tag), spanHandler);
   }
+  return kj::none;
+}
 
+jsg::Optional<jsg::Ref<user_tracing::Span>> Tracing::getInvocationSpan(
+    jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler) {
+  if (!IoContext::hasCurrent()) {
+    return kj::none;
+  }
+  KJ_IF_SOME(tag, IoContext::current().getUserTracingInvocationTag(js)) {
+    return getInvocationSpanFromTag(js, kj::mv(tag), spanHandler);
+  }
   return kj::none;
 }
 

--- a/src/workerd/api/tracing.c++
+++ b/src/workerd/api/tracing.c++
@@ -534,14 +534,12 @@ jsg::Optional<jsg::Ref<user_tracing::Span>> getInvocationSpanFromTag(jsg::Lock& 
     jsg::JsObject tag,
     const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler) {
   constexpr auto CACHE_KEY = "workerd.invocationSpan"_kj;
-  auto& state = jsg::unwrapOpaqueRef<IoOwn<UserTracingInvocationSpanTag>>(js.v8Isolate, tag);
-  jsg::Optional<jsg::Ref<user_tracing::Span>> result;
-  state->request->runIfAlive([&](IoContext::IncomingRequest& request) {
+  auto& ioContext = IoContext::current();
+  KJ_IF_SOME(request, ioContext.getIncomingRequestForUserTracingInvocation(js, tag)) {
     if (tag.hasPrivate(js, CACHE_KEY)) {
       auto cached = tag.getPrivate(js, CACHE_KEY);
       KJ_IF_SOME(span, spanHandler.tryUnwrap(js, cached)) {
-        result = kj::mv(span);
-        return;
+        return kj::mv(span);
       }
     }
 
@@ -551,11 +549,11 @@ jsg::Optional<jsg::Ref<user_tracing::Span>> getInvocationSpanFromTag(jsg::Lock& 
     }
     kj::Own<user_tracing::SpanState> spanState = kj::refcounted<user_tracing::InvocationSpanState>(
         request.getRootUserTraceSpan(), kj::mv(tracer), request.getInvocationSpanContext().clone());
-    auto span = js.alloc<user_tracing::Span>(IoContext::current().addObject(kj::mv(spanState)));
+    auto span = js.alloc<user_tracing::Span>(ioContext.addObject(kj::mv(spanState)));
     tag.setPrivate(js, CACHE_KEY, jsg::JsValue(spanHandler.wrap(js, span.addRef())));
-    result = kj::mv(span);
-  });
-  return result;
+    return span;
+  }
+  return kj::none;
 }
 
 }  // namespace

--- a/src/workerd/api/tracing.h
+++ b/src/workerd/api/tracing.h
@@ -106,7 +106,8 @@ class Span: public jsg::Object {
   void recordException(
       jsg::Lock& js, jsg::Value exception, const jsg::TypeHandler<ExceptionData>& exceptionHandler);
 
-  // Ends the span and submits its content to the tracing system. Idempotent.
+  // Ends the span and submits its content to the tracing system. Idempotent. This is a no-op for a
+  // runtime-owned invocation span, whose lifecycle is owned by the runtime.
   void end();
 
   JSG_RESOURCE_TYPE(Span) {
@@ -190,11 +191,20 @@ class Tracing: public jsg::Object {
   jsg::Optional<jsg::Ref<user_tracing::Span>> getActiveSpan(
       jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler);
 
+  // Returns the runtime-owned invocation span regardless of which user-created span is active.
+  // Returns undefined outside an invocation. The returned span can record attributes, but end() is
+  // a no-op because the runtime owns its lifecycle. In root-detached actor execution, this follows
+  // the invocation currently selected by runtime attribution, which may differ from the callback's
+  // originating invocation.
+  jsg::Optional<jsg::Ref<user_tracing::Span>> getInvocationSpan(
+      jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler);
+
   JSG_RESOURCE_TYPE(Tracing) {
     JSG_METHOD(enterSpan);
     JSG_METHOD(startActiveSpan);
     JSG_METHOD(startSpan);
     JSG_METHOD(getActiveSpan);
+    JSG_METHOD(getInvocationSpan);
 
     // Use the _NAMED variant so the property ends up as `tracing.Span` rather than
     // `tracing["user_tracing::Span"]`.
@@ -217,6 +227,7 @@ class Tracing: public jsg::Object {
       ): T;
       startSpan(name: string): Span;
       getActiveSpan(): Span | undefined;
+      getInvocationSpan(): Span | undefined;
     });
   }
 };

--- a/src/workerd/api/tracing.h
+++ b/src/workerd/api/tracing.h
@@ -192,10 +192,11 @@ class Tracing: public jsg::Object {
       jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler);
 
   // Returns the runtime-owned invocation span regardless of which user-created span is active.
-  // Returns undefined outside an invocation. The returned span can record attributes, but end() is
-  // a no-op because the runtime owns its lifecycle. In root-detached actor execution, this follows
-  // the invocation currently selected by runtime attribution, which may differ from the callback's
-  // originating invocation.
+  // Returns undefined outside an invocation, after the originating invocation has completed, or
+  // when the current async context originated in a different IoContext. The returned span can
+  // record attributes, but end() is a no-op because the runtime owns its lifecycle. In
+  // root-detached actor execution, this follows the invocation currently selected by runtime
+  // attribution, which may differ from the callback's originating invocation.
   jsg::Optional<jsg::Ref<user_tracing::Span>> getInvocationSpan(
       jsg::Lock& js, const jsg::TypeHandler<jsg::Ref<user_tracing::Span>>& spanHandler);
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -310,6 +310,7 @@ kj::Date IoContext::IncomingRequest::nowForTraceOnset() {
 }
 
 IoContext::IncomingRequest::~IoContext_IncomingRequest() noexcept(false) {
+  selfRef->invalidate();
   if (!wasDelivered) {
     KJ_IF_SOME(w, workerTracer) {
       w->markUnused();
@@ -1262,10 +1263,21 @@ jsg::AsyncContextFrame::StorageScope IoContext::makeAsyncTraceScope(
       js, lock.getTraceAsyncContextKey(), js.v8Ref(spanHandle));
 }
 
+namespace {
+
+constexpr auto USER_TRACING_INVOCATION_TAG = "workerd.userTracingInvocation"_kj;
+
+}  // namespace
+
 jsg::AsyncContextFrame::StorageScope IoContext::makeUserAsyncTraceScope(
     Worker::Lock& lock, kj::Maybe<SpanParent> userSpanOverride) {
   auto& ioContext = IoContext::current();
   jsg::Lock& js = lock;
+  kj::Maybe<jsg::JsObject> invocationTag;
+  if (userSpanOverride != kj::none) {
+    invocationTag = getCurrentUserTracingInvocationTag(js);
+  }
+
   SpanParent userSpan(nullptr);
   KJ_IF_SOME(sp, kj::mv(userSpanOverride)) {
     userSpan = kj::mv(sp);
@@ -1293,8 +1305,48 @@ jsg::AsyncContextFrame::StorageScope IoContext::makeUserAsyncTraceScope(
       kj::mv(userSpan), kj::mv(tracer), kj::mv(invocationSpanContext));
   auto ioOwnAsyncContext = ioContext.addObject(kj::mv(asyncContext));
   auto contextHandle = jsg::wrapOpaque(js.v8Context(), kj::mv(ioOwnAsyncContext));
+
+  if (invocationTag == kj::none) {
+    invocationTag = getOrCreateUserTracingInvocationTag(js, getCurrentIncomingRequest());
+  }
+
+  jsg::JsObject contextHolder(contextHandle.As<v8::Object>());
+  contextHolder.setPrivate(js, USER_TRACING_INVOCATION_TAG, KJ_ASSERT_NONNULL(invocationTag));
   return jsg::AsyncContextFrame::StorageScope(
       js, lock.getUserTraceAsyncContextKey(), js.v8Ref(contextHandle));
+}
+
+kj::Maybe<jsg::JsObject> IoContext::getCurrentUserTracingInvocationTag(jsg::Lock& js) {
+  KJ_IF_SOME(frame, jsg::AsyncContextFrame::current(js)) {
+    auto key = getCurrentLock().getUserTraceAsyncContextKey();
+    KJ_IF_SOME(value, frame.get(*key)) {
+      jsg::JsObject holder(value.getHandle(js).As<v8::Object>());
+      if (holder.hasPrivate(js, USER_TRACING_INVOCATION_TAG)) {
+        return holder.getPrivate(js, USER_TRACING_INVOCATION_TAG).tryCast<jsg::JsObject>();
+      }
+    }
+  }
+  return kj::none;
+}
+
+kj::Maybe<jsg::JsObject> IoContext::getUserTracingInvocationTag(jsg::Lock& js) {
+  KJ_IF_SOME(tag, getCurrentUserTracingInvocationTag(js)) {
+    return kj::mv(tag);
+  }
+  if (!incomingRequests.empty()) {
+    return getOrCreateUserTracingInvocationTag(js, getCurrentIncomingRequest());
+  }
+  return kj::none;
+}
+
+jsg::JsObject IoContext::getOrCreateUserTracingInvocationTag(
+    jsg::Lock& js, IncomingRequest& incomingRequest) {
+  if (incomingRequest.userTracingInvocationTag == kj::none) {
+    auto state = kj::heap<UserTracingInvocationSpanTag>(incomingRequest.getWeakRef());
+    auto tag = js.opaque(addObject(kj::mv(state)));
+    incomingRequest.userTracingInvocationTag = jsg::JsRef(js, tag);
+  }
+  return KJ_ASSERT_NONNULL(incomingRequest.userTracingInvocationTag).getHandle(js);
 }
 
 SpanParent IoContext::getCurrentTraceSpan() {

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1272,7 +1272,6 @@ jsg::AsyncContextFrame::StorageScope IoContext::makeUserAsyncTraceScope(
   } else {
     userSpan = getRootUserTraceSpan();
   }
-
   kj::Maybe<tracing::InvocationSpanContext> invocationSpanContext;
   if (userSpan.isObserved()) {
     auto& baseContext = getCurrentIncomingRequest().getInvocationSpanContext();

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -310,7 +310,6 @@ kj::Date IoContext::IncomingRequest::nowForTraceOnset() {
 }
 
 IoContext::IncomingRequest::~IoContext_IncomingRequest() noexcept(false) {
-  selfRef->invalidate();
   if (!wasDelivered) {
     KJ_IF_SOME(w, workerTracer) {
       w->markUnused();
@@ -1305,12 +1304,18 @@ jsg::AsyncContextFrame::StorageScope IoContext::makeUserAsyncTraceScope(
       kj::mv(userSpan), kj::mv(tracer), kj::mv(invocationSpanContext));
   auto ioOwnAsyncContext = ioContext.addObject(kj::mv(asyncContext));
   auto contextHandle = jsg::wrapOpaque(js.v8Context(), kj::mv(ioOwnAsyncContext));
+  jsg::JsObject contextHolder(contextHandle.As<v8::Object>());
 
   if (invocationTag == kj::none) {
-    invocationTag = getOrCreateUserTracingInvocationTag(js, getCurrentIncomingRequest());
+    auto& request = getCurrentIncomingRequest();
+    KJ_IF_SOME(anchor, request.userTracingInvocationAnchor) {
+      invocationTag = anchor.getHandle(js);
+    } else {
+      request.userTracingInvocationAnchor = jsg::JsRef(js, contextHolder);
+      invocationTag = contextHolder;
+    }
   }
 
-  jsg::JsObject contextHolder(contextHandle.As<v8::Object>());
   contextHolder.setPrivate(js, USER_TRACING_INVOCATION_TAG, KJ_ASSERT_NONNULL(invocationTag));
   return jsg::AsyncContextFrame::StorageScope(
       js, lock.getUserTraceAsyncContextKey(), js.v8Ref(contextHandle));
@@ -1334,19 +1339,23 @@ kj::Maybe<jsg::JsObject> IoContext::getUserTracingInvocationTag(jsg::Lock& js) {
     return kj::mv(tag);
   }
   if (!incomingRequests.empty()) {
-    return getOrCreateUserTracingInvocationTag(js, getCurrentIncomingRequest());
+    KJ_IF_SOME(anchor, getCurrentIncomingRequest().userTracingInvocationAnchor) {
+      return anchor.getHandle(js);
+    }
   }
   return kj::none;
 }
 
-jsg::JsObject IoContext::getOrCreateUserTracingInvocationTag(
-    jsg::Lock& js, IncomingRequest& incomingRequest) {
-  if (incomingRequest.userTracingInvocationTag == kj::none) {
-    auto state = kj::heap<UserTracingInvocationSpanTag>(incomingRequest.getWeakRef());
-    auto tag = js.opaque(addObject(kj::mv(state)));
-    incomingRequest.userTracingInvocationTag = jsg::JsRef(js, tag);
+kj::Maybe<IoContext::IncomingRequest&> IoContext::getIncomingRequestForUserTracingInvocation(
+    jsg::Lock& js, jsg::JsObject invocationTag) {
+  for (auto& request: incomingRequests) {
+    KJ_IF_SOME(anchor, request.userTracingInvocationAnchor) {
+      if (jsg::JsValue(anchor.getHandle(js)).strictEquals(invocationTag)) {
+        return request;
+      }
+    }
   }
-  return KJ_ASSERT_NONNULL(incomingRequest.userTracingInvocationTag).getHandle(js);
+  return kj::none;
 }
 
 SpanParent IoContext::getCurrentTraceSpan() {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -107,6 +107,8 @@ class UserTraceAsyncContext final {
 // already completed.
 class IoContext_IncomingRequest final {
  public:
+  using WeakRef = workerd::WeakRef<IoContext_IncomingRequest>;
+
   IoContext_IncomingRequest(kj::Own<IoContext> context,
       kj::Rc<IoChannelFactory> ioChannelFactory,
       kj::Own<RequestObserver> metrics,
@@ -116,6 +118,10 @@ class IoContext_IncomingRequest final {
       kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory = kj::none);
   KJ_DISALLOW_COPY_AND_MOVE(IoContext_IncomingRequest);
   ~IoContext_IncomingRequest() noexcept(false);
+
+  kj::Own<WeakRef> getWeakRef() {
+    return kj::addRef(*selfRef);
+  }
 
   IoContext& getContext() {
     return *context;
@@ -213,6 +219,8 @@ class IoContext_IncomingRequest final {
   kj::Rc<IoChannelFactory> ioChannelFactory;
   kj::Maybe<kj::Own<AccessInfo>> accessInfo;
   kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory;
+  kj::Own<WeakRef> selfRef = kj::refcounted<WeakRef>(kj::Badge<IoContext_IncomingRequest>(), *this);
+  kj::Maybe<jsg::JsRef<jsg::JsObject>> userTracingInvocationTag;
 
   // Root user trace span for this request. Populated during delivered() via
   // BaseTracer::makeUserRequestSpan(); otherwise a null SpanParent. The tracer it references
@@ -251,6 +259,15 @@ class IoContext_IncomingRequest final {
   kj::Promise<T> maybeAddGcPassForTest(kj::Promise<T> promise);
 
   friend class IoContext;
+};
+
+// Request-specific state carried through the user-tracing async context as an opaque JS object.
+// The request is weakly referenced so captured async contexts cannot extend request lifetime.
+struct UserTracingInvocationSpanTag {
+  explicit UserTracingInvocationSpanTag(kj::Own<IoContext_IncomingRequest::WeakRef> request)
+      : request(kj::mv(request)) {}
+
+  kj::Own<IoContext_IncomingRequest::WeakRef> request;
 };
 
 // IoContext holds state associated with a single I/O context. For stateless requests, each
@@ -1112,6 +1129,13 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   jsg::AsyncContextFrame::StorageScope makeUserAsyncTraceScope(
       Worker::Lock& lock, kj::Maybe<SpanParent> userSpan = kj::none) KJ_WARN_UNUSED_RESULT;
 
+  // Returns the invocation tag propagated by the current user-tracing async context.
+  kj::Maybe<jsg::JsObject> getCurrentUserTracingInvocationTag(jsg::Lock& js);
+
+  // Returns the propagated invocation tag, falling back to the request currently used for runtime
+  // attribution when execution is detached into the root async context.
+  kj::Maybe<jsg::JsObject> getUserTracingInvocationTag(jsg::Lock& js);
+
   // Returns the current span being recorded.  If called while the JS lock is held, uses the trace
   // information from the current async context, if available.
   SpanParent getCurrentTraceSpan();
@@ -1258,6 +1282,8 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   void taskFailed(kj::Exception&& exception) override;
   void requireCurrent();
   void checkFarGet(const DeleteQueue& expectedQueue, const std::type_info& type);
+  jsg::JsObject getOrCreateUserTracingInvocationTag(
+      jsg::Lock& js, IncomingRequest& incomingRequest);
 
   kj::Maybe<jsg::JsRef<jsg::JsObject>> promiseContextTag;
   kj::Maybe<jsg::JsRef<jsg::JsObject>> entrypointHandler;

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -107,8 +107,6 @@ class UserTraceAsyncContext final {
 // already completed.
 class IoContext_IncomingRequest final {
  public:
-  using WeakRef = workerd::WeakRef<IoContext_IncomingRequest>;
-
   IoContext_IncomingRequest(kj::Own<IoContext> context,
       kj::Rc<IoChannelFactory> ioChannelFactory,
       kj::Own<RequestObserver> metrics,
@@ -118,10 +116,6 @@ class IoContext_IncomingRequest final {
       kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory = kj::none);
   KJ_DISALLOW_COPY_AND_MOVE(IoContext_IncomingRequest);
   ~IoContext_IncomingRequest() noexcept(false);
-
-  kj::Own<WeakRef> getWeakRef() {
-    return kj::addRef(*selfRef);
-  }
 
   IoContext& getContext() {
     return *context;
@@ -219,8 +213,7 @@ class IoContext_IncomingRequest final {
   kj::Rc<IoChannelFactory> ioChannelFactory;
   kj::Maybe<kj::Own<AccessInfo>> accessInfo;
   kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory;
-  kj::Own<WeakRef> selfRef = kj::refcounted<WeakRef>(kj::Badge<IoContext_IncomingRequest>(), *this);
-  kj::Maybe<jsg::JsRef<jsg::JsObject>> userTracingInvocationTag;
+  kj::Maybe<jsg::JsRef<jsg::JsObject>> userTracingInvocationAnchor;
 
   // Root user trace span for this request. Populated during delivered() via
   // BaseTracer::makeUserRequestSpan(); otherwise a null SpanParent. The tracer it references
@@ -259,15 +252,6 @@ class IoContext_IncomingRequest final {
   kj::Promise<T> maybeAddGcPassForTest(kj::Promise<T> promise);
 
   friend class IoContext;
-};
-
-// Request-specific state carried through the user-tracing async context as an opaque JS object.
-// The request is weakly referenced so captured async contexts cannot extend request lifetime.
-struct UserTracingInvocationSpanTag {
-  explicit UserTracingInvocationSpanTag(kj::Own<IoContext_IncomingRequest::WeakRef> request)
-      : request(kj::mv(request)) {}
-
-  kj::Own<IoContext_IncomingRequest::WeakRef> request;
 };
 
 // IoContext holds state associated with a single I/O context. For stateless requests, each
@@ -1136,6 +1120,10 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   // attribution when execution is detached into the root async context.
   kj::Maybe<jsg::JsObject> getUserTracingInvocationTag(jsg::Lock& js);
 
+  // Finds the live request associated with an invocation tag in this IoContext.
+  kj::Maybe<IncomingRequest&> getIncomingRequestForUserTracingInvocation(
+      jsg::Lock& js, jsg::JsObject invocationTag) KJ_LIFETIMEBOUND;
+
   // Returns the current span being recorded.  If called while the JS lock is held, uses the trace
   // information from the current async context, if available.
   SpanParent getCurrentTraceSpan();
@@ -1282,9 +1270,6 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   void taskFailed(kj::Exception&& exception) override;
   void requireCurrent();
   void checkFarGet(const DeleteQueue& expectedQueue, const std::type_info& type);
-  jsg::JsObject getOrCreateUserTracingInvocationTag(
-      jsg::Lock& js, IncomingRequest& incomingRequest);
-
   kj::Maybe<jsg::JsRef<jsg::JsObject>> promiseContextTag;
   kj::Maybe<jsg::JsRef<jsg::JsObject>> entrypointHandler;
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4850,6 +4850,7 @@ interface Tracing {
   ): T;
   startSpan(name: string): Span;
   getActiveSpan(): Span | undefined;
+  getInvocationSpan(): Span | undefined;
   Span: typeof Span;
 }
 declare abstract class Span {

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4859,6 +4859,7 @@ export interface Tracing {
   ): T;
   startSpan(name: string): Span;
   getActiveSpan(): Span | undefined;
+  getInvocationSpan(): Span | undefined;
   Span: typeof Span;
 }
 export declare abstract class Span {

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -4573,6 +4573,7 @@ interface Tracing {
   ): T;
   startSpan(name: string): Span;
   getActiveSpan(): Span | undefined;
+  getInvocationSpan(): Span | undefined;
   Span: typeof Span;
 }
 declare abstract class Span {

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -4582,6 +4582,7 @@ export interface Tracing {
   ): T;
   startSpan(name: string): Span;
   getActiveSpan(): Span | undefined;
+  getInvocationSpan(): Span | undefined;
   Span: typeof Span;
 }
 export declare abstract class Span {


### PR DESCRIPTION
We want to encourage users to enrich spans by adding attributes on them, especially the root invocation span since that contains so much rich information. It's likely that you will want to have access to it in a lot of different parts of your codebase.

If you don't create any child spans, then `tracing.getActiveSpan()` will do this, but as soon as someone wraps that function in a custom span, now you're annotating the wrong span! [You can work around this by saving a reference to the root span](https://jeremymorrell.dev/blog/a-practitioners-guide-to-wide-events/#write-a-middleware-to-help-you) but that requires a lot of setup.

This is a place where we can be slightly opinionated. The system should do this for you.

This adds `tracing.getInvocationSpan` which will always return a reference to the root invocation span if one exists.

```ts
let span = tracing.getInvocationSpan()

// this will be queryable alongside the other attributes we automatically add
// such as colo, http method, geo, browser info, etc
span.setAttributes({
  "user.id": "important-vip"
});
```