### PR TITLE
Automatically inject python_workers flags for python entrypoints

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -143,6 +143,7 @@ wd_cc_library(
         ":compatibility-date_capnp",
         ":maximum-compatibility-date",
         ":release-version",
+        "//src/workerd/util:strong-bool",
         "@capnp-cpp//src/capnp",
         "@capnp-cpp//src/kj",
     ],

--- a/src/workerd/io/compatibility-date-test.c++
+++ b/src/workerd/io/compatibility-date-test.c++
@@ -360,6 +360,44 @@ KJ_TEST("compatibility flag parsing") {
       {}, CompatibilityDateValidation::FUTURE_FOR_TEST, false, false);
 }
 
+KJ_TEST("auto-injected pythonWorkers compat flags in flag implication") {
+  capnp::MallocMessageBuilder message;
+  auto orphanage = message.getOrphanage();
+
+  auto flagListOrphan = orphanage.newOrphan<capnp::List<capnp::Text>>(1);
+  auto flagList = flagListOrphan.get();
+  flagList.set(0, "auto_inject_python_workers"_kj);
+
+  auto outputOrphan = orphanage.newOrphan<CompatibilityFlags>();
+  auto output = outputOrphan.get();
+
+  // When python is a main module, the auto-injected flags should be set
+  SimpleWorkerErrorReporter errorReporter;
+  compileCompatibilityFlags("2025-10-16", flagList.asReader(), output, errorReporter, true,
+      CompatibilityDateValidation::FUTURE_FOR_TEST, nullptr, MainModuleIsPython::YES);
+  KJ_EXPECT(errorReporter.errors.size() == 0, kj::strArray(errorReporter.errors, "; "));
+
+  auto flags = output.asReader();
+  KJ_EXPECT(flags.getAutoInjectPythonWorkers());
+  KJ_EXPECT(flags.getPythonWorkers());
+  KJ_EXPECT(flags.getPythonWorkflows());
+  KJ_EXPECT(flags.getPythonWorkers20250116());
+  KJ_EXPECT(flags.getPythonDedicatedSnapshot());
+
+  // Without the gate, a Python main module alone injects nothing.
+  auto emptyFlagsOrphan = orphanage.newOrphan<capnp::List<capnp::Text>>(0);
+  auto gateOffOrphan = orphanage.newOrphan<CompatibilityFlags>();
+  auto gateOffOutput = gateOffOrphan.get();
+  compileCompatibilityFlags("2025-10-16", emptyFlagsOrphan.get().asReader(), gateOffOutput,
+      errorReporter, true, CompatibilityDateValidation::FUTURE_FOR_TEST, nullptr,
+      MainModuleIsPython::YES);
+  KJ_EXPECT(errorReporter.errors.size() == 0, kj::strArray(errorReporter.errors, "; "));
+
+  auto gateOffFlags = gateOffOutput.asReader();
+  KJ_EXPECT(!gateOffFlags.getAutoInjectPythonWorkers());
+  KJ_EXPECT(!gateOffFlags.getPythonWorkers());
+}
+
 KJ_TEST("a reporter that ignores warnings accepts a redundant compatibility flag") {
   // A reporter that leaves `addWarning()` at its default -- as deploy-time validation does, since
   // it distinguishes only valid configurations from invalid ones -- must not see a redundant flag

--- a/src/workerd/io/compatibility-date.c++
+++ b/src/workerd/io/compatibility-date.c++
@@ -105,7 +105,8 @@ static void compileCompatibilityFlags(kj::StringPtr compatDate,
     ValidationErrorReporter& errorReporter,
     bool allowExperimentalFeatures,
     CompatibilityDateValidation dateValidation,
-    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags) {
+    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags,
+    MainModuleIsPython mainModuleIsPython) {
   auto parsedCompatDate = CompatDate::parse(compatDate, errorReporter);
 
   switch (dateValidation) {
@@ -261,6 +262,13 @@ static void compileCompatibilityFlags(kj::StringPtr compatDate,
     dynamicOutput.set(field, enableByFlag || (enableByDate && !disableByFlag));
   }
 
+  // Inject python_workers compat flag if the main entrypoint is Python.
+  // The order is important, as there are other compat flags derived from python_workers compat flag.
+  // So python_workers compat flag should be set before implying other compat flags.
+  if (mainModuleIsPython.toBool() && output.getAutoInjectPythonWorkers()) {
+    output.setPythonWorkers(true);
+  }
+
   for (auto& implied: impliedByList) {
     if (capnp::toDynamic(output).get(implied.other).as<bool>()) {
       dynamicOutput.set(implied.field, true);
@@ -278,7 +286,8 @@ void compileCompatibilityFlags(kj::StringPtr compatDate,
     ValidationErrorReporter& errorReporter,
     bool allowExperimentalFeatures,
     CompatibilityDateValidation dateValidation,
-    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags) {
+    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags,
+    MainModuleIsPython mainModuleIsPython) {
   kj::HashSet<kj::String> flagSet;
   flagSet.reserve(compatFlags.size());
   for (auto flag: compatFlags) {
@@ -288,7 +297,7 @@ void compileCompatibilityFlags(kj::StringPtr compatDate,
   }
 
   return compileCompatibilityFlags(compatDate, kj::mv(flagSet), output, errorReporter,
-      allowExperimentalFeatures, dateValidation, allowedExperimentalFlags);
+      allowExperimentalFeatures, dateValidation, allowedExperimentalFlags, mainModuleIsPython);
 }
 
 void compileCompatibilityFlags(kj::StringPtr compatDate,
@@ -297,7 +306,8 @@ void compileCompatibilityFlags(kj::StringPtr compatDate,
     ValidationErrorReporter& errorReporter,
     bool allowExperimentalFeatures,
     CompatibilityDateValidation dateValidation,
-    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags) {
+    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags,
+    MainModuleIsPython mainModuleIsPython) {
   kj::HashSet<kj::String> flagSet;
   flagSet.reserve(compatFlags.size());
   for (auto& flag: compatFlags) {
@@ -307,7 +317,7 @@ void compileCompatibilityFlags(kj::StringPtr compatDate,
   }
 
   return compileCompatibilityFlags(compatDate, kj::mv(flagSet), output, errorReporter,
-      allowExperimentalFeatures, dateValidation, allowedExperimentalFlags);
+      allowExperimentalFeatures, dateValidation, allowedExperimentalFlags, mainModuleIsPython);
 }
 
 namespace {

--- a/src/workerd/io/compatibility-date.capnp
+++ b/src/workerd/io/compatibility-date.capnp
@@ -1671,4 +1671,12 @@ struct CompatibilityFlags @0x8f8c1b68151b6cef {
   # abort, and UA-fired events on WebSocket, EventSource, and MessagePort) use the spec's
   # report-and-continue semantics. Internal runtime event delivery (fetch, scheduled, etc.)
   # is not affected and always propagates.
+
+  autoInjectPythonWorkers @189 :Bool
+      $compatEnableFlag("auto_inject_python_workers")
+      $compatDisableFlag("no_auto_inject_python_workers")
+      $experimental;
+  # When enabled, a Worker whose entrypoint is Python are automatically
+  # considered as a Python Worker. This flag will be obsoleted once the feature
+  # is stable.
 }

--- a/src/workerd/io/compatibility-date.h
+++ b/src/workerd/io/compatibility-date.h
@@ -6,6 +6,7 @@
 
 #include <workerd/io/compatibility-date.capnp.h>
 #include <workerd/io/validation.h>
+#include <workerd/util/strong-bool.h>
 
 namespace workerd {
 
@@ -31,20 +32,26 @@ enum class CompatibilityDateValidation {
   FUTURE_FOR_TEST
 };
 
+// Whether the Worker's main module is declared as a Python module.
+// This value is used to derive and inject compat flags related to Python Workers.
+WD_STRONG_BOOL(MainModuleIsPython);
+
 void compileCompatibilityFlags(kj::StringPtr compatDate,
     capnp::List<capnp::Text>::Reader compatFlags,
     CompatibilityFlags::Builder output,
     ValidationErrorReporter& errorReporter,
     bool allowExperimentalFeatures,
     CompatibilityDateValidation dateValidation,
-    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags);
+    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags,
+    MainModuleIsPython mainModuleIsPython = MainModuleIsPython::NO);
 void compileCompatibilityFlags(kj::StringPtr compatDate,
     kj::ArrayPtr<const kj::String> compatFlags,
     CompatibilityFlags::Builder output,
     ValidationErrorReporter& errorReporter,
     bool allowExperimentalFeatures,
     CompatibilityDateValidation dateValidation,
-    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags);
+    kj::ArrayPtr<const kj::StringPtr> allowedExperimentalFlags,
+    MainModuleIsPython mainModuleIsPython = MainModuleIsPython::NO);
 
 // Return an array of compatibility enable-flags which express the given FeatureFlags. The returned
 // StringPtrs point to FeatureFlags annotation parameters, which live in static storage.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -5512,6 +5512,20 @@ kj::Own<WorkerStubChannel> Server::WorkerService::loadIsolate(uint loaderChannel
   return channels.workerLoaders[loaderChannel]->loadIsolate(kj::mv(name), kj::mv(fetchSource));
 }
 
+static MainModuleIsPython isPythonMainModule(config::Worker::Reader conf) {
+  if (!conf.isModules()) {
+    // Service workers syntax has no main module.
+    return MainModuleIsPython::NO;
+  }
+  auto modules = conf.getModules();
+  if (modules.size() == 0) {
+    // An empty module list is a config error, reported elsewhere.
+    return MainModuleIsPython::NO;
+  }
+  // The first module is the main module.
+  return modules[0].isPythonModule() ? MainModuleIsPython::YES : MainModuleIsPython::NO;
+}
+
 kj::Promise<kj::Own<Server::Service>> Server::makeWorker(kj::StringPtr name,
     config::Worker::Reader conf,
     capnp::List<config::Extension>::Reader extensions) {
@@ -5535,11 +5549,12 @@ kj::Promise<kj::Own<Server::Service>> Server::makeWorker(kj::StringPtr name,
     // Use FUTURE_FOR_TEST to allow any valid date (including far future like 2999-12-31)
     // without validation against CODE_VERSION or current date.
     compileCompatibilityFlags(overrideDate, conf.getCompatibilityFlags(), featureFlags,
-        errorReporter, experimental, CompatibilityDateValidation::FUTURE_FOR_TEST, nullptr);
+        errorReporter, experimental, CompatibilityDateValidation::FUTURE_FOR_TEST, nullptr,
+        isPythonMainModule(conf));
   } else if (conf.hasCompatibilityDate()) {
     compileCompatibilityFlags(conf.getCompatibilityDate(), conf.getCompatibilityFlags(),
         featureFlags, errorReporter, experimental, CompatibilityDateValidation::CODE_VERSION,
-        nullptr);
+        nullptr, isPythonMainModule(conf));
   } else {
     errorReporter.addError(kj::str("Worker must specify compatibilityDate."));
   }


### PR DESCRIPTION
This update compat flags calculation logic so that running and deploying Python workers does not need  `python_workers` compat flag explicitly set. `python_workers` compat flag is now injected automatically when the main entrypoint in Python.

I added a temporary compat flag `auto_inject_python_workers` that enables this behavior, which can be either removed or obsoleted after testing and when we release Python workers GA