### PR TITLE
Tag post-delivery exceptions to distinguish runtime failures

### DIFF
--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -9,6 +9,7 @@
 #include <workerd/io/features.h>
 #include <workerd/io/stored-value.h>
 #include <workerd/io/tracer.h>
+#include <workerd/io/worker-interface.h>
 #include <workerd/jsg/ser.h>
 #include <workerd/util/autogate.h>
 #include <workerd/util/completion-membrane.h>
@@ -2453,6 +2454,7 @@ kj::Promise<WorkerInterface::CustomEvent::Result> JsRpcSessionCustomEvent::run(
     // Make sure the top-level capability is revoked with the same exception that `run()` is
     // throwing, rather than some generic revocation exception.
     auto e = kj::getCaughtExceptionAsKj();
+    markExceptionAsDelivered(e);
     // These are exceptions for a top-level jsRpc call and will cause the jsRpc customEvent to have
     // an exception outcome – log the exception to avoid reporting an exception outcome without the
     // actual exception.

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -610,6 +610,14 @@ kj_test(
 )
 
 kj_test(
+    src = "worker-entrypoint-test.c++",
+    deps = [
+        ":worker-entrypoint",
+        "//src/workerd/tests:test-fixture",
+    ],
+)
+
+kj_test(
     src = "hibernation-manager-test.c++",
     deps = [
         ":io",

--- a/src/workerd/io/worker-entrypoint-test.c++
+++ b/src/workerd/io/worker-entrypoint-test.c++
@@ -1,0 +1,375 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "worker-entrypoint.h"
+
+#include <workerd/tests/test-fixture.h>
+
+#include <kj/test.h>
+
+namespace workerd {
+namespace {
+
+class FailingIoChannelFactory final: public TestFixture::DummyIoChannelFactory {
+ public:
+  FailingIoChannelFactory(TimerChannel& timer): DummyIoChannelFactory(timer) {}
+
+  kj::Own<WorkerInterface> startSubrequest(uint channel, SubrequestMetadata metadata) override {
+    return WorkerInterface::fromException(KJ_EXCEPTION(FAILED, "connect failed"));
+  }
+};
+
+class ThrowingIoChannelFactory final: public TestFixture::DummyIoChannelFactory {
+ public:
+  ThrowingIoChannelFactory(TimerChannel& timer): DummyIoChannelFactory(timer) {}
+
+  kj::Own<WorkerInterface> startSubrequest(uint channel, SubrequestMetadata metadata) override {
+    kj::throwFatalException(KJ_EXCEPTION(FAILED, "channel creation failed"));
+  }
+};
+
+class RejectingTimerChannel final: public TimerChannel {
+ public:
+  void syncTime() override {}
+
+  kj::Date now(kj::Maybe<kj::Date>) override {
+    return kj::UNIX_EPOCH;
+  }
+
+  kj::Promise<void> atTime(kj::Date) override {
+    return KJ_EXCEPTION(FAILED, "alarm scheduling failed");
+  }
+
+  kj::Promise<void> afterLimitTimeout(kj::Duration) override {
+    return kj::NEVER_DONE;
+  }
+};
+
+class TestConnectResponse final: public kj::HttpService::ConnectResponse {
+ public:
+  void accept(uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+    KJ_FAIL_ASSERT("connect unexpectedly succeeded");
+  }
+
+  kj::Own<kj::AsyncOutputStream> reject(uint statusCode,
+      kj::StringPtr statusText,
+      const kj::HttpHeaders& headers,
+      kj::Maybe<uint64_t> expectedBodySize) override {
+    KJ_FAIL_ASSERT("connect unexpectedly returned an HTTP error");
+  }
+};
+
+class ThrowingConnectResponse final: public kj::HttpService::ConnectResponse {
+ public:
+  void accept(uint statusCode, kj::StringPtr statusText, const kj::HttpHeaders& headers) override {
+    KJ_FAIL_ASSERT("connect unexpectedly succeeded");
+  }
+
+  kj::Own<kj::AsyncOutputStream> reject(uint statusCode,
+      kj::StringPtr statusText,
+      const kj::HttpHeaders& headers,
+      kj::Maybe<uint64_t> expectedBodySize) override {
+    kj::throwFatalException(KJ_EXCEPTION(FAILED, "connect rejection failed"));
+  }
+};
+
+class TestResponse final: public kj::HttpService::Response {
+ public:
+  kj::Own<kj::AsyncOutputStream> send(uint statusCode,
+      kj::StringPtr statusText,
+      const kj::HttpHeaders& headers,
+      kj::Maybe<uint64_t> expectedBodySize) override {
+    return kj::heap<kj::NullStream>();
+  }
+
+  kj::Own<kj::WebSocket> acceptWebSocket(const kj::HttpHeaders& headers) override {
+    KJ_FAIL_ASSERT("request unexpectedly returned a WebSocket");
+  }
+};
+
+class ThrowingResponse final: public kj::HttpService::Response {
+ public:
+  kj::Own<kj::AsyncOutputStream> send(uint statusCode,
+      kj::StringPtr statusText,
+      const kj::HttpHeaders& headers,
+      kj::Maybe<uint64_t> expectedBodySize) override {
+    kj::throwFatalException(KJ_EXCEPTION(FAILED, "response send failed"));
+  }
+
+  kj::Own<kj::WebSocket> acceptWebSocket(const kj::HttpHeaders& headers) override {
+    KJ_FAIL_ASSERT("request unexpectedly returned a WebSocket");
+  }
+};
+
+class FailingCustomEvent final: public WorkerInterface::CustomEvent {
+ public:
+  kj::Promise<Result> run(kj::Own<IoContext_IncomingRequest> incomingRequest,
+      kj::Maybe<kj::StringPtr> entrypointName,
+      kj::Maybe<Worker::VersionInfo> versionInfo,
+      Frankenvalue props,
+      kj::TaskSet& waitUntilTasks,
+      bool isDynamicDispatch) override {
+    incomingRequest->delivered();
+    incomingRequest->drain(waitUntilTasks, kj::mv(incomingRequest));
+    kj::throwFatalException(KJ_EXCEPTION(FAILED, "custom event failed"));
+  }
+
+  kj::Promise<Result> sendRpc(capnp::HttpOverCapnpFactory& httpOverCapnpFactory,
+      capnp::ByteStreamFactory& byteStreamFactory,
+      FrankenvalueHandler& frankenvalueHandler,
+      rpc::EventDispatcher::Client dispatcher) override {
+    KJ_UNIMPLEMENTED();
+  }
+
+  kj::Promise<Result> notSupported() override {
+    KJ_UNIMPLEMENTED();
+  }
+
+  uint16_t getType() override {
+    return 123;
+  }
+
+  tracing::EventInfo getEventInfo() const override {
+    return tracing::CustomEventInfo();
+  }
+};
+
+class RecordingObserver final: public RequestObserver, public WorkerInterface {
+ public:
+  WorkerInterface& wrapWorkerInterface(WorkerInterface& worker) override {
+    inner = worker;
+    return *this;
+  }
+
+  void reportFailure(const kj::Exception& exception, FailureSource source) override {
+    ++failureCount;
+    if (outcome == kj::none) {
+      outcome = outcomeFromException(exception, source);
+    }
+  }
+
+  kj::Promise<void> request(kj::HttpMethod method,
+      kj::StringPtr url,
+      const kj::HttpHeaders& headers,
+      kj::AsyncInputStream& requestBody,
+      kj::HttpService::Response& response) override {
+    try {
+      co_await KJ_ASSERT_NONNULL(inner).request(method, url, headers, requestBody, response);
+    } catch (...) {
+      auto exception = kj::getCaughtExceptionAsKj();
+      reportFailure(exception, FailureSource::OTHER);
+      kj::throwFatalException(kj::mv(exception));
+    }
+  }
+
+  kj::Promise<void> connect(kj::StringPtr host,
+      const kj::HttpHeaders& headers,
+      kj::AsyncIoStream& connection,
+      ConnectResponse& response,
+      kj::HttpConnectSettings settings) override {
+    KJ_UNIMPLEMENTED();
+  }
+
+  kj::Promise<void> prewarm(kj::StringPtr url) override {
+    KJ_UNIMPLEMENTED();
+  }
+
+  kj::Promise<ScheduledResult> runScheduled(kj::Date scheduledTime, kj::StringPtr cron) override {
+    KJ_UNIMPLEMENTED();
+  }
+
+  kj::Promise<AlarmResult> runAlarm(kj::Date scheduledTime, uint32_t retryCount) override {
+    KJ_UNIMPLEMENTED();
+  }
+
+  kj::Promise<CustomEvent::Result> customEvent(kj::Own<CustomEvent> event) override {
+    KJ_UNIMPLEMENTED();
+  }
+
+  kj::Maybe<EventOutcome> outcome;
+
+  uint failureCount = 0;
+
+ private:
+  kj::Maybe<WorkerInterface&> inner;
+};
+
+KJ_TEST("connect pass-through tags failures after delivery") {
+  capnp::MallocMessageBuilder flagsMessage;
+  auto flags = flagsMessage.initRoot<CompatibilityFlags>();
+  flags.setConnectPassThrough(true);
+
+  TestFixture fixture(TestFixture::SetupParams{
+    .featureFlags = flags.asReader(),
+    .useRealTimers = false,
+    .ioChannelFactory = kj::Function<kj::Rc<IoChannelFactory>(TimerChannel&)>(
+        [](TimerChannel& timer) -> kj::Rc<IoChannelFactory> {
+    return kj::rc<FailingIoChannelFactory>(timer);
+  }),
+  });
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+  kj::HttpHeaderTable headerTable;
+  kj::HttpHeaders headers(headerTable);
+  kj::NullStream connection;
+  TestConnectResponse response;
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    entrypoint->connect("example.com", headers, connection, response, {})
+        .wait(fixture.getWaitScope());
+  });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getDescription().contains("connect failed"));
+  KJ_EXPECT(e.getDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID) != kj::none);
+}
+
+KJ_TEST("connect pass-through tags channel creation failures after delivery") {
+  capnp::MallocMessageBuilder flagsMessage;
+  auto flags = flagsMessage.initRoot<CompatibilityFlags>();
+  flags.setConnectPassThrough(true);
+
+  TestFixture fixture(TestFixture::SetupParams{
+    .featureFlags = flags.asReader(),
+    .useRealTimers = false,
+    .ioChannelFactory = kj::Function<kj::Rc<IoChannelFactory>(TimerChannel&)>(
+        [](TimerChannel& timer) -> kj::Rc<IoChannelFactory> {
+    return kj::rc<ThrowingIoChannelFactory>(timer);
+  }),
+  });
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+  kj::HttpHeaderTable headerTable;
+  kj::HttpHeaders headers(headerTable);
+  kj::NullStream connection;
+  TestConnectResponse response;
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    entrypoint->connect("example.com", headers, connection, response, {})
+        .wait(fixture.getWaitScope());
+  });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getDescription().contains("channel creation failed"));
+  KJ_EXPECT(e.getDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID) != kj::none);
+}
+
+KJ_TEST("connect rejection failures stay tagged after delivery") {
+  TestFixture fixture;
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+  kj::HttpHeaderTable headerTable;
+  kj::HttpHeaders headers(headerTable);
+  kj::NullStream connection;
+  ThrowingConnectResponse response;
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    entrypoint->connect("example.com", headers, connection, response, {})
+        .wait(fixture.getWaitScope());
+  });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getDescription().contains("connect rejection failed"));
+  KJ_EXPECT(e.getDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID) != kj::none);
+}
+
+KJ_TEST("alarm scheduling tags failures after delivery") {
+  RejectingTimerChannel timer;
+  TestFixture fixture(TestFixture::SetupParams{
+    .actorId = Worker::Actor::Id(kj::str("alarm-test")),
+    .useRealTimers = false,
+    .ioChannelFactory = kj::Function<kj::Rc<IoChannelFactory>(TimerChannel&)>(
+        [&timer](TimerChannel&) -> kj::Rc<IoChannelFactory> {
+    return kj::rc<TestFixture::DummyIoChannelFactory>(timer);
+  }),
+  });
+  auto scheduledTime = kj::UNIX_EPOCH + kj::SECONDS;
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+
+  auto exception = kj::runCatchingExceptions(
+      [&]() { entrypoint->runAlarm(scheduledTime, 0).wait(fixture.getWaitScope()); });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getDescription().contains("alarm scheduling failed"));
+  KJ_EXPECT(e.getDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID) != kj::none);
+}
+
+KJ_TEST("custom events tag failures after delivery") {
+  TestFixture fixture;
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    entrypoint->customEvent(kj::heap<FailingCustomEvent>()).wait(fixture.getWaitScope());
+  });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getDescription().contains("custom event failed"));
+  KJ_EXPECT(e.getDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID) != kj::none);
+}
+
+KJ_TEST("synthetic response failures stay tagged after delivery") {
+  static constexpr auto source = R"(
+    export default {
+      fetch() { throw new Error("handler failed"); }
+    };
+  )"_kj;
+
+  TestFixture fixture(TestFixture::SetupParams{.mainModuleSource = source});
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+  kj::HttpHeaderTable headerTable;
+  kj::HttpHeaders headers(headerTable);
+  kj::NullStream requestBody;
+  ThrowingResponse response;
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    entrypoint->request(kj::HttpMethod::GET, "https://example.com", headers, requestBody, response)
+        .wait(fixture.getWaitScope());
+  });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getDescription().contains("response send failed"));
+  KJ_EXPECT(e.getDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID) != kj::none);
+}
+
+KJ_TEST("output gate failure replaces an earlier handler failure") {
+  static constexpr auto source = R"(
+    export default {
+      fetch() { throw new Error("handler failed"); }
+    };
+  )"_kj;
+
+  auto observer = kj::refcounted<RecordingObserver>();
+  TestFixture fixture(TestFixture::SetupParams{
+    .mainModuleSource = source,
+    .actorId = Worker::Actor::Id(kj::str("output-gate-test")),
+    .useRealTimers = false,
+    .requestObserverFactory = kj::Function<kj::Own<RequestObserver>()>(
+        [&observer]() -> kj::Own<RequestObserver> { return kj::addRef(*observer); }),
+  });
+
+  auto gatePaf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(gatePaf.promise), nullptr);
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+  kj::HttpHeaderTable headerTable;
+  kj::HttpHeaders headers(headerTable);
+  kj::NullStream requestBody;
+  TestResponse response;
+  auto request =
+      entrypoint->request(
+                    kj::HttpMethod::GET, "https://example.com", headers, requestBody, response)
+          .eagerlyEvaluate(nullptr);
+
+  fixture.pollEventLoop();
+  gatePaf.fulfiller->reject(KJ_EXCEPTION(OVERLOADED, "output gate failed"));
+
+  auto exception = kj::runCatchingExceptions([&]() { request.wait(fixture.getWaitScope()); });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getType() == kj::Exception::Type::OVERLOADED);
+  KJ_EXPECT(e.getDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID) != kj::none);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(observer->outcome) == EventOutcome::INTERNAL_ERROR);
+  KJ_EXPECT(observer->failureCount == 1);
+
+  KJ_EXPECT_THROW_MESSAGE("output gate failed", blocker.wait(fixture.getWaitScope()));
+}
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -496,10 +496,26 @@ kj::Promise<void> WorkerEntrypoint::requestImpl(kj::HttpMethod method,
         context.logUncaughtExceptionAsync(
             UncaughtExceptionSource::REQUEST_HANDLER, exception.clone());
 
+        // Record a failure if cancellation interrupts either wait. Otherwise the WorkerInterface
+        // wrapper reports it. An output-gate failure takes precedence over the handler failure.
+        kj::Maybe<kj::Exception> outputGateException;
+        auto reportFailure = kj::defer([&]() {
+          KJ_IF_SOME(e, outputGateException) {
+            metricsForCatch->reportFailure(e);
+          } else {
+            metricsForCatch->reportFailure(exception);
+          }
+        });
+
         // Do not allow the exception to escape the isolate without waiting for the output gate to
         // open. Note that in the success path, this is taken care of in `FetchEvent::respondWith()`.
         // If the gate is broken, that exception propagates and replaces the original.
-        co_await context.waitForOutputLocks();
+        KJ_TRY {
+          co_await context.waitForOutputLocks();
+        }
+        KJ_CATCH(e) {
+          outputGateException.emplace(kj::mv(e));
+        }
         TRACE_EVENT("workerd", "WorkerEntrypoint::request() after output lock wait",
             PERFETTO_TERMINATING_FLOW_FROM_POINTER(this));
         // Yield to give a pending cancellation (e.g., the caller dropping our promise because
@@ -508,6 +524,11 @@ kj::Promise<void> WorkerEntrypoint::requestImpl(kj::HttpMethod method,
         // the chain crossed into the next `.then` after this catch; without it, downstream
         // observers can mistake a canceled request for one that threw.
         co_await kj::yield();
+        KJ_IF_SOME(e, outputGateException) {
+          reportFailure.cancel();
+          kj::throwFatalException(kj::mv(e));
+        }
+        reportFailure.cancel();
         kj::throwFatalException(kj::mv(exception));
       }
     }  // Above KJ_DEFER fires here: abort signal + drain.
@@ -539,6 +560,9 @@ kj::Promise<void> WorkerEntrypoint::requestImpl(kj::HttpMethod method,
     TRACE_EVENT("workerd", "WorkerEntrypoint::request() exception",
         PERFETTO_TERMINATING_FLOW_FROM_POINTER(this));
 
+    // Stage 1 called `delivered()`, so exceptions reaching this catch are post-delivery failures.
+    markExceptionAsDelivered(exception);
+
     auto isInternalException = !jsg::isTunneledException(exception.getDescription()) &&
         !jsg::isDoNotLogException(exception.getDescription());
     if (!loggedExceptionEarlier) {
@@ -557,11 +581,18 @@ kj::Promise<void> WorkerEntrypoint::requestImpl(kj::HttpMethod method,
     }
 
     auto sendSyntheticStatus = [&](uint statusCode, kj::StringPtr statusText) {
-      if (wrappedResponse->isSent()) return;
-      kj::HttpHeaders errorHeaders(threadContext.getHeaderTable());
-      wrappedResponse->send(statusCode, statusText, errorHeaders, static_cast<uint64_t>(0));
-      KJ_IF_SOME(t, workerTracer) {
-        t.setReturn(kj::none, tracing::FetchResponseInfo(wrappedResponse->getHttpResponseStatus()));
+      KJ_TRY {
+        if (wrappedResponse->isSent()) return;
+        kj::HttpHeaders errorHeaders(threadContext.getHeaderTable());
+        wrappedResponse->send(statusCode, statusText, errorHeaders, static_cast<uint64_t>(0));
+        KJ_IF_SOME(t, workerTracer) {
+          t.setReturn(
+              kj::none, tracing::FetchResponseInfo(wrappedResponse->getHttpResponseStatus()));
+        }
+      }
+      KJ_CATCH(e) {
+        markExceptionAsDelivered(e);
+        kj::throwFatalException(kj::mv(e));
       }
     };
 
@@ -655,12 +686,17 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
     // connect_pass_through feature flag means we should just forward the connect request on to
     // the global outbound.
 
-    auto next = context.getSubrequestChannelNoChecks(
-        IoContext::NEXT_CLIENT_CHANNEL, false, kj::mv(cfBlobJson));
-
     // Note: Intentionally return without co_await so that the `incomingRequest` is destroyed,
     //   because we don't have any need to keep the context around.
-    return next->connect(host, headers, connection, response, settings);
+    return kj::evalNow([&]() {
+      auto next = context.getSubrequestChannelNoChecks(
+          IoContext::NEXT_CLIENT_CHANNEL, false, kj::mv(cfBlobJson));
+      return next->connect(host, headers, connection, response, kj::mv(settings))
+          .attach(kj::mv(next));
+    }).catch_([](kj::Exception&& exception) -> kj::Promise<void> {
+      markExceptionAsDelivered(exception);
+      return kj::mv(exception);
+    });
   }
 
   // TODO(soon): Implement basic TLS support for connect handler.
@@ -714,6 +750,8 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
   }))
           .catch_([this, isActor, &response, metrics = kj::mv(metricsForCatch), workerTracer](
                       kj::Exception&& exception) mutable -> kj::Promise<void> {
+    markExceptionAsDelivered(exception);
+
     // Don't return errors to end user.
     auto isInternalException = !jsg::isTunneledException(exception.getDescription()) &&
         !jsg::isDoNotLogException(exception.getDescription());
@@ -752,18 +790,24 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
       // an exception.
       metrics->reportFailure(exception);
 
-      kj::HttpHeaders headers(threadContext.getHeaderTable());
-      if (exception.getType() == kj::Exception::Type::OVERLOADED) {
-        // Overloaded-type exceptions generally represent some resource exhaustion (i.e. not
-        // necessarily an internal error) and correspond to HTTP error 503.
-        response.reject(503, "Service Unavailable", headers, static_cast<uint64_t>(0));
-      } else {
-        response.reject(500, "Internal Server Error", headers, static_cast<uint64_t>(0));
+      KJ_TRY {
+        kj::HttpHeaders headers(threadContext.getHeaderTable());
+        if (exception.getType() == kj::Exception::Type::OVERLOADED) {
+          // Overloaded-type exceptions generally represent some resource exhaustion (i.e. not
+          // necessarily an internal error) and correspond to HTTP error 503.
+          response.reject(503, "Service Unavailable", headers, static_cast<uint64_t>(0));
+        } else {
+          response.reject(500, "Internal Server Error", headers, static_cast<uint64_t>(0));
+        }
+        KJ_IF_SOME(t, workerTracer) {
+          t.setReturn(kj::none,
+              tracing::FetchResponseInfo(
+                  exception.getType() == kj::Exception::Type::OVERLOADED ? 503 : 500));
+        }
       }
-      KJ_IF_SOME(t, workerTracer) {
-        t.setReturn(kj::none,
-            tracing::FetchResponseInfo(
-                exception.getType() == kj::Exception::Type::OVERLOADED ? 503 : 500));
+      KJ_CATCH(e) {
+        markExceptionAsDelivered(e);
+        return kj::mv(e);
       }
 
       return kj::READY_NOW;
@@ -868,7 +912,12 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarmImpl(
 
   incomingRequest->delivered();
 
-  auto scheduleAlarmResult = co_await actor.scheduleAlarm(scheduledTime);
+  auto scheduleAlarmResult = co_await kj::evalNow([&]() {
+    return actor.scheduleAlarm(scheduledTime);
+  }).catch_([](kj::Exception&& exception) -> kj::Promise<WorkerInterface::ScheduleAlarmResult> {
+    markExceptionAsDelivered(exception);
+    return kj::mv(exception);
+  });
   KJ_SWITCH_ONEOF(scheduleAlarmResult) {
     KJ_CASE_ONEOF(af, WorkerInterface::AlarmFulfiller) {
       // We're now in charge of running this alarm!
@@ -883,7 +932,7 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarmImpl(
         incomingRequest->drain(waitUntilTasks, kj::mv(incomingRequest));
       });
 
-      try {
+      KJ_TRY {
         auto result = co_await context.run(
             [scheduledTime, retryCount, entrypointName = entrypointName.clone(),
                 versionInfo = kj::mv(versionInfo),
@@ -922,11 +971,13 @@ kj::Promise<WorkerInterface::AlarmResult> WorkerEntrypoint::runAlarmImpl(
         af.fulfill(result.asOutcome());
         cancellationGuard.cancel();
         co_return kj::mv(result);
-      } catch (const kj::Exception& e) {
+      }
+      KJ_CATCH(e) {
+        markExceptionAsDelivered(e);
         // We failed, inform any other entrypoints that may be waiting upon us.
         af.reject(e);
         cancellationGuard.cancel();
-        throw;
+        kj::throwFatalException(kj::mv(e));
       }
     }
     KJ_CASE_ONEOF(outcome, WorkerInterface::AlarmOutcome) {
@@ -1025,11 +1076,17 @@ kj::Promise<WorkerInterface::CustomEvent::Result> WorkerEntrypoint::customEvent(
     t.setEventInfo(*incomingRequest, event->getEventInfo());
   }
 
-  return wrapWithCanceler(
-      event
-          ->run(kj::mv(incomingRequest), asPtr(entrypointName), kj::mv(versionInfo), kj::mv(props),
-              waitUntilTasks, isDynamicDispatch)
-          .attach(kj::mv(event)));
+  KJ_TRY {
+    return wrapWithCanceler(
+        event
+            ->run(kj::mv(incomingRequest), asPtr(entrypointName), kj::mv(versionInfo),
+                kj::mv(props), waitUntilTasks, isDynamicDispatch)
+            .attach(kj::mv(event)));
+  }
+  KJ_CATCH(exception) {
+    markExceptionAsDelivered(exception);
+    return kj::mv(exception);
+  }
 }
 
 }  // namespace

--- a/src/workerd/io/worker-interface.h
+++ b/src/workerd/io/worker-interface.h
@@ -20,6 +20,17 @@ class FrankenvalueHandler;
 class IoContext_IncomingRequest;
 struct Worker_VersionInfo;
 
+// Identifies exceptions propagated after `IncomingRequest::delivered()`. This detail survives RPC,
+// allowing consumers to distinguish runtime failures from startup failures. Any path that calls
+// `delivered()` must add it before propagating an exception.
+constexpr kj::Exception::DetailTypeId WORKER_REQUEST_DELIVERED_DETAIL_ID = 0x9d3c7f2e6b1a8450ull;
+
+inline void markExceptionAsDelivered(kj::Exception& exception) {
+  if (exception.getDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID) == kj::none) {
+    exception.setDetail(WORKER_REQUEST_DELIVERED_DETAIL_ID, kj::heapArray<kj::byte>(0));
+  }
+}
+
 // An interface representing the services made available by a worker/pipeline to handle a
 // request.
 class WorkerInterface: public kj::HttpService {
@@ -140,8 +151,8 @@ class WorkerInterface: public kj::HttpService {
       EventOutcome outcome;
     };
 
-    // Deliver the event to an isolate in this process. `incomingRequest` has been newly-allocated
-    // for this event.
+    // Deliver the event to an isolate in this process. `incomingRequest` is new for this event;
+    // implementations must call `delivered()` before starting work.
     virtual kj::Promise<Result> run(kj::Own<IoContext_IncomingRequest> incomingRequest,
         kj::Maybe<kj::StringPtr> entrypointName,
         kj::Maybe<Worker_VersionInfo> versionInfo,

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -36,6 +36,7 @@ wd_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/workerd/io",
+        "//src/workerd/io:worker-entrypoint",
         "//src/workerd/jsg",
         "//src/workerd/server:workerd-api",
         "//src/workerd/util:autogate",

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -13,6 +13,7 @@
 #include <workerd/io/limit-enforcer.h>
 #include <workerd/io/observer.h>
 #include <workerd/io/tracer.h>
+#include <workerd/io/worker-entrypoint.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/setup.h>
 #include <workerd/server/workerd-api.h>
@@ -515,6 +516,31 @@ TestFixture::Response TestFixture::runRequest(
   });
 
   return {.statusCode = response.statusCode, .body = response.body->str()};
+}
+
+kj::Own<WorkerInterface> TestFixture::makeWorkerEntrypoint() {
+  kj::Rc<IoChannelFactory> channelFactory;
+  KJ_IF_SOME(factory, ioChannelFactory) {
+    channelFactory = factory(*timerChannel);
+  } else {
+    channelFactory = kj::rc<DummyIoChannelFactory>(*timerChannel);
+  }
+
+  kj::Own<RequestObserver> observer;
+  KJ_IF_SOME(factory, requestObserverFactory) {
+    observer = factory();
+  } else {
+    observer = kj::refcounted<RequestObserver>();
+  }
+
+  kj::Maybe<kj::Own<Worker::Actor>> actorRef;
+  KJ_IF_SOME(a, actor) {
+    actorRef = kj::addRef(*a);
+  }
+
+  return newWorkerEntrypoint(threadContext, kj::atomicAddRef(*worker), kj::none, Frankenvalue(),
+      kj::mv(actorRef), kj::heap<MockLimitEnforcer>(), kj::Own<void>(), kj::mv(channelFactory),
+      kj::mv(observer), waitUntilTasks, false, kj::none, kj::none, kj::none);
 }
 
 }  // namespace workerd

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -116,6 +116,9 @@ struct TestFixture {
   // Performs HTTP request on the default module handler, and waits for full response.
   Response runRequest(kj::HttpMethod method, kj::StringPtr url, kj::StringPtr body);
 
+  // Constructs the same WorkerEntrypoint wrapper used in production.
+  kj::Own<WorkerInterface> makeWorkerEntrypoint();
+
   // Create a new IoContext, owned by the caller. Use this when you need an IoContext that
   // outlives a single IncomingRequest, e.g. to model an actor receiving multiple requests.
   kj::Own<IoContext> newIoContext();


### PR DESCRIPTION
Introduce WORKER_REQUEST_DELIVERED_DETAIL_ID as the authoritative boundary between startup and runtime failures.

Centralize custom-event delivery and tag escaping CONNECT, alarm, custom-event, and request failures. Preserve the final output-gate failure in request metrics while still reporting cancellation during the gate wait.

Clean up failed or replaced alarm scheduling state and guard replacement races with a generation. Add focused regression tests for each boundary.