### PR TITLE
Implement TS DigestStream

### DIFF
--- a/src/per_isolate/crypto/AGENTS.md
+++ b/src/per_isolate/crypto/AGENTS.md
@@ -35,11 +35,30 @@ declaration in `src/workerd/api/crypto/digest-bootstrap.h`.
 Two parts of that contract are easy to break:
 
 - **`update()` takes strings, and returns a byte count.** Strings are NOT
-  encoded on the TypeScript side. `jsg::Lock::toString()` emits WTF-8, which
-  differs from `TextEncoder` for unpaired surrogates, and both DigestStream
-  implementations must agree. The return value exists because a string's UTF-8
-  length is not observable from JavaScript. `crypto-streams-test.js`
-  (`stringChunksAreNotTextEncoded`) pins this for both implementations.
+  encoded on the TypeScript side, because the default encoding is not
+  expressible in JavaScript: a lone surrogate is hashed as WTF-8 (`ED A0 80`),
+  and `TextEncoder` can only produce the U+FFFD substitution. The return value
+  exists because a string's UTF-8 length is not observable from JavaScript.
+- **The string encoding is fixed at context creation**, by
+  `createDigestContext(name, toWellFormed)`. `toWellFormed: true` opts into the
+  U+FFFD substitution; the default is WTF-8 and must stay that way for
+  backwards compatibility. `crypto-streams-test.js` pins both directions for
+  both implementations — `stringChunksAreNotTextEncodedByDefault` catches a
+  changed default, `toWellFormedMatchesTextEncoder` catches an ignored option.
+- **`toWellFormed` is a streaming encoder, so it is stateful.** A surrogate pair
+  can be split across two writes, so a lead surrogate ending a chunk is held
+  back until the next chunk decides whether it pairs. Consequences for the
+  contract: `update()` can return 0 for a non-empty chunk, and **`flush()` must
+  be called before `digest()`** to account for a lead that was never paired
+  (3 bytes, U+FFFD). `digest()` flushes internally too, so forgetting
+  `flush()` costs an accurate `bytesWritten`, never a correct digest. The
+  default WTF-8 encoding is stateless and joins nothing — that is the historical
+  behavior, so the two encodings can disagree on `bytesWritten` across chunks
+  (4 bytes for a joined pair vs 3+3 for two lone surrogates).
+- **The option bag is coerced, not type-checked.** JSG unwraps
+  `jsg::Optional<bool>` with ToBoolean, so `{toWellFormed: 'false'}` opts *in*.
+  The TypeScript side reproduces this with `!!`, and
+  `toWellFormedIsCoerced`/`toWellFormedDefaultsToFalse` hold the two together.
 - **Chunks are not copied.** The digest consumes bytes synchronously inside
   `update()`, so a copy would be pure overhead — unlike
   `webstreams/identity.ts`, which copies because it enqueues. The consequence

--- a/src/per_isolate/crypto/AGENTS.md
+++ b/src/per_isolate/crypto/AGENTS.md
@@ -1,0 +1,74 @@
+# src/per_isolate/crypto/
+
+TypeScript reimplementations of crypto APIs that must be replaced when the
+`typescript_implemented_streams` compat flag is on. Parent directory
+conventions (primordials discipline, private-brand dispatch, no `instanceof`)
+apply — see `src/per_isolate/AGENTS.md`.
+
+## WHY THIS EXISTS
+
+`DigestStream` is one of only two `WritableStream` subclasses in the runtime.
+When the streams flag swaps `globalThis.WritableStream` for the TypeScript
+class, a C++ subclass of the *C++* `WritableStream` no longer passes the
+brand checks used by `pipeTo`, and `instanceof WritableStream` becomes false.
+Reimplementing the subclass in TypeScript is what restores the hierarchy.
+
+The other subclass, `FileSystemWritableFileStream`
+(`src/workerd/api/filesystem.h`), has the same problem but is not addressed
+here: it is constructed from C++ rather than by user code, so it needs a
+native source/sink bridge instead of a straight port.
+
+## FILE MAP
+
+| File               | Role                                                          |
+| ------------------ | ------------------------------------------------------------- |
+| `digest-stream.ts` | `DigestStream` — WritableStream subclass over a native digest |
+
+## THE C++ CONTRACT
+
+`digest-stream.ts` owns only the stream semantics. Hashing is done by a native
+`DigestContextHandle` (`src/workerd/api/crypto/crypto.h`), reached through
+`utils.createDigestContext(name)`, which is registered in
+`src/workerd/io/per-isolate-bootstrap.c++` via the deliberately crypto-free
+declaration in `src/workerd/api/crypto/digest-bootstrap.h`.
+
+Two parts of that contract are easy to break:
+
+- **`update()` takes strings, and returns a byte count.** Strings are NOT
+  encoded on the TypeScript side. `jsg::Lock::toString()` emits WTF-8, which
+  differs from `TextEncoder` for unpaired surrogates, and both DigestStream
+  implementations must agree. The return value exists because a string's UTF-8
+  length is not observable from JavaScript. `crypto-streams-test.js`
+  (`stringChunksAreNotTextEncoded`) pins this for both implementations.
+- **Chunks are not copied.** The digest consumes bytes synchronously inside
+  `update()`, so a copy would be pure overhead — unlike
+  `webstreams/identity.ts`, which copies because it enqueues. The consequence
+  is that SharedArrayBuffer-backed views are read in place.
+
+## PARITY
+
+Both implementations run `crypto-streams-test.js` unmodified, under
+`crypto-streams-test.wd-test` (C++) and `crypto-streams-ts-test.wd-test`
+(TypeScript). Behavior shared between them belongs in that file so drift fails
+one config or the other. TypeScript-only behavior — and the one intentional
+divergence below — belongs in `ts-digest-stream-test.js`.
+
+`ts-digest-stream-test.js`'s `isRealWritableStreamSubclass` is the canary that
+the `main.ts` install actually took effect; without it the rest of the suite
+would pass against the C++ implementation too.
+
+## INTENTIONAL DIVERGENCE
+
+The digest promise is marked handled (`utils.markPromiseHandled`), so
+abandoning it produces no unhandled-rejection report. The C++ implementation
+does report in that case. This is accepted: consuming `digest` is optional, an
+abort is already surfaced through the writer's `ready`/`closed` promises, and
+marking does not propagate to derived promises — `stream.digest.then(f)` with
+no `catch` still reports.
+
+## ANTI-PATTERNS
+
+- **NEVER** encode string chunks here; forward them to `update()`.
+- **NEVER** reference `this` in the sink closures passed to `super()` — they
+  are evaluated before `super()` returns, while `this` is still in its
+  temporal dead zone. Build the state object first and capture that.

--- a/src/per_isolate/crypto/digest-stream.ts
+++ b/src/per_isolate/crypto/digest-stream.ts
@@ -1,0 +1,272 @@
+'use strict';
+
+// DigestStream — a non-standard workerd extension that hashes everything
+// written to it and exposes the result as a promise. It is a real subclass of
+// WritableStream, which is the reason it is implemented here: the C++ version
+// subclasses the C++ WritableStream, so under the
+// `typescript_implemented_streams` flag it would inherit from the wrong class.
+//
+// The hashing is done by a native context obtained from
+// utils.createDigestContext(); this module owns only the stream semantics and
+// the state machine. See DigestContextHandle in
+// src/workerd/api/crypto/crypto.h for the native side.
+//
+// STATE MACHINE
+//
+// The digest state is tracked separately from the parent WritableStream's state
+// and does not always agree with it. dispose() errors the digest without
+// touching the WritableStream, so a disposed stream is still `writable` and
+// still hands out a writer; the first write then fails from the sink. The three
+// digest states are:
+//
+//   ready   — accepting writes; the native context is live.
+//   closed  — close() ran, digest resolved, native context finalized.
+//   errored — abort() or dispose() ran, digest rejected with `storedError`.
+//
+// Writes in `closed` resolve without hashing, and writes in `errored` re-reject
+// with the stored error. Neither is reachable through a well-behaved
+// WritableStream, which rejects such writes before the sink sees them, but the
+// arms exist so the sink can never hash into a finalized context.
+//
+// NO COPY
+//
+// Chunks are handed to the native context as-is. Unlike
+// IdentityTransformStream, which copies because it enqueues chunks for a reader
+// to observe later, the digest consumes bytes synchronously inside update() and
+// never retains them, so copying would be pure overhead. The consequence is
+// that SharedArrayBuffer-backed views are read in place, and a concurrent write
+// from another thread races the hash — as it does in C++.
+//
+// STRINGS
+//
+// String chunks are forwarded to the native context rather than encoded here.
+// jsg::Lock::toString() produces WTF-8, which differs from TextEncoder for
+// unpaired surrogates; routing both implementations through the same conversion
+// keeps their digests byte-identical. This is also why update() returns a byte
+// count — a string's UTF-8 length is not observable from JavaScript.
+
+import type {
+  UnderlyingSink,
+  WritableStream as WritableStreamType,
+} from '../webstreams/types';
+
+const {
+  ArrayBufferPrototypeByteLengthGet,
+  BigInt,
+  DataViewPrototypeGetByteLength,
+  ObjectDefineProperties,
+  PromiseWithResolvers,
+  SymbolDispose,
+  SymbolToStringTag,
+  TypeError,
+  TypedArrayPrototypeGetByteLength,
+  TypedArrayPrototypeGetSymbolToStringTag,
+} = primordials;
+
+const {
+  isArrayBuffer,
+  isArrayBufferView,
+  markPromiseHandled,
+  createDigestContext,
+} = utils;
+
+const { WritableStream } = require('webstreams/writable') as {
+  WritableStream: typeof WritableStreamType;
+};
+
+type Chunk = ArrayBuffer | ArrayBufferView | string;
+
+type DigestState = {
+  // Cleared once the digest is finalized or discarded, so a stale sink can
+  // never reach a context that native code has already consumed.
+  context: DigestContext | undefined;
+  promise: Promise<ArrayBuffer>;
+  resolve: (value: ArrayBuffer) => void;
+  reject: (reason?: unknown) => void;
+  state: 'ready' | 'closed' | 'errored';
+  storedError: unknown;
+  // Tracked as a number rather than a bigint to keep writes allocation-free;
+  // converted at the getter. Exact to 2^53 bytes, far beyond any worker.
+  bytesWritten: number;
+};
+
+function isActualObject(value: unknown): boolean {
+  return value != null && typeof value === 'object';
+}
+
+function byteLengthOf(chunk: ArrayBuffer | ArrayBufferView): number {
+  if (isArrayBuffer(chunk)) {
+    return ArrayBufferPrototypeByteLengthGet(chunk);
+  }
+  // A view: either a TypedArray or a DataView. The tag getter returns the
+  // internal [[TypedArrayName]], and undefined for a DataView.
+  if (TypedArrayPrototypeGetSymbolToStringTag(chunk) !== undefined) {
+    return TypedArrayPrototypeGetByteLength(chunk as Uint8Array);
+  }
+  return DataViewPrototypeGetByteLength(chunk as DataView);
+}
+
+// Collapses the WebCrypto-style `string | { name }` algorithm parameter to a
+// name. Unrecognized names are not rejected here — createDigestContext() throws
+// for those, which is what keeps the error type and message identical to C++.
+function normalizeAlgorithmName(algorithm: unknown): string {
+  if (typeof algorithm === 'string') return algorithm;
+  if (algorithm === null || algorithm === undefined) {
+    throw new TypeError(
+      'DigestStream requires a digest algorithm name, or an object with a ' +
+        'name property.'
+    );
+  }
+  if (typeof algorithm === 'object') {
+    // A user-provided object, so ordinary property access and coercion are the
+    // correct behavior here. A missing name coerces to "undefined" and then
+    // fails the algorithm lookup, exactly as it does in C++.
+    return `${(algorithm as { name?: unknown }).name}`;
+  }
+  return `${algorithm as { toString(): string }}`;
+}
+
+function createDigestState(algorithm: unknown): DigestState {
+  const context = createDigestContext(normalizeAlgorithmName(algorithm));
+  const { promise, resolve, reject } = PromiseWithResolvers() as {
+    promise: Promise<ArrayBuffer>;
+    resolve: (value: ArrayBuffer) => void;
+    reject: (reason?: unknown) => void;
+  };
+  // Reading `digest` is optional — a stream may be used only for bytesWritten,
+  // or abandoned entirely — and an abort is already surfaced through the
+  // writer's ready/closed promises. An unobserved rejection here is therefore
+  // not worth reporting. Marked before returning, so no rejecting path can run
+  // first. Derived promises are unaffected: `stream.digest.then(f)` with no
+  // catch still reports, so a real consumer mistake stays visible.
+  markPromiseHandled(promise);
+  return {
+    context,
+    promise,
+    resolve,
+    reject,
+    state: 'ready',
+    storedError: undefined,
+    bytesWritten: 0,
+  };
+}
+
+function digestWrite(state: DigestState, chunk: unknown): void {
+  const isBytes = isArrayBuffer(chunk) || isArrayBufferView(chunk);
+  if (!isBytes && typeof chunk !== 'string') {
+    // A bare SharedArrayBuffer lands here: V8 does not report it as an
+    // ArrayBuffer. A view onto one is accepted, as in C++.
+    throw new TypeError(
+      'DigestStream is a byte stream but received an object of ' +
+        'non-ArrayBuffer/ArrayBufferView/string type on its writable side.'
+    );
+  }
+
+  // Zero-length writes short-circuit ahead of the state check, so they neither
+  // observe a finalized context nor move the byte count. An empty string is
+  // always zero UTF-8 bytes, so the length test is sound for both input kinds.
+  if (isBytes) {
+    if (byteLengthOf(chunk as ArrayBuffer | ArrayBufferView) === 0) return;
+  } else if ((chunk as string).length === 0) {
+    return;
+  }
+
+  if (state.state === 'closed') return;
+  if (state.state === 'errored') throw state.storedError;
+
+  const context = state.context;
+  if (context === undefined) {
+    throw new TypeError('The digest context has already been finalized.');
+  }
+  state.bytesWritten += context.update(chunk as Chunk);
+}
+
+function digestClose(state: DigestState): void {
+  if (state.state === 'closed') return;
+  if (state.state === 'errored') throw state.storedError;
+
+  const context = state.context;
+  if (context === undefined) {
+    throw new TypeError('The digest context has already been finalized.');
+  }
+  state.context = undefined;
+  state.state = 'closed';
+  state.resolve(context.digest());
+}
+
+function digestError(state: DigestState, reason: unknown): void {
+  // Already closed or errored: nothing to do, matching the C++ abort().
+  if (state.state !== 'ready') return;
+  state.context = undefined;
+  state.state = 'errored';
+  state.storedError = reason;
+  state.reject(reason);
+}
+
+class DigestStream extends WritableStream<ArrayBuffer | ArrayBufferView> {
+  #state: DigestState;
+
+  constructor(algorithm: string | { name: string }) {
+    // The state is built before super() because the sink closures below capture
+    // it — they cannot reference `this`, which is in its temporal dead zone
+    // until super() returns. An unrecognized algorithm therefore also throws
+    // before any stream exists, as in C++.
+    const state = createDigestState(algorithm);
+    const sink: UnderlyingSink<ArrayBuffer | ArrayBufferView> = {
+      write(chunk: ArrayBuffer | ArrayBufferView): void {
+        digestWrite(state, chunk);
+      },
+      close(): void {
+        digestClose(state);
+      },
+      abort(reason?: unknown): void {
+        digestError(state, reason);
+      },
+    };
+    super(sink);
+    this.#state = state;
+  }
+
+  // Returns the identical promise object on every access, matching the C++
+  // jsg::MemoizedIdentity.
+  get digest(): Promise<ArrayBuffer> {
+    if (!isActualObject(this) || !(#state in this)) {
+      throw new TypeError('Illegal invocation');
+    }
+    return this.#state.promise;
+  }
+
+  get bytesWritten(): bigint {
+    if (!isActualObject(this) || !(#state in this)) {
+      throw new TypeError('Illegal invocation');
+    }
+    return BigInt(this.#state.bytesWritten);
+  }
+
+  [SymbolDispose](): void {
+    if (!isActualObject(this) || !(#state in this)) {
+      throw new TypeError('Illegal invocation');
+    }
+    // Errors the digest but deliberately leaves the WritableStream alone, so
+    // the stream stays writable and the failure surfaces from the first write.
+    // Idempotent: digestError() ignores non-ready states.
+    digestError(this.#state, new TypeError('The DigestStream was disposed.'));
+  }
+}
+
+ObjectDefineProperties(DigestStream.prototype, {
+  __proto__: null,
+  digest: { __proto__: null, enumerable: true },
+  bytesWritten: { __proto__: null, enumerable: true },
+  [SymbolToStringTag]: {
+    __proto__: null,
+    value: 'DigestStream',
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  },
+});
+
+module.exports = {
+  DigestStream,
+};

--- a/src/per_isolate/crypto/digest-stream.ts
+++ b/src/per_isolate/crypto/digest-stream.ts
@@ -40,10 +40,16 @@
 // STRINGS
 //
 // String chunks are forwarded to the native context rather than encoded here.
-// jsg::Lock::toString() produces WTF-8, which differs from TextEncoder for
-// unpaired surrogates; routing both implementations through the same conversion
-// keeps their digests byte-identical. This is also why update() returns a byte
-// count — a string's UTF-8 length is not observable from JavaScript.
+// A lone surrogate has no UTF-8 encoding, and the default is to hash it as
+// WTF-8 (U+D800 becomes ED A0 80) — which TextEncoder cannot produce, since it
+// always substitutes U+FFFD. Callers who want the substitution opt in with
+// `{toWellFormed: true}`, and the choice is fixed when the native context is
+// created. Routing both implementations through the same native conversion is
+// what keeps their digests byte-identical under either setting.
+//
+// This is also why update() returns a byte count — a string's UTF-8 length is
+// not observable from JavaScript. Both encodings happen to agree on it, since a
+// lone surrogate and U+FFFD are both three bytes.
 
 import type {
   UnderlyingSink,
@@ -126,8 +132,29 @@ function normalizeAlgorithmName(algorithm: unknown): string {
   return `${algorithm as { toString(): string }}`;
 }
 
-function createDigestState(algorithm: unknown): DigestState {
-  const context = createDigestContext(normalizeAlgorithmName(algorithm));
+// Mirrors how JSG unwraps `jsg::Optional<DigestStream::Options>`: undefined and
+// null give an empty bag, any object has its field read with ToBoolean, and a
+// primitive is a TypeError. Arrays and functions are objects here, as they are
+// to v8::Value::IsObject(), so they are accepted and simply have no field. The
+// message reproduces the one JSG generates so both implementations report the
+// same thing for the same mistake.
+function readToWellFormed(options: unknown): boolean {
+  if (options === undefined || options === null) return false;
+  if (typeof options !== 'object' && typeof options !== 'function') {
+    throw new TypeError(
+      "Failed to construct 'DigestStream': constructor parameter 2 is not of " +
+        "type 'Options'."
+    );
+  }
+  // A user-provided bag, so ordinary property access and ToBoolean are correct.
+  return !!(options as { toWellFormed?: unknown }).toWellFormed;
+}
+
+function createDigestState(algorithm: unknown, options: unknown): DigestState {
+  // JSG unwraps constructor arguments left to right, so a bad algorithm must be
+  // reported before a bad option bag.
+  const name = normalizeAlgorithmName(algorithm);
+  const context = createDigestContext(name, readToWellFormed(options));
   const { promise, resolve, reject } = PromiseWithResolvers() as {
     promise: Promise<ArrayBuffer>;
     resolve: (value: ArrayBuffer) => void;
@@ -189,6 +216,10 @@ function digestClose(state: DigestState): void {
   if (context === undefined) {
     throw new TypeError('The digest context has already been finalized.');
   }
+  // Nothing further can arrive, so anything the encoder held back is now final.
+  // digest() would fold this in regardless; calling flush() first is what makes
+  // those bytes show up in bytesWritten.
+  state.bytesWritten += context.flush();
   state.context = undefined;
   state.state = 'closed';
   state.resolve(context.digest());
@@ -206,12 +237,15 @@ function digestError(state: DigestState, reason: unknown): void {
 class DigestStream extends WritableStream<ArrayBuffer | ArrayBufferView> {
   #state: DigestState;
 
-  constructor(algorithm: string | { name: string }) {
+  constructor(
+    algorithm: string | { name: string },
+    options?: { toWellFormed?: boolean }
+  ) {
     // The state is built before super() because the sink closures below capture
     // it — they cannot reference `this`, which is in its temporal dead zone
     // until super() returns. An unrecognized algorithm therefore also throws
     // before any stream exists, as in C++.
-    const state = createDigestState(algorithm);
+    const state = createDigestState(algorithm, options);
     const sink: UnderlyingSink<ArrayBuffer | ArrayBufferView> = {
       write(chunk: ArrayBuffer | ArrayBufferView): void {
         digestWrite(state, chunk);

--- a/src/per_isolate/main.ts
+++ b/src/per_isolate/main.ts
@@ -196,6 +196,31 @@ if (compatFlags['typescript_implemented_streams']) {
   // Bootstrap the cpp exports module
   require('webstreams/cpp_exports');
 
+  // DigestStream subclasses WritableStream, so the C++ one would inherit from
+  // the C++ WritableStream that the assignments above just replaced. Swap in
+  // the TypeScript implementation so the hierarchy is consistent.
+  //
+  // JSG installs nested types on the prototype rather than the instance, so
+  // this reaches every `crypto.DigestStream` — including the lazily created
+  // `globalThis.crypto` singleton, which is deliberately not touched here.
+  // The attributes match what JSG_NESTED_TYPE installs (ObjectTemplate::Set
+  // with no attributes, i.e. all three true), so the swap is invisible to
+  // property introspection.
+  const { DigestStream } = require('crypto/digest-stream');
+  const { Crypto } = globalThis as unknown as {
+    Crypto: { prototype: object };
+  };
+  ObjectDefineProperties(Crypto.prototype, {
+    __proto__: null,
+    DigestStream: {
+      __proto__: null,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: DigestStream,
+    },
+  });
+
   // Internal-only: expose the DrainingReader for testing expectedLength
   // pass-through (Content-Length integration). Gated by a separate
   // experimental flag that may never lose its experimental annotation.

--- a/src/per_isolate/per_isolate-env.d.ts
+++ b/src/per_isolate/per_isolate-env.d.ts
@@ -84,19 +84,28 @@ declare const utils: {
   // The C++ compression codec factory (api/compression.h:
   // newCompressionCodecCallback), consumed by webstreams/compression.
   newCompressionCodec(mode: string, format: string): unknown;
-  createDigestContext(algorithm: string): DigestContext;
+  createDigestContext(algorithm: string, toWellFormed: boolean): DigestContext;
 };
 
 // Native incremental digest, backing the TypeScript DigestStream. Obtained only
 // from utils.createDigestContext(); it has no JS-reachable constructor.
 //
-// Strings are passed through rather than encoded on this side so that both
-// DigestStream implementations hash them identically — see DigestContextHandle
-// in src/workerd/api/crypto/crypto.h.
+// Strings are passed through rather than encoded on this side because the
+// default WTF-8 encoding is not expressible in JavaScript — TextEncoder always
+// substitutes U+FFFD. The string encoding is fixed when the context is created;
+// see DigestContextHandle in src/workerd/api/crypto/crypto.h.
 declare interface DigestContext {
   // Returns the number of bytes consumed, which for a string is its UTF-8
-  // length. Throws once digest() has been called.
+  // length. Under toWellFormed this can be 0 for a non-empty chunk, when the
+  // chunk ended with the lead half of a surrogate pair and the encoder is
+  // waiting to see whether the next chunk completes it. Throws once digest()
+  // has been called.
   update(chunk: ArrayBuffer | ArrayBufferView | string): number;
+  // Consumes any bytes still owed at end of stream and returns how many there
+  // were: 3 for a lead surrogate that was held back and never paired, else 0.
+  // digest() does this too, so calling it is only needed to keep a byte count
+  // accurate. Must precede digest().
+  flush(): number;
   // Finalizes the digest. Throws if called more than once.
   digest(): ArrayBuffer;
 }

--- a/src/per_isolate/per_isolate-env.d.ts
+++ b/src/per_isolate/per_isolate-env.d.ts
@@ -56,6 +56,7 @@ declare const primordials: {
   readonly SymbolIterator: typeof Symbol.iterator;
   readonly SymbolAsyncIterator: typeof Symbol.asyncIterator;
   readonly SymbolToStringTag: typeof Symbol.toStringTag;
+  readonly SymbolDispose: typeof Symbol.dispose;
 
   // uncurryThis accepts Function (the typeof-narrowed type) in addition to
   // properly typed callables, so callers don't need to cast after a
@@ -83,4 +84,19 @@ declare const utils: {
   // The C++ compression codec factory (api/compression.h:
   // newCompressionCodecCallback), consumed by webstreams/compression.
   newCompressionCodec(mode: string, format: string): unknown;
+  createDigestContext(algorithm: string): DigestContext;
 };
+
+// Native incremental digest, backing the TypeScript DigestStream. Obtained only
+// from utils.createDigestContext(); it has no JS-reachable constructor.
+//
+// Strings are passed through rather than encoded on this side so that both
+// DigestStream implementations hash them identically — see DigestContextHandle
+// in src/workerd/api/crypto/crypto.h.
+declare interface DigestContext {
+  // Returns the number of bytes consumed, which for a string is its UTF-8
+  // length. Throws once digest() has been called.
+  update(chunk: ArrayBuffer | ArrayBufferView | string): number;
+  // Finalizes the digest. Throws if called more than once.
+  digest(): ArrayBuffer;
+}

--- a/src/per_isolate/primordials.ts
+++ b/src/per_isolate/primordials.ts
@@ -250,6 +250,10 @@ const StringPrototypeStartsWith = uncurryThis(String.prototype.startsWith);
 const SymbolIterator = Symbol.iterator;
 const SymbolAsyncIterator = Symbol.asyncIterator;
 const SymbolToStringTag = Symbol.toStringTag;
+// Only the sync disposer is captured: JSG's guidance (jsg.h, JSG_DISPOSE) is to
+// implement Symbol.dispose and avoid defining Symbol.asyncDispose alongside it,
+// and no bootstrap class defines the async form.
+const SymbolDispose = Symbol.dispose;
 
 // WeakRef / FinalizationRegistry
 // These globals exist during bootstrap — their deletion from the global is
@@ -808,6 +812,7 @@ module.exports = ObjectFreeze({
 
   // Symbol
   SymbolAsyncIterator,
+  SymbolDispose,
   SymbolIterator,
   SymbolToStringTag,
 

--- a/src/workerd/api/crypto/crypto.c++
+++ b/src/workerd/api/crypto/crypto.c++
@@ -790,16 +790,49 @@ class OpenSSLDigestContext final: public DigestContext {
   kj::Own<EVP_MD_CTX> context;
 };
 
-DigestStream::DigestContextPtr DigestStream::initContext(SubtleCrypto::HashAlgorithm& algorithm) {
-  if (algorithm.name == "crc32") {
+kj::Own<DigestContext> newDigestContext(kj::StringPtr algorithm) {
+  if (algorithm == "crc32") {
     return kj::heap<CRC32DigestContext>();
-  } else if (algorithm.name == "crc32c") {
+  } else if (algorithm == "crc32c") {
     return kj::heap<CRC32CDigestContext>();
-  } else if (algorithm.name == "crc64nvme") {
+  } else if (algorithm == "crc64nvme") {
     return kj::heap<CRC64NVMEDigestContext>();
   } else {
-    return kj::heap<OpenSSLDigestContext>(algorithm.name);
+    return kj::heap<OpenSSLDigestContext>(algorithm);
   }
+}
+
+DigestStream::DigestContextPtr DigestStream::initContext(SubtleCrypto::HashAlgorithm& algorithm) {
+  return newDigestContext(algorithm.name);
+}
+
+uint32_t DigestContextHandle::update(
+    jsg::Lock& js, kj::OneOf<jsg::JsBufferSource, kj::String> chunk) {
+  auto& ctx =
+      *JSG_REQUIRE_NONNULL(context, TypeError, "The digest context has already been finalized.");
+
+  KJ_SWITCH_ONEOF(chunk) {
+    KJ_CASE_ONEOF(source, jsg::JsBufferSource) {
+      auto bytes = source.asArrayPtr();
+      if (bytes.size() == 0) return 0;
+      ctx.write(bytes);
+      return bytes.size();
+    }
+    KJ_CASE_ONEOF(str, kj::String) {
+      auto bytes = str.asBytes();
+      if (bytes.size() == 0) return 0;
+      ctx.write(bytes);
+      return bytes.size();
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+jsg::JsArrayBuffer DigestContextHandle::digest(jsg::Lock& js) {
+  auto ctx = kj::mv(
+      JSG_REQUIRE_NONNULL(context, TypeError, "The digest context has already been finalized."));
+  context = kj::none;
+  return ctx->close(js);
 }
 
 DigestStream::DigestStream(kj::Own<WritableStreamController> controller,

--- a/src/workerd/api/crypto/crypto.c++
+++ b/src/workerd/api/crypto/crypto.c++
@@ -5,6 +5,7 @@
 #include "crypto.h"
 
 #include "impl.h"
+#include "simdutf.h"
 
 #include <workerd/api/crypto/crc-impl.h>
 #include <workerd/api/crypto/endianness.h>
@@ -790,6 +791,91 @@ class OpenSSLDigestContext final: public DigestContext {
   kj::Own<EVP_MD_CTX> context;
 };
 
+namespace {
+// U+FFFD, the encoding of any surrogate that turns out to be unpaired.
+constexpr char REPLACEMENT_UTF8[] = "\xEF\xBF\xBD";
+constexpr size_t REPLACEMENT_UTF8_LEN = 3;
+
+// True for a UTF-16 lead (high) surrogate, U+D800..U+DBFF — the first half of a
+// pair encoding a non-BMP code point, and so the only unit whose encoding can
+// depend on what comes after it.
+constexpr bool isLeadSurrogate(char16_t unit) {
+  return (unit & 0xFC00) == 0xD800;
+}
+
+// Packages UTF-16 as the UTF-8 bytes to hash, substituting U+FFFD for unpaired
+// surrogates. kj::String is the carrier because that is what the callers already
+// pass to DigestContext::write(); the bytes are not text and may contain NULs.
+kj::String wellFormedUtf8(kj::ArrayPtr<const char16_t> utf16) {
+  if (utf16.size() == 0) return kj::String();
+
+  auto sized = simdutf::utf8_length_from_utf16_with_replacement(utf16.begin(), utf16.size());
+  auto buf = kj::heapArray<char>(sized.count + 1);
+
+  // to_well_formed_utf16 rewrites in place, so only take a copy when there is
+  // actually an unpaired surrogate to replace.
+  size_t written;
+  if (sized.error == simdutf::error_code::SURROGATE) {
+    auto fixed = kj::heapArray<char16_t>(utf16.size());
+    simdutf::to_well_formed_utf16(utf16.begin(), utf16.size(), fixed.begin());
+    written = simdutf::convert_utf16_to_utf8(fixed.begin(), fixed.size(), buf.begin());
+  } else {
+    written = simdutf::convert_utf16_to_utf8(utf16.begin(), utf16.size(), buf.begin());
+  }
+
+  KJ_DASSERT(written == sized.count);
+  buf[written] = '\0';
+  return kj::String(kj::mv(buf));
+}
+}  // namespace
+
+kj::String DigestStringEncoder::encode(jsg::Lock& js, jsg::JsString str) {
+  if (encoding == DigestStringEncoding::WTF8) {
+    // WriteUtf8V2 without kReplaceInvalidUtf8, so lone surrogates survive as the
+    // three bytes V8 holds them in.
+    return str.toString(js);
+  }
+
+  // Read the chunk into UTF-16, reserving room to re-attach a lead surrogate
+  // carried over from the previous chunk so a pair split across the boundary is
+  // seen here as the single code point it is.
+  size_t prefix = pendingLead == kj::none ? 0 : 1;
+  size_t end = prefix + str.length(js);
+  if (end == 0) return kj::String();
+
+  auto utf16 = kj::heapArray<char16_t>(end);
+  KJ_IF_SOME(lead, pendingLead) {
+    utf16[0] = lead;
+    pendingLead = kj::none;
+  }
+  auto dest = utf16.slice(prefix);
+  str.writeInto(js, kj::arrayPtr(reinterpret_cast<uint16_t*>(dest.begin()), dest.size()));
+
+  // A lead surrogate at the very end may pair with whatever comes next, so it
+  // cannot be encoded until the next chunk (or flush()) settles the question.
+  if (isLeadSurrogate(utf16[end - 1])) {
+    pendingLead = utf16[--end];
+  }
+
+  return wellFormedUtf8(utf16.first(end));
+}
+
+kj::Maybe<kj::String> DigestStringEncoder::flush() {
+  // Nothing followed the lead surrogate, so it was unpaired after all.
+  if (pendingLead == kj::none) return kj::none;
+  pendingLead = kj::none;
+  return kj::str(kj::ArrayPtr<const char>(REPLACEMENT_UTF8, REPLACEMENT_UTF8_LEN));
+}
+
+namespace {
+DigestStringEncoding readDigestEncoding(jsg::Optional<DigestStream::Options>& options) {
+  KJ_IF_SOME(o, options) {
+    if (o.toWellFormed.orDefault(false)) return DigestStringEncoding::WELL_FORMED;
+  }
+  return DigestStringEncoding::WTF8;
+}
+}  // namespace
+
 kj::Own<DigestContext> newDigestContext(kj::StringPtr algorithm) {
   if (algorithm == "crc32") {
     return kj::heap<CRC32DigestContext>();
@@ -807,7 +893,7 @@ DigestStream::DigestContextPtr DigestStream::initContext(SubtleCrypto::HashAlgor
 }
 
 uint32_t DigestContextHandle::update(
-    jsg::Lock& js, kj::OneOf<jsg::JsBufferSource, kj::String> chunk) {
+    jsg::Lock& js, kj::OneOf<jsg::JsBufferSource, jsg::JsString> chunk) {
   auto& ctx =
       *JSG_REQUIRE_NONNULL(context, TypeError, "The digest context has already been finalized.");
 
@@ -818,8 +904,11 @@ uint32_t DigestContextHandle::update(
       ctx.write(bytes);
       return bytes.size();
     }
-    KJ_CASE_ONEOF(str, kj::String) {
-      auto bytes = str.asBytes();
+    KJ_CASE_ONEOF(str, jsg::JsString) {
+      // May be empty even for a non-empty chunk, when the whole chunk was a lead
+      // surrogate that the encoder is holding back for the next one.
+      auto converted = encoder.encode(js, str);
+      auto bytes = converted.asBytes();
       if (bytes.size() == 0) return 0;
       ctx.write(bytes);
       return bytes.size();
@@ -828,9 +917,26 @@ uint32_t DigestContextHandle::update(
   KJ_UNREACHABLE;
 }
 
+uint32_t DigestContextHandle::flush() {
+  auto& ctx =
+      *JSG_REQUIRE_NONNULL(context, TypeError, "The digest context has already been finalized.");
+  KJ_IF_SOME(owed, encoder.flush()) {
+    auto bytes = owed.asBytes();
+    ctx.write(bytes);
+    return bytes.size();
+  }
+  return 0;
+}
+
 jsg::JsArrayBuffer DigestContextHandle::digest(jsg::Lock& js) {
   auto ctx = kj::mv(
       JSG_REQUIRE_NONNULL(context, TypeError, "The digest context has already been finalized."));
+  // Whatever the encoder still owes belongs in the digest even if the caller did
+  // not ask for the byte count. flush() is idempotent, so having already called
+  // it is fine.
+  KJ_IF_SOME(owed, encoder.flush()) {
+    ctx->write(owed.asBytes());
+  }
   context = kj::none;
   return ctx->close(js);
 }
@@ -838,10 +944,12 @@ jsg::JsArrayBuffer DigestContextHandle::digest(jsg::Lock& js) {
 DigestStream::DigestStream(kj::Own<WritableStreamController> controller,
     SubtleCrypto::HashAlgorithm algorithm,
     jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>>::Resolver resolver,
-    jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> promise)
+    jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> promise,
+    DigestStringEncoding encoding)
     : WritableStream(kj::mv(controller)),
       promise(kj::mv(promise)),
-      state(Ready(kj::mv(algorithm), kj::mv(resolver))) {}
+      state(Ready(kj::mv(algorithm), kj::mv(resolver))),
+      encoder(encoding) {}
 
 void DigestStream::dispose(jsg::Lock& js) {
   JSG_TRY(js) {
@@ -895,6 +1003,13 @@ kj::Maybe<StreamStates::Errored> DigestStream::close(jsg::Lock& js) {
       return errored.addRef(js);
     }
     KJ_CASE_ONEOF(ready, Ready) {
+      // A lead surrogate the encoder is still holding is unpaired now that no
+      // further chunk can complete it.
+      KJ_IF_SOME(owed, encoder.flush()) {
+        auto bytes = owed.asBytes();
+        ready.context->write(bytes);
+        bytesWritten += bytes.size();
+      }
       ready.resolver.resolve(js, ready.context->close(js).addRef(js));
       state.init<StreamStates::Closed>();
       return kj::none;
@@ -911,11 +1026,13 @@ void DigestStream::abort(jsg::Lock& js, jsg::JsValue reason) {
   }
 }
 
-jsg::Ref<DigestStream> DigestStream::constructor(jsg::Lock& js, Algorithm algorithm) {
+jsg::Ref<DigestStream> DigestStream::constructor(
+    jsg::Lock& js, Algorithm algorithm, jsg::Optional<Options> options) {
   auto paf = js.newPromiseAndResolver<jsg::JsRef<jsg::JsArrayBuffer>>();
 
   auto stream = js.alloc<DigestStream>(newWritableStreamJsController(),
-      interpretAlgorithmParam(kj::mv(algorithm)), kj::mv(paf.resolver), kj::mv(paf.promise));
+      interpretAlgorithmParam(kj::mv(algorithm)), kj::mv(paf.resolver), kj::mv(paf.promise),
+      readDigestEncoding(options));
 
   // clang-format off
   stream->getController().setup(js, UnderlyingSink{
@@ -933,8 +1050,11 @@ jsg::Ref<DigestStream> DigestStream::constructor(jsg::Lock& js, Algorithm algori
           stream.bytesWritten += source.size();
           return js.resolvedPromise();
         } else if (chunk->IsString()) {
-          // If we receive a string, we'll convert that to UTF-8 bytes and digest that.
-          auto str = js.toString(chunk);
+          // Lone surrogates become WTF-8, or U+FFFD when the stream was constructed
+          // with toWellFormed. Shared with the TypeScript implementation so both
+          // hash a given string identically. Empty under toWellFormed when the
+          // chunk ended mid-surrogate-pair, whose lead is held for the next one.
+          auto str = stream.encoder.encode(js, jsg::JsString(chunk.As<v8::String>()));
           if (str.size() == 0) return js.resolvedPromise();
           KJ_IF_SOME(error, stream.write(js, str.asBytes())) {
             return js.rejectedPromise<void>(kj::mv(error));

--- a/src/workerd/api/crypto/crypto.c++
+++ b/src/workerd/api/crypto/crypto.c++
@@ -877,11 +877,16 @@ DigestStringEncoding readDigestEncoding(jsg::Optional<DigestStream::Options>& op
 }  // namespace
 
 kj::Own<DigestContext> newDigestContext(kj::StringPtr algorithm) {
-  if (algorithm == "crc32") {
+  // Case-insensitive, matching the OpenSSL lookup in the final branch, which
+  // accepts any casing of its own digest names.
+  auto named = [&algorithm](
+                   kj::StringPtr name) { return strcasecmp(algorithm.cStr(), name.cStr()) == 0; };
+
+  if (named("crc32"_kj)) {
     return kj::heap<CRC32DigestContext>();
-  } else if (algorithm == "crc32c") {
+  } else if (named("crc32c"_kj)) {
     return kj::heap<CRC32CDigestContext>();
-  } else if (algorithm == "crc64nvme") {
+  } else if (named("crc64nvme"_kj)) {
     return kj::heap<CRC64NVMEDigestContext>();
   } else {
     return kj::heap<OpenSSLDigestContext>(algorithm);

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -663,30 +663,93 @@ class DigestContext {
 // for unrecognized names.
 kj::Own<DigestContext> newDigestContext(kj::StringPtr algorithm);
 
+// Selects how a string chunk is turned into the bytes a digest consumes.
+//
+// A lone surrogate has no UTF-8 encoding, so the two answers differ: WTF-8
+// encodes it literally (U+D800 becomes ED A0 80), while WELL_FORMED substitutes
+// U+FFFD (EF BF BD). Both are three bytes, so for a chunk considered on its own
+// the choice changes only the digest, not bytesWritten.
+//
+// The counts can differ across chunks, though, because only WELL_FORMED joins a
+// surrogate pair split over two of them: it encodes the pair as one 4-byte code
+// point where WTF-8 encodes two lone surrogates as 3 bytes each.
+//
+// WTF-8 is the default because it is what DigestStream has always done. Callers
+// opt into WELL_FORMED with `new DigestStream(algorithm, {toWellFormed: true})`.
+enum class DigestStringEncoding {
+  WTF8,
+  WELL_FORMED,
+};
+
+// Converts the string chunks of one digest to the bytes to hash. Both
+// DigestStream implementations route their string chunks through here, which is
+// what keeps their digests byte-identical under either encoding.
+//
+// WELL_FORMED is a streaming text encoder, so it is stateful: a surrogate pair
+// may be split across two chunks, and the halves only mean anything together.
+// encode() therefore holds a lead surrogate at the end of a chunk back until the
+// next one arrives, and flush() reports whatever is left at end of stream — at
+// which point a still-unpaired lead surrogate really is unpaired. This mirrors
+// TextEncoderStream (api/streams/encoding.c++).
+//
+// WTF8 is stateless: each chunk is encoded exactly as V8 holds it. A pair split
+// across chunks therefore hashes as two lone surrogates rather than as the code
+// point they form. That is the historical DigestStream behavior; joining them
+// would change the digests of existing callers.
+class DigestStringEncoder {
+ public:
+  explicit DigestStringEncoder(DigestStringEncoding encoding): encoding(encoding) {}
+
+  // The bytes this chunk contributes. Under WELL_FORMED this may omit a trailing
+  // lead surrogate, and may begin with one omitted from the previous chunk.
+  kj::String encode(jsg::Lock& js, jsg::JsString str);
+
+  // The bytes owed at end of stream: U+FFFD for a lead surrogate that was held
+  // back and never paired, or none when nothing is outstanding. Idempotent.
+  kj::Maybe<kj::String> flush();
+
+ private:
+  DigestStringEncoding encoding;
+
+  // WELL_FORMED only: a lead surrogate that ended the previous chunk. Its
+  // encoding is not yet decided, because a trail surrogate opening the next
+  // chunk would pair with it.
+  kj::Maybe<char16_t> pendingLead;
+};
+
 // A JS-visible handle around a DigestContext. This is the native backing for the
 // TypeScript DigestStream; it is not registered on the global scope and is
 // excluded from the generated types. Instances reach the per-isolate bootstrap
 // through createDigestContext() (digest-bootstrap.h).
 //
-// Strings are converted to bytes here rather than in TypeScript so that both
-// DigestStream implementations hash them identically: jsg::Lock::toString()
-// emits WTF-8 for unpaired surrogates, whereas TextEncoder would substitute
-// U+FFFD. Sharing this conversion keeps the two implementations byte-identical,
-// and means a future change to the conversion applies to both at once.
+// Strings are converted to bytes here rather than in TypeScript because the
+// conversion is not expressible in JavaScript: TextEncoder always substitutes
+// U+FFFD, so it cannot produce the default WTF-8 encoding. Sharing
+// DigestStringEncoder with the C++ DigestStream keeps the two byte-identical.
 class DigestContextHandle final: public jsg::Object {
  public:
-  DigestContextHandle(kj::Own<DigestContext> context): context(kj::mv(context)) {}
+  DigestContextHandle(kj::Own<DigestContext> context, DigestStringEncoding encoding)
+      : context(kj::mv(context)),
+        encoder(encoding) {}
 
   // Feeds a chunk into the digest and returns the number of bytes consumed. The
   // return value is what lets the caller track a byte count for strings, whose
   // UTF-8 length is not observable from JavaScript.
-  uint32_t update(jsg::Lock& js, kj::OneOf<jsg::JsBufferSource, kj::String> chunk);
+  uint32_t update(jsg::Lock& js, kj::OneOf<jsg::JsBufferSource, jsg::JsString> chunk);
+
+  // Feeds in any bytes owed at end of stream and returns how many there were,
+  // so the caller can finish its byte count. See DigestStringEncoder::flush();
+  // this is only ever nonzero for a toWellFormed stream whose last chunk ended
+  // mid-surrogate-pair. Idempotent, and digest() does it too, so skipping this
+  // costs an accurate byte count but never a wrong digest.
+  uint32_t flush();
 
   // Finalizes the digest. Throws if called more than once.
   jsg::JsArrayBuffer digest(jsg::Lock& js);
 
   JSG_RESOURCE_TYPE(DigestContextHandle) {
     JSG_METHOD(update);
+    JSG_METHOD(flush);
     JSG_METHOD(digest);
 
     // Internal plumbing type: keep it out of the generated TypeScript types.
@@ -696,6 +759,7 @@ class DigestContextHandle final: public jsg::Object {
  private:
   // Cleared by digest(); kj::none marks the handle as already finalized.
   kj::Maybe<kj::Own<DigestContext>> context;
+  DigestStringEncoder encoder;
 };
 
 class DigestStream: public WritableStream {
@@ -703,12 +767,26 @@ class DigestStream: public WritableStream {
   using DigestContextPtr = kj::Own<DigestContext>;
   using Algorithm = kj::OneOf<kj::String, SubtleCrypto::HashAlgorithm>;
 
+  struct Options {
+    // When true, lone surrogates in string chunks are replaced with U+FFFD so
+    // that the bytes hashed are well-formed UTF-8. Defaults to false, which
+    // hashes them as WTF-8 — the behavior DigestStream has always had.
+    //
+    // Only string chunks are affected; ArrayBuffer and ArrayBufferView chunks
+    // are already bytes.
+    jsg::Optional<bool> toWellFormed;
+
+    JSG_STRUCT(toWellFormed);
+  };
+
   explicit DigestStream(kj::Own<WritableStreamController> controller,
       SubtleCrypto::HashAlgorithm algorithm,
       jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>>::Resolver resolver,
-      jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> promise);
+      jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>> promise,
+      DigestStringEncoding encoding);
 
-  static jsg::Ref<DigestStream> constructor(jsg::Lock& js, Algorithm algorithm);
+  static jsg::Ref<DigestStream> constructor(
+      jsg::Lock& js, Algorithm algorithm, jsg::Optional<Options> options);
 
   jsg::MemoizedIdentity<jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>>>& getDigest() {
     return promise;
@@ -751,6 +829,9 @@ class DigestStream: public WritableStream {
   jsg::MemoizedIdentity<jsg::Promise<jsg::JsRef<jsg::JsArrayBuffer>>> promise;
   kj::OneOf<Ready, StreamStates::Closed, StreamStates::Errored> state;
   uint64_t bytesWritten = 0;
+  // Only the sink's string path feeds this, but close() must flush it: under
+  // toWellFormed it can be holding back the lead half of a surrogate pair.
+  DigestStringEncoder encoder;
 
   kj::Maybe<StreamStates::Errored> write(jsg::Lock& js, kj::ArrayPtr<kj::byte> buffer);
   kj::Maybe<StreamStates::Errored> close(jsg::Lock& js);
@@ -823,7 +904,8 @@ class Crypto: public jsg::Object {
       api::CryptoKey::KeyAlgorithm, api::CryptoKey::AesKeyAlgorithm,                               \
       api::CryptoKey::HmacKeyAlgorithm, api::CryptoKey::RsaKeyAlgorithm,                           \
       api::CryptoKey::EllipticKeyAlgorithm, api::CryptoKey::ArbitraryKeyAlgorithm,                 \
-      api::CryptoKey::AsymmetricKeyDetails, api::DigestStream, api::DigestContextHandle
+      api::CryptoKey::AsymmetricKeyDetails, api::DigestStream, api::DigestStream::Options,         \
+      api::DigestContextHandle
 
 }  // namespace workerd::api
 

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -658,8 +658,8 @@ class DigestContext {
 };
 
 // Creates a digest context for the named algorithm. The CRC names ("crc32",
-// "crc32c", "crc64nvme") match exactly; everything else is looked up as an
-// OpenSSL digest, which is case-insensitive and throws a DOMNotSupportedError
+// "crc32c", "crc64nvme") are matched case-insensitively, as are the OpenSSL
+// digests that every other name is looked up as. Throws a DOMNotSupportedError
 // for unrecognized names.
 kj::Own<DigestContext> newDigestContext(kj::StringPtr algorithm);
 

--- a/src/workerd/api/crypto/crypto.h
+++ b/src/workerd/api/crypto/crypto.h
@@ -657,6 +657,47 @@ class DigestContext {
   virtual jsg::JsArrayBuffer close(jsg::Lock& js) = 0;
 };
 
+// Creates a digest context for the named algorithm. The CRC names ("crc32",
+// "crc32c", "crc64nvme") match exactly; everything else is looked up as an
+// OpenSSL digest, which is case-insensitive and throws a DOMNotSupportedError
+// for unrecognized names.
+kj::Own<DigestContext> newDigestContext(kj::StringPtr algorithm);
+
+// A JS-visible handle around a DigestContext. This is the native backing for the
+// TypeScript DigestStream; it is not registered on the global scope and is
+// excluded from the generated types. Instances reach the per-isolate bootstrap
+// through createDigestContext() (digest-bootstrap.h).
+//
+// Strings are converted to bytes here rather than in TypeScript so that both
+// DigestStream implementations hash them identically: jsg::Lock::toString()
+// emits WTF-8 for unpaired surrogates, whereas TextEncoder would substitute
+// U+FFFD. Sharing this conversion keeps the two implementations byte-identical,
+// and means a future change to the conversion applies to both at once.
+class DigestContextHandle final: public jsg::Object {
+ public:
+  DigestContextHandle(kj::Own<DigestContext> context): context(kj::mv(context)) {}
+
+  // Feeds a chunk into the digest and returns the number of bytes consumed. The
+  // return value is what lets the caller track a byte count for strings, whose
+  // UTF-8 length is not observable from JavaScript.
+  uint32_t update(jsg::Lock& js, kj::OneOf<jsg::JsBufferSource, kj::String> chunk);
+
+  // Finalizes the digest. Throws if called more than once.
+  jsg::JsArrayBuffer digest(jsg::Lock& js);
+
+  JSG_RESOURCE_TYPE(DigestContextHandle) {
+    JSG_METHOD(update);
+    JSG_METHOD(digest);
+
+    // Internal plumbing type: keep it out of the generated TypeScript types.
+    JSG_TS_OVERRIDE(type DigestContextHandle = never);
+  }
+
+ private:
+  // Cleared by digest(); kj::none marks the handle as already finalized.
+  kj::Maybe<kj::Own<DigestContext>> context;
+};
+
 class DigestStream: public WritableStream {
  public:
   using DigestContextPtr = kj::Own<DigestContext>;
@@ -782,7 +823,7 @@ class Crypto: public jsg::Object {
       api::CryptoKey::KeyAlgorithm, api::CryptoKey::AesKeyAlgorithm,                               \
       api::CryptoKey::HmacKeyAlgorithm, api::CryptoKey::RsaKeyAlgorithm,                           \
       api::CryptoKey::EllipticKeyAlgorithm, api::CryptoKey::ArbitraryKeyAlgorithm,                 \
-      api::CryptoKey::AsymmetricKeyDetails, api::DigestStream
+      api::CryptoKey::AsymmetricKeyDetails, api::DigestStream, api::DigestContextHandle
 
 }  // namespace workerd::api
 

--- a/src/workerd/api/crypto/digest-bootstrap.c++
+++ b/src/workerd/api/crypto/digest-bootstrap.c++
@@ -8,7 +8,8 @@
 
 namespace workerd::api {
 
-jsg::JsValue createDigestContext(jsg::Lock& js, kj::StringPtr algorithm) {
+jsg::JsValue createDigestContext(
+    jsg::Lock& js, kj::StringPtr algorithm, ToWellFormed toWellFormed) {
   // newDigestContext() validates the algorithm name and throws for unrecognized
   // ones, so this must run before the handle is allocated.
   auto context = newDigestContext(algorithm);
@@ -19,7 +20,8 @@ jsg::JsValue createDigestContext(jsg::Lock& js, kj::StringPtr algorithm) {
   auto& handler = KJ_ASSERT_NONNULL(js.tryGetTypeHandler<jsg::Ref<DigestContextHandle>>(),
       "DigestContextHandle is missing from the isolate type list");
 
-  return jsg::JsValue(handler.wrap(js, js.alloc<DigestContextHandle>(kj::mv(context))));
+  auto encoding = toWellFormed ? DigestStringEncoding::WELL_FORMED : DigestStringEncoding::WTF8;
+  return jsg::JsValue(handler.wrap(js, js.alloc<DigestContextHandle>(kj::mv(context), encoding)));
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/crypto/digest-bootstrap.c++
+++ b/src/workerd/api/crypto/digest-bootstrap.c++
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "digest-bootstrap.h"
+
+#include "crypto.h"
+
+namespace workerd::api {
+
+jsg::JsValue createDigestContext(jsg::Lock& js, kj::StringPtr algorithm) {
+  // newDigestContext() validates the algorithm name and throws for unrecognized
+  // ones, so this must run before the handle is allocated.
+  auto context = newDigestContext(algorithm);
+
+  // DigestContextHandle is registered in EW_CRYPTO_ISOLATE_TYPES, so the handler
+  // is always present. Asserting rather than propagating keeps the caller (a raw
+  // bootstrap callback) free of a failure mode it could not act on.
+  auto& handler = KJ_ASSERT_NONNULL(js.tryGetTypeHandler<jsg::Ref<DigestContextHandle>>(),
+      "DigestContextHandle is missing from the isolate type list");
+
+  return jsg::JsValue(handler.wrap(js, js.alloc<DigestContextHandle>(kj::mv(context))));
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/crypto/digest-bootstrap.h
+++ b/src/workerd/api/crypto/digest-bootstrap.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/jsg/jsg.h>
+
+namespace workerd::api {
+
+// Creates the native digest object that backs the TypeScript DigestStream. The
+// result exposes update(chunk) and digest() to JavaScript; see
+// DigestContextHandle in crypto.h for their semantics.
+//
+// Throws a DOMNotSupportedError if the algorithm name is not recognized, which
+// is what gives the TypeScript DigestStream constructor the same error type and
+// message as the C++ one.
+//
+// This declaration deliberately mentions no crypto types, so the per-isolate
+// bootstrap can reach the factory without depending on the crypto headers.
+jsg::JsValue createDigestContext(jsg::Lock& js, kj::StringPtr algorithm);
+
+}  // namespace workerd::api

--- a/src/workerd/api/crypto/digest-bootstrap.h
+++ b/src/workerd/api/crypto/digest-bootstrap.h
@@ -5,8 +5,16 @@
 #pragma once
 
 #include <workerd/jsg/jsg.h>
+#include <workerd/util/strong-bool.h>
 
 namespace workerd::api {
+
+// Selects how string chunks are encoded. NO gives WTF-8, which encodes a lone
+// surrogate literally; YES substitutes U+FFFD for it. This is the crypto-free
+// spelling of DigestStringEncoding (crypto.h), which createDigestContext()
+// translates to; the two exist separately so this header can stay free of
+// crypto dependencies.
+WD_STRONG_BOOL(ToWellFormed);
 
 // Creates the native digest object that backs the TypeScript DigestStream. The
 // result exposes update(chunk) and digest() to JavaScript; see
@@ -18,6 +26,6 @@ namespace workerd::api {
 //
 // This declaration deliberately mentions no crypto types, so the per-isolate
 // bootstrap can reach the factory without depending on the crypto headers.
-jsg::JsValue createDigestContext(jsg::Lock& js, kj::StringPtr algorithm);
+jsg::JsValue createDigestContext(jsg::Lock& js, kj::StringPtr algorithm, ToWellFormed toWellFormed);
 
 }  // namespace workerd::api

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -496,6 +496,12 @@ wd_test(
 )
 
 wd_test(
+    src = "crypto-streams-ts-test.wd-test",
+    args = ["--experimental"],
+    data = ["crypto-streams-test.js"],
+)
+
+wd_test(
     src = "data-url-fetch-test.wd-test",
     args = ["--experimental"],
     data = ["data-url-fetch-test.js"],
@@ -1347,6 +1353,12 @@ wd_test(
 wd_test(
     src = "htmlrewriter-transform-cancel-test.wd-test",
     data = ["htmlrewriter-transform-cancel-test.js"],
+)
+
+wd_test(
+    src = "ts-digest-stream-test.wd-test",
+    args = ["--experimental"],
+    data = ["ts-digest-stream-test.js"],
 )
 
 wd_test(

--- a/src/workerd/api/tests/crypto-streams-test.js
+++ b/src/workerd/api/tests/crypto-streams-test.js
@@ -240,6 +240,58 @@ export const defaultEncodingIsPerChunk = {
   },
 };
 
+// Algorithm names are matched case-insensitively, for the CRCs as well as for
+// the OpenSSL digests. Every casing of a name must select the same algorithm,
+// so the digests are compared rather than merely checked for not throwing.
+export const algorithmNamesAreCaseInsensitive = {
+  async test() {
+    const variants = {
+      crc32: ['crc32', 'CRC32', 'Crc32', 'cRc32'],
+      crc32c: ['crc32c', 'CRC32C', 'Crc32c', 'crc32C', 'cRc32C'],
+      crc64nvme: ['crc64nvme', 'CRC64NVME', 'Crc64Nvme', 'crc64NVME'],
+      md5: ['md5', 'MD5', 'Md5'],
+      'sha-256': ['sha-256', 'SHA-256', 'Sha-256'],
+    };
+
+    for (const [canonical, names] of Object.entries(variants)) {
+      const expected = await digestOf(canonical, 'hello');
+      for (const name of names) {
+        deepStrictEqual(
+          await digestOf(name, 'hello'),
+          expected,
+          `${name} should select the same algorithm as ${canonical}`
+        );
+      }
+    }
+  },
+};
+
+// Case-insensitivity must not turn a nonsense name into a match: the comparison
+// is over the whole name, so a CRC name with anything extra still fails.
+export const crcNamesStillRequireAnExactSpelling = {
+  test() {
+    for (const name of [
+      'crc',
+      'crc3',
+      'crc322',
+      'crc32d',
+      ' crc32',
+      'crc32 ',
+      'crc-32',
+      'crc64',
+      'crc64nvm',
+      'crc64nvmex',
+      'nvme',
+    ]) {
+      throws(
+        () => new crypto.DigestStream(name),
+        { name: 'NotSupportedError' },
+        `${JSON.stringify(name)} should not be a valid algorithm`
+      );
+    }
+  },
+};
+
 // The option bag follows Web IDL dictionary rules: undefined and null are an
 // empty bag, any object is read for its fields, and a primitive is a TypeError.
 // Arrays and functions count as objects, so they are accepted and simply carry

--- a/src/workerd/api/tests/crypto-streams-test.js
+++ b/src/workerd/api/tests/crypto-streams-test.js
@@ -10,21 +10,20 @@ import {
 } from 'node:assert';
 import { Buffer } from 'node:buffer';
 
-async function digestOf(algorithm, chunk) {
-  const stream = new crypto.DigestStream(algorithm);
+async function digestOf(algorithm, chunk, options) {
+  const stream = new crypto.DigestStream(algorithm, options);
   const writer = stream.getWriter();
   await writer.write(chunk);
   await writer.close();
   return new Uint8Array(await stream.digest);
 }
 
-// String chunks are converted to bytes by the runtime rather than by
-// TextEncoder, and the two disagree on unpaired surrogates: the runtime emits
-// WTF-8 (ED A0 80) where TextEncoder substitutes U+FFFD (EF BF BD). This test
-// pins that difference for BOTH implementations, so it fails loudly if either
-// one changes independently — the string-encoding behavior is expected to be
-// revisited, and when it is, this is the tripwire that says so.
-export const stringChunksAreNotTextEncoded = {
+// A lone surrogate has no UTF-8 encoding, so string chunks have two possible
+// byte sequences. By default the runtime emits WTF-8 (ED A0 80); TextEncoder
+// substitutes U+FFFD (EF BF BD). The default must stay WTF-8 for backwards
+// compatibility, which is what this pins — for BOTH implementations, so it
+// fails loudly if either drifts.
+export const stringChunksAreNotTextEncodedByDefault = {
   async test() {
     const viaString = await digestOf('md5', '\uD800');
     const viaEncoder = await digestOf(
@@ -34,7 +33,7 @@ export const stringChunksAreNotTextEncoded = {
     notDeepStrictEqual(
       viaString,
       viaEncoder,
-      'string chunks must not be TextEncoder-encoded'
+      'string chunks must not be TextEncoder-encoded by default'
     );
 
     // Well-formed strings agree with TextEncoder, so only the lone-surrogate
@@ -43,6 +42,261 @@ export const stringChunksAreNotTextEncoded = {
       await digestOf('md5', 'h\u00e9llo\u{1F600}'),
       await digestOf('md5', new TextEncoder().encode('h\u00e9llo\u{1F600}'))
     );
+  },
+};
+
+// toWellFormed: true opts into the substitution, making string chunks agree
+// with TextEncoder — and therefore with every other UTF-8 producer.
+export const toWellFormedMatchesTextEncoder = {
+  async test() {
+    const opts = { toWellFormed: true };
+    for (const input of [
+      '\uD800', // lone high surrogate
+      '\uDFFF', // lone low surrogate
+      'a\uD800b', // surrogate between well-formed text
+      '\uD800\uD800', // two lone high surrogates
+      '\uDC00\uD800', // reversed pair: both are lone
+    ]) {
+      deepStrictEqual(
+        await digestOf('md5', input, opts),
+        await digestOf('md5', new TextEncoder().encode(input)),
+        `toWellFormed should match TextEncoder for ${JSON.stringify(input)}`
+      );
+    }
+
+    // A valid surrogate pair is not a lone surrogate, so the option changes
+    // nothing for it.
+    const pair = '\uD83D\uDE00';
+    deepStrictEqual(
+      await digestOf('md5', pair, opts),
+      await digestOf('md5', pair)
+    );
+  },
+};
+
+// The option only affects strings, and only strings containing lone
+// surrogates. Everything else must hash identically either way, or the option
+// would be a silent breaking change for existing callers who set it.
+export const toWellFormedIsInertForValidInput = {
+  async test() {
+    const enc = new TextEncoder();
+    for (const input of ['', 'hello', 'h\u00e9llo\u{1F600}\u{10FFFF}']) {
+      deepStrictEqual(
+        await digestOf('md5', input, { toWellFormed: true }),
+        await digestOf('md5', input, { toWellFormed: false }),
+        `well-formed input must be unaffected: ${JSON.stringify(input)}`
+      );
+    }
+    // Byte chunks are already bytes; the option cannot apply to them even when
+    // they hold an invalid UTF-8 sequence.
+    for (const bytes of [
+      enc.encode('hello'),
+      new Uint8Array([0xed, 0xa0, 0x80]), // WTF-8 lone surrogate
+      new Uint8Array([0xff, 0xfe]), // not UTF-8 at all
+    ]) {
+      deepStrictEqual(
+        await digestOf('md5', bytes, { toWellFormed: true }),
+        await digestOf('md5', bytes, { toWellFormed: false })
+      );
+    }
+  },
+};
+
+// The two encodings agree on byte count: a lone surrogate is three bytes in
+// WTF-8, and U+FFFD is three bytes too. So bytesWritten is unaffected.
+export const toWellFormedDoesNotChangeBytesWritten = {
+  async test() {
+    for (const options of [
+      undefined,
+      { toWellFormed: false },
+      { toWellFormed: true },
+    ]) {
+      const stream = new crypto.DigestStream('md5', options);
+      const writer = stream.getWriter();
+      await writer.write('a\uD800b');
+      await writer.close();
+      await stream.digest;
+      strictEqual(stream.bytesWritten, 5n);
+    }
+  },
+};
+
+// Every spelling of "not requested" must give the historical WTF-8 behavior,
+// since anything else would break existing callers.
+export const toWellFormedDefaultsToFalse = {
+  async test() {
+    const expected = await digestOf('md5', '\uD800');
+    for (const options of [
+      undefined,
+      {},
+      { toWellFormed: undefined },
+      { toWellFormed: false },
+      { toWellFormed: 0 },
+      { toWellFormed: '' },
+      { toWellFormed: null },
+      { somethingElse: true },
+    ]) {
+      deepStrictEqual(
+        await digestOf('md5', '\uD800', options),
+        expected,
+        `should default to WTF-8: ${JSON.stringify(options)}`
+      );
+    }
+  },
+};
+
+async function digestOfChunks(algorithm, chunks, options) {
+  const stream = new crypto.DigestStream(algorithm, options);
+  const writer = stream.getWriter();
+  for (const chunk of chunks) {
+    await writer.write(chunk);
+  }
+  await writer.close();
+  return {
+    digest: new Uint8Array(await stream.digest),
+    bytesWritten: stream.bytesWritten,
+  };
+}
+
+// toWellFormed asks for the input to be treated as text, so a surrogate pair
+// split across two writes is one code point that happens to arrive in two
+// pieces — not two unpaired surrogates. The encoder therefore holds a trailing
+// lead surrogate back until the next chunk, exactly as TextEncoderStream does.
+export const toWellFormedJoinsSurrogatePairsAcrossChunks = {
+  async test() {
+    const opts = { toWellFormed: true };
+    const enc = new TextEncoder();
+
+    for (const [chunks, whole] of [
+      [['ab\uD800', '\uDC00c'], 'ab\uD800\uDC00c'],
+      // The pair is the entire input, split at the boundary.
+      [['\uD800', '\uDC00'], '\uD800\uDC00'],
+      // Lead ends a chunk that is otherwise empty of text.
+      [['a', '\uD83D', '\uDE00', 'b'], 'a\uD83D\uDE00b'],
+      // Several pairs, each split.
+      [['\uD83D', '\uDE00\uD83D', '\uDE01'], '\uD83D\uDE00\uD83D\uDE01'],
+      // A pair split with the second half followed by more text.
+      [['x\uD83D', '\uDE00yz'], 'x\uD83D\uDE00yz'],
+    ]) {
+      const split = await digestOfChunks('md5', chunks, opts);
+      deepStrictEqual(
+        split.digest,
+        await digestOf('md5', whole, opts),
+        `split ${JSON.stringify(chunks)} should match whole ${JSON.stringify(whole)}`
+      );
+      // And since the joined input is well-formed, it must also match what any
+      // other UTF-8 encoder would produce.
+      deepStrictEqual(split.digest, await digestOf('md5', enc.encode(whole)));
+      strictEqual(
+        split.bytesWritten,
+        BigInt(enc.encode(whole).byteLength),
+        `bytesWritten for ${JSON.stringify(chunks)}`
+      );
+    }
+  },
+};
+
+// A lead surrogate held back from the final chunk is never paired, so it is an
+// unpaired surrogate and must be flushed as U+FFFD when the stream closes.
+export const toWellFormedFlushesDanglingLeadSurrogate = {
+  async test() {
+    const opts = { toWellFormed: true };
+    const enc = new TextEncoder();
+
+    for (const [chunks, whole] of [
+      [['ab\uD800'], 'ab\uD800'],
+      [['ab', '\uD800'], 'ab\uD800'],
+      // Lead followed by a chunk that cannot pair with it: the lead resolves to
+      // U+FFFD and the next chunk is encoded normally.
+      [['a\uD800', 'b'], 'a\uD800b'],
+      [['a\uD800', '\uD800b'], 'a\uD800\uD800b'],
+      // A trail surrogate with nothing pending is unpaired on its own.
+      [['a', '\uDC00b'], 'a\uDC00b'],
+      [['\uDC00\uD800'], '\uDC00\uD800'],
+    ]) {
+      const split = await digestOfChunks('md5', chunks, opts);
+      deepStrictEqual(
+        split.digest,
+        await digestOf('md5', enc.encode(whole)),
+        `${JSON.stringify(chunks)} should encode as ${JSON.stringify(whole)}`
+      );
+      strictEqual(split.bytesWritten, BigInt(enc.encode(whole).byteLength));
+    }
+  },
+};
+
+// The default encoding is deliberately NOT a streaming text encoder: each chunk
+// is encoded exactly as V8 holds it, so a pair split across writes becomes two
+// separately-encoded lone surrogates rather than one code point. This differs
+// from the whole-string digest, and that difference is the historical behavior —
+// changing it would silently alter existing callers' digests.
+export const defaultEncodingIsPerChunk = {
+  async test() {
+    const split = await digestOfChunks('md5', ['ab\uD800', '\uDC00c']);
+    const whole = await digestOf('md5', 'ab\uD800\uDC00c');
+    notDeepStrictEqual(split.digest, whole);
+    // Two lone surrogates at 3 bytes each, rather than one 4-byte code point.
+    strictEqual(split.bytesWritten, 3n + 3n + 3n);
+  },
+};
+
+// The option bag follows Web IDL dictionary rules: undefined and null are an
+// empty bag, any object is read for its fields, and a primitive is a TypeError.
+// Arrays and functions count as objects, so they are accepted and simply carry
+// no field.
+export const optionBagAcceptsObjectsAndRejectsPrimitives = {
+  test() {
+    for (const options of [undefined, null, {}, [], () => {}, new Date()]) {
+      const stream = new crypto.DigestStream('md5', options);
+      stream[Symbol.dispose]();
+    }
+
+    for (const options of [0, 1, '', 'x', true, false, 1n, Symbol.iterator]) {
+      throws(
+        () => new crypto.DigestStream('md5', options),
+        {
+          name: 'TypeError',
+          message:
+            "Failed to construct 'DigestStream': constructor parameter 2 is " +
+            "not of type 'Options'.",
+        },
+        `should reject primitive option bag: ${String(options)}`
+      );
+    }
+  },
+};
+
+// Argument type-checking happens before the algorithm name is looked up, so a
+// bad option bag is reported ahead of an unrecognized algorithm. 'foo' is a
+// perfectly good string — it only fails later, when the digest is created.
+export const argumentTypesAreCheckedBeforeAlgorithmLookup = {
+  test() {
+    throws(() => new crypto.DigestStream('foo', 0), {
+      name: 'TypeError',
+      message:
+        "Failed to construct 'DigestStream': constructor parameter 2 is not " +
+        "of type 'Options'.",
+    });
+    // With a well-typed option bag, the algorithm lookup is reached and fails.
+    throws(() => new crypto.DigestStream('foo', { toWellFormed: true }), {
+      name: 'NotSupportedError',
+    });
+  },
+};
+
+// The field is coerced with ToBoolean rather than type-checked, so any truthy
+// value opts in. Pinned for both implementations because the C++ side gets
+// this from JSG and the TypeScript side has to match it by hand.
+export const toWellFormedIsCoerced = {
+  async test() {
+    const expected = await digestOf('md5', '\uD800', { toWellFormed: true });
+    for (const value of [true, 1, 'false', [], {}, Symbol.iterator]) {
+      deepStrictEqual(
+        await digestOf('md5', '\uD800', { toWellFormed: value }),
+        expected,
+        `truthy ${String(value)} should opt in`
+      );
+    }
   },
 };
 

--- a/src/workerd/api/tests/crypto-streams-test.js
+++ b/src/workerd/api/tests/crypto-streams-test.js
@@ -1,8 +1,50 @@
 // Copyright (c) 2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-import { strictEqual, deepStrictEqual, rejects, throws } from 'node:assert';
+import {
+  strictEqual,
+  deepStrictEqual,
+  notDeepStrictEqual,
+  rejects,
+  throws,
+} from 'node:assert';
 import { Buffer } from 'node:buffer';
+
+async function digestOf(algorithm, chunk) {
+  const stream = new crypto.DigestStream(algorithm);
+  const writer = stream.getWriter();
+  await writer.write(chunk);
+  await writer.close();
+  return new Uint8Array(await stream.digest);
+}
+
+// String chunks are converted to bytes by the runtime rather than by
+// TextEncoder, and the two disagree on unpaired surrogates: the runtime emits
+// WTF-8 (ED A0 80) where TextEncoder substitutes U+FFFD (EF BF BD). This test
+// pins that difference for BOTH implementations, so it fails loudly if either
+// one changes independently — the string-encoding behavior is expected to be
+// revisited, and when it is, this is the tripwire that says so.
+export const stringChunksAreNotTextEncoded = {
+  async test() {
+    const viaString = await digestOf('md5', '\uD800');
+    const viaEncoder = await digestOf(
+      'md5',
+      new TextEncoder().encode('\uD800')
+    );
+    notDeepStrictEqual(
+      viaString,
+      viaEncoder,
+      'string chunks must not be TextEncoder-encoded'
+    );
+
+    // Well-formed strings agree with TextEncoder, so only the lone-surrogate
+    // case is special.
+    deepStrictEqual(
+      await digestOf('md5', 'h\u00e9llo\u{1F600}'),
+      await digestOf('md5', new TextEncoder().encode('h\u00e9llo\u{1F600}'))
+    );
+  },
+};
 
 export const digeststream = {
   async test() {

--- a/src/workerd/api/tests/crypto-streams-ts-test.wd-test
+++ b/src/workerd/api/tests/crypto-streams-ts-test.wd-test
@@ -1,0 +1,25 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+# Runs the unmodified crypto-streams-test.js against the TypeScript DigestStream.
+# Sharing the test file with crypto-streams-test.wd-test is the point: any
+# behavioral drift between the two implementations fails one config or the other.
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "crypto-streams-ts-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "crypto-streams-test.js")
+        ],
+        compatibilityFlags = [
+          "nodejs_compat",
+          "typescript_implemented_streams",
+          "experimental",
+        ],
+      )
+    ),
+  ],
+  autogates = [
+    "workerd-autogate-per-isolate-javascript-bootstrap",
+  ],
+);

--- a/src/workerd/api/tests/ts-digest-stream-test.js
+++ b/src/workerd/api/tests/ts-digest-stream-test.js
@@ -352,23 +352,6 @@ export const allAlgorithms = {
   },
 };
 
-// Algorithm names go to the same lookup as the C++ version, which is
-// case-insensitive for OpenSSL digests but exact for the CRCs.
-export const algorithmNameCasing = {
-  async test() {
-    // OpenSSL lookup tolerates case.
-    for (const name of ['md5', 'MD5', 'sha-256', 'SHA-256']) {
-      const stream = new crypto.DigestStream(name);
-      stream[Symbol.dispose]();
-    }
-    // CRC names are matched exactly, so the uppercase forms fall through to the
-    // OpenSSL lookup and fail.
-    throws(() => new crypto.DigestStream('CRC32'));
-    throws(() => new crypto.DigestStream('CRC32C'));
-    throws(() => new crypto.DigestStream('CRC64NVME'));
-  },
-};
-
 export const writeAfterCloseRejects = {
   async test() {
     const stream = new crypto.DigestStream('md5');

--- a/src/workerd/api/tests/ts-digest-stream-test.js
+++ b/src/workerd/api/tests/ts-digest-stream-test.js
@@ -1,0 +1,469 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Tests specific to the TypeScript DigestStream. Behavior shared with the C++
+// implementation is covered by crypto-streams-test.js, which both
+// implementations run unmodified; this file covers what only the TypeScript
+// version can do, plus the edge cases neither had coverage for.
+
+import { strictEqual, deepStrictEqual, ok, rejects, throws } from 'node:assert';
+
+// The reason this implementation exists: with typescript_implemented_streams
+// enabled, the C++ DigestStream inherits from the C++ WritableStream, which is
+// no longer the WritableStream user code sees. These assertions fail against
+// the C++ implementation, so they double as proof that the swap took effect —
+// without them the rest of this file would pass either way.
+export const isRealWritableStreamSubclass = {
+  test() {
+    const stream = new crypto.DigestStream('md5');
+    ok(
+      stream instanceof WritableStream,
+      'DigestStream instance must be a WritableStream'
+    );
+    strictEqual(
+      Object.getPrototypeOf(crypto.DigestStream),
+      WritableStream,
+      'DigestStream must extend the global WritableStream'
+    );
+    strictEqual(
+      Object.getPrototypeOf(crypto.DigestStream.prototype),
+      WritableStream.prototype
+    );
+    // Inherited members must be reachable, not shadowed.
+    strictEqual(typeof stream.getWriter, 'function');
+    strictEqual(stream.locked, false);
+  },
+};
+
+// The user-visible consequence of the above: piping into a DigestStream.
+// pipeTo checks its destination with a brand check, so a foreign WritableStream
+// is rejected outright.
+export const pipeToWorks = {
+  async test() {
+    const check = new Uint8Array([
+      93, 65, 64, 42, 188, 75, 42, 118, 185, 113, 157, 145, 16, 23, 197, 146,
+    ]);
+    const enc = new TextEncoder();
+    const digestStream = new crypto.DigestStream('md5');
+
+    const source = new ReadableStream({
+      start(controller) {
+        controller.enqueue(enc.encode('hello'));
+        controller.close();
+      },
+    });
+
+    await source.pipeTo(digestStream);
+    deepStrictEqual(new Uint8Array(await digestStream.digest), check);
+    strictEqual(digestStream.bytesWritten, 5n);
+  },
+};
+
+export const pipeThroughIntoDigest = {
+  async test() {
+    const enc = new TextEncoder();
+    const digestStream = new crypto.DigestStream('crc32');
+    const { readable, writable } = new TransformStream();
+
+    const writer = writable.getWriter();
+    const pipe = readable.pipeTo(digestStream);
+    await writer.write(enc.encode('Hello world'));
+    await writer.close();
+    await pipe;
+
+    // Same expectation as the shared AWS CRC vector for 'Hello world'.
+    deepStrictEqual(
+      new Uint8Array(await digestStream.digest),
+      new Uint8Array([0x8b, 0xd6, 0x9e, 0x52])
+    );
+  },
+};
+
+export const digestPromiseIdentityIsStable = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    const first = stream.digest;
+    const second = stream.digest;
+    strictEqual(first, second, 'digest must return the same promise object');
+
+    const writer = stream.getWriter();
+    await writer.close();
+    await first;
+    // Still the same object after settling.
+    strictEqual(stream.digest, first);
+  },
+};
+
+export const bytesWrittenIsBigInt = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    strictEqual(typeof stream.bytesWritten, 'bigint');
+    strictEqual(stream.bytesWritten, 0n);
+
+    const writer = stream.getWriter();
+    await writer.write(new Uint8Array(3));
+    strictEqual(stream.bytesWritten, 3n);
+    // A zero-length write must not move the counter.
+    await writer.write(new Uint8Array(0));
+    strictEqual(stream.bytesWritten, 3n);
+    // Strings count their UTF-8 length, not their UTF-16 length.
+    await writer.write('\u00e9');
+    strictEqual(stream.bytesWritten, 5n);
+    await writer.close();
+  },
+};
+
+export const toStringTag = {
+  test() {
+    const stream = new crypto.DigestStream('md5');
+    strictEqual(
+      Object.prototype.toString.call(stream),
+      '[object DigestStream]'
+    );
+  },
+};
+
+export const rejectsNonByteChunks = {
+  async test() {
+    const expected =
+      'DigestStream is a byte stream but received an object ' +
+      'of non-ArrayBuffer/ArrayBufferView/string type on its writable side.';
+
+    for (const bad of [123, null, undefined, {}, [], true, Symbol.iterator]) {
+      const stream = new crypto.DigestStream('md5');
+      const writer = stream.getWriter();
+      await rejects(writer.write(bad), { message: expected });
+    }
+  },
+};
+
+// A bare SharedArrayBuffer is not an ArrayBuffer as far as V8 is concerned, so
+// it is rejected; a view onto one is accepted. This split is inherited from the
+// C++ implementation and was previously untested.
+export const sharedArrayBufferHandling = {
+  async test() {
+    if (typeof SharedArrayBuffer === 'undefined') return;
+
+    {
+      const stream = new crypto.DigestStream('md5');
+      const writer = stream.getWriter();
+      await rejects(writer.write(new SharedArrayBuffer(8)), {
+        message:
+          'DigestStream is a byte stream but received an object ' +
+          'of non-ArrayBuffer/ArrayBufferView/string type on its writable side.',
+      });
+    }
+
+    {
+      const stream = new crypto.DigestStream('md5');
+      const writer = stream.getWriter();
+      await writer.write(new Uint8Array(new SharedArrayBuffer(4)));
+      await writer.close();
+      await stream.digest;
+      strictEqual(stream.bytesWritten, 4n);
+    }
+  },
+};
+
+export const unknownAlgorithmThrowsSynchronously = {
+  test() {
+    throws(() => new crypto.DigestStream('foo'));
+    throws(() => new crypto.DigestStream(''));
+    // A missing name coerces to "undefined" and then fails the lookup.
+    throws(() => new crypto.DigestStream({}));
+    throws(() => new crypto.DigestStream(null));
+    throws(() => new crypto.DigestStream(undefined));
+  },
+};
+
+export const algorithmAsObject = {
+  async test() {
+    const check = new Uint8Array([
+      93, 65, 64, 42, 188, 75, 42, 118, 185, 113, 157, 145, 16, 23, 197, 146,
+    ]);
+    const stream = new crypto.DigestStream({ name: 'md5' });
+    const writer = stream.getWriter();
+    await writer.write('hello');
+    await writer.close();
+    deepStrictEqual(new Uint8Array(await stream.digest), check);
+  },
+};
+
+// dispose() errors the digest without touching the WritableStream, so a
+// zero-length write still resolves: the sink short-circuits on length before it
+// ever looks at the digest state. Non-empty writes reject. Neither ordering was
+// previously covered.
+export const disposeThenZeroLengthWrite = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    stream[Symbol.dispose]();
+
+    // The stream itself is untouched by dispose.
+    strictEqual(stream.locked, false);
+
+    const writer = stream.getWriter();
+    await writer.write(new Uint8Array(0));
+    await writer.write('');
+
+    await rejects(writer.write(new Uint8Array(1)), {
+      message: 'The DigestStream was disposed.',
+    });
+    await rejects(stream.digest, { message: 'The DigestStream was disposed.' });
+  },
+};
+
+export const disposeIsIdempotent = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    stream[Symbol.dispose]();
+    stream[Symbol.dispose]();
+    stream[Symbol.dispose]();
+    await rejects(stream.digest, { message: 'The DigestStream was disposed.' });
+  },
+};
+
+// Closing resolves the digest; a later dispose must not overwrite it.
+export const disposeAfterCloseIsNoOp = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    const writer = stream.getWriter();
+    await writer.write('hello');
+    await writer.close();
+    const digest = await stream.digest;
+    stream[Symbol.dispose]();
+    // Still resolved with the same value, not rejected.
+    strictEqual(await stream.digest, digest);
+  },
+};
+
+export const abortRejectsDigest = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    const writer = stream.getWriter();
+    const reason = new Error('boom');
+    await writer.abort(reason);
+    await rejects(stream.digest, { message: 'boom' });
+  },
+};
+
+// Accessors are brand-checked rather than instanceof-checked, so they must
+// reject a plain object even if its prototype is set correctly.
+export const accessorsAreBrandChecked = {
+  test() {
+    const fake = Object.create(crypto.DigestStream.prototype);
+    throws(() => fake.digest, { name: 'TypeError' });
+    throws(() => fake.bytesWritten, { name: 'TypeError' });
+    throws(() => fake[Symbol.dispose](), { name: 'TypeError' });
+
+    const desc = Object.getOwnPropertyDescriptor(
+      crypto.DigestStream.prototype,
+      'digest'
+    );
+    strictEqual(typeof desc.get, 'function');
+    strictEqual(desc.set, undefined);
+  },
+};
+
+// The digest promise is marked handled, so abandoning it produces no
+// unhandled-rejection report. This is a deliberate divergence from the C++
+// implementation, which is why it is asserted here and not in the shared file.
+export const abandonedDigestIsNotReported = {
+  async test() {
+    const reports = [];
+    const onReport = (event) => {
+      reports.push(event.reason);
+      event.preventDefault();
+    };
+    addEventListener('unhandledrejection', onReport);
+    try {
+      {
+        const stream = new crypto.DigestStream('md5');
+        stream[Symbol.dispose]();
+      }
+      // Give the microtask queue and the rejection-report turn a chance to run.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      await scheduler.wait(1);
+      strictEqual(
+        reports.length,
+        0,
+        `expected no unhandled rejection, got: ${reports.map(String)}`
+      );
+
+      // But marking handled must not propagate to derived promises: a consumer
+      // that attaches a then() with no catch still gets a report.
+      {
+        const stream = new crypto.DigestStream('md5');
+        stream.digest.then(() => {});
+        stream[Symbol.dispose]();
+      }
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      await scheduler.wait(1);
+      strictEqual(reports.length, 1, 'derived promise should still report');
+      strictEqual(reports[0].message, 'The DigestStream was disposed.');
+    } finally {
+      removeEventListener('unhandledrejection', onReport);
+    }
+  },
+};
+
+// Writes are not copied, so a view is read in place. Mutating the buffer after
+// the write resolves must not change the digest.
+export const chunkIsConsumedSynchronously = {
+  async test() {
+    const buf = new Uint8Array([1, 2, 3, 4]);
+    const stream = new crypto.DigestStream('crc32');
+    const writer = stream.getWriter();
+    await writer.write(buf);
+    buf.fill(0xff);
+    await writer.close();
+    const mutated = new Uint8Array(await stream.digest);
+
+    const reference = new crypto.DigestStream('crc32');
+    const refWriter = reference.getWriter();
+    await refWriter.write(new Uint8Array([1, 2, 3, 4]));
+    await refWriter.close();
+    deepStrictEqual(mutated, new Uint8Array(await reference.digest));
+  },
+};
+
+// Every algorithm the C++ implementation accepts must still be reachable, and
+// each must produce a distinct digest length.
+export const allAlgorithms = {
+  async test() {
+    const sizes = {
+      md5: 16,
+      'SHA-1': 20,
+      'SHA-256': 32,
+      'SHA-384': 48,
+      'SHA-512': 64,
+      crc32: 4,
+      crc32c: 4,
+      crc64nvme: 8,
+    };
+    for (const [name, size] of Object.entries(sizes)) {
+      const stream = new crypto.DigestStream(name);
+      const writer = stream.getWriter();
+      await writer.write('abc');
+      await writer.close();
+      const digest = await stream.digest;
+      strictEqual(digest.byteLength, size, `${name} digest size`);
+    }
+  },
+};
+
+// Algorithm names go to the same lookup as the C++ version, which is
+// case-insensitive for OpenSSL digests but exact for the CRCs.
+export const algorithmNameCasing = {
+  async test() {
+    // OpenSSL lookup tolerates case.
+    for (const name of ['md5', 'MD5', 'sha-256', 'SHA-256']) {
+      const stream = new crypto.DigestStream(name);
+      stream[Symbol.dispose]();
+    }
+    // CRC names are matched exactly, so the uppercase forms fall through to the
+    // OpenSSL lookup and fail.
+    throws(() => new crypto.DigestStream('CRC32'));
+    throws(() => new crypto.DigestStream('CRC32C'));
+    throws(() => new crypto.DigestStream('CRC64NVME'));
+  },
+};
+
+export const writeAfterCloseRejects = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    const writer = stream.getWriter();
+    await writer.close();
+    await rejects(writer.write(new Uint8Array(1)));
+    // The digest is unaffected by the failed write.
+    strictEqual((await stream.digest).byteLength, 16);
+    strictEqual(stream.bytesWritten, 0n);
+  },
+};
+
+export const multipleWritesAccumulate = {
+  async test() {
+    const check = new Uint8Array([
+      198, 247, 195, 114, 100, 29, 210, 94, 15, 221, 240, 33, 83, 117, 86, 31,
+    ]);
+    const stream = new crypto.DigestStream('md5');
+    const writer = stream.getWriter();
+    const enc = new TextEncoder();
+    // Mixed input kinds must concatenate in write order.
+    await writer.write(enc.encode('hel'));
+    await writer.write('lo');
+    await writer.write(new Uint8Array(0));
+    await writer.write(enc.encode('there'));
+    await writer.close();
+    deepStrictEqual(new Uint8Array(await stream.digest), check);
+    strictEqual(stream.bytesWritten, 10n);
+  },
+};
+
+// A DataView is an ArrayBufferView, so its byteOffset and byteLength must be
+// honored rather than the whole backing buffer being hashed.
+export const dataViewRespectsOffset = {
+  async test() {
+    const backing = new Uint8Array([9, 9, 1, 2, 3, 4, 9, 9]);
+    const stream = new crypto.DigestStream('crc32');
+    const writer = stream.getWriter();
+    await writer.write(new DataView(backing.buffer, 2, 4));
+    await writer.close();
+
+    const reference = new crypto.DigestStream('crc32');
+    const refWriter = reference.getWriter();
+    await refWriter.write(new Uint8Array([1, 2, 3, 4]));
+    await refWriter.close();
+
+    deepStrictEqual(
+      new Uint8Array(await stream.digest),
+      new Uint8Array(await reference.digest)
+    );
+    strictEqual(stream.bytesWritten, 4n);
+  },
+};
+
+// The digest is single-use: a second close must not try to finalize the native
+// context again.
+export const doubleCloseIsSafe = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    const writer = stream.getWriter();
+    await writer.close();
+    await rejects(writer.close());
+    strictEqual((await stream.digest).byteLength, 16);
+  },
+};
+
+export const constructorIsSubclassable = {
+  async test() {
+    class MyDigest extends crypto.DigestStream {
+      constructor() {
+        super('md5');
+        this.tag = 'mine';
+      }
+    }
+    const stream = new MyDigest();
+    strictEqual(stream.tag, 'mine');
+    ok(stream instanceof crypto.DigestStream);
+    ok(stream instanceof WritableStream);
+    const writer = stream.getWriter();
+    await writer.write('hello');
+    await writer.close();
+    strictEqual((await stream.digest).byteLength, 16);
+  },
+};
+
+// Digests must be reachable from a plain `new WritableStream`-style teardown:
+// releasing the writer without closing leaves the digest pending forever, which
+// must not throw or crash.
+export const abandonedWriterDoesNotThrow = {
+  async test() {
+    const stream = new crypto.DigestStream('md5');
+    const writer = stream.getWriter();
+    await writer.write('hello');
+    writer.releaseLock();
+    strictEqual(stream.bytesWritten, 5n);
+    strictEqual(stream.locked, false);
+  },
+};

--- a/src/workerd/api/tests/ts-digest-stream-test.wd-test
+++ b/src/workerd/api/tests/ts-digest-stream-test.wd-test
@@ -1,0 +1,21 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "ts-digest-stream-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "ts-digest-stream-test.js")
+        ],
+        compatibilityFlags = [
+          "nodejs_compat",
+          "typescript_implemented_streams",
+          "experimental",
+        ],
+      )
+    ),
+  ],
+  autogates = [
+    "workerd-autogate-per-isolate-javascript-bootstrap",
+  ],
+);

--- a/src/workerd/io/per-isolate-bootstrap.c++
+++ b/src/workerd/io/per-isolate-bootstrap.c++
@@ -157,8 +157,11 @@ static void CreateDigestContext(const v8::FunctionCallbackInfo<v8::Value>& args)
       auto name = jsg::JsValue(args[0]);
       auto str = JSG_REQUIRE_NONNULL(name.tryCast<jsg::JsString>(), TypeError,
           "createDigestContext() expects a string argument");
+      // The caller has already reduced the option bag to a boolean, so this is
+      // ToBoolean on an actual boolean and cannot run user code.
+      auto toWellFormed = api::ToWellFormed(args[1]->BooleanValue(args.GetIsolate()));
       args.GetReturnValue().Set(
-          v8::Local<v8::Value>(api::createDigestContext(js, str.toString(js))));
+          v8::Local<v8::Value>(api::createDigestContext(js, str.toString(js), toWellFormed)));
     });
   });
 }

--- a/src/workerd/io/per-isolate-bootstrap.c++
+++ b/src/workerd/io/per-isolate-bootstrap.c++
@@ -5,6 +5,7 @@
 #include "per-isolate-bootstrap.h"
 
 #include <workerd/api/compression.h>
+#include <workerd/api/crypto/digest-bootstrap.h>
 #include <workerd/io/compatibility-date.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/jsvalue.h>
@@ -144,6 +145,24 @@ static void GetApiSymbol(const v8::FunctionCallbackInfo<v8::Value>& args) {
   });
 }
 
+// Creates the native digest object backing the TypeScript DigestStream. Unlike
+// its neighbors this allocates and can throw (an unrecognized algorithm name
+// raises a DOMNotSupportedError), so it is registered as a plain method rather
+// than a fast-API call, and needs liftKj to turn a thrown kj::Exception into a
+// JS exception.
+static void CreateDigestContext(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  jsg::liftKj(args.GetIsolate(), [&] {
+    auto& js = jsg::Lock::from(args.GetIsolate());
+    js.withinHandleScope([&] {
+      auto name = jsg::JsValue(args[0]);
+      auto str = JSG_REQUIRE_NONNULL(name.tryCast<jsg::JsString>(), TypeError,
+          "createDigestContext() expects a string argument");
+      args.GetReturnValue().Set(
+          v8::Local<v8::Value>(api::createDigestContext(js, str.toString(js))));
+    });
+  });
+}
+
 static const v8::CFunction fast_mark_promise_handled_ =
     v8::CFunction::Make(MarkPromiseHandledFastApi);
 
@@ -186,6 +205,7 @@ jsg::JsRef<jsg::JsObject> createUtilsObject(jsg::Lock& js) {
     "markPromiseHandled",
     "getApiSymbol",
     "newCompressionCodec",
+    "createDigestContext",
   };
   auto tmpl = v8::DictionaryTemplate::New(js.v8Isolate, names);
   v8::MaybeLocal<v8::Value> values[] = {
@@ -196,6 +216,7 @@ jsg::JsRef<jsg::JsObject> createUtilsObject(jsg::Lock& js) {
     getFastMethod(js, MarkPromiseHandled, &fast_mark_promise_handled_),
     getMethod(js, GetApiSymbol),
     getMethod(js, api::newCompressionCodecCallback),
+    getMethod(js, CreateDigestContext),
   };
 
   static_assert(kj::arrayPtr(names).size() == kj::arrayPtr(values).size());

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -1596,9 +1596,15 @@ interface CryptoKeyArbitraryKeyAlgorithm {
 declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
-  constructor(algorithm: string | SubtleCryptoHashAlgorithm);
+  constructor(
+    algorithm: string | SubtleCryptoHashAlgorithm,
+    options?: DigestStreamOptions,
+  );
   readonly digest: Promise<ArrayBuffer>;
   get bytesWritten(): number | bigint;
+}
+interface DigestStreamOptions {
+  toWellFormed?: boolean;
 }
 /**
  * The **`TextDecoder`** interface represents a decoder for a specific text encoding, such as UTF-8, ISO-8859-2, or GBK. A decoder takes an array of bytes as input and returns a JavaScript string.

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -1600,9 +1600,15 @@ export interface CryptoKeyArbitraryKeyAlgorithm {
 export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
-  constructor(algorithm: string | SubtleCryptoHashAlgorithm);
+  constructor(
+    algorithm: string | SubtleCryptoHashAlgorithm,
+    options?: DigestStreamOptions,
+  );
   readonly digest: Promise<ArrayBuffer>;
   get bytesWritten(): number | bigint;
+}
+export interface DigestStreamOptions {
+  toWellFormed?: boolean;
 }
 /**
  * The **`TextDecoder`** interface represents a decoder for a specific text encoding, such as UTF-8, ISO-8859-2, or GBK. A decoder takes an array of bytes as input and returns a JavaScript string.

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -1571,9 +1571,15 @@ interface CryptoKeyArbitraryKeyAlgorithm {
 declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
-  constructor(algorithm: string | SubtleCryptoHashAlgorithm);
+  constructor(
+    algorithm: string | SubtleCryptoHashAlgorithm,
+    options?: DigestStreamOptions,
+  );
   readonly digest: Promise<ArrayBuffer>;
   get bytesWritten(): number | bigint;
+}
+interface DigestStreamOptions {
+  toWellFormed?: boolean;
 }
 /**
  * The **`TextDecoder`** interface represents a decoder for a specific text encoding, such as UTF-8, ISO-8859-2, or GBK. A decoder takes an array of bytes as input and returns a JavaScript string.

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -1575,9 +1575,15 @@ export interface CryptoKeyArbitraryKeyAlgorithm {
 export declare class DigestStream extends WritableStream<
   ArrayBuffer | ArrayBufferView
 > {
-  constructor(algorithm: string | SubtleCryptoHashAlgorithm);
+  constructor(
+    algorithm: string | SubtleCryptoHashAlgorithm,
+    options?: DigestStreamOptions,
+  );
   readonly digest: Promise<ArrayBuffer>;
   get bytesWritten(): number | bigint;
+}
+export interface DigestStreamOptions {
+  toWellFormed?: boolean;
 }
 /**
  * The **`TextDecoder`** interface represents a decoder for a specific text encoding, such as UTF-8, ISO-8859-2, or GBK. A decoder takes an array of bytes as input and returns a JavaScript string.


### PR DESCRIPTION
Implement the TypeScript-version of `DigestStream`

Also includes two fixes to both implementations, one dealing with the case-insensitive matching for the crc algorithm names, and the second a new option to handle split surrogates.