### PR TITLE
fix(deps): bump docs-build Python deps (Pygments/idna/requests/urllib3)

### DIFF
--- a/src/pyodide/internal/sphinx/requirements-doc.txt
+++ b/src/pyodide/internal/sphinx/requirements-doc.txt
@@ -3,7 +3,7 @@ babel==2.16.0
 certifi==2024.12.14
 charset-normalizer==3.4.1
 docutils==0.21.2
-idna==3.10
+idna==3.15
 imagesize==1.4.1
 Jinja2==3.1.6
 markdown-it-py==3.0.0
@@ -12,9 +12,9 @@ mdit-py-plugins==0.4.2
 mdurl==0.1.2
 myst-parser==4.0.0
 packaging==24.2
-Pygments==2.19.1
+Pygments==2.20.0
 PyYAML==6.0.2
-requests==2.32.5
+requests==2.33.0
 snowballstemmer==2.2.0
 Sphinx==8.1.3
 sphinx-markdown-builder==0.6.7
@@ -25,4 +25,4 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 tabulate==0.9.0
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
Automated dependency bump to address 4 disclosed CVEs in the Sphinx docs-build toolchain (`src/pyodide/internal/sphinx/requirements-doc.txt`). This file has no lockfile hashes, so the bump is a direct pin edit.

- **Pygments** `2.19.1` → `2.20.0` — [GHSA-5239-wwwm-4pmq](https://github.com/advisories/GHSA-5239-wwwm-4pmq) / PYSEC-2026-2987
- **idna** `3.10` → `3.15` — [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) / PYSEC-2026-215
- **requests** `2.32.5` → `2.33.0` — [GHSA-gc5v-m9x4-r6x2](https://github.com/advisories/GHSA-gc5v-m9x4-r6x2) / PYSEC-2026-2275
- **urllib3** `2.6.3` → `2.7.0` — [GHSA-mf9v-mfxr-j63j](https://github.com/advisories/GHSA-mf9v-mfxr-j63j), [GHSA-qccp-gfcp-xxvc](https://github.com/advisories/GHSA-qccp-gfcp-xxvc) / PYSEC-2026-141, PYSEC-2026-142

Each target version was verified against the OSV API to carry zero remaining advisories. Detected by [osv-scanner](https://google.github.io/osv-scanner/) against this file specifically (the other `osv-scanner` hits in this repo — `postcss`/`sharp`/`esbuild` in `pnpm-lock.yaml` — are transitive devDependencies of the root tooling package and need a `pnpm`-driven lockfile regen I couldn't safely do in this environment, so they're left for a follow-up rather than bundled here).

Scope: this file only feeds the internal Sphinx documentation build for the Pyodide integration — it's not part of the `workerd` runtime binary or its request-serving path.

---
Filed by [Aeon](https://github.com/aeonfun/aeon).
