### PR TITLE
Store references for internal and user span parents on call argument …

### DIFF
--- a/src/workerd/api/restore.c++
+++ b/src/workerd/api/restore.c++
@@ -85,7 +85,7 @@ jsg::Promise<jsg::Value> restoreCurrentEntrypoint(jsg::Lock& js,
         auto client = stub->getClient();
         stub->dispose();
         auto restored = js.alloc<JsRpcStub>(
-            ioctx.addObject(kj::heap(kj::mv(client))), ioctx.addObject(kj::mv(channel)));
+            ioctx.addObject(kj::heap(kj::mv(client))), ioctx.addObject(kj::mv(channel)), kj::none);
         return jsg::Value(js.v8Isolate, rpcStubHandler.wrap(js, kj::mv(restored)));
       }
     }

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -199,8 +199,8 @@ wd_test(
     tags = ["no-coverage"],
 )
 
-# Regression test: a callback passed as an RPC argument, when invoked by the callee, must
-# produce a jsRpcCall span nested under the method's server-side jsRpcCall span.
+# Regression test for callback ancestry across outbound stub calls and transient re-entry
+# dispatches.
 wd_test(
     src = "jsrpc-callback-trace-test.wd-test",
     args = ["--experimental"],

--- a/src/workerd/api/tests/jsrpc-callback-trace-test-tail.js
+++ b/src/workerd/api/tests/jsrpc-callback-trace-test-tail.js
@@ -2,15 +2,11 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-// Streaming tail worker that validates jsRpcCall span nesting for callback arguments.
-//
-// Within the CallbackService (jsrpc) invocation we expect:
-//   onset
-//     jsRpcCall (jsrpc.method = "invokeCallback", target_kind = "entrypoint")  <- server dispatch
-//       jsRpcCall (target_kind = "stub")                                       <- server invokes cb
-//
-// The inner (callback) jsRpcCall must be a child of the method's jsRpcCall span, proving the
-// argument stub recorded the correct originating call.
+// Streaming tail worker that validates both directions of JSRPC callback tracing.
+// The CallbackService invocation contains its dispatch and outbound stub calls.
+
+// The caller invocation contains the outbound service call and transient re-entry dispatches.
+// Each callback span must nest under the jsRpcCall that originated it.
 
 import * as assert from 'node:assert';
 import unsafe from 'workerd:unsafe';
@@ -57,83 +53,152 @@ export default {
   },
 };
 
-// Find the server-side CallbackService JSRPC invocation and its two jsRpcCall spans, or return
-// null if they haven't all arrived yet. Tail events are delivered asynchronously, so callers poll.
+function jsRpcCalls(data) {
+  if (!data) return [];
+  return [...data.spans.entries()]
+    .filter(([, span]) => span.name === 'jsRpcCall')
+    .map(([spanId, span]) => ({ spanId, ...span }));
+}
+
+// Find both callback invocations and their spans, or return incomplete results.
+// Tail events are delivered asynchronously, so callers poll.
 function findCallbackSpans() {
-  let target = null;
+  let caller = null;
+  let callee = null;
   for (const data of invocations.values()) {
+    const calls = jsRpcCalls(data);
     if (
       data.onset.info === 'jsrpc' &&
       data.onset.entrypoint === 'CallbackService'
     ) {
-      target = data;
-      break;
+      callee = data;
+    } else if (
+      calls.some(
+        (span) =>
+          span.attrs['jsrpc.method'] === 'invokeCallbacks' &&
+          span.attrs['jsrpc.target_kind'] === 'fetcher'
+      )
+    ) {
+      caller = data;
     }
   }
-  if (!target) return { target: null, methodSpan: null, callbackSpan: null };
 
-  const jsRpcCalls = [...target.spans.entries()]
-    .filter(([, s]) => s.name === 'jsRpcCall')
-    .map(([spanId, s]) => ({ spanId, ...s }));
-
-  // The method dispatch span (server-side jsRpcCall for invokeCallback) and the callback
-  // invocation span (the server calling back into the client stub, target_kind=stub).
-  const methodSpan = jsRpcCalls.find(
-    (s) => s.attrs['jsrpc.method'] === 'invokeCallback'
-  );
-  const callbackSpan = jsRpcCalls.find(
-    (s) => s.attrs['jsrpc.target_kind'] === 'stub'
-  );
-  return { target, methodSpan, callbackSpan };
+  const callerCalls = jsRpcCalls(caller);
+  const calleeCalls = jsRpcCalls(callee);
+  return {
+    caller,
+    callee,
+    callerDispatch: callerCalls.find(
+      (span) => span.attrs['jsrpc.method'] === 'invokeCallbacks'
+    ),
+    calleeDispatch: calleeCalls.find(
+      (span) => span.attrs['jsrpc.method'] === 'invokeCallbacks'
+    ),
+    callerTransientCalls: callerCalls.filter(
+      (span) => span.attrs['jsrpc.target_kind'] === 'transient'
+    ),
+    calleeStubCalls: calleeCalls.filter(
+      (span) => span.attrs['jsrpc.target_kind'] === 'stub'
+    ),
+  };
 }
 
 export const test = {
   async test() {
     const tracingEnabled = unsafe.isTestAutogateEnabled();
-    // Poll until the invocation and both spans have arrived rather than relying on a fixed delay.
+    // Poll until the expected spans arrive or, with tracing disabled, the invocation completes.
+    // Tail events are asynchronous, so avoid relying on a fixed delay.
     const deadline = Date.now() + 5000;
     let found = findCallbackSpans();
     while (
       !(tracingEnabled
-        ? found.methodSpan && found.callbackSpan
-        : found.target?.complete) &&
+        ? found.callerDispatch &&
+          found.calleeDispatch &&
+          found.callerTransientCalls.length === 3 &&
+          found.calleeStubCalls.length === 3
+        : found.callee?.complete) &&
       Date.now() < deadline
     ) {
       await scheduler.wait(10);
       found = findCallbackSpans();
     }
 
-    const { target, methodSpan, callbackSpan } = found;
+    const {
+      caller,
+      callee,
+      callerDispatch,
+      calleeDispatch,
+      callerTransientCalls,
+      calleeStubCalls,
+    } = found;
     assert.ok(
-      target,
+      callee,
       'Could not find the CallbackService JSRPC invocation in tail events'
     );
     if (!tracingEnabled) {
-      assert.ok(target.complete, 'CallbackService invocation did not complete');
+      assert.ok(callee.complete, 'CallbackService invocation did not complete');
       assert.strictEqual(
-        [...target.spans.values()].filter((span) => span.name === 'jsRpcCall')
-          .length,
+        jsRpcCalls(callee).length,
         0,
         'jsRpcCall spans must not be emitted while the autogate is disabled'
       );
       return;
     }
-    assert.ok(methodSpan, 'Missing jsRpcCall span for invokeCallback');
-    assert.ok(
-      callbackSpan,
-      'Missing jsRpcCall span for the callback invocation (target_kind=stub)'
+
+    assert.ok(caller, 'Could not find the caller invocation in tail events');
+    assert.ok(callerDispatch, 'Missing caller jsRpcCall for invokeCallbacks');
+    assert.ok(calleeDispatch, 'Missing callee jsRpcCall for invokeCallbacks');
+    assert.strictEqual(
+      calleeStubCalls.length,
+      3,
+      'Expected three outbound stub callback spans in the callee'
+    );
+    assert.strictEqual(
+      callerTransientCalls.length,
+      3,
+      'Expected three transient callback dispatch spans in the caller'
     );
 
-    // The core assertion: the callback jsRpcCall nests under the method jsRpcCall, not the onset.
-    assert.strictEqual(
-      callbackSpan.parentId,
-      methodSpan.spanId,
-      'Callback jsRpcCall should nest under the method jsRpcCall span, not the onset'
+    const expectedMethods = new Set(['(this)', 'invokeTarget', 'invokeProxy']);
+    assert.deepStrictEqual(
+      new Set(calleeStubCalls.map((span) => span.attrs['jsrpc.method'])),
+      expectedMethods,
+      'Expected one callee stub span for each transient argument call'
     );
-    assert.notStrictEqual(
-      callbackSpan.parentId,
-      target.rootSpanId,
-      'Callback jsRpcCall must not be parented directly under the onset span'
+    assert.deepStrictEqual(
+      new Set(callerTransientCalls.map((span) => span.attrs['jsrpc.method'])),
+      expectedMethods,
+      'Expected one caller transient span for each callback dispatch'
     );
+
+    // Callee stub calls must stay under the server dispatch after the async boundary.
+    // This verifies the async trace scopes installed by JsRpcTargetBase::callImpl().
+    for (const callbackSpan of calleeStubCalls) {
+      assert.strictEqual(
+        callbackSpan.parentId,
+        calleeDispatch.spanId,
+        `Callee callback ${callbackSpan.attrs['jsrpc.method']} should nest under invokeCallbacks`
+      );
+      assert.notStrictEqual(
+        callbackSpan.parentId,
+        callee.rootSpanId,
+        `Callee callback ${callbackSpan.attrs['jsrpc.method']} must not nest under the onset`
+      );
+    }
+
+    // Caller transient dispatches must stay under the call that exported their capabilities.
+    // This verifies the TransientJsRpcTarget::originatingCall path.
+    for (const callbackSpan of callerTransientCalls) {
+      assert.strictEqual(
+        callbackSpan.parentId,
+        callerDispatch.spanId,
+        `Caller callback ${callbackSpan.attrs['jsrpc.method']} should nest under invokeCallbacks`
+      );
+      assert.notStrictEqual(
+        callbackSpan.parentId,
+        caller.rootSpanId,
+        `Caller callback ${callbackSpan.attrs['jsrpc.method']} must not nest under the onset`
+      );
+    }
   },
 };

--- a/src/workerd/api/tests/jsrpc-callback-trace-test.js
+++ b/src/workerd/api/tests/jsrpc-callback-trace-test.js
@@ -2,27 +2,48 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-// Regression test for JSRPC tracing: when an RPC method receives a callback/stub as an argument
-// and invokes it, the follow-up jsRpcCall (the server calling back into the client) must nest
-// under the server-side jsRpcCall span of the method that received the callback -- not become a
-// sibling of it under the onset. The parent/child relationship is asserted in the tail worker's
-// test() handler (see jsrpc-callback-trace-test-tail.js).
+// Regression test for JSRPC callback tracing across both sides of a re-entrant call.
+// The tail worker checks callee async propagation and caller transient dispatch ancestry.
 
-import { WorkerEntrypoint } from 'cloudflare:workers';
+import { WorkerEntrypoint, RpcTarget } from 'cloudflare:workers';
+
+class TargetCallback extends RpcTarget {
+  invokeTarget() {
+    return 43;
+  }
+
+  invokeProxy() {
+    return 44;
+  }
+}
 
 export class CallbackService extends WorkerEntrypoint {
-  // Receives a callback (serialized as an RPC stub) and invokes it. Invoking `cb` makes an RPC
-  // back to the caller, producing a client-side jsRpcCall span within this invocation's trace.
-  async invokeCallback(cb) {
-    return await cb();
+  // Cross an async boundary before invoking each transient argument shape.
+  // Their calls must remain children of this server dispatch span.
+  async invokeCallbacks(fn, target, proxy) {
+    await scheduler.wait(1);
+    return [await fn(), await target.invokeTarget(), await proxy.invokeProxy()];
   }
 }
 
 export default {
   async test(controller, env, ctx) {
-    const result = await env.CallbackService.invokeCallback(() => 42);
-    if (result !== 42) {
-      throw new Error(`Expected callback result 42, got ${result}`);
+    const target = new TargetCallback();
+    const proxyTarget = new TargetCallback();
+    const result = await env.CallbackService.invokeCallbacks(
+      () => 42,
+      target,
+      new Proxy(proxyTarget, {})
+    );
+    if (
+      result.length !== 3 ||
+      result[0] !== 42 ||
+      result[1] !== 43 ||
+      result[2] !== 44
+    ) {
+      throw new Error(
+        `Expected callback results [42,43,44], got ${JSON.stringify(result)}`
+      );
     }
   },
 };

--- a/src/workerd/api/tests/jsrpc-callback-trace-test.wd-test
+++ b/src/workerd/api/tests/jsrpc-callback-trace-test.wd-test
@@ -1,12 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
 
-# Regression test for JSRPC tracing: a callback passed as an RPC argument, when invoked by the
-# callee, must produce a jsRpcCall span nested under the method's server-side jsRpcCall span.
-# The nesting is asserted in the tail worker's test() handler.
+# Regression test for JSRPC tracing across callback arguments and re-entry.
+# The tail worker verifies both callee stub calls and caller transient dispatches.
 
 const unitTests :Workerd.Config = (
   # The default variant verifies that tracing remains disabled. The @all-autogates variant verifies
-  # the span hierarchy.
+  # both span hierarchies.
   services = [
     (name = "jsrpc-callback-trace-test", worker = .mainWorker),
     (name = "tail", worker = .tailWorker),

--- a/src/workerd/api/tests/jsrpc-pipelined-trace-test-tail.js
+++ b/src/workerd/api/tests/jsrpc-pipelined-trace-test-tail.js
@@ -82,11 +82,29 @@ function findInvocations() {
   }
   if (!caller || !callee) return { caller: null, callee: null };
 
-  // Expect both dispatches on the callee and both client-side calls on the caller.
-  if (spansNamed(callee, 'jsRpcCall').length < 2)
+  // Wait for the exact method set and callee links, since attributes can follow spanOpen.
+  // This prevents span counts from making partially attributed data look complete.
+  const expectedMethods = new Set([
+    'getCounter',
+    'increment',
+    'incrementDuplicate',
+  ]);
+  const callerCalls = spansNamed(caller, 'jsRpcCall');
+  const calleeCalls = spansNamed(callee, 'jsRpcCall');
+  const hasExpectedMethods = (calls) => {
+    const methods = new Set(calls.map((span) => span.attrs['jsrpc.method']));
+    return (
+      calls.length === expectedMethods.size &&
+      methods.size === expectedMethods.size &&
+      [...expectedMethods].every((method) => methods.has(method))
+    );
+  };
+  if (!hasExpectedMethods(callerCalls) || !hasExpectedMethods(calleeCalls)) {
     return { caller: null, callee: null };
-  if (spansNamed(caller, 'jsRpcCall').length < 2)
+  }
+  if (!calleeCalls.every((span) => span.attrs['jsrpc.caller_span_id'])) {
     return { caller: null, callee: null };
+  }
   return { caller, callee };
 }
 
@@ -121,16 +139,29 @@ export const test = {
     );
     const sessionSpanId = sessionSpans[0].spanId;
 
-    // Sanity check that the caller nests its own calls as expected: the increment call was made on
-    // a stub returned by getCounter, so it nests under getCounter's span.
+    // The pipelined call and duplicate-stub call both use ancestry from getCounter.
+    // The callee onset is likewise parented to the call that opened the session.
     const callerGetCounter = callerCalls.find(
       (s) => s.attrs['jsrpc.method'] === 'getCounter'
     );
     assert.ok(callerGetCounter, "Missing caller's getCounter jsRpcCall span");
+    const callerIncrement = callerCallsByMethod.get('increment');
+    const callerIncrementDuplicate =
+      callerCallsByMethod.get('incrementDuplicate');
     assert.strictEqual(
       callerGetCounter.parentId,
       sessionSpanId,
       "The caller's first call should nest under the jsRpcSession span"
+    );
+    assert.strictEqual(
+      callerIncrement.parentId,
+      callerGetCounter.spanId,
+      'The pipelined increment call should nest under getCounter'
+    );
+    assert.strictEqual(
+      callerIncrementDuplicate.parentId,
+      callerGetCounter.spanId,
+      'The duplicate-stub call should nest under getCounter'
     );
     assert.strictEqual(
       callee.onset.parentId,
@@ -172,8 +203,8 @@ export const test = {
       );
     }
 
-    // The two dispatches must link to *different* caller calls, proving the link tracks the
-    // individual call rather than something session-wide.
+    // All three dispatches must link to different caller calls, proving per-call attribution.
+    // This includes the pipelined call and the call made through dup().
     const distinctLinks = new Set(
       calleeCalls.map((s) => s.attrs['jsrpc.caller_span_id'])
     );

--- a/src/workerd/api/tests/jsrpc-pipelined-trace-test.js
+++ b/src/workerd/api/tests/jsrpc-pipelined-trace-test.js
@@ -22,6 +22,11 @@ class Counter extends RpcTarget {
     this.#value += amount;
     return this.#value;
   }
+
+  incrementDuplicate(amount) {
+    this.#value += amount;
+    return this.#value;
+  }
 }
 
 export class CounterService extends WorkerEntrypoint {
@@ -34,13 +39,17 @@ export class CounterService extends WorkerEntrypoint {
 
 export default {
   async test(controller, env, ctx) {
-    // Opens the session.
-    const counter = await env.CounterService.getCounter();
-
-    // Reuses the session opened above, so this is delivered to the same callee invocation.
-    const result = await counter.increment(5);
-    if (result !== 5) {
-      throw new Error(`Expected 5, got ${result}`);
+    // Pipeline increment before resolving the stub returned by getCounter.
+    // Then duplicate the resolved stub to verify it retains the same ancestry.
+    const counterPromise = env.CounterService.getCounter();
+    const incrementPromise = counterPromise.increment(5);
+    const counter = await counterPromise;
+    const result = await incrementPromise;
+    const duplicateResult = await counter.dup().incrementDuplicate(2);
+    if (result !== 5 || duplicateResult !== 7) {
+      throw new Error(
+        `Expected results 5 and 7, got ${result} and ${duplicateResult}`
+      );
     }
   },
 };

--- a/src/workerd/api/worker-rpc.c++
+++ b/src/workerd/api/worker-rpc.c++
@@ -13,6 +13,7 @@
 #include <workerd/jsg/ser.h>
 #include <workerd/util/autogate.h>
 #include <workerd/util/completion-membrane.h>
+#include <workerd/util/strong-bool.h>
 
 #include <capnp/membrane.h>
 
@@ -321,6 +322,14 @@ void tryCallDisposeMethod(jsg::Lock& js, jsg::JsValue value) {
 }
 
 kj::Maybe<IoOwn<TraceContextParent>> ownOriginatingCall(
+    IoContext& ioCtx, kj::Maybe<TraceContextParent> originatingCall) {
+  KJ_IF_SOME(call, originatingCall) {
+    return ioCtx.addObject(kj::heap(kj::mv(call)));
+  }
+  return kj::none;
+}
+
+kj::Maybe<IoOwn<TraceContextParent>> ownOriginatingCall(
     kj::Maybe<TraceContextParent> originatingCall) {
   KJ_IF_SOME(call, originatingCall) {
     return IoContext::current().addObject(kj::heap(kj::mv(call)));
@@ -365,6 +374,7 @@ void JsRpcPromise::dispose(jsg::Lock& js) {
 
   state = Disposed();
   weakRef->disposed = true;
+  originatingCall = kj::none;
 }
 
 // See comment at call site for explanation.
@@ -606,7 +616,8 @@ JsRpcPromiseAndPipeline callImpl(jsg::Lock& js,
               ? RpcSerializerExternalHandler::DUPLICATE
               : RpcSerializerExternalHandler::TRANSFER;
 
-          RpcSerializerExternalHandler externalHandler(stubOwnership, client);
+          RpcSerializerExternalHandler externalHandler(
+              stubOwnership, client, jsRpcCallSpan.getSpanParentsIfObserved());
           serializeJsValue(js, jsg::JsValue(arr), externalHandler, [&](capnp::MessageSize hint) {
             // TODO(perf): Actually use the size hint.
             return builder.getOperation().initCallWithArgs();
@@ -935,20 +946,24 @@ JsRpcClientProvider::ClientForOneCall JsRpcStub::getClientForOneCall(
 }
 
 jsg::Ref<JsRpcStub> JsRpcStub::dup(jsg::Lock& js) {
+  // Reading and re-owning the parent both need the originating IoContext, which the
+  // channel-number-only branch below may lack. Such stubs never carry an originating call.
+  auto callParent = ownOriginatingCall(
+      originatingCall.map([](IoOwn<TraceContextParent>& p) { return p->addRef(); }));
   KJ_IF_SOME(cap, capnpClient) {
     auto& ioctx = IoContext::current();
     KJ_IF_SOME(chan, rpcChannel) {
       // Both cap and channel.
       return js.alloc<JsRpcStub>(
-          ioctx.addObject(kj::heap(*cap)), ioctx.addObject(kj::addRef(*chan)));
+          ioctx.addObject(kj::heap(*cap)), ioctx.addObject(kj::addRef(*chan)), kj::mv(callParent));
     } else {
       // Cap only.
-      return js.alloc<JsRpcStub>(ioctx.addObject(kj::heap(*cap)));
+      return js.alloc<JsRpcStub>(ioctx.addObject(kj::heap(*cap)), kj::mv(callParent));
     }
   } else KJ_IF_SOME(chan, rpcChannel) {
     // Channel only.
     auto& ioctx = IoContext::current();
-    return js.alloc<JsRpcStub>(ioctx.addObject(kj::addRef(*chan)));
+    return js.alloc<JsRpcStub>(ioctx.addObject(kj::addRef(*chan)), kj::mv(callParent));
   } else KJ_IF_SOME(num, channelNumber) {
     // Neither cap nor channel, only channel number. Note: We may have no IoContext in this
     // case.
@@ -962,6 +977,7 @@ void JsRpcStub::dispose() {
   capnpClient = kj::none;
   rpcChannel = kj::none;
   externalMemoryAdjustment = kj::none;
+  originatingCall = kj::none;
   KJ_IF_SOME(d, disposalGroup) {
     d.list.remove(*this);
     disposalGroup = kj::none;
@@ -1114,7 +1130,7 @@ jsg::Ref<JsRpcStub> JsRpcStub::deserialize(
           "serialized RpcStub had invalid cap table index");
 
       KJ_IF_SOME(channel, kj::tryDowncast<IoChannelFactory::RpcChannel>(cap)) {
-        return js.alloc<JsRpcStub>(IoContext::current().addObject(kj::addRef(channel)));
+        return js.alloc<JsRpcStub>(IoContext::current().addObject(kj::addRef(channel)), kj::none);
       } else KJ_IF_SOME(channel, kj::tryDowncast<IoChannelCapTableEntry>(cap)) {
         // NOTE: In this case we are quite possibly not in any I/O context! This case happens
         //   when a JsRpcStub is in the `env` object (e.g. of a Dynamic Worker) and refers to a
@@ -1159,7 +1175,7 @@ jsg::Ref<JsRpcStub> JsRpcStub::deserialize(
           "RpcStub cannot be deserialized in this context.");
       auto& ioctx = IoContext::current();
       auto channel = storedHandler.readRpcChannel(ioctx.getIoChannelFactory());
-      return js.alloc<JsRpcStub>(ioctx.addObject(kj::mv(channel)));
+      return js.alloc<JsRpcStub>(ioctx.addObject(kj::mv(channel)), kj::none);
     }
   }
 
@@ -1321,6 +1337,7 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
   // Tracing tag value for jsrpc.target_kind on the server-side per-call span
   // (see JsRpcClientProvider::getRpcTargetKind for the client-side equivalent).
   virtual kj::LiteralStringConst getTargetKind() = 0;
+  virtual kj::Maybe<TraceContextParent&> tryGetOriginatingCall() = 0;
 
   kj::Promise<void> callImpl(Worker::Lock& lock, IoContext& ctx, CallContext callContext) {
     jsg::Lock& js = lock;
@@ -1349,11 +1366,17 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       }
     }
 
+    auto jsRpcTracingEnabled = util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING);
     TraceContext jsRpcCallSpan;
-    if (util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING)) {
-      // Server-side jsRpcCall, attached to the dispatch promise below so it stays open through JS
-      // invocation and result serialization.
-      jsRpcCallSpan = ctx.makeUserTraceSpan("jsRpcCall"_kjc);
+    if (jsRpcTracingEnabled) {
+      // Server-side jsRpcCall, nested under an exported capability's origin when available.
+      // It stays open through JS invocation and result serialization via the dispatch promise.
+      jsRpcCallSpan = [&]() -> TraceContext {
+        KJ_IF_SOME(parent, tryGetOriginatingCall()) {
+          return parent.newChild("jsRpcCall"_kjc);
+        }
+        return ctx.makeUserTraceSpan("jsRpcCall"_kjc);
+      }();
       jsRpcCallSpan.setTag("jsrpc.method"_kjc, methodNameForTrace.asPtr());
       jsRpcCallSpan.setTag("jsrpc.target_kind"_kjc, getTargetKind());
       jsRpcCallSpan.setTag("jsrpc.operation"_kjc,
@@ -1371,14 +1394,6 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
     }
 
     maybeSetJsRpcInfo(ctx, methodNameForTrace);
-
-    auto targetInfo = getTargetInfo(lock, ctx);
-
-    // We will try to get the function, if we can't we'll throw an error to the client.
-    auto [propHandle, thisArg] =
-        tryGetProperty(lock, targetInfo.target, params, targetInfo.allowInstanceProperties, ctx);
-
-    auto op = params.getOperation();
 
     auto handleResult = [&](InvocationResult&& invocationResult) {
       // Given a handle for the result, if it's a promise, await the promise, then serialize the
@@ -1497,6 +1512,14 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
     };
 
     auto dispatch = [&]() -> kj::Promise<void> {
+      auto targetInfo = getTargetInfo(lock, ctx);
+
+      // Look up the requested property. If it is unavailable, tryGetProperty() throws an error
+      // that is returned to the client.
+      auto [propHandle, thisArg] =
+          tryGetProperty(lock, targetInfo.target, params, targetInfo.allowInstanceProperties, ctx);
+
+      auto op = params.getOperation();
       switch (op.which()) {
         case rpc::JsRpcTarget::CallParams::Operation::CALL_WITH_ARGS: {
           // Note that using isFunctionForRpc(js, propHandle) here would be incorrect, since that
@@ -1539,6 +1562,18 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
       KJ_FAIL_ASSERT("unknown JsRpcTarget::CallParams::Operation", (uint)op.which());
     };
 
+    if (!jsRpcTracingEnabled) return dispatch();
+
+    auto jsRpcCallSpanIsObserved = jsRpcCallSpan.isObserved();
+    SpanParent traceParent =
+        jsRpcCallSpanIsObserved ? jsRpcCallSpan.getInternalSpanParent() : ctx.getCurrentTraceSpan();
+    SpanParent userTraceParent =
+        jsRpcCallSpanIsObserved ? jsRpcCallSpan.getUserSpanParent() : ctx.getCurrentUserTraceSpan();
+
+    jsg::AsyncContextFrame::StorageScope traceScope =
+        ctx.makeAsyncTraceScope(lock, kj::mv(traceParent));
+    jsg::AsyncContextFrame::StorageScope userTraceScope =
+        ctx.makeUserAsyncTraceScope(lock, kj::mv(userTraceParent));
     return dispatch().attach(kj::mv(jsRpcCallSpan));
   }
 
@@ -1812,13 +1847,19 @@ class JsRpcTargetBase: public rpc::JsRpcTarget::Server {
   };
 };
 
+WD_STRONG_BOOL(AllowInstanceProperties);
+
 class TransientJsRpcTarget final: public JsRpcTargetBase {
  public:
-  TransientJsRpcTarget(
-      jsg::Lock& js, IoContext& ioCtx, jsg::JsObject object, bool allowInstanceProperties = false)
+  TransientJsRpcTarget(jsg::Lock& js,
+      IoContext& ioCtx,
+      jsg::JsObject object,
+      AllowInstanceProperties allowInstanceProperties,
+      kj::Maybe<TraceContextParent> originatingCall)
       : JsRpcTargetBase(ioCtx, MayOutliveIncomingRequest()),
+        originatingCall(ownOriginatingCall(ioCtx, kj::mv(originatingCall))),
         handles(ioCtx.addObjectReverse(kj::heap<Handles>(js, object))),
-        allowInstanceProperties(allowInstanceProperties) {
+        allowInstanceProperties(allowInstanceProperties.toBool()) {
     // Check for the existence of a dispose function now so that the destructor doesn't have to
     // take an isolate lock if there isn't one.
     auto getResult = object.get(js, js.symbolDispose());
@@ -1835,11 +1876,11 @@ class TransientJsRpcTarget final: public JsRpcTargetBase {
       jsg::JsObject object,
       kj::Maybe<jsg::V8Ref<v8::Function>> dispose,
       kj::Vector<kj::Own<void>> stubDisposers,
-      bool allowInstanceProperties = false)
+      AllowInstanceProperties allowInstanceProperties = AllowInstanceProperties::NO)
       : JsRpcTargetBase(ioCtx, MayOutliveIncomingRequest()),
         handles(ioCtx.addObjectReverse(kj::heap<Handles>(js, object))),
         disposeFulfiller(addDisposeTask(js, ioCtx, object, kj::mv(dispose), kj::mv(stubDisposers))),
-        allowInstanceProperties(allowInstanceProperties) {}
+        allowInstanceProperties(allowInstanceProperties.toBool()) {}
 
   ~TransientJsRpcTarget() noexcept(false) {
     KJ_IF_SOME(f, kj::mv(disposeFulfiller)) {
@@ -1856,6 +1897,10 @@ class TransientJsRpcTarget final: public JsRpcTargetBase {
   }
 
  private:
+  // The caller-side jsRpcCall that exported this capability, so that re-entrant calls back into
+  // this target nest under it. Held via IoOwn because the target may outlive the IoContext.
+  kj::Maybe<IoOwn<TraceContextParent>> originatingCall;
+
   struct Handles {
     jsg::JsRef<jsg::JsObject> object;
 
@@ -1914,6 +1959,13 @@ class TransientJsRpcTarget final: public JsRpcTargetBase {
     return "transient"_kjc;
   }
 
+  kj::Maybe<TraceContextParent&> tryGetOriginatingCall() override {
+    KJ_IF_SOME(parent, originatingCall) {
+      return *parent;
+    }
+    return kj::none;
+  }
+
   void maybeSetJsRpcInfo(IoContext& ctx, const kj::ConstString& methodNameForTrace) override {}
 };
 
@@ -1922,8 +1974,8 @@ static rpc::JsRpcTarget::Client makeJsRpcTargetForSingleLoopbackCall(
     jsg::Lock& js, jsg::JsObject obj) {
   // We intentionally do not want to hook up the disposer here since we're not taking ownership
   // of the object.
-  return rpc::JsRpcTarget::Client(kj::heap<TransientJsRpcTarget>(
-      js, IoContext::current(), obj, kj::none, kj::Vector<kj::Own<void>>(), true));
+  return rpc::JsRpcTarget::Client(kj::heap<TransientJsRpcTarget>(js, IoContext::current(), obj,
+      kj::none, kj::Vector<kj::Own<void>>(), AllowInstanceProperties::YES));
 }
 
 template <typename Func>
@@ -1954,7 +2006,7 @@ MakeCallPipeline::Result serializeJsValueWithPipeline(jsg::Lock& js,
 
   // Now that we've extracted our dispose function, we can serialize our value.
   RpcSerializerExternalHandler externalHandler(
-      RpcSerializerExternalHandler::TRANSFER, kj::mv(externalPusher));
+      RpcSerializerExternalHandler::TRANSFER, kj::mv(externalPusher), kj::none);
   serializeJsValue(js, value, externalHandler, kj::mv(makeBuilder));
 
   auto stubDisposers = externalHandler.releaseStubDisposers();
@@ -1965,14 +2017,15 @@ MakeCallPipeline::Result serializeJsValueWithPipeline(jsg::Lock& js,
       // to pipeline on it. (If we return null, we'll get "called null capability" out of
       // Cap'n Proto, which will be treated as an internal error.)
       return MakeCallPipeline::NonPipelinable{
-        .errorPipeline = rpc::JsRpcTarget::Client(kj::heap<TransientJsRpcTarget>(
-            js, IoContext::current(), js.obj(), kj::none, kj::Vector<kj::Own<void>>(), true))};
+        .errorPipeline =
+            rpc::JsRpcTarget::Client(kj::heap<TransientJsRpcTarget>(js, IoContext::current(),
+                js.obj(), kj::none, kj::Vector<kj::Own<void>>(), AllowInstanceProperties::YES))};
     });
 
     if (obj.getPrototype(js) == js.obj().getPrototype(js)) {
       // It's a plain object.
-      auto pipeline = kj::heap<TransientJsRpcTarget>(
-          js, IoContext::current(), obj, kj::mv(maybeDispose), kj::mv(stubDisposers), true);
+      auto pipeline = kj::heap<TransientJsRpcTarget>(js, IoContext::current(), obj,
+          kj::mv(maybeDispose), kj::mv(stubDisposers), AllowInstanceProperties::YES);
 
       return MakeCallPipeline::Object{
         .cap = rpc::JsRpcTarget::Client(kj::mv(pipeline)), .hasDispose = hasDispose};
@@ -1990,8 +2043,8 @@ MakeCallPipeline::Result serializeJsValueWithPipeline(jsg::Lock& js,
       // serialize it, so we can't use `SingleStub()`. Note we set `allowInstanceProperties` to
       // `false` here because the wildcard property of a `Fetcher` is a prototype property, and
       // that's what we want to expose for pipelining.
-      auto pipeline = kj::heap<TransientJsRpcTarget>(
-          js, IoContext::current(), obj, kj::mv(maybeDispose), kj::mv(stubDisposers), false);
+      auto pipeline = kj::heap<TransientJsRpcTarget>(js, IoContext::current(), obj,
+          kj::mv(maybeDispose), kj::mv(stubDisposers), AllowInstanceProperties::NO);
 
       return MakeCallPipeline::Object{
         .cap = rpc::JsRpcTarget::Client(kj::mv(pipeline)), .hasDispose = hasDispose};
@@ -2001,8 +2054,9 @@ MakeCallPipeline::Result serializeJsValueWithPipeline(jsg::Lock& js,
       // TODO(soon): What if someone returns e.g. a Map with a disposer on it? Should we honor that
       //   disposer?
       return MakeCallPipeline::NonPipelinable{
-        .errorPipeline = rpc::JsRpcTarget::Client(kj::heap<TransientJsRpcTarget>(
-            js, IoContext::current(), js.obj(), kj::none, kj::Vector<kj::Own<void>>(), true))};
+        .errorPipeline =
+            rpc::JsRpcTarget::Client(kj::heap<TransientJsRpcTarget>(js, IoContext::current(),
+                js.obj(), kj::none, kj::Vector<kj::Own<void>>(), AllowInstanceProperties::YES))};
     }
   });
 }
@@ -2062,10 +2116,10 @@ jsg::Ref<JsRpcStub> JsRpcStub::constructor(jsg::Lock& js, jsg::JsObject object) 
   bool allowInstanceProperties = JSG_REQUIRE_NONNULL(checkStubType(js, object), TypeError,
       "RpcStubs can only wrap plain objects, functions, and RpcTarget derivatives.");
 
-  rpc::JsRpcTarget::Client cap =
-      kj::heap<TransientJsRpcTarget>(js, ioctx, object, allowInstanceProperties);
+  rpc::JsRpcTarget::Client cap = kj::heap<TransientJsRpcTarget>(
+      js, ioctx, object, AllowInstanceProperties(allowInstanceProperties), kj::none);
 
-  return js.alloc<JsRpcStub>(ioctx.addObject(kj::heap(kj::mv(cap))));
+  return js.alloc<JsRpcStub>(ioctx.addObject(kj::heap(kj::mv(cap))), kj::none);
 }
 
 bool JsRpcStub::shouldImplicitlyStubify(jsg::Lock& js, jsg::JsObject object) {
@@ -2143,7 +2197,8 @@ void JsRpcTarget::serialize(jsg::Lock& js, jsg::Serializer& serializer) {
     }
   }
 
-  rpc::JsRpcTarget::Client cap = kj::heap<TransientJsRpcTarget>(js, IoContext::current(), handle);
+  rpc::JsRpcTarget::Client cap = kj::heap<TransientJsRpcTarget>(js, IoContext::current(), handle,
+      AllowInstanceProperties::NO, externalHandler->getOriginatingCall());
 
   externalHandler->write([cap = kj::mv(cap)](rpc::JsValue::External::Builder builder) mutable {
     builder.initRpcTarget().setCap(kj::mv(cap));
@@ -2179,8 +2234,8 @@ void RpcSerializerExternalHandler::serializeFunction(
     }
   }
 
-  rpc::JsRpcTarget::Client cap =
-      kj::heap<TransientJsRpcTarget>(js, IoContext::current(), handle, true);
+  rpc::JsRpcTarget::Client cap = kj::heap<TransientJsRpcTarget>(
+      js, IoContext::current(), handle, AllowInstanceProperties::YES, getOriginatingCall());
   write([cap = kj::mv(cap)](rpc::JsValue::External::Builder builder) mutable {
     builder.initRpcTarget().setCap(kj::mv(cap));
   });
@@ -2233,8 +2288,8 @@ void RpcSerializerExternalHandler::serializeProxy(
   // Great, we've concluded we can indeed point a stub at this proxy.
   serializer.writeRawUint32(static_cast<uint>(rpc::SerializationTag::JS_RPC_STUB));
 
-  rpc::JsRpcTarget::Client cap =
-      kj::heap<TransientJsRpcTarget>(js, IoContext::current(), handle, allowInstanceProperties);
+  rpc::JsRpcTarget::Client cap = kj::heap<TransientJsRpcTarget>(js, IoContext::current(), handle,
+      AllowInstanceProperties(allowInstanceProperties), getOriginatingCall());
   write([cap = kj::mv(cap)](rpc::JsValue::External::Builder builder) mutable {
     builder.initRpcTarget().setCap(kj::mv(cap));
   });
@@ -2390,6 +2445,10 @@ class EntrypointJsRpcTarget final: public JsRpcTargetBase {
 
   kj::LiteralStringConst getTargetKind() override {
     return "entrypoint"_kjc;
+  }
+
+  kj::Maybe<TraceContextParent&> tryGetOriginatingCall() override {
+    return kj::none;
   }
 
   void maybeSetJsRpcInfo(IoContext& ctx, const kj::ConstString& methodNameForTrace) override {

--- a/src/workerd/api/worker-rpc.h
+++ b/src/workerd/api/worker-rpc.h
@@ -42,10 +42,12 @@ class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandle
 
   // `getExternalPusherFunc` will be called at most once, the first time a stream is encountered in
   // serialization, to get the ExternalPusher that should be used.
-  RpcSerializerExternalHandler(
-      StubOwnership stubOwnership, rpc::JsValue::ExternalPusher::Client externalPusher)
+  RpcSerializerExternalHandler(StubOwnership stubOwnership,
+      rpc::JsValue::ExternalPusher::Client externalPusher,
+      kj::Maybe<TraceContextParent> originatingCall)
       : stubOwnership(stubOwnership),
-        externalPusher(kj::mv(externalPusher)) {}
+        externalPusher(kj::mv(externalPusher)),
+        originatingCall(kj::mv(originatingCall)) {}
 
   inline StubOwnership getStubOwnership() {
     return stubOwnership;
@@ -71,6 +73,10 @@ class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandle
 
   size_t size() {
     return externals.size();
+  }
+
+  kj::Maybe<TraceContextParent> getOriginatingCall() {
+    return originatingCall.map([](TraceContextParent& parent) { return parent.addRef(); });
   }
 
   // Add an object that will be released once the serialized value is no longer needed to handle
@@ -109,6 +115,10 @@ class RpcSerializerExternalHandler final: public jsg::Serializer::ExternalHandle
  private:
   StubOwnership stubOwnership;
   rpc::JsValue::ExternalPusher::Client externalPusher;
+
+  // The jsRpcCall that exported capabilities in this payload, used to parent callbacks.
+  // Absent on untraced calls and serializer uses without an originating RPC.
+  kj::Maybe<TraceContextParent> originatingCall;
 
   kj::Vector<BuilderCallback> externals;
   kj::Vector<kj::Own<void>> stubDisposers;
@@ -439,15 +449,25 @@ class JsRpcProperty: public JsRpcClientProvider {
 // `JsRpcStub::sendJsRpc()`.
 class JsRpcStub: public JsRpcClientProvider {
  public:
-  // Only deserialize() needs ExternalMemoryAdjustment — it extracts a new capability from an RPC
-  // response, creating MembraneHook + forked promise allocations. The other callers (dup() and
-  // constructor()) just refcount existing capabilities or create local loopbacks.
-  JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient): capnpClient(kj::mv(capnpClient)) {}
-  JsRpcStub(
-      IoOwn<rpc::JsRpcTarget::Client> capnpClient, IoOwn<IoChannelFactory::RpcChannel> rpcChannel)
+  // Only deserialize() needs ExternalMemoryAdjustment for allocations made while extracting a new
+  // capability from an RPC response; dup() and constructor() do not create those allocations.
+
+  // These overloads accept an already-owned originatingCall so dup() can retain the parent in the
+  // current IoContext.
+  JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient,
+      kj::Maybe<IoOwn<TraceContextParent>> originatingCall)
       : capnpClient(kj::mv(capnpClient)),
-        rpcChannel(kj::mv(rpcChannel)) {}
-  JsRpcStub(IoOwn<IoChannelFactory::RpcChannel> rpcChannel): rpcChannel(kj::mv(rpcChannel)) {}
+        originatingCall(kj::mv(originatingCall)) {}
+  JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient,
+      IoOwn<IoChannelFactory::RpcChannel> rpcChannel,
+      kj::Maybe<IoOwn<TraceContextParent>> originatingCall)
+      : capnpClient(kj::mv(capnpClient)),
+        rpcChannel(kj::mv(rpcChannel)),
+        originatingCall(kj::mv(originatingCall)) {}
+  JsRpcStub(IoOwn<IoChannelFactory::RpcChannel> rpcChannel,
+      kj::Maybe<IoOwn<TraceContextParent>> originatingCall)
+      : rpcChannel(kj::mv(rpcChannel)),
+        originatingCall(kj::mv(originatingCall)) {}
   JsRpcStub(IoOwn<rpc::JsRpcTarget::Client> capnpClient,
       RpcStubDisposalGroup& disposalGroup,
       jsg::ExternalMemoryAdjustment externalMemoryAdjustment,


### PR DESCRIPTION
Workflows rely on RPC re-entry. Consider the following code snippet:

```ts
export class MyWorkflow extends WorkflowEntrypoint {
	async run(event: WorkflowEvent, step: WorkflowStep) {
		const example = await step.do('foo', async () => {
			console.log('inside foo')
		});}
}
```

Span placement for this type of rpc calls is currently incorrect: the callback param invoked on the client side appears as a sibling span to the `step.do()` jsrpc call span. This PR captures the hierarchy of spans more accurately

The callback that gets passed inside the `step.do()` jsrpc call is serialized as a transient rpc target and keeps `originatingCall` with the parent span. This allows us to when re-entering the rpc from the server's perspective, be able to add this `transient` rpc call as a child span to the one that exposed the original capability. Moreover, we install it again on async context (we need to since async context is lost on every rpc re-entrance).

In other words, this PR attempts to solve two different but connected things:

- installing the jsrpc call spans into async context - makes the log instrumentation work out of the box since it just reads the current span
- fixes span placement on rpc re-entrance - makes the spans themselves be correctly placed on the trace

Ultimately, this is what the correct trace should look like for the previous server-side `run()` implementation

<img width="1624" height="568" alt="image" src="https://github.com/user-attachments/assets/bb813862-1578-48d6-81c4-8254ab723cab" />
