### PR TITLE
capnp-mock.h: Clean up unused local KJ_LOG_AT(), etc. definitions

### DIFF
--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -25,12 +25,19 @@
 namespace workerd::server {
 namespace {
 
+// TODO(cleanup): Move these macro definitions to KJ?:
+
+#ifndef KJ_FAIL_EXPECT_AT
 #define KJ_FAIL_EXPECT_AT(location, ...) KJ_LOG_AT(ERROR, location, ##__VA_ARGS__);
+#endif
+
+#ifndef KJ_EXPECT_AT
 #define KJ_EXPECT_AT(cond, location, ...)                                                          \
   if (auto _kjCondition = ::kj::_::MAGIC_ASSERT << cond)                                           \
     ;                                                                                              \
   else                                                                                             \
     KJ_FAIL_EXPECT_AT(location, "failed: expected " #cond, _kjCondition, ##__VA_ARGS__)
+#endif
 
 jsg::V8System v8System({"--expose-gc"_kj});
 

--- a/src/workerd/util/capnp-mock.h
+++ b/src/workerd/util/capnp-mock.h
@@ -16,62 +16,6 @@
 namespace workerd {
 
 // =======================================================================================
-// KJ assert macros that support specifying a SourceLocation. These allow our test functions
-// below to capture the caller's SourceLocation for use in errors, which is nice.
-//
-// TODO(cleanup): Move this to KJ!
-
-#ifndef KJ_REQUIRE_AT
-#define KJ_REQUIRE_AT(cond, location, ...)                                                         \
-  if (auto _kjCondition = ::kj::_::MAGIC_ASSERT << cond) {                                         \
-  } else                                                                                           \
-    for (::kj::_::Debug::Fault f(location.fileName, location.lineNumber,                           \
-             ::kj::Exception::Type::FAILED, #cond, "_kjCondition," #__VA_ARGS__, _kjCondition,     \
-             ##__VA_ARGS__);                                                                       \
-         ; f.fatal())
-#endif
-
-#ifndef KJ_FAIL_REQUIRE_AT
-#define KJ_FAIL_REQUIRE_AT(location, ...)                                                          \
-  for (::kj::_::Debug::Fault f(location.fileName, location.lineNumber,                             \
-           ::kj::Exception::Type::FAILED, nullptr, #__VA_ARGS__, ##__VA_ARGS__);                   \
-       ; f.fatal())
-#endif
-
-#ifndef KJ_REQUIRE_NONNULL_AT
-#define KJ_REQUIRE_NONNULL_AT(value, location, ...)                                                \
-  (*({                                                                                             \
-    auto _kj_result = ::kj::_::readMaybe(value);                                                   \
-    if (KJ_UNLIKELY(!_kj_result)) {                                                                \
-      ::kj::_::Debug::Fault(location.fileName, location.lineNumber, ::kj::Exception::Type::FAILED, \
-          #value " != nullptr", #__VA_ARGS__, ##__VA_ARGS__)                                       \
-          .fatal();                                                                                \
-    }                                                                                              \
-    kj::mv(_kj_result);                                                                            \
-  }))
-#endif
-
-#ifndef KJ_ASSERT_AT
-#define KJ_ASSERT_AT KJ_REQUIRE_AT
-#endif
-
-#ifndef KJ_FAIL_ASSERT_AT
-#define KJ_FAIL_ASSERT_AT KJ_FAIL_REQUIRE_AT
-#endif
-
-#ifndef KJ_ASSERT_NONNULL_AT
-#define KJ_ASSERT_NONNULL_AT KJ_REQUIRE_NONNULL_AT
-#endif
-
-#ifndef KJ_LOG_AT
-#define KJ_LOG_AT(severity, location, ...)                                                         \
-  for (bool _kj_shouldLog = ::kj::_::Debug::shouldLog(::kj::LogSeverity::severity); _kj_shouldLog; \
-       _kj_shouldLog = false)                                                                      \
-  ::kj::_::Debug::log(location.fileName, location.lineNumber, ::kj::LogSeverity::severity,         \
-      #__VA_ARGS__, ##__VA_ARGS__)
-#endif
-
-// =======================================================================================
 // Cap'n Proto mocking framework
 //
 // TODO(cleanup): Move this to Cap'n Proto!


### PR DESCRIPTION
Implementations are now present in kj/debug.h, so the local definitions have no effect, added in: https://github.com/capnproto/capnproto/pull/2411 .

Also, add #ifndef guards to some local KJ_FAIL_EXPECT_AT/KJ_EXPECT_AT definitions, to enable a similar future cleanup of those.