### PR TITLE
Cancel stateless tasks before request teardown to correctly close their spans

### DIFF
--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -113,6 +113,7 @@ wd_cc_library(
         "//src/workerd/jsg",
         "//src/workerd/jsg:inspector",
         "//src/workerd/jsg:script",
+        "//src/workerd/util:autogate",
         "//src/workerd/util:checked-queue",
         "//src/workerd/util:consume",
         "//src/workerd/util:exception",
@@ -630,6 +631,7 @@ kj_test(
     deps = [
         ":io",
         "//src/workerd/tests:test-fixture",
+        "//src/workerd/util:autogate",
     ],
 )
 

--- a/src/workerd/io/incoming-request-test.c++
+++ b/src/workerd/io/incoming-request-test.c++
@@ -9,6 +9,7 @@
 #include <workerd/io/tracer.h>
 #include <workerd/io/worker.h>
 #include <workerd/tests/test-fixture.h>
+#include <workerd/util/autogate.h>
 
 #include <kj/async.h>
 #include <kj/test.h>
@@ -87,11 +88,11 @@ KJ_TEST("trace onset synchronizes an idle actor's clock before reading it") {
   fixture.drainAndDestroy(kj::mv(request));
 }
 
-KJ_TEST(
-    "request owning the final IoContext reference cancels tasks before it stops being current") {
+KJ_TEST("final context task cleanup follows the JSRPC tracing gate") {
   TestFixture fixture;
   auto request = fixture.newIncomingRequest();
   auto& context = request->getContext();
+  auto gateEnabled = util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING);
 
   bool taskWasCanceledWhileRequestWasCurrent = false;
   context.addTask(kj::Promise<void>(kj::NEVER_DONE).attach(kj::defer([&]() {
@@ -100,11 +101,13 @@ KJ_TEST(
 
   fixture.drainAndDestroy(kj::mv(request));
 
-  KJ_EXPECT(taskWasCanceledWhileRequestWasCurrent);
+  KJ_EXPECT(taskWasCanceledWhileRequestWasCurrent == gateEnabled);
 }
 
 KJ_TEST(
     "request owning the final IoContext reference cancels reentry before it stops being current") {
+  if (!util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING)) return;
+
   TestFixture fixture;
   auto request = fixture.newIncomingRequest();
   auto& context = request->getContext();
@@ -131,6 +134,8 @@ KJ_TEST(
 }
 
 KJ_TEST("request owning the final IoContext reference preserves its abort reason") {
+  if (!util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING)) return;
+
   TestFixture fixture;
   auto request = fixture.newIncomingRequest();
   auto& context = request->getContext();
@@ -152,6 +157,8 @@ KJ_TEST("request owning the final IoContext reference preserves its abort reason
 }
 
 KJ_TEST("final request cancels wait-until tasks before it stops being current") {
+  if (!util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING)) return;
+
   TestFixture fixture;
   auto request = fixture.newIncomingRequest();
   auto& context = request->getContext();
@@ -168,6 +175,8 @@ KJ_TEST("final request cancels wait-until tasks before it stops being current") 
 }
 
 KJ_TEST("final request completes cleanup after cancellation throws") {
+  if (!util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING)) return;
+
   class ThrowOnDestruction: private kj::UnwindDetector {
    public:
     ~ThrowOnDestruction() noexcept(false) {

--- a/src/workerd/io/incoming-request-test.c++
+++ b/src/workerd/io/incoming-request-test.c++
@@ -87,6 +87,129 @@ KJ_TEST("trace onset synchronizes an idle actor's clock before reading it") {
   fixture.drainAndDestroy(kj::mv(request));
 }
 
+KJ_TEST(
+    "request owning the final IoContext reference cancels tasks before it stops being current") {
+  TestFixture fixture;
+  auto request = fixture.newIncomingRequest();
+  auto& context = request->getContext();
+
+  bool taskWasCanceledWhileRequestWasCurrent = false;
+  context.addTask(kj::Promise<void>(kj::NEVER_DONE).attach(kj::defer([&]() {
+    taskWasCanceledWhileRequestWasCurrent = context.hasCurrentIncomingRequest();
+  })));
+
+  fixture.drainAndDestroy(kj::mv(request));
+
+  KJ_EXPECT(taskWasCanceledWhileRequestWasCurrent);
+}
+
+KJ_TEST(
+    "request owning the final IoContext reference cancels reentry before it stops being current") {
+  TestFixture fixture;
+  auto request = fixture.newIncomingRequest();
+  auto& context = request->getContext();
+  auto& waitScope = fixture.getWaitScope();
+
+  bool callbackWasCanceledWhileRequestWasCurrent = false;
+  kj::Function<kj::Promise<void>()> callback;
+  context
+      .run([&](Worker::Lock&, IoContext& context) {
+    callback = context.makeReentryCallback([&](Worker::Lock&, IoContext& context) {
+      return kj::Promise<void>(kj::NEVER_DONE).attach(kj::defer([&]() {
+        callbackWasCanceledWhileRequestWasCurrent = context.hasCurrentIncomingRequest();
+      }));
+    });
+  }).wait(waitScope);
+  auto pendingTask = callback();
+  KJ_EXPECT(!pendingTask.poll(waitScope));
+
+  fixture.drainAndDestroy(kj::mv(request));
+
+  KJ_EXPECT(callbackWasCanceledWhileRequestWasCurrent);
+  KJ_EXPECT_THROW_MESSAGE(
+      "The execution context responding to this call was canceled", pendingTask.wait(waitScope));
+}
+
+KJ_TEST("request owning the final IoContext reference preserves its abort reason") {
+  TestFixture fixture;
+  auto request = fixture.newIncomingRequest();
+  auto& context = request->getContext();
+  auto& waitScope = fixture.getWaitScope();
+
+  kj::Function<kj::Promise<void>()> callback;
+  context
+      .run([&callback](Worker::Lock&, IoContext& context) {
+    callback = context.makeReentryCallback(
+        [](Worker::Lock&, IoContext&) { return kj::Promise<void>(kj::NEVER_DONE); });
+  }).wait(waitScope);
+  auto pendingTask = callback();
+  KJ_EXPECT(!pendingTask.poll(waitScope));
+  context.abort(KJ_EXCEPTION(FAILED, "jsg.Error: test abort reason"));
+
+  fixture.drainAndDestroy(kj::mv(request));
+
+  KJ_EXPECT_THROW_MESSAGE("test abort reason", pendingTask.wait(waitScope));
+}
+
+KJ_TEST("final request cancels wait-until tasks before it stops being current") {
+  TestFixture fixture;
+  auto request = fixture.newIncomingRequest();
+  auto& context = request->getContext();
+
+  bool waitUntilWasCanceledWhileRequestWasCurrent = false;
+  context.addWaitUntil(kj::Promise<void>(kj::NEVER_DONE).attach(kj::defer([&]() {
+    waitUntilWasCanceledWhileRequestWasCurrent = context.hasCurrentIncomingRequest();
+  })));
+  context.abort(KJ_EXCEPTION(FAILED, "test abort reason"));
+
+  fixture.drainAndDestroy(kj::mv(request));
+
+  KJ_EXPECT(waitUntilWasCanceledWhileRequestWasCurrent);
+}
+
+KJ_TEST("final request completes cleanup after cancellation throws") {
+  class ThrowOnDestruction: private kj::UnwindDetector {
+   public:
+    ~ThrowOnDestruction() noexcept(false) {
+      catchExceptionsIfUnwinding([]() { KJ_FAIL_REQUIRE("test cancellation failure"); });
+    }
+  };
+
+  TestFixture fixture;
+  auto request = fixture.newIncomingRequest();
+  auto& context = request->getContext();
+  auto& waitScope = fixture.getWaitScope();
+
+  bool callbackWasCanceledWhileRequestWasCurrent = false;
+  bool taskWasCanceledWhileRequestWasCurrent = false;
+  kj::Function<kj::Promise<void>()> callback;
+  kj::Function<kj::Promise<void>()> throwingCallback;
+  context
+      .run([&](Worker::Lock&, IoContext& context) {
+    callback = context.makeReentryCallback([&](Worker::Lock&, IoContext& context) {
+      return kj::Promise<void>(kj::NEVER_DONE).attach(kj::defer([&]() {
+        callbackWasCanceledWhileRequestWasCurrent = context.hasCurrentIncomingRequest();
+      }));
+    });
+    throwingCallback = context.makeReentryCallback([](Worker::Lock&, IoContext&) {
+      return kj::Promise<void>(kj::NEVER_DONE).attach(kj::heap<ThrowOnDestruction>());
+    });
+  }).wait(waitScope);
+  auto pendingTask = callback();
+  auto throwingPendingTask = throwingCallback();
+  KJ_EXPECT(!pendingTask.poll(waitScope));
+  KJ_EXPECT(!throwingPendingTask.poll(waitScope));
+
+  context.addTask(kj::Promise<void>(kj::NEVER_DONE).attach(kj::defer([&]() {
+    taskWasCanceledWhileRequestWasCurrent = context.hasCurrentIncomingRequest();
+  })));
+
+  KJ_EXPECT_THROW_MESSAGE("test cancellation failure", [&]() { request = nullptr; }());
+
+  KJ_EXPECT(callbackWasCanceledWhileRequestWasCurrent);
+  KJ_EXPECT(taskWasCanceledWhileRequestWasCurrent);
+}
+
 // Regression test: two IncomingRequests share a single actor IoContext, as happens when a Durable
 // Object receives overlapping requests. Draining the older, superseded request hits drain()'s
 // "a newer request has taken over" early return.

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -317,6 +317,42 @@ IoContext::IncomingRequest::~IoContext_IncomingRequest() noexcept(false) {
     return;
   }
 
+  bool hadUndrainedWaitUntilTasks = !waitedForWaitUntil && !context->waitUntilTasks.isEmpty();
+  kj::Maybe<kj::Exception> cancellationException;
+
+  if (!context->isShared()) {
+    // Reentry callbacks may have spans attached to their pending promises. Cancel them while the
+    // request is still current so those spans close before the request outcome is reported.
+    while (!context->canceler.isEmpty()) {
+      KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
+        KJ_IF_SOME(e, context->abortException) {
+          context->canceler.cancel(e);
+        } else {
+          context->canceler.cancel(JSG_KJ_EXCEPTION(
+              FAILED, Error, "The execution context responding to this call was canceled."));
+        }
+      })) {
+        // Canceler unlinks the callback before destroying its promise, so another attempt makes
+        // progress after a promise destructor throws.
+        if (cancellationException == kj::none) {
+          cancellationException = kj::mv(exception);
+        }
+      }
+    }
+
+    KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() { context->tasks.clear(); })) {
+      if (cancellationException == kj::none) {
+        cancellationException = kj::mv(exception);
+      }
+    }
+
+    KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() { context->waitUntilTasks.clear(); })) {
+      if (cancellationException == kj::none) {
+        cancellationException = kj::mv(exception);
+      }
+    }
+  }
+
   // Hack: We need to report an accurate time stamps for the STW outcome event, but the timer may
   // not be available when the outcome event gets reported. Define the outcome event time as the
   // time when the incoming request shuts down.
@@ -329,7 +365,7 @@ IoContext::IncomingRequest::~IoContext_IncomingRequest() noexcept(false) {
     context->limitEnforcer->reportMetrics(*metrics);
     context->lastDeliveredLocation = deliveredLocation;
 
-    if (!waitedForWaitUntil && !context->waitUntilTasks.isEmpty()) {
+    if (hadUndrainedWaitUntilTasks) {
       KJ_LOG(WARNING, "failed to invoke drain() on IncomingRequest before destroying it",
           kj::getStackTrace());
     }
@@ -365,6 +401,11 @@ IoContext::IncomingRequest::~IoContext_IncomingRequest() noexcept(false) {
   // Remove incoming request after canceling waitUntil tasks, which may have spans attached that
   // require accessing a timer from the active request.
   context->incomingRequests.remove(*this);
+
+  KJ_IF_SOME(exception, cancellationException) {
+    unwindDetector.catchExceptionsIfUnwinding(
+        [&]() { kj::throwRecoverableException(kj::mv(exception)); });
+  }
 }
 
 InputGate::Lock IoContext::getInputLock() {

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -10,6 +10,7 @@
 #include <workerd/io/worker.h>
 #include <workerd/jsg/jsg.h>
 #include <workerd/jsg/setup.h>
+#include <workerd/util/autogate.h>
 #include <workerd/util/own-util.h>
 #include <workerd/util/sentry.h>
 #include <workerd/util/thread-scopes.h>
@@ -320,7 +321,7 @@ IoContext::IncomingRequest::~IoContext_IncomingRequest() noexcept(false) {
   bool hadUndrainedWaitUntilTasks = !waitedForWaitUntil && !context->waitUntilTasks.isEmpty();
   kj::Maybe<kj::Exception> cancellationException;
 
-  if (!context->isShared()) {
+  if (util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING) && !context->isShared()) {
     // Reentry callbacks may have spans attached to their pending promises. Cancel them while the
     // request is still current so those spans close before the request outcome is reported.
     while (!context->canceler.isEmpty()) {

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -230,6 +230,8 @@ class IoContext_IncomingRequest final {
 
   bool wasDelivered = false;
 
+  kj::UnwindDetector unwindDetector;
+
   // Used for debugging, tracks whether we properly called drain() or some other mechanism to
   // wait for waitUntil tasks.
   bool waitedForWaitUntil = false;


### PR DESCRIPTION
Stateless context tasks can own trace spans that need the current IncomingRequest while they close. Cancel those tasks before recording the request outcome and removing the request.

Preserve abort reasons and undrained-task diagnostics while matching IoContext's task and timer destruction order.