### PR TITLE
STOR-5489: Count retried actor fetches once

### DIFF
--- a/src/workerd/api/actor-fetch-retry-test.c++
+++ b/src/workerd/api/actor-fetch-retry-test.c++
@@ -60,6 +60,21 @@ class TestStreamSource final: public ReadableStreamSource {
   }
 };
 
+class RecordingRequestObserver final: public RequestObserver {
+ public:
+  explicit RecordingRequestObserver(kj::Vector<CountSubrequest>& countSubrequests)
+      : countSubrequests(countSubrequests) {}
+
+  kj::Own<WorkerInterface> wrapSubrequestClient(
+      kj::Own<WorkerInterface> client, CountSubrequest countSubrequest) override {
+    countSubrequests.add(countSubrequest);
+    return kj::mv(client);
+  }
+
+ private:
+  kj::Vector<CountSubrequest>& countSubrequests;
+};
+
 class RetryMetadataOutgoingFactory final: public Fetcher::OutgoingFactory {
  public:
   RetryMetadataOutgoingFactory(bool& ordinaryDispatchCalled,
@@ -78,6 +93,7 @@ class RetryMetadataOutgoingFactory final: public Fetcher::OutgoingFactory {
 
   Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String>,
       kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+      CountSubrequest,
       MakeUserSpanParent) override {
     capturedMetadata = kj::mv(actorRetryRequestMetadata);
     return {.client = kj::heap<MockFetchTarget>(), .spanParents = kj::none};
@@ -143,6 +159,7 @@ struct ReplayState {
   kj::Maybe<kj::Own<kj::WebSocket>> acceptedWebSocket;
   kj::Vector<IoChannelFactory::ActorRetryRequestMetadata> metadata;
   kj::Vector<kj::Array<kj::byte>> requestBodies;
+  kj::Vector<CountSubrequest> countSubrequests;
   uint requestCount = 0;
   uint webSocketRequestCount = 0;
   uint retryCount = 0;
@@ -244,8 +261,10 @@ class ReplayOutgoingFactory final: public Fetcher::OutgoingFactory {
 
   Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String>,
       kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+      CountSubrequest countSubrequest,
       MakeUserSpanParent) override {
     state.metadata.add(KJ_REQUIRE_NONNULL(actorRetryRequestMetadata));
+    state.countSubrequests.add(countSubrequest);
     return {.client = kj::heap<ReplayFetchTarget>(state), .spanParents = kj::none};
   }
 
@@ -519,6 +538,11 @@ KJ_TEST("actor fetch updates retry metadata and rewinds the body") {
   for (auto& metadata: state.metadata) {
     KJ_EXPECT(metadata.retryGateEnabled == ActorRetryGateEnabled::YES);
   }
+  KJ_ASSERT(state.countSubrequests.size() == 4);
+  KJ_EXPECT(state.countSubrequests[0] == CountSubrequest::YES);
+  KJ_EXPECT(state.countSubrequests[1] == CountSubrequest::NO);
+  KJ_EXPECT(state.countSubrequests[2] == CountSubrequest::NO);
+  KJ_EXPECT(state.countSubrequests[3] == CountSubrequest::NO);
   KJ_ASSERT(state.requestBodies.size() == 4);
   for (auto& body: state.requestBodies) {
     KJ_EXPECT(body == "request body"_kj.asBytes());
@@ -680,7 +704,7 @@ KJ_TEST("replica actor fetch retries a request-level disconnect on its primary c
   KJ_EXPECT(state.metadata[0].nonce == state.metadata[1].nonce);
   KJ_EXPECT(state.metadata[0].isRetry == IsActorRetry::NO);
   KJ_EXPECT(state.metadata[1].isRetry == IsActorRetry::YES);
-  KJ_EXPECT(checkedSubrequestCount == 2);
+  KJ_EXPECT(checkedSubrequestCount == 1);
 }
 
 KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for retries") {
@@ -689,6 +713,7 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
   uint checkedSubrequestCount = 0;
   kj::Vector<kj::String> locationHints;
   kj::Vector<kj::String> cohorts;
+  kj::Vector<CountSubrequest> countSubrequests;
   TestFixture fixture(TestFixture::SetupParams{
     .useRealTimers = false,
     .ioChannelFactory = kj::Function<kj::Rc<IoChannelFactory>(TimerChannel&)>(
@@ -696,6 +721,8 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
     return kj::rc<ActorIoChannelFactory>(
         timer, capturedMetadata, channelCount, locationHints, cohorts);
   }),
+    .requestObserverFactory = kj::Function<kj::Own<RequestObserver>()>(
+        [&]() { return kj::refcounted<RecordingRequestObserver>(countSubrequests); }),
     .checkedSubrequestCount = checkedSubrequestCount,
   });
 
@@ -714,7 +741,7 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
           .isRetry = IsActorRetry::YES,
           .retryGateEnabled = ActorRetryGateEnabled::NO,
         },
-        [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
+        CountSubrequest::YES, [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
 
     KJ_IF_SOME(metadata, capturedMetadata) {
       KJ_EXPECT(metadata.nonce == 0x123456789abcdef0);
@@ -732,8 +759,8 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
           .isRetry = IsActorRetry::YES,
           .retryGateEnabled = ActorRetryGateEnabled::NO,
         },
-        [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
-    KJ_EXPECT(checkedSubrequestCount == 2);
+        CountSubrequest::NO, [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
+    KJ_EXPECT(checkedSubrequestCount == 1);
     KJ_EXPECT(channelCount == 2);
     KJ_ASSERT(locationHints.size() == 2);
     KJ_EXPECT(locationHints[0] == "location");
@@ -741,6 +768,9 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
     KJ_ASSERT(cohorts.size() == 2);
     KJ_EXPECT(cohorts[0] == "cohort");
     KJ_EXPECT(cohorts[1] == "cohort");
+    KJ_ASSERT(countSubrequests.size() == 2);
+    KJ_EXPECT(countSubrequests[0] == CountSubrequest::YES);
+    KJ_EXPECT(countSubrequests[1] == CountSubrequest::NO);
   });
 }
 

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -24,11 +24,15 @@ namespace {
 constexpr size_t ESTIMATED_EXTERNAL_MEMORY_PER_ACTOR_CHANNEL = 32768;
 
 template <typename StartRequest>
-kj::Own<WorkerInterface> startActorSubrequest(IoContext& context, StartRequest& startRequest) {
+kj::Own<WorkerInterface> startActorSubrequest(
+    IoContext& context, StartRequest& startRequest, CountSubrequest countSubrequest) {
   auto options = IoContext::SubrequestOptions{.inHouse = true,
     .wrapMetrics = true,
     .operationName = kj::ConstString("durable_object_subrequest"_kjc)};
-  auto client = context.getSubrequest(startRequest, kj::mv(options));
+  // Retries reuse the logical fetch's initial admission, bypassing its limit check and count.
+  auto client = countSubrequest
+      ? context.getSubrequest(startRequest, kj::mv(options))
+      : context.getSubrequestNoChecks(startRequest, kj::mv(options), CountSubrequest::NO);
   return context.getMetrics().wrapActorSubrequestClient(kj::mv(client));
 }
 
@@ -69,7 +73,7 @@ Fetcher::OutgoingFactory::Result LocalActorOutgoingFactory::newSingleUseClient(
           .parentSpan = tracing.getInternalSpanParent(),
           .userSpanParent = kj::mv(userSpanParent)});
   };
-  auto client = startActorSubrequest(context, startRequest);
+  auto client = startActorSubrequest(context, startRequest, CountSubrequest::YES);
   return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
 }
 
@@ -115,17 +119,19 @@ void GlobalActorOutgoingFactory::onActorFetchRetry() {
 
 Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) {
-  return newSingleUseClientWithActorRetryMetadata(kj::mv(cfStr), kj::none, makeUserSpanParent);
+  return newSingleUseClientWithActorRetryMetadata(
+      kj::mv(cfStr), kj::none, CountSubrequest::YES, kj::mv(makeUserSpanParent));
 }
 
 Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::
     newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
         kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+        CountSubrequest countSubrequest,
         MakeUserSpanParent makeUserSpanParent) {
   auto& context = IoContext::current();
 
   kj::Maybe<TraceContextParent> spanParents;
-  auto startRequest = [&](TraceContext& tracing, IoChannelFactory& ioChannelFactory) {
+  auto makeClient = [&](TraceContext& tracing, IoChannelFactory& ioChannelFactory) {
     tracing.setTag("objectId"_kjc, id->toString());
     spanParents = tracing.getSpanParents();
     auto userSpanParent = tracing.getUserSpanParent();
@@ -139,7 +145,7 @@ Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::
           .userSpanParent = kj::mv(userSpanParent),
           .actorRetryRequestMetadata = kj::mv(actorRetryRequestMetadata)});
   };
-  auto client = startActorSubrequest(context, startRequest);
+  auto client = startActorSubrequest(context, makeClient, countSubrequest);
   return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
 }
 
@@ -151,12 +157,13 @@ kj::Own<IoChannelFactory::SubrequestChannel> GlobalActorOutgoingFactory::getSubr
 Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) {
   return newSingleUseClientWithActorRetryMetadata(
-      kj::mv(cfStr), kj::none, kj::mv(makeUserSpanParent));
+      kj::mv(cfStr), kj::none, CountSubrequest::YES, kj::mv(makeUserSpanParent));
 }
 
 Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::
     newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
         kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+        CountSubrequest countSubrequest,
         MakeUserSpanParent makeUserSpanParent) {
   auto& context = IoContext::current();
 
@@ -176,7 +183,7 @@ Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::
       .userSpanParent = kj::mv(userSpanParent),
       .actorRetryRequestMetadata = kj::mv(actorRetryRequestMetadata)});
   };
-  auto client = startActorSubrequest(context, startRequest);
+  auto client = startActorSubrequest(context, startRequest, countSubrequest);
   return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
 }
 

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -354,6 +354,7 @@ class GlobalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
   void onActorFetchRetry() override;
   Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
       kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+      CountSubrequest countSubrequest,
       MakeUserSpanParent makeUserSpanParent) override;
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() override;
 
@@ -425,6 +426,7 @@ class ReplicaActorOutgoingFactory final: public Fetcher::OutgoingFactory {
   }
   Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
       kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+      CountSubrequest countSubrequest,
       MakeUserSpanParent makeUserSpanParent) override;
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() override;
 

--- a/src/workerd/api/bench-container-ingress.c++
+++ b/src/workerd/api/bench-container-ingress.c++
@@ -234,7 +234,7 @@ class DirectOutgoingFactory final: public Fetcher::OutgoingFactory {
         [this, &makeUserSpanParent](auto& tracing, auto& channelFactory) {
       makeUserSpanParent(tracing);
       return kj::heap<DirectWorkerInterface>(client);
-    }, {.inHouse = false, .wrapMetrics = false});
+    }, {.inHouse = false, .wrapMetrics = false}, CountSubrequest::YES);
     return {.client = kj::mv(result), .spanParents = kj::none};
   }
 

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -1456,7 +1456,7 @@ class Container::TcpPortOutgoingFactory final: public Fetcher::OutgoingFactory {
         [&](auto& tracing, auto& channelFactory) -> kj::Own<WorkerInterface> {
       makeUserSpanParent(tracing);
       return kj::heap<TcpPortWorkerInterface>(entropySource, headerTable, portState.addRef());
-    }, {.inHouse = false, .wrapMetrics = false});
+    }, {.inHouse = false, .wrapMetrics = false}, CountSubrequest::YES);
     return {.client = kj::mv(client), .spanParents = kj::none};
   }
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1483,6 +1483,10 @@ class ActorFetchRetryState {
     return deadline != kj::none;
   }
 
+  CountSubrequest countSubrequest() const {
+    return CountSubrequest(attemptCount == 1);
+  }
+
   kj::Maybe<kj::Exception> checkDeadline();
   kj::OneOf<kj::Duration, kj::Exception> prepareRetry(kj::Exception exception);
 
@@ -1754,14 +1758,16 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
   ioContext.getMetrics().setNextSubrequestBodyRewindable(SubrequestBodyRewindable(bodyRewindable));
 
   kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata;
+  auto countSubrequest = CountSubrequest::YES;
   KJ_IF_SOME(state, retryState) {
     actorRetryRequestMetadata = state.getMetadata();
+    countSubrequest = state.countSubrequest();
   }
 
   // Get client and trace context (if needed) in one clean call
   auto clientWithTracing = fetcher->getClientWithTracing(ioContext,
       jsRequest->serializeCfBlobJson(js), "fetch"_kjc,
-      kj::mv(actorRetryRequestMetadata));
+      kj::mv(actorRetryRequestMetadata), countSubrequest);
   auto traceContext = kj::mv(clientWithTracing.traceContext);
 
   // TODO(cleanup): Don't convert to HttpClient. Use the HttpService interface instead. This
@@ -2773,14 +2779,15 @@ jsg::Promise<Fetcher::ScheduledResult> Fetcher::scheduled(
 kj::Own<WorkerInterface> Fetcher::getClient(
     IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
   auto clientWithTracing = getClientWithTracing(
-      ioContext, kj::mv(cfStr), kj::mv(operationName), kj::none);
+      ioContext, kj::mv(cfStr), kj::mv(operationName), kj::none, CountSubrequest::YES);
   return clientWithTracing.client.attach(kj::mv(clientWithTracing.traceContext));
 }
 
 Fetcher::ClientWithTracing Fetcher::getClientWithTracing(IoContext& ioContext,
     kj::Maybe<kj::String> cfStr,
     kj::ConstString operationName,
-    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata) {
+    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+    CountSubrequest countSubrequest) {
   KJ_IF_SOME(metadata, actorRetryRequestMetadata) {
     auto& outgoingFactory = KJ_REQUIRE_NONNULL(
         channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>(),
@@ -2789,12 +2796,14 @@ Fetcher::ClientWithTracing Fetcher::getClientWithTracing(IoContext& ioContext,
         "actor retry metadata supplied to an unsupported Fetcher");
     if (!util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING)) {
       auto result = outgoingFactory->newSingleUseClientWithActorRetryMetadata(kj::mv(cfStr),
-          kj::mv(metadata), [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
+          kj::mv(metadata), countSubrequest,
+          [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
       return ClientWithTracing{kj::mv(result.client), kj::none};
     }
     kj::Maybe<TraceContext> traceContext;
     auto result = outgoingFactory->newSingleUseClientWithActorRetryMetadata(kj::mv(cfStr),
-        kj::mv(metadata), [&](TraceContext& outerTraceContext) -> kj::Maybe<SpanParent> {
+        kj::mv(metadata), countSubrequest,
+        [&](TraceContext& outerTraceContext) -> kj::Maybe<SpanParent> {
       if (!outerTraceContext.isObserved()) return kj::none;
       traceContext = outerTraceContext.getSpanParents().newChild(operationName.clone());
       return KJ_ASSERT_NONNULL(traceContext).getUserSpanParent();

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -265,6 +265,7 @@ class Fetcher: public JsRpcClientProvider {
     // metadata rather than silently starting a new logical call.
     virtual Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
         kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+        CountSubrequest countSubrequest,
         MakeUserSpanParent makeUserSpanParent) {
       KJ_FAIL_REQUIRE("actor retry metadata supplied to an unsupported Fetcher");
     }
@@ -330,7 +331,8 @@ class Fetcher: public JsRpcClientProvider {
   [[nodiscard]] ClientWithTracing getClientWithTracing(IoContext& ioContext,
       kj::Maybe<kj::String> cfStr,
       kj::ConstString operationName,
-      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata);
+      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
+      CountSubrequest countSubrequest);
 
   bool supportsActorFetchRetries();
   void onActorFetchRetry();

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -1163,7 +1163,7 @@ Fetcher::OutgoingFactory::Result StreamOutgoingFactory::newSingleUseClient(
       [&](auto& tracing, auto& channelFactory) -> kj::Own<WorkerInterface> {
     makeUserSpanParent(tracing);
     return kj::heap<StreamWorkerInterface>(kj::addRef(*this));
-  }, {.inHouse = false, .wrapMetrics = false});
+  }, {.inHouse = false, .wrapMetrics = false}, CountSubrequest::YES);
   return {.client = kj::mv(client), .spanParents = kj::none};
 }
 

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1036,7 +1036,8 @@ kj::Rc<ExternalPusherImpl> IoContext::getExternalPusher() {
 
 kj::Own<WorkerInterface> IoContext::getSubrequestNoChecks(
     kj::FunctionParam<kj::Own<WorkerInterface>(TraceContext&, IoChannelFactory&)> func,
-    SubrequestOptions options) {
+    SubrequestOptions options,
+    CountSubrequest countSubrequest) {
   TraceContext tracing;
   KJ_IF_SOME(n, options.operationName) {
     tracing = makeUserTraceSpan(n.clone());
@@ -1051,7 +1052,7 @@ kj::Own<WorkerInterface> IoContext::getSubrequestNoChecks(
 
   if (options.wrapMetrics) {
     auto& metrics = getMetrics();
-    ret = metrics.wrapSubrequestClient(kj::mv(ret));
+    ret = metrics.wrapSubrequestClient(kj::mv(ret), countSubrequest);
     ret = worker->getIsolate().wrapSubrequestClient(
         kj::mv(ret), getHeaderIds().contentEncoding, metrics);
   }
@@ -1077,7 +1078,7 @@ kj::Own<WorkerInterface> IoContext::getSubrequest(
     kj::FunctionParam<kj::Own<WorkerInterface>(TraceContext&, IoChannelFactory&)> func,
     SubrequestOptions options) {
   limitEnforcer->newSubrequest(options.inHouse);
-  return getSubrequestNoChecks(kj::mv(func), kj::mv(options));
+  return getSubrequestNoChecks(kj::mv(func), kj::mv(options), CountSubrequest::YES);
 }
 
 kj::Own<WorkerInterface> IoContext::getSubrequestChannel(
@@ -1138,7 +1139,8 @@ kj::Own<WorkerInterface> IoContext::getSubrequestChannelNoChecks(uint channel,
         .inHouse = isInHouse,
         .wrapMetrics = !isInHouse,
         .operationName = kj::mv(operationName),
-      });
+      },
+      CountSubrequest::YES);
 }
 
 kj::Own<WorkerInterface> IoContext::getSubrequestChannelImpl(uint channel,

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -935,7 +935,8 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   // should route through this function or getSubrequest().
   kj::Own<WorkerInterface> getSubrequestNoChecks(
       kj::FunctionParam<kj::Own<WorkerInterface>(TraceContext&, IoChannelFactory&)> func,
-      SubrequestOptions options);
+      SubrequestOptions options,
+      CountSubrequest countSubrequest);
 
   // If creating a new subrequest is permitted, calls the given factory function synchronously to
   // create one.

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -23,6 +23,8 @@ class IoContext;
 // Whether an outgoing subrequest's request body can be rewound (e.g. a buffered or null body), and
 // so the request could be re-sent. See RequestObserver::setNextSubrequestBodyRewindable().
 WD_STRONG_BOOL(SubrequestBodyRewindable);
+// Whether an outgoing request contributes to the logical subrequest count.
+WD_STRONG_BOOL(CountSubrequest);
 class WorkerInterface;
 class LimitEnforcer;
 class TimerChannel;
@@ -121,8 +123,10 @@ class RequestObserver: public kj::Refcounted {
     return worker;
   }
 
-  // Wrap an HttpClient so that its usage is counted in the request's subrequest stats.
-  virtual kj::Own<WorkerInterface> wrapSubrequestClient(kj::Own<WorkerInterface> client) {
+  // Wrap an HttpClient to observe its request and response activity. `countSubrequest` controls
+  // whether its usage contributes to the request's logical subrequest count.
+  virtual kj::Own<WorkerInterface> wrapSubrequestClient(
+      kj::Own<WorkerInterface> client, CountSubrequest countSubrequest) {
     return kj::mv(client);
   }
 


### PR DESCRIPTION
Charge the subrequest limit and generic subrequest count only for the first attempt of a logical Durable Object fetch.

Keep the metrics and actor subrequest wrappers on retries so tracing and per-attempt actor metrics remain intact.