### PR TITLE
STOR-5552: Serialize WebSocket writes across hibernation

### DIFF
--- a/src/workerd/api/hibernatable-adapter.c++
+++ b/src/workerd/api/hibernatable-adapter.c++
@@ -147,7 +147,8 @@ kj::Maybe<kj::Date> HibernatableWebSocketAdapter::getAutoResponseTimestamp() {
   unimplemented();
 }
 
-kj::Promise<void> HibernatableWebSocketAdapter::sendAutoResponse(kj::String, kj::WebSocket&) {
+kj::Promise<void> HibernatableWebSocketAdapter::sendAutoResponse(
+    kj::String, kj::WebSocket&, kj::Promise<void>) {
   unimplemented();
 }
 

--- a/src/workerd/api/hibernatable-adapter.h
+++ b/src/workerd/api/hibernatable-adapter.h
@@ -81,7 +81,8 @@ class HibernatableWebSocketAdapter final: public WebSocketAdapter {
   void setAutoResponseStatus(
       kj::Maybe<kj::Date> time, kj::Promise<void> autoResponsePromise) override;
   kj::Maybe<kj::Date> getAutoResponseTimestamp() override;
-  kj::Promise<void> sendAutoResponse(kj::String message, kj::WebSocket& ws) override;
+  kj::Promise<void> sendAutoResponse(
+      kj::String message, kj::WebSocket& ws, kj::Promise<void> writeBarrier) override;
 
   void setPeer(jsg::WeakRef<WebSocket> peer) override;
   bool peerIsAwaitingCoupling(jsg::Lock& js) override;

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -1104,12 +1104,16 @@ void LegacyWebSocketAdapter::ensurePumping(jsg::Lock& js) {
   if (!native.isPumping) {
     auto& context = IoContext::current();
     auto& accepted = KJ_ASSERT_NONNULL(native.state.tryGet<Accepted>());
-    auto completion = kj::newPromiseAndFulfiller<void>();
-    autoResponseStatus.maybePumpCompletion =
-        completion.promise.catch_([](kj::Exception&&) {}).fork();
-    auto promise = kj::evalNow([&, fulfiller = kj::mv(completion.fulfiller)]() mutable {
+    kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> pumpCompletion;
+    if (accepted.isHibernatable()) {
+      auto completion = kj::newPromiseAndFulfiller<void>();
+      autoResponseStatus.maybePumpCompletion =
+          completion.promise.catch_([](kj::Exception&&) {}).fork();
+      pumpCompletion = kj::mv(completion.fulfiller);
+    }
+    auto promise = kj::evalNow([&, pumpCompletion = kj::mv(pumpCompletion)]() mutable {
       return accepted.canceler.wrap(pump(context, *outgoingMessages, *accepted.ws, native,
-          autoResponseStatus, observer, kj::mv(fulfiller)));
+          autoResponseStatus, observer, kj::mv(pumpCompletion)));
     });
 
     // TODO(cleanup): We use awaitIoLegacy() here because we don't want this to count as a pending
@@ -1221,7 +1225,7 @@ kj::Promise<void> LegacyWebSocketAdapter::pump(IoContext& context,
     Native& native,
     AutoResponse& autoResponse,
     kj::Maybe<kj::Own<WebSocketObserver>>& observer,
-    kj::Own<kj::PromiseFulfiller<void>> pumpCompletion) {
+    kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> pumpCompletion) {
   KJ_ASSERT(!native.isPumping);
   native.isPumping = true;
   autoResponse.isPumping = true;
@@ -1253,8 +1257,11 @@ kj::Promise<void> LegacyWebSocketAdapter::pump(IoContext& context,
       native.outgoingAborted = true;
     }
 
-    pumpCompletion->fulfill();
-    autoResponse.maybePumpCompletion = kj::none;
+    if (pumpCompletion != kj::none) {
+      auto completion = kj::mv(KJ_ASSERT_NONNULL(pumpCompletion));
+      completion->fulfill();
+      autoResponse.maybePumpCompletion = kj::none;
+    }
   });
 
   // If we have a ongoingAutoResponse, we must co_await it here because there's a ws.send()

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -256,8 +256,9 @@ kj::Maybe<kj::Date> WebSocket::getAutoResponseTimestamp() {
   return impl->getAutoResponseTimestamp();
 }
 
-kj::Promise<void> WebSocket::sendAutoResponse(kj::String message, kj::WebSocket& ws) {
-  return impl->sendAutoResponse(kj::mv(message), ws);
+kj::Promise<void> WebSocket::sendAutoResponse(
+    kj::String message, kj::WebSocket& ws, kj::Promise<void> writeBarrier) {
+  return impl->sendAutoResponse(kj::mv(message), ws, kj::mv(writeBarrier));
 }
 
 void WebSocket::setPeer(jsg::WeakRef<WebSocket> peer) {
@@ -1103,9 +1104,12 @@ void LegacyWebSocketAdapter::ensurePumping(jsg::Lock& js) {
   if (!native.isPumping) {
     auto& context = IoContext::current();
     auto& accepted = KJ_ASSERT_NONNULL(native.state.tryGet<Accepted>());
-    auto promise = kj::evalNow([&]() {
-      return accepted.canceler.wrap(
-          pump(context, *outgoingMessages, *accepted.ws, native, autoResponseStatus, observer));
+    auto completion = kj::newPromiseAndFulfiller<void>();
+    autoResponseStatus.maybePumpCompletion =
+        completion.promise.catch_([](kj::Exception&&) {}).fork();
+    auto promise = kj::evalNow([&, fulfiller = kj::mv(completion.fulfiller)]() mutable {
+      return accepted.canceler.wrap(pump(context, *outgoingMessages, *accepted.ws, native,
+          autoResponseStatus, observer, kj::mv(fulfiller)));
     });
 
     // TODO(cleanup): We use awaitIoLegacy() here because we don't want this to count as a pending
@@ -1168,7 +1172,8 @@ void LegacyWebSocketAdapter::ensurePumping(jsg::Lock& js) {
   }
 }
 
-kj::Promise<void> LegacyWebSocketAdapter::sendAutoResponse(kj::String message, kj::WebSocket& ws) {
+kj::Promise<void> LegacyWebSocketAdapter::sendAutoResponse(
+    kj::String message, kj::WebSocket& ws, kj::Promise<void> writeBarrier) {
   if (autoResponseStatus.isClosed) {
     return kj::READY_NOW;
   } else if (autoResponseStatus.isPumping) {
@@ -1177,7 +1182,9 @@ kj::Promise<void> LegacyWebSocketAdapter::sendAutoResponse(kj::String message, k
         AutoResponse::Pending{kj::mv(message), kj::mv(completion.fulfiller)});
     return kj::mv(completion.promise);
   } else {
-    return ws.send(message).attach(kj::mv(message));
+    return writeBarrier.then([message = kj::mv(message), &ws]() mutable {
+      return ws.send(message).attach(kj::mv(message));
+    });
   }
 }
 
@@ -1213,7 +1220,8 @@ kj::Promise<void> LegacyWebSocketAdapter::pump(IoContext& context,
     kj::WebSocket& ws,
     Native& native,
     AutoResponse& autoResponse,
-    kj::Maybe<kj::Own<WebSocketObserver>>& observer) {
+    kj::Maybe<kj::Own<WebSocketObserver>>& observer,
+    kj::Own<kj::PromiseFulfiller<void>> pumpCompletion) {
   KJ_ASSERT(!native.isPumping);
   native.isPumping = true;
   autoResponse.isPumping = true;
@@ -1244,6 +1252,9 @@ kj::Promise<void> LegacyWebSocketAdapter::pump(IoContext& context,
       // Setting `outgoingAborted` stops us from even trying to queue any more messages.
       native.outgoingAborted = true;
     }
+
+    pumpCompletion->fulfill();
+    autoResponse.maybePumpCompletion = kj::none;
   });
 
   // If we have a ongoingAutoResponse, we must co_await it here because there's a ws.send()
@@ -1585,6 +1596,7 @@ WebSocket::HibernationPackage LegacyWebSocketAdapter::buildPackageForHibernation
     .maybeTags = kj::none,
     .closedOutgoingConnection = closedOutgoingForHib,
     .allowHalfOpen = allowHalfOpen,
+    .maybePumpCompletion = kj::mv(autoResponseStatus.maybePumpCompletion),
   };
 }
 

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -220,6 +220,9 @@ class WebSocket: public EventTarget {
 
     // Whether the WebSocket allows half-open close state.
     AllowHalfOpen allowHalfOpen = AllowHalfOpen::YES;
+
+    // Resolves when a pump that was active at hibernation settles. This does not own the pump.
+    kj::Maybe<kj::ForkedPromise<void>> maybePumpCompletion;
   };
 
   ~WebSocket() noexcept(false) = default;
@@ -330,7 +333,8 @@ class WebSocket: public EventTarget {
   // These methods are c++ only and are not exposed to our js interface.
   kj::Maybe<kj::Date> getAutoResponseTimestamp();
 
-  kj::Promise<void> sendAutoResponse(kj::String message, kj::WebSocket& ws);
+  kj::Promise<void> sendAutoResponse(
+      kj::String message, kj::WebSocket& ws, kj::Promise<void> writeBarrier);
 
   int getReadyState();
 
@@ -541,7 +545,8 @@ class WebSocketAdapter {
   virtual void setAutoResponseStatus(
       kj::Maybe<kj::Date> time, kj::Promise<void> autoResponsePromise) = 0;
   virtual kj::Maybe<kj::Date> getAutoResponseTimestamp() = 0;
-  virtual kj::Promise<void> sendAutoResponse(kj::String message, kj::WebSocket& ws) = 0;
+  virtual kj::Promise<void> sendAutoResponse(
+      kj::String message, kj::WebSocket& ws, kj::Promise<void> writeBarrier) = 0;
 
   // -------------------------------------------------------------------------
   // Peer tracking (the other end of a WebSocketPair).
@@ -631,7 +636,8 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
   void setAutoResponseStatus(
       kj::Maybe<kj::Date> time, kj::Promise<void> autoResponsePromise) override;
   kj::Maybe<kj::Date> getAutoResponseTimestamp() override;
-  kj::Promise<void> sendAutoResponse(kj::String message, kj::WebSocket& ws) override;
+  kj::Promise<void> sendAutoResponse(
+      kj::String message, kj::WebSocket& ws, kj::Promise<void> writeBarrier) override;
 
   void setPeer(jsg::WeakRef<WebSocket> peer) override;
   bool peerIsAwaitingCoupling(jsg::Lock& js) override;
@@ -765,6 +771,8 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
       kj::Own<kj::PromiseFulfiller<void>> fulfiller;
     };
     kj::Maybe<OwnedAutoResponsePromise> ongoingAutoResponse;
+    // Allows a replacement adapter to wait for this adapter's pump without keeping it alive.
+    kj::Maybe<kj::ForkedPromise<void>> maybePumpCompletion;
     workerd::util::Queue<Pending> pendingAutoResponseDeque;
     size_t queuedAutoResponses = 0;
     bool isPumping = false;
@@ -772,6 +780,9 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
 
     JSG_MEMORY_INFO(AutoResponse) {
       tracker.trackFieldWithSize("ongoingAutoResponse", sizeof(kj::Promise<void>));
+      if (maybePumpCompletion != kj::none) {
+        tracker.trackFieldWithSize("maybePumpCompletion", sizeof(kj::ForkedPromise<void>));
+      }
       pendingAutoResponseDeque.forEach(
           [&](const Pending& pending) { tracker.trackField(nullptr, pending.message); });
     }
@@ -818,7 +829,8 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
       kj::WebSocket& ws,
       Native& native,
       AutoResponse& autoResponse,
-      kj::Maybe<kj::Own<WebSocketObserver>>& observer);
+      kj::Maybe<kj::Own<WebSocketObserver>>& observer,
+      kj::Own<kj::PromiseFulfiller<void>> pumpCompletion);
 
   kj::Promise<kj::Maybe<kj::Exception>> readLoop(
       kj::Maybe<kj::Own<InputGate::CriticalSection>> cs, size_t maxMessageSize);
@@ -831,8 +843,7 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
   void tryReleaseNative(jsg::Lock& js);
 
   // ---------------------------------------------------------------------------
-  // Members. The pre-EW-10817 `api::WebSocket` layout, with the addition of `shell` (the
-  // back-reference for event dispatch / JSG_THIS).
+  // Members retained by the legacy adapter while the EW-10817 refactor is incomplete.
   // ---------------------------------------------------------------------------
 
   // Back-reference to the JSG-visible shell. Used to dispatch events

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -830,7 +830,7 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
       Native& native,
       AutoResponse& autoResponse,
       kj::Maybe<kj::Own<WebSocketObserver>>& observer,
-      kj::Own<kj::PromiseFulfiller<void>> pumpCompletion);
+      kj::Maybe<kj::Own<kj::PromiseFulfiller<void>>> pumpCompletion);
 
   kj::Promise<kj::Maybe<kj::Exception>> readLoop(
       kj::Maybe<kj::Own<InputGate::CriticalSection>> cs, size_t maxMessageSize);

--- a/src/workerd/io/hibernation-manager-test.c++
+++ b/src/workerd/io/hibernation-manager-test.c++
@@ -11,10 +11,6 @@
 // in-progress refactor work. They may go stale relative to the current
 // implementation as that work lands. The tests themselves are the source of
 // truth for the contract; comments are best-effort context.
-//
-// One test uses KJ_EXPECT_LOG to capture the remaining "another message send
-// is already in progress" assertion as an expected ERROR log. It passes while
-// the general outgoing-queue bug is present and will fail when that fix lands.
 
 #include <workerd/api/web-socket.h>
 #include <workerd/io/legacy-hibernation-manager.h>

--- a/src/workerd/io/hibernation-manager-test.c++
+++ b/src/workerd/io/hibernation-manager-test.c++
@@ -680,6 +680,62 @@ KJ_TEST("HibernationManager: in-flight auto-response survives repeated hibernati
   fixture.drainAndDestroy(kj::mv(request));
 }
 
+KJ_TEST("HibernationManager: active auto-response after revival waits for old pump") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("revived-active-autoresp")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  sendFromDo(fixture, *request, *hm, "before-hibernation"_kj);
+  fixture.pollEventLoop();
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    KJ_ASSERT(hm->getWebSockets(env.js, kj::none).size() == 1);
+  });
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+
+  auto first = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(first.is<kj::String>() && first.get<kj::String>() == "before-hibernation"_kj);
+  auto pong = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(pong.is<kj::String>() && pong.get<kj::String>() == "pong"_kj);
+  KJ_ASSERT(stats.customEventCalls == 0, stats.customEventCalls);
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST("HibernationManager: manager teardown cancels deferred auto-response") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("teardown-deferred-autoresp")));
+  auto hm = makeTestHm(fixture, "ping"_kj, "pong"_kj);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  sendFromDo(fixture, *request, *hm, "blocked"_kj);
+  fixture.pollEventLoop();
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
+
+  kj::Maybe<jsg::Ref<api::WebSocket>> retained;
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto websockets = hm->getWebSockets(env.js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    retained = websockets[0].addRef();
+  });
+
+  // Queue an auto-response behind the old pump, then keep its fork alive through the revived API
+  // WebSocket while destroying the manager and its native WebSocket.
+  end1->send("ping"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+  fixture.enterContext(*request, [&](const TestFixture::Environment&) { hm = nullptr; });
+  fixture.pollEventLoop();
+
+  KJ_ASSERT(stats.customEventCalls == 0, stats.customEventCalls);
+  fixture.enterContext(*request, [&](const TestFixture::Environment&) { retained = kj::none; });
+  end1 = nullptr;
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
 KJ_TEST("HibernationManager: packaged in-flight auto-response finishes before close") {
   DispatchStats stats;
   TestFixture fixture(stubLoopbackParams(stats, kj::str("packaged-autoresp")));
@@ -739,11 +795,10 @@ KJ_TEST("HibernationManager: rejected packaged auto-response removes revived Web
   fixture.drainAndDestroy(kj::mv(request));
 }
 
-KJ_TEST("HibernationManager: in-flight DO send orphans BlockedSend during hibernation") {
-  // Regression test for EW-10817. Same shape as the auto-response variant above but driven by
-  // a DO-side ws.send() — the pump creates a BlockedSend on the pipe (no BPT yet), hibernation
-  // orphans it, and the next operation on the new api::WebSocket trips the assertion.
-  //
+KJ_TEST("HibernationManager: revived sends wait across repeated hibernation") {
+  // A DO-side send can remain blocked after hibernation while the revived api::WebSocket queues
+  // another operation on the same native WebSocket. The revived pump must wait for the old pump
+  // so both operations reach the peer in order.
   DispatchStats stats;
   TestFixture fixture(stubLoopbackParams(stats, kj::str("ew-10817-dosend")));
   auto hm = makeTestHm(fixture);
@@ -757,24 +812,35 @@ KJ_TEST("HibernationManager: in-flight DO send orphans BlockedSend during hibern
   // Hibernate.
   fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
 
-  // Unhibernate + close → hits orphaned BlockedSend.
-  {
-    KJ_EXPECT_LOG(ERROR, "another message send is already in progress");
-    fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
-      auto& js = env.js;
-      auto websockets = hm->getWebSockets(js, kj::none);
-      KJ_ASSERT(websockets.size() == 1);
-      websockets[0]->close(js, 1001, jsg::USVString(kj::str("stale")));
-    });
+  sendFromDo(fixture, *request, *hm, "after-first-hibernation"_kj);
+  fixture.pollEventLoop();
 
-    fixture.pollEventLoop();
-  }
+  // Package the replacement adapter while its pump is waiting for the original send.
+  fixture.enterWorkerLock([&](Worker::Lock& lock) { hm->hibernateWebSockets(lock); });
 
-  // Receive the orphaned "hello from DO" from the pipe — it was sent before hibernation but
-  // the pump is stuck on its BlockedSend. Consuming it unblocks the pump so drainAndDestroy()
-  // below can complete cleanly. Once EW-10817 is fixed, this becomes a positive assertion
-  // about the message content.
-  end1->receive().wait(fixture.getWaitScope());
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("after-hibernation")));
+  });
+  fixture.pollEventLoop();
+
+  auto message = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(message.is<kj::String>() && message.get<kj::String>() == "hello from DO"_kj);
+
+  auto revivedMessage = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(revivedMessage.is<kj::String>() &&
+      revivedMessage.get<kj::String>() == "after-first-hibernation"_kj);
+
+  auto closePromise = end1->receive();
+  fixture.pollEventLoop();
+  KJ_ASSERT(closePromise.poll(fixture.getWaitScope()), "revived close remained blocked");
+  auto closeMessage = closePromise.wait(fixture.getWaitScope());
+  KJ_ASSERT(closeMessage.is<kj::WebSocket::Close>());
+  auto& close = closeMessage.get<kj::WebSocket::Close>();
+  KJ_ASSERT(close.code == 1001, close.code);
+  KJ_ASSERT(close.reason == "after-hibernation"_kj, close.reason);
   fixture.drainAndDestroy(kj::mv(request));
 }
 

--- a/src/workerd/io/legacy-hibernation-manager.c++
+++ b/src/workerd/io/legacy-hibernation-manager.c++
@@ -58,17 +58,16 @@ jsg::Ref<api::WebSocket> LegacyHibernationManagerImpl::HibernatableWebSocket::
     // Recreate our tags array for the api::WebSocket.
     package.maybeTags = getTags();
 
-    // Now that we unhibernated the WebSocket, we can set the last received autoResponse timestamp
-    // that was stored in the corresponding HibernatableWebSocket. Share an autoResponsePromise
-    // branch with api::websocket while retaining the fork in case the socket hibernates again.
-    kj::Promise<void> autoResponsePromise = kj::READY_NOW;
-    KJ_IF_SOME(promise, this->maybeAutoResponsePromise) {
-      autoResponsePromise = promise.addBranch();
+    // Share the previous send with api::WebSocket while retaining the fork in case the socket
+    // hibernates again before it settles.
+    kj::Promise<void> writeBarrier = kj::READY_NOW;
+    KJ_IF_SOME(promise, this->maybeWriteBarrier) {
+      writeBarrier = promise.addBranch();
     }
     activeOrPackage
         .init<jsg::Ref<api::WebSocket>>(api::WebSocket::hibernatableFromNative(
             js, KJ_REQUIRE_NONNULL(ws).addRef(), kj::mv(package)))
-        ->setAutoResponseStatus(autoResponseTimestamp, kj::mv(autoResponsePromise));
+        ->setAutoResponseStatus(autoResponseTimestamp, kj::mv(writeBarrier));
   }
   return activeOrPackage.get<jsg::Ref<api::WebSocket>>().addRef();
 }
@@ -225,8 +224,13 @@ void LegacyHibernationManagerImpl::hibernateWebSockets(Worker::Lock& lock) {
       KJ_IF_SOME(active, ws->activeOrPackage.tryGet<jsg::Ref<api::WebSocket>>()) {
         // Transfers ownership of properties from api::WebSocket to HibernatableWebSocket via the
         // HibernationPackage.
-        ws->activeOrPackage.init<api::WebSocket::HibernationPackage>(
-            active.get()->buildPackageForHibernation());
+        auto package = active.get()->buildPackageForHibernation();
+        if (package.maybePumpCompletion != kj::none) {
+          auto completion = kj::mv(KJ_ASSERT_NONNULL(package.maybePumpCompletion));
+          package.maybePumpCompletion = kj::none;
+          ws->maybeWriteBarrier = kj::mv(completion);
+        }
+        ws->activeOrPackage.init<api::WebSocket::HibernationPackage>(kj::mv(package));
       } else {
       }  // Here to quash compiler warning
     }
@@ -344,11 +348,16 @@ kj::Promise<void> LegacyHibernationManagerImpl::readLoop(HibernatableWebSocket& 
                 // Since we had a request set, we must have and response that's sent back using the
                 // same websocket here. The sending of response is managed in web-socket to avoid
                 // possible racing problems with regular websocket messages.
-                hib.maybeAutoResponsePromise =
-                    apiWs->sendAutoResponse(kj::mv(responseCopy), ws).fork();
-                auto& promise = KJ_ASSERT_NONNULL(hib.maybeAutoResponsePromise);
+                kj::Promise<void> previous = kj::READY_NOW;
+                KJ_IF_SOME(promise, hib.maybeWriteBarrier) {
+                  previous = promise.addBranch();
+                }
+                hib.maybeWriteBarrier =
+                    hib.writeCanceler
+                        .wrap(apiWs->sendAutoResponse(kj::mv(responseCopy), ws, kj::mv(previous)))
+                        .fork();
+                auto& promise = KJ_ASSERT_NONNULL(hib.maybeWriteBarrier);
                 apiWs->setAutoResponseStatus(hib.autoResponseTimestamp, promise.addBranch());
-                KJ_DEFER(hib.maybeAutoResponsePromise = kj::none);
                 co_await promise;
               }
               KJ_CASE_ONEOF(package, api::WebSocket::HibernationPackage) {
@@ -357,10 +366,16 @@ kj::Promise<void> LegacyHibernationManagerImpl::readLoop(HibernatableWebSocket& 
                   // If we do that, we have to provide it with the promise to avoid races. This can
                   // happen if we have a websocket hibernating, that unhibernates and sends a
                   // message while ws.send() for auto-response is also sending.
-                  hib.maybeAutoResponsePromise =
-                      ws.send(responseCopy.asArray()).attach(kj::mv(responseCopy)).fork();
-                  KJ_DEFER(hib.maybeAutoResponsePromise = kj::none);
-                  co_await KJ_ASSERT_NONNULL(hib.maybeAutoResponsePromise);
+                  kj::Promise<void> previous = kj::READY_NOW;
+                  KJ_IF_SOME(promise, hib.maybeWriteBarrier) {
+                    previous = promise.addBranch();
+                  }
+                  auto response =
+                      previous.then([&ws, responseCopy = kj::mv(responseCopy)]() mutable {
+                    return ws.send(responseCopy.asArray()).attach(kj::mv(responseCopy));
+                  });
+                  hib.maybeWriteBarrier = hib.writeCanceler.wrap(kj::mv(response)).fork();
+                  co_await KJ_ASSERT_NONNULL(hib.maybeWriteBarrier);
                 }
               }
             }

--- a/src/workerd/io/legacy-hibernation-manager.c++
+++ b/src/workerd/io/legacy-hibernation-manager.c++
@@ -52,6 +52,13 @@ kj::Array<kj::String> LegacyHibernationManagerImpl::HibernatableWebSocket::getTa
   return tags;
 }
 
+kj::Promise<void> LegacyHibernationManagerImpl::HibernatableWebSocket::branchWriteBarrier() {
+  KJ_IF_SOME(promise, maybeWriteBarrier) {
+    return promise.addBranch();
+  }
+  return kj::READY_NOW;
+}
+
 jsg::Ref<api::WebSocket> LegacyHibernationManagerImpl::HibernatableWebSocket::
     getActiveOrUnhibernate(jsg::Lock& js) {
   KJ_IF_SOME(package, activeOrPackage.tryGet<api::WebSocket::HibernationPackage>()) {
@@ -60,14 +67,10 @@ jsg::Ref<api::WebSocket> LegacyHibernationManagerImpl::HibernatableWebSocket::
 
     // Share the previous send with api::WebSocket while retaining the fork in case the socket
     // hibernates again before it settles.
-    kj::Promise<void> writeBarrier = kj::READY_NOW;
-    KJ_IF_SOME(promise, this->maybeWriteBarrier) {
-      writeBarrier = promise.addBranch();
-    }
     activeOrPackage
         .init<jsg::Ref<api::WebSocket>>(api::WebSocket::hibernatableFromNative(
             js, KJ_REQUIRE_NONNULL(ws).addRef(), kj::mv(package)))
-        ->setAutoResponseStatus(autoResponseTimestamp, kj::mv(writeBarrier));
+        ->setAutoResponseStatus(autoResponseTimestamp, branchWriteBarrier());
   }
   return activeOrPackage.get<jsg::Ref<api::WebSocket>>().addRef();
 }
@@ -348,14 +351,10 @@ kj::Promise<void> LegacyHibernationManagerImpl::readLoop(HibernatableWebSocket& 
                 // Since we had a request set, we must have and response that's sent back using the
                 // same websocket here. The sending of response is managed in web-socket to avoid
                 // possible racing problems with regular websocket messages.
-                kj::Promise<void> previous = kj::READY_NOW;
-                KJ_IF_SOME(promise, hib.maybeWriteBarrier) {
-                  previous = promise.addBranch();
-                }
-                hib.maybeWriteBarrier =
-                    hib.writeCanceler
-                        .wrap(apiWs->sendAutoResponse(kj::mv(responseCopy), ws, kj::mv(previous)))
-                        .fork();
+                hib.maybeWriteBarrier = hib.writeCanceler
+                                            .wrap(apiWs->sendAutoResponse(
+                                                kj::mv(responseCopy), ws, hib.branchWriteBarrier()))
+                                            .fork();
                 auto& promise = KJ_ASSERT_NONNULL(hib.maybeWriteBarrier);
                 apiWs->setAutoResponseStatus(hib.autoResponseTimestamp, promise.addBranch());
                 co_await promise;
@@ -366,12 +365,8 @@ kj::Promise<void> LegacyHibernationManagerImpl::readLoop(HibernatableWebSocket& 
                   // If we do that, we have to provide it with the promise to avoid races. This can
                   // happen if we have a websocket hibernating, that unhibernates and sends a
                   // message while ws.send() for auto-response is also sending.
-                  kj::Promise<void> previous = kj::READY_NOW;
-                  KJ_IF_SOME(promise, hib.maybeWriteBarrier) {
-                    previous = promise.addBranch();
-                  }
-                  auto response =
-                      previous.then([&ws, responseCopy = kj::mv(responseCopy)]() mutable {
+                  auto response = hib.branchWriteBarrier().then(
+                      [&ws, responseCopy = kj::mv(responseCopy)]() mutable {
                     return ws.send(responseCopy.asArray()).attach(kj::mv(responseCopy));
                   });
                   hib.maybeWriteBarrier = hib.writeCanceler.wrap(kj::mv(response)).fork();

--- a/src/workerd/io/legacy-hibernation-manager.h
+++ b/src/workerd/io/legacy-hibernation-manager.h
@@ -129,9 +129,14 @@ class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManag
     // Stores the last received autoResponseRequest timestamp.
     kj::Maybe<kj::Date> autoResponseTimestamp;
 
-    // Keeps track of the currently ongoing websocket auto-response send promise. A revived
-    // api::WebSocket receives a branch so the manager can retain this across repeated hibernation.
-    kj::Maybe<kj::ForkedPromise<void>> maybeAutoResponsePromise;
+    // Serializes writes against the previous adapter's pump or the latest auto-response send.
+    // A revived api::WebSocket receives a branch while the manager retains the barrier. We keep
+    // the latest barrier after it settles because a completion callback could otherwise clear a
+    // newer replacement; retention is bounded to one barrier per WebSocket.
+    kj::Maybe<kj::ForkedPromise<void>> maybeWriteBarrier;
+
+    // Cancels promises that borrow `ws`. Declared after `ws` so it is destroyed first.
+    kj::Canceler writeCanceler;
 
     friend LegacyHibernationManagerImpl;
   };

--- a/src/workerd/io/legacy-hibernation-manager.h
+++ b/src/workerd/io/legacy-hibernation-manager.h
@@ -88,6 +88,9 @@ class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManag
     // Returns an owned copy of the tags associated with this HibernatableWebSocket.
     kj::Array<kj::String> getTags();
 
+    // Returns a branch of the latest write barrier, or an already-completed promise if none exists.
+    kj::Promise<void> branchWriteBarrier();
+
     // Returns a reference to the active websocket. If the websocket is currently hibernating,
     // we have to unhibernate it first. The process moves values from the HibernatableWebSocket
     // to the api::WebSocket.


### PR DESCRIPTION
## Summary

A hibernatable WebSocket can replace its API adapter while the old adapter's output pump is still blocked in `kj::WebSocket::send()`.Writes from the revived adapter then race the old send and hit the
single-send assertion.

Carry a settlement-only signal from the old pump through the hibernation package. The hibernation manager uses it to order revived sends, closes, and auto-responses without retaining the old pump or its `IoContext`.

The barrier does not preserve a message canceled during `IoContext`
destruction. It only prevents a replacement adapter from writing before
the old pump has settled.