### PR TITLE
[DRAFT] Keep the actor active while a container TCP port connection is open

### DIFF
--- a/src/workerd/api/container-test.c++
+++ b/src/workerd/api/container-test.c++
@@ -12,7 +12,9 @@
 
 #include <capnp/compat/byte-stream.h>
 #include <capnp/message.h>
+#include <kj/compat/http.h>
 #include <kj/test.h>
+#include <kj/timer.h>
 
 namespace workerd::api {
 namespace {
@@ -273,16 +275,20 @@ Container::DirectorySnapshot makeDirectorySnapshot(kj::StringPtr id, kj::StringP
 }
 
 enum class TunnelReuseGate { DISABLED, ENABLED };
+enum class ActorPinGate { DISABLED, ENABLED };
 
 class AutogateScope {
  public:
-  AutogateScope(TunnelReuseGate gate = TunnelReuseGate::ENABLED) {
+  AutogateScope(TunnelReuseGate gate = TunnelReuseGate::ENABLED,
+      ActorPinGate pinGate = ActorPinGate::DISABLED) {
+    kj::Vector<kj::StringPtr> gates(2);
     if (gate == TunnelReuseGate::ENABLED) {
-      util::Autogate::initAutogateNamesForTest(
-          {"container-tunnel-reuse"_kj}, util::IgnoreAllAutogatesEnv::YES);
-    } else {
-      util::Autogate::initAutogateNamesForTest({}, util::IgnoreAllAutogatesEnv::YES);
+      gates.add("container-tunnel-reuse"_kj);
     }
+    if (pinGate == ActorPinGate::ENABLED) {
+      gates.add("container-port-actor-pin"_kj);
+    }
+    util::Autogate::initAutogateNamesForTest(gates.asPtr(), util::IgnoreAllAutogatesEnv::YES);
   }
 
   ~AutogateScope() noexcept(false) {
@@ -300,6 +306,16 @@ enum class ResponseMode {
   CONNECT_FAILURE,
   UPSTREAM_FAILURE,
   UPSTREAM_END_FAILURE,
+  // Serves a real kj::HttpServer over the tunnel that accepts a WebSocket upgrade and echoes
+  // frames back. Used to exercise the upgrade path end-to-end, handshake included.
+  WEBSOCKET_ECHO,
+  // Like WEBSOCKET_ECHO, but the container drops the socket after the first message instead of
+  // completing a close handshake. Models the remote vanishing mid-session.
+  WEBSOCKET_ABRUPT_CLOSE,
+  // Sends response headers, then withholds the body until the test releases it. This is the
+  // deferred-proxying window: headers are through (so the IncomingRequest would be gone in
+  // production) but the exchange is not finished.
+  BLOCKED_BODY,
 };
 
 enum class WaitForClose { NO, YES };
@@ -338,6 +354,95 @@ class FailingEndOutput final: public capnp::ExplicitEndOutputStream {
   }
 };
 
+// Presents the two halves of a mock tunnel as one stream, so a real kj::HttpServer can be run
+// over it. Port.connect() hands the directions to us separately (an inbound pipe and an outbound
+// ByteStream), but HttpServer wants a single AsyncIoStream.
+class JoinedTunnelStream final: public kj::AsyncIoStream {
+ public:
+  JoinedTunnelStream(kj::Own<kj::AsyncInputStream> in, kj::Own<capnp::ExplicitEndOutputStream> out)
+      : in(kj::mv(in)),
+        out(kj::mv(out)) {}
+
+  kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+    return in->tryRead(buffer, minBytes, maxBytes);
+  }
+
+  kj::Maybe<uint64_t> tryGetLength() override {
+    return in->tryGetLength();
+  }
+
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
+    return out->write(buffer);
+  }
+
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override {
+    return out->write(pieces);
+  }
+
+  kj::Promise<void> whenWriteDisconnected() override {
+    return out->whenWriteDisconnected();
+  }
+
+  void shutdownWrite() override {
+    // No-op. AsyncIoStream's half-close is synchronous, but ExplicitEndOutputStream::end() is a
+    // promise, so there is nothing correct to do here synchronously; the peer sees EOF when this
+    // object is destroyed.
+    //
+    // This is only sound because the sole user is serveWebSocket(), and a WebSocket session never
+    // half-closes -- it ends by closing the whole connection. Do not reuse this class for a
+    // plain HTTP response whose body is connection-close-delimited: the client would wait for an
+    // EOF that never arrives.
+  }
+
+ private:
+  kj::Own<kj::AsyncInputStream> in;
+  kj::Own<capnp::ExplicitEndOutputStream> out;
+};
+
+// HttpService that accepts a WebSocket upgrade and echoes every message back until the peer
+// closes. Runs on the container side of the tunnel.
+class WebSocketEchoService final: public kj::HttpService {
+ public:
+  WebSocketEchoService(const kj::HttpHeaderTable& headerTable, bool abruptAfterFirstMessage)
+      : headerTable(headerTable),
+        abruptAfterFirstMessage(abruptAfterFirstMessage) {}
+
+  kj::Promise<void> request(kj::HttpMethod method,
+      kj::StringPtr url,
+      const kj::HttpHeaders& headers,
+      kj::AsyncInputStream& requestBody,
+      Response& response) override {
+    KJ_REQUIRE(headers.isWebSocket(), "expected a WebSocket upgrade");
+    kj::HttpHeaders responseHeaders(headerTable);
+    auto ws = response.acceptWebSocket(responseHeaders);
+    co_await echo(*ws).attach(kj::mv(ws));
+  }
+
+ private:
+  const kj::HttpHeaderTable& headerTable;
+  bool abruptAfterFirstMessage;
+
+  kj::Promise<void> echo(kj::WebSocket& ws) {
+    for (;;) {
+      auto message = co_await ws.receive();
+      KJ_SWITCH_ONEOF(message) {
+        KJ_CASE_ONEOF(text, kj::String) {
+          co_await ws.send(kj::StringPtr(text));
+          // Returning drops the WebSocket, which tears the connection down with no close frame.
+          if (abruptAfterFirstMessage) co_return;
+        }
+        KJ_CASE_ONEOF(data, kj::Array<kj::byte>) {
+          co_await ws.send(data.asPtr());
+        }
+        KJ_CASE_ONEOF(close, kj::WebSocket::Close) {
+          co_await ws.close(close.code, close.reason);
+          co_return;
+        }
+      }
+    }
+  }
+};
+
 class TestPort final: public rpc::Container::Port::Server, private kj::TaskSet::ErrorHandler {
  public:
   TestPort(capnp::ByteStreamFactory& byteStreamFactory,
@@ -345,13 +450,15 @@ class TestPort final: public rpc::Container::Port::Server, private kj::TaskSet::
       size_t& connectCount,
       kj::Maybe<kj::PromiseFulfiller<void>&> closeFulfiller,
       kj::Maybe<bool&> upEndedUncleanly = kj::none,
-      bool deferConnect = false)
+      bool deferConnect = false,
+      kj::Maybe<kj::ForkedPromise<void>&> releaseBody = kj::none)
       : byteStreamFactory(byteStreamFactory),
         mode(mode),
         connectCount(connectCount),
         closeFulfiller(closeFulfiller),
         upEndedUncleanly(upEndedUncleanly),
         deferConnect(deferConnect),
+        releaseBody(releaseBody),
         tasks(*this) {}
 
   kj::Promise<void> connect(ConnectContext context) override {
@@ -392,7 +499,11 @@ class TestPort final: public rpc::Container::Port::Server, private kj::TaskSet::
       return serve(kj::mv(upPipe.in), kj::mv(down));
     }
     context.getResults().setUp(kj::mv(upCap));
-    tasks.add(serve(kj::mv(upPipe.in), kj::mv(down)));
+    if (mode == ResponseMode::WEBSOCKET_ECHO || mode == ResponseMode::WEBSOCKET_ABRUPT_CLOSE) {
+      tasks.add(serveWebSocket(kj::mv(upPipe.in), kj::mv(down)));
+    } else {
+      tasks.add(serve(kj::mv(upPipe.in), kj::mv(down)));
+    }
     return kj::READY_NOW;
   }
 
@@ -403,6 +514,11 @@ class TestPort final: public rpc::Container::Port::Server, private kj::TaskSet::
   kj::Maybe<kj::PromiseFulfiller<void>&> closeFulfiller;
   kj::Maybe<bool&> upEndedUncleanly;
   bool deferConnect;
+  // Fires when a BLOCKED_BODY response should finish sending. Forked so serve() can take a branch.
+  kj::Maybe<kj::ForkedPromise<void>&> releaseBody;
+  kj::TimerImpl wsTimer{kj::origin<kj::TimePoint>()};
+  kj::HttpHeaderTable wsHeaderTable;
+  WebSocketEchoService wsService{wsHeaderTable, mode == ResponseMode::WEBSOCKET_ABRUPT_CLOSE};
   kj::TaskSet tasks;
   kj::Maybe<kj::Own<capnp::ExplicitEndOutputStream>> heldDown;
 
@@ -431,6 +547,16 @@ class TestPort final: public rpc::Container::Port::Server, private kj::TaskSet::
       }
     }
     co_return true;
+  }
+
+  // `wsTimer`, `wsHeaderTable` and `wsService` are members rather than locals because HttpServer
+  // holds them by reference for as long as it is serving, and the serving promise outlives this
+  // call. They are declared before `tasks`, so they are destroyed after it.
+  kj::Promise<void> serveWebSocket(
+      kj::Own<kj::AsyncInputStream> input, kj::Own<capnp::ExplicitEndOutputStream> down) {
+    auto server = kj::heap<kj::HttpServer>(wsTimer, wsHeaderTable, wsService);
+    auto stream = kj::heap<JoinedTunnelStream>(kj::mv(input), kj::mv(down));
+    return server->listenHttp(kj::mv(stream)).attach(kj::mv(server));
   }
 
   kj::Promise<void> serve(
@@ -462,9 +588,17 @@ class TestPort final: public rpc::Container::Port::Server, private kj::TaskSet::
           notifyClose();
           // Intentionally omit end() to simulate an unclean capability drop.
           co_return;
+        case ResponseMode::BLOCKED_BODY:
+          co_await down->write("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n"_kjb);
+          co_await KJ_ASSERT_NONNULL(releaseBody, "BLOCKED_BODY needs a release signal")
+              .addBranch();
+          co_await down->write("done"_kjb);
+          break;
         case ResponseMode::CONNECT_FAILURE:
         case ResponseMode::UPSTREAM_FAILURE:
         case ResponseMode::UPSTREAM_END_FAILURE:
+        case ResponseMode::WEBSOCKET_ECHO:
+        case ResponseMode::WEBSOCKET_ABRUPT_CLOSE:
           KJ_UNREACHABLE;
         case ResponseMode::MALFORMED_KEEP_OPEN:
           co_await down->write("not an HTTP response\r\n\r\n"_kjb);
@@ -495,13 +629,15 @@ class TestContainerServer final: public rpc::Container::Server {
       size_t& connectCount,
       kj::Maybe<kj::PromiseFulfiller<void>&> closeFulfiller = kj::none,
       kj::Maybe<bool&> upEndedUncleanly = kj::none,
-      bool deferConnect = false)
+      bool deferConnect = false,
+      kj::Maybe<kj::ForkedPromise<void>&> releaseBody = kj::none)
       : byteStreamFactory(byteStreamFactory),
         mode(mode),
         connectCount(connectCount),
         closeFulfiller(closeFulfiller),
         upEndedUncleanly(upEndedUncleanly),
-        deferConnect(deferConnect) {}
+        deferConnect(deferConnect),
+        releaseBody(releaseBody) {}
 
   kj::Promise<void> start(StartContext context) override {
     return kj::READY_NOW;
@@ -512,8 +648,8 @@ class TestContainerServer final: public rpc::Container::Server {
   }
 
   kj::Promise<void> getTcpPort(GetTcpPortContext context) override {
-    context.getResults().setPort(kj::heap<TestPort>(
-        byteStreamFactory, mode, connectCount, closeFulfiller, upEndedUncleanly, deferConnect));
+    context.getResults().setPort(kj::heap<TestPort>(byteStreamFactory, mode, connectCount,
+        closeFulfiller, upEndedUncleanly, deferConnect, releaseBody));
     return kj::READY_NOW;
   }
 
@@ -524,6 +660,33 @@ class TestContainerServer final: public rpc::Container::Server {
   kj::Maybe<kj::PromiseFulfiller<void>&> closeFulfiller;
   kj::Maybe<bool&> upEndedUncleanly;
   bool deferConnect;
+  kj::Maybe<kj::ForkedPromise<void>&> releaseBody;
+};
+
+// Response that reports when the headers arrive, separately from when the exchange finishes. Used
+// to observe the window between the two, which is where deferred proxying drops the IncomingRequest.
+class HeaderSignalResponse final: public kj::HttpService::Response {
+ public:
+  explicit HeaderSignalResponse(kj::PromiseFulfiller<void>& headersFulfiller)
+      : headersFulfiller(headersFulfiller) {}
+
+  kj::Own<kj::AsyncOutputStream> send(uint statusCode,
+      kj::StringPtr statusText,
+      const kj::HttpHeaders& headers,
+      kj::Maybe<uint64_t> expectedBodySize) override {
+    this->statusCode = statusCode;
+    headersFulfiller.fulfill();
+    return kj::heap<kj::NullStream>();
+  }
+
+  kj::Own<kj::WebSocket> acceptWebSocket(const kj::HttpHeaders& headers) override {
+    KJ_UNREACHABLE;
+  }
+
+  uint statusCode = 0;
+
+ private:
+  kj::PromiseFulfiller<void>& headersFulfiller;
 };
 
 class TestResponse final: public kj::HttpService::Response {
@@ -617,6 +780,38 @@ void runTunnelTest(ResponseMode mode,
 TestFixture makeFixture() {
   return TestFixture(TestFixture::SetupParams{
     .useRealTimers = false,
+    .requestObserverFactory = kj::Function<kj::Own<RequestObserver>()>(
+        []() -> kj::Own<RequestObserver> { return kj::refcounted<TracingRequestObserver>(); }),
+  });
+}
+
+// Records the RequestTracker transitions that drive hibernation. `active()` fires on 0 -> 1 and
+// `inactive()` on 1 -> 0, so the counts also tell us whether transitions were coalesced.
+class RecordingTrackerHooks final: public RequestTracker::Hooks {
+ public:
+  void active() override {
+    ++activeCount;
+  }
+  void inactive() override {
+    ++inactiveCount;
+  }
+
+  uint activeCount = 0;
+  uint inactiveCount = 0;
+};
+
+// A fixture whose IoContext has an actor carrying `tracker`. The plain makeFixture() has no actor
+// at all, which is the "no actor to pin" case; these tests need one so that
+// Worker::Actor::addRef() produces a RequestTracker::ActiveRequest.
+//
+// Note the fixture's IncomingRequest is built directly rather than via WorkerEntrypoint, so it
+// holds no actor reference of its own. The tracker therefore starts inactive and reflects only
+// what the code under test pins.
+TestFixture makeActorFixture(RequestTracker& tracker) {
+  return TestFixture(TestFixture::SetupParams{
+    .actorId = Worker::Actor::Id(kj::str("container-pin-test")),
+    .useRealTimers = false,
+    .actorRequestTracker = tracker,
     .requestObserverFactory = kj::Function<kj::Own<RequestObserver>()>(
         []() -> kj::Own<RequestObserver> { return kj::refcounted<TracingRequestObserver>(); }),
   });
@@ -1502,6 +1697,749 @@ KJ_TEST("Container request errors do not wait for open tunnel pumps") {
 
   KJ_EXPECT(rejected);
   KJ_EXPECT(connectCount == 1);
+}
+
+// =======================================================================================
+// Actor pinning.
+//
+// A container tunnel is bound to the actor: the rpc::Container::Client it derives from is owned by
+// Worker::Actor::Impl and arrives on the actor-start RPC, so hibernating the actor revokes the
+// tunnel mid-stream. Hibernation is driven by RequestTracker reaching zero active requests, and
+// deferred proxying releases the IncomingRequest -- the thing that normally holds the actor active
+// -- as soon as the response headers are through. So each open connection must hold the actor
+// active itself, and must stop doing so promptly when the connection ends, however it ends.
+//
+// Each test below runs with the pin gate both on and off, and asserts the opposite outcome in each
+// case. The gate-off runs are what stop these tests from passing vacuously: the actor ref used to
+// be held for the WorkerInterface's whole lifetime, which made assertions like "is the actor
+// pinned while a request is in flight" true whether or not the pin mechanism worked at all.
+
+// True iff the gate is on. Keeps the expectations below readable.
+bool pinned(ActorPinGate gate) {
+  return gate == ActorPinGate::ENABLED;
+}
+
+// Runs a plain fetch through a container TCP port and checks the actor is pinned for the exchange
+// and released afterwards. Covers both the pooled and non-pooled tunnel paths, which are separate
+// call sites in TcpPortWorkerInterface::request().
+void runFetchPinTest(TunnelReuseGate gate, ActorPinGate pinGate) {
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(gate, pinGate);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  KJ_EXPECT(!tracker->isActive(), "the fixture itself must not pin the actor");
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    auto container =
+        env.js.alloc<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
+                                    byteStreamFactory, ResponseMode::KEEP_ALIVE, connectCount)),
+            true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    auto promise = makeTestRequest(*client, headerTable);
+    KJ_EXPECT(tracker->isActive() == pinned(pinGate));
+
+    return promise.attach(kj::mv(client), kj::mv(fetcher), kj::mv(container));
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(!tracker->isActive(), "the pin must be released once the exchange completes");
+  KJ_EXPECT(hooks.activeCount == (pinned(pinGate) ? 1 : 0));
+  KJ_EXPECT(hooks.inactiveCount == (pinned(pinGate) ? 1 : 0));
+}
+
+KJ_TEST("Container fetch pins the actor for a pooled tunnel") {
+  runFetchPinTest(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+}
+
+KJ_TEST("Container fetch does not pin a pooled tunnel when gated off") {
+  runFetchPinTest(TunnelReuseGate::ENABLED, ActorPinGate::DISABLED);
+}
+
+KJ_TEST("Container fetch pins the actor for a non-pooled tunnel") {
+  runFetchPinTest(TunnelReuseGate::DISABLED, ActorPinGate::ENABLED);
+}
+
+KJ_TEST("Container fetch does not pin a non-pooled tunnel when gated off") {
+  runFetchPinTest(TunnelReuseGate::DISABLED, ActorPinGate::DISABLED);
+}
+
+// What happens to the pin between "headers delivered" and "body finished".
+enum class BlockedBodyEnding { COMPLETES, CANCELLED };
+
+// The case the whole change exists for. In production, deferred proxying releases the
+// IncomingRequest -- the thing that normally keeps the actor active -- as soon as the response
+// headers are through. If the pin were released at the same point, the actor could hibernate while
+// the body was still streaming and the tunnel would die mid-response. Every other fetch test here
+// uses a 2-byte body that completes immediately, so none of them can see this window at all.
+void runBlockedBodyPinTest(TunnelReuseGate gate, BlockedBodyEnding ending) {
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(gate, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto release = kj::newPromiseAndFulfiller<void>();
+    auto releaseForked = release.promise.fork();
+    auto headers1 = kj::newPromiseAndFulfiller<void>();
+
+    auto container = env.js.alloc<Container>(
+        rpc::Container::Client(kj::heap<TestContainerServer>(byteStreamFactory,
+            ResponseMode::BLOCKED_BODY, connectCount, kj::none, kj::none, false, releaseForked)),
+        true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    kj::HttpHeaders headers(headerTable);
+    kj::NullStream requestBody;
+    HeaderSignalResponse response(*headers1.fulfiller);
+
+    auto requestPromise = client->request(
+        kj::HttpMethod::GET, "http://container/"_kj, headers, requestBody, response);
+
+    // Wait for the headers to arrive. The body is still blocked at the container.
+    co_await kj::mv(headers1.promise);
+    KJ_EXPECT(response.statusCode == 200);
+    KJ_EXPECT(tracker->isActive(),
+        "the pin must outlive the response headers -- this is the deferred-proxying window");
+
+    if (ending == BlockedBodyEnding::CANCELLED) {
+      // Abandoning the fetch mid-body must release the pin, not strand it.
+      requestPromise = nullptr;
+      KJ_EXPECT(!tracker->isActive(), "cancelling mid-body must release the pin");
+    } else {
+      release.fulfiller->fulfill();
+      co_await requestPromise;
+      KJ_EXPECT(!tracker->isActive(), "completing the body must release the pin");
+    }
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(hooks.activeCount == 1);
+  KJ_EXPECT(hooks.inactiveCount == 1);
+}
+
+KJ_TEST("Container fetch holds the pin across a blocked body, pooled") {
+  runBlockedBodyPinTest(TunnelReuseGate::ENABLED, BlockedBodyEnding::COMPLETES);
+}
+
+KJ_TEST("Container fetch holds the pin across a blocked body, non-pooled") {
+  runBlockedBodyPinTest(TunnelReuseGate::DISABLED, BlockedBodyEnding::COMPLETES);
+}
+
+KJ_TEST("Container fetch releases the pin when cancelled mid-body, pooled") {
+  runBlockedBodyPinTest(TunnelReuseGate::ENABLED, BlockedBodyEnding::CANCELLED);
+}
+
+KJ_TEST("Container fetch releases the pin when cancelled mid-body, non-pooled") {
+  runBlockedBodyPinTest(TunnelReuseGate::DISABLED, BlockedBodyEnding::CANCELLED);
+}
+
+KJ_TEST("Container fetch does not pin when there is no actor") {
+  // getTcpPort() is only reachable from a Durable Object today, but TcpPortWorkerInterface must not
+  // assume that: IoContext::getActor() returns none outside an actor, and the pin is simply absent.
+  // makeFixture() builds an actor-less IoContext, so this exercises that path with the gate on.
+  auto fixture = makeFixture();
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) {
+    KJ_EXPECT(env.context.getActor() == kj::none);
+    auto container =
+        env.js.alloc<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
+                                    byteStreamFactory, ResponseMode::KEEP_ALIVE, connectCount)),
+            true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    return makeTestRequest(*client, env.context.getHeaderTable())
+        .attach(kj::mv(client), kj::mv(fetcher), kj::mv(container));
+  });
+
+  KJ_EXPECT(connectCount == 1);
+}
+
+// Which side ends a raw tunnel. The pin must be released either way: the actor is pinned to protect
+// a connection that is in use, so anything that ends the connection must end the pin, and neither
+// case may depend on the JS Socket object being dropped or garbage collected.
+enum class TunnelCloser { CONTAINER, CLIENT };
+
+void runConnectPinTest(ActorPinGate pinGate, TunnelCloser closer) {
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, pinGate);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  // When the container is the one to close, it disconnects after the first request; when the client
+  // closes, the container would happily stay open forever.
+  auto mode = closer == TunnelCloser::CONTAINER ? ResponseMode::TRUNCATED_DISCONNECT
+                                                : ResponseMode::KEEP_ALIVE;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = env.js.alloc<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
+                                                 byteStreamFactory, mode, connectCount)),
+        true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    auto pipe = kj::newTwoWayPipe();
+    TestConnectResponse response;
+    kj::NullStream discard;
+    kj::HttpHeaders headers(headerTable);
+    kj::HttpConnectSettings settings{.useTls = false};
+
+    auto connectPromise =
+        client->connect("container"_kjc, headers, *pipe.ends[0], response, settings);
+    KJ_EXPECT(tracker->isActive() == pinned(pinGate), "an open tunnel must pin iff gated on");
+
+    if (closer == TunnelCloser::CONTAINER) {
+      // Drive both directions because the pipe is unbuffered.
+      auto driveRequest =
+          pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb).then([]() -> kj::Promise<void> {
+        return kj::NEVER_DONE;
+      });
+      auto drainResponse = pipe.ends[1]->pumpTo(discard).then(
+          [](uint64_t) -> kj::Promise<void> { return kj::NEVER_DONE; });
+
+      bool threw = false;
+      try {
+        co_await connectPromise.exclusiveJoin(kj::mv(driveRequest))
+            .exclusiveJoin(kj::mv(drainResponse));
+      } catch (...) {
+        auto exception = kj::getCaughtExceptionAsKj();
+        // Validate the *kind* of failure. A bare catch(...) would also accept, say, a graceful
+        // close being misreported, or a mock bug -- which matters here because connectImpl() races
+        // clean completion against rejectWhenDisconnected().
+        KJ_EXPECT(exception.getType() == kj::Exception::Type::DISCONNECTED, exception);
+        threw = true;
+      }
+      KJ_EXPECT(threw, "expected the container's disconnect to fail connect()");
+      KJ_EXPECT(response.accepted);
+    } else {
+      // Complete a real round trip first, so the tunnel is definitely open and the pin definitely
+      // taken. Awaiting our own reads and writes is what lets the event loop turn and the tunnel
+      // get established; connectPromise resumes on the loop even though nobody awaits it.
+      co_await pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb);
+      char buffer[64];
+      auto amount = co_await pipe.ends[1]->tryRead(buffer, 1, kj::size(buffer));
+      KJ_EXPECT(amount > 0, "expected the container to respond before we abandon the tunnel");
+      KJ_EXPECT(tracker->isActive() == pinned(pinGate), "still open, so still pinned");
+
+      // Now abandon it from this side. Cancelling destroys connectImpl()'s frame, which is what
+      // must drop the pin -- note there is no JS Socket here to be collected, which is the point:
+      // release must not depend on one.
+      connectPromise = nullptr;
+    }
+
+    KJ_EXPECT(!tracker->isActive(), "the pin must be gone as soon as the tunnel ends");
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(!tracker->isActive());
+  KJ_EXPECT(hooks.activeCount == (pinned(pinGate) ? 1 : 0));
+  KJ_EXPECT(hooks.inactiveCount == (pinned(pinGate) ? 1 : 0));
+}
+
+KJ_TEST("Container connect() unpins the actor when the container closes") {
+  runConnectPinTest(ActorPinGate::ENABLED, TunnelCloser::CONTAINER);
+}
+
+KJ_TEST("Container connect() unpins the actor when the client closes") {
+  runConnectPinTest(ActorPinGate::ENABLED, TunnelCloser::CLIENT);
+}
+
+KJ_TEST("Container connect() resolves cleanly when both directions close") {
+  // Regression test for connectImpl(). Both pump tasks used to end in kj::NEVER_DONE, so the join
+  // could only ever complete by *failing*: a fully clean close never resolved connect() at all,
+  // the coroutine never reached co_return, and its locals -- including the pin -- were never
+  // destroyed. This test asserts the clean path both resolves and releases.
+  //
+  // It also covers the race introduced by resolving on the clean path: connectImpl() now does
+  // cleanClose.exclusiveJoin(portStream.rejectWhenDisconnected()), and the container drops its
+  // capability as part of closing. If the disconnect could win that race, this test would fail
+  // intermittently, so it is worth running at a high --runs_per_test.
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = env.js.alloc<Container>(
+        rpc::Container::Client(kj::heap<TestContainerServer>(
+            byteStreamFactory, ResponseMode::CLOSE_AFTER_RESPONSE, connectCount)),
+        true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    auto pipe = kj::newTwoWayPipe();
+    TestConnectResponse response;
+    kj::HttpHeaders headers(headerTable);
+    kj::HttpConnectSettings settings{.useTls = false};
+
+    auto connectPromise =
+        client->connect("container"_kjc, headers, *pipe.ends[0], response, settings);
+    KJ_EXPECT(tracker->isActive());
+
+    // Half-close our side so the up pump reaches EOF; the container ends the down direction after
+    // responding. Both directions closing cleanly is what makes connectImpl() resolve rather than
+    // fail, and draining to EOF is what lets the down pump finish.
+    co_await pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb);
+    pipe.ends[1]->shutdownWrite();
+
+    kj::NullStream discard;
+    co_await pipe.ends[1]->pumpTo(discard);
+
+    // Must not throw: this is a graceful close, and reporting it as a disconnect would surface a
+    // spurious socket error to the DO.
+    co_await kj::mv(connectPromise);
+
+    KJ_EXPECT(!tracker->isActive(), "a clean close must release the pin");
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(hooks.activeCount == 1);
+  KJ_EXPECT(hooks.inactiveCount == 1);
+}
+
+KJ_TEST("Container connect() unpins when the tunnel closes, not when the socket is dropped") {
+  // The distinction this test exists for: "the tunnel closed" and "JS dropped the Socket" are
+  // different events, potentially far apart. A DO can hold a Socket in a Map long after the remote
+  // end has gone away, and IoOwn teardown additionally waits on V8 collecting the wrapper.
+  //
+  // Attaching the pin to the connect promise (promise.attach(pin)) ties its release to the *later*
+  // event, because a promise's attachments are destroyed when the promise node is destroyed, not
+  // when the promise settles -- and kj's connect adapter attaches that node to the returned stream
+  // (kj/compat/http.c++:7124), which the Socket owns via IoOwn. Holding the pin as a local in
+  // connectImpl()'s coroutine body ties it to the earlier event instead, because coroutine locals
+  // are destroyed at co_return.
+  //
+  // The promise is held in a variable and never awaited, which is what the real system does: the
+  // stream owns it as a plain attachment and the coroutine inside progresses on the event loop.
+  // (fork() does NOT model this -- ForkHub drops the inner node once it settles, keeping only the
+  // result, so attachments are released at settle time and the distinction disappears.)
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto paf = kj::newPromiseAndFulfiller<void>();
+    auto container = env.js.alloc<Container>(
+        rpc::Container::Client(kj::heap<TestContainerServer>(
+            byteStreamFactory, ResponseMode::TRUNCATED_DISCONNECT, connectCount, *paf.fulfiller)),
+        true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    auto pipe = kj::newTwoWayPipe();
+    TestConnectResponse response;
+    kj::HttpHeaders headers(headerTable);
+    kj::HttpConnectSettings settings{.useTls = false};
+
+    // Never awaited, never cancelled: this stands in for the Socket holding the promise.
+    auto connectPromise =
+        client->connect("container"_kjc, headers, *pipe.ends[0], response, settings);
+    KJ_EXPECT(tracker->isActive(), "an open tunnel must pin the actor");
+
+    // Drive the request and wait for the container to report that it has disconnected. Awaiting
+    // our own I/O is what lets the event loop turn, which is what lets connectImpl() make progress.
+    // The response has to be drained concurrently: the pipe is unbuffered, so otherwise the
+    // container blocks writing its reply and never gets as far as disconnecting.
+    kj::NullStream discard;
+    auto drainResponse = pipe.ends[1]->pumpTo(discard).then(
+        [](uint64_t) -> kj::Promise<void> { return kj::NEVER_DONE; });
+    co_await pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb);
+    co_await paf.promise.exclusiveJoin(kj::mv(drainResponse));
+
+    // Let the disconnect propagate into connectImpl(). Bounded by event-loop turns rather than
+    // wall-clock time, so this is deterministic: with the pin held as a coroutine local it is
+    // released within a turn or two of the pumps failing; if it were attached to the promise node
+    // instead, `connectPromise` still owns that node here and it would never be released.
+    for (uint i = 0; i < 100 && tracker->isActive(); ++i) {
+      co_await kj::evalLater([]() {});
+    }
+
+    KJ_EXPECT(!tracker->isActive(),
+        "the pin must be released when the tunnel closes, not when the socket is dropped");
+
+    // Only now drop the promise, i.e. the socket.
+    connectPromise = nullptr;
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(hooks.activeCount == 1);
+  KJ_EXPECT(hooks.inactiveCount == 1);
+}
+
+KJ_TEST("Container connect() unpins after both sides close cleanly") {
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = env.js.alloc<Container>(
+        rpc::Container::Client(kj::heap<TestContainerServer>(
+            byteStreamFactory, ResponseMode::CLOSE_AFTER_RESPONSE, connectCount)),
+        true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    auto pipe = kj::newTwoWayPipe();
+    TestConnectResponse response;
+    kj::HttpHeaders headers(headerTable);
+    kj::HttpConnectSettings settings{.useTls = false};
+
+    // Keep the promise alive after both halves close, just as a retained JS Socket keeps the
+    // underlying connection alive after reaching EOF.
+    auto connectPromise =
+        client->connect("container"_kjc, headers, *pipe.ends[0], response, settings);
+    KJ_EXPECT(tracker->isActive());
+
+    co_await pipe.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb);
+    pipe.ends[1]->shutdownWrite();
+
+    kj::NullStream discard;
+    co_await pipe.ends[1]->pumpTo(discard);
+
+    for (uint i = 0; i < 100 && tracker->isActive(); ++i) {
+      co_await kj::evalLater([]() {});
+    }
+
+    KJ_EXPECT(!tracker->isActive(),
+        "both clean half-closes must release the pin before the socket is dropped");
+    connectPromise = nullptr;
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(hooks.activeCount == 1);
+  KJ_EXPECT(hooks.inactiveCount == 1);
+}
+
+KJ_TEST("Container connect() does not pin when gated off, container closes") {
+  runConnectPinTest(ActorPinGate::DISABLED, TunnelCloser::CONTAINER);
+}
+
+KJ_TEST("Container connect() does not pin when gated off, client closes") {
+  runConnectPinTest(ActorPinGate::DISABLED, TunnelCloser::CLIENT);
+}
+
+// Every failure path must release the pin too. The mechanism is that connectImpl()/request() hold
+// the pin in a coroutine local, so it is destroyed on throw as well as on normal return -- but that
+// is exactly the kind of claim that deserves a test per path rather than one argument.
+void runFetchFailurePinTest(ResponseMode mode) {
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = env.js.alloc<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
+                                                 byteStreamFactory, mode, connectCount)),
+        true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    bool threw = false;
+    try {
+      co_await makeTestRequest(*client, headerTable);
+    } catch (...) {
+      threw = true;
+    }
+    KJ_EXPECT(threw, "expected the fetch to fail");
+
+    for (uint i = 0; i < 100 && tracker->isActive(); ++i) {
+      co_await kj::evalLater([]() {});
+    }
+    KJ_EXPECT(!tracker->isActive(), "a failed fetch must not leak the pin");
+  });
+
+  KJ_EXPECT(hooks.inactiveCount == hooks.activeCount, "every pin taken must have been released");
+}
+
+KJ_TEST("Container fetch does not leak the pin when the tunnel fails to open") {
+  runFetchFailurePinTest(ResponseMode::CONNECT_FAILURE);
+}
+
+KJ_TEST("Container fetch does not leak the pin when the upstream write fails") {
+  runFetchFailurePinTest(ResponseMode::UPSTREAM_FAILURE);
+}
+
+KJ_TEST("Container fetch does not leak the pin on a malformed response") {
+  runFetchFailurePinTest(ResponseMode::MALFORMED_KEEP_OPEN);
+}
+
+KJ_TEST("Container connect() does not leak the pin when the upstream half-close fails") {
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = env.js.alloc<Container>(
+        rpc::Container::Client(kj::heap<TestContainerServer>(
+            byteStreamFactory, ResponseMode::UPSTREAM_END_FAILURE, connectCount)),
+        true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    auto pipe = kj::newTwoWayPipe();
+    TestConnectResponse response;
+    kj::HttpHeaders headers(headerTable);
+    kj::HttpConnectSettings settings{.useTls = false};
+
+    auto connectPromise =
+        client->connect("container"_kjc, headers, *pipe.ends[0], response, settings);
+    KJ_EXPECT(tracker->isActive());
+
+    auto closeWrite = pipe.ends[1]->write("request"_kjb).then([&pipe]() -> kj::Promise<void> {
+      pipe.ends[1]->shutdownWrite();
+      return kj::NEVER_DONE;
+    });
+
+    bool threw = false;
+    try {
+      co_await connectPromise.exclusiveJoin(kj::mv(closeWrite));
+    } catch (...) {
+      auto exception = kj::getCaughtExceptionAsKj();
+      KJ_EXPECT(exception.getDescription() == "jsg.Error: Upstream end failed", exception);
+      threw = true;
+    }
+    KJ_EXPECT(threw, "expected the upstream half-close to fail connect()");
+    KJ_EXPECT(!tracker->isActive(), "a failed half-close must not leak the pin");
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(hooks.activeCount == 1);
+  KJ_EXPECT(hooks.inactiveCount == 1);
+}
+
+KJ_TEST("Container does not leak the pin when a WebSocket handshake fails") {
+  // The container answers a plain 200 instead of upgrading, so openWebSocket() yields a body rather
+  // than a WebSocket. The exchange still has to release the pin.
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container =
+        env.js.alloc<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
+                                    byteStreamFactory, ResponseMode::KEEP_ALIVE, connectCount)),
+            true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    auto httpClient = kj::newHttpClient(*client);
+    kj::HttpHeaders headers(headerTable);
+    auto response = co_await httpClient->openWebSocket("http://container/"_kj, headers);
+    KJ_EXPECT(response.statusCode == 200, "expected the upgrade to be refused");
+    KJ_EXPECT(response.webSocketOrBody.is<kj::Own<kj::AsyncInputStream>>());
+
+    // Drain the body so the exchange finishes.
+    auto& body =
+        KJ_ASSERT_NONNULL(response.webSocketOrBody.tryGet<kj::Own<kj::AsyncInputStream>>());
+    kj::NullStream discard;
+    co_await body->pumpTo(discard);
+
+    for (uint i = 0; i < 100 && tracker->isActive(); ++i) {
+      co_await kj::evalLater([]() {});
+    }
+    KJ_EXPECT(!tracker->isActive(), "a refused upgrade must not leak the pin");
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(hooks.activeCount == 1);
+  KJ_EXPECT(hooks.inactiveCount == 1);
+}
+
+KJ_TEST("Container pins the actor once for concurrent connections on one port") {
+  // newSingleUseClient() runs per operation (api/http.c++:2532), so each connection carries its own
+  // pin and activeRequests counts them. RequestTracker only fires its hooks on the 0->1 and 1->0
+  // edges, so N concurrent connections must produce exactly one active()/inactive() pair, and the
+  // actor must stay pinned until the *last* connection closes -- not the first.
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, ActorPinGate::ENABLED);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container =
+        env.js.alloc<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
+                                    byteStreamFactory, ResponseMode::KEEP_ALIVE, connectCount)),
+            true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto& headerTable = env.context.getHeaderTable();
+    kj::HttpHeaders headers(headerTable);
+    kj::HttpConnectSettings settings{.useTls = false};
+
+    // Two separate getClient() calls, i.e. two separate WorkerInterfaces, i.e. two separate pins.
+    auto client1 = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto client2 = fetcher->getClient(env.context, kj::none, "container"_kjc);
+
+    auto pipe1 = kj::newTwoWayPipe();
+    auto pipe2 = kj::newTwoWayPipe();
+    TestConnectResponse response1;
+    TestConnectResponse response2;
+
+    auto connect1 = client1->connect("container"_kjc, headers, *pipe1.ends[0], response1, settings);
+    auto connect2 = client2->connect("container"_kjc, headers, *pipe2.ends[0], response2, settings);
+    KJ_EXPECT(tracker->isActive());
+
+    // Complete a round trip on each so both tunnels are genuinely open.
+    char buffer[64];
+    co_await pipe1.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb);
+    KJ_EXPECT(co_await pipe1.ends[1]->tryRead(buffer, 1, kj::size(buffer)) > 0);
+    co_await pipe2.ends[1]->write("GET / HTTP/1.1\r\n\r\n"_kjb);
+    KJ_EXPECT(co_await pipe2.ends[1]->tryRead(buffer, 1, kj::size(buffer)) > 0);
+
+    KJ_EXPECT(connectCount == 2, "each raw connect() opens its own tunnel");
+    KJ_EXPECT(hooks.activeCount == 1, "two connections, but only one 0->1 edge");
+
+    // Close the first. Note we deliberately keep client1 alive: the pin was moved out of it into
+    // connectImpl()'s frame, so dropping the promise alone must be enough to release one count.
+    connect1 = nullptr;
+    KJ_EXPECT(tracker->isActive(), "the second connection must still hold the actor");
+    KJ_EXPECT(hooks.inactiveCount == 0, "releasing one of two must not fire inactive()");
+
+    connect2 = nullptr;
+    KJ_EXPECT(!tracker->isActive(), "the last connection closing must release the actor");
+  });
+
+  KJ_EXPECT(hooks.activeCount == 1);
+  KJ_EXPECT(hooks.inactiveCount == 1);
+}
+
+// How a WebSocket session ends.
+enum class WebSocketEnding {
+  CLEAN_CLOSE,    // close handshake completes
+  REMOTE_ABRUPT,  // container drops the socket with no close frame
+  CLIENT_ABANDON  // we drop our end without closing
+};
+
+void runWebSocketPinTest(ActorPinGate pinGate, WebSocketEnding ending) {
+  RecordingTrackerHooks hooks;
+  auto tracker = kj::refcounted<RequestTracker>(hooks);
+  auto fixture = makeActorFixture(*tracker);
+  AutogateScope autogateScope(TunnelReuseGate::ENABLED, pinGate);
+  capnp::ByteStreamFactory byteStreamFactory;
+  size_t connectCount = 0;
+
+  auto mode = ending == WebSocketEnding::REMOTE_ABRUPT ? ResponseMode::WEBSOCKET_ABRUPT_CLOSE
+                                                       : ResponseMode::WEBSOCKET_ECHO;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto container = env.js.alloc<Container>(rpc::Container::Client(kj::heap<TestContainerServer>(
+                                                 byteStreamFactory, mode, connectCount)),
+        true);
+    auto fetcher = container->getTcpPort(env.js, 8080);
+    auto client = fetcher->getClient(env.context, kj::none, "container"_kjc);
+    auto& headerTable = env.context.getHeaderTable();
+
+    // Drive the handshake through kj's HttpClient-over-HttpService adapter rather than a hand-built
+    // Response: the upgrade takes a round trip, so the accepted WebSocket only exists after a
+    // co_await, and the adapter is what knows how to wait for it. It also owns the outstanding
+    // request(), which is what holds the pin.
+    auto httpClient = kj::newHttpClient(*client);
+
+    kj::HttpHeaders headers(headerTable);
+    auto response = co_await httpClient->openWebSocket("http://container/"_kj, headers);
+    KJ_EXPECT(response.statusCode == 101);
+    auto ws = kj::mv(KJ_ASSERT_NONNULL(
+        response.webSocketOrBody.tryGet<kj::Own<kj::WebSocket>>(), "expected a WebSocket upgrade"));
+
+    // Prove the session really works before asserting anything about the pin, so that a broken
+    // handshake is reported as such rather than as a spurious pinning failure.
+    co_await ws->send("ping"_kj);
+    auto echoed = co_await ws->receive();
+    KJ_EXPECT(KJ_ASSERT_NONNULL(echoed.tryGet<kj::String>()) == "ping"_kj);
+
+    // The HTTP exchange is long over but the session is open: this is the window in which
+    // hibernation used to kill the tunnel.
+    KJ_EXPECT(tracker->isActive() == pinned(pinGate));
+
+    switch (ending) {
+      case WebSocketEnding::CLEAN_CLOSE: {
+        co_await ws->close(1000, "done"_kj);
+        auto closeMessage = co_await ws->receive();
+        KJ_EXPECT(closeMessage.is<kj::WebSocket::Close>());
+        break;
+      }
+      case WebSocketEnding::REMOTE_ABRUPT: {
+        // The container has already dropped its end. Reading surfaces the disconnect.
+        try {
+          co_await ws->receive();
+        } catch (...) {
+          // Expected: the session ended without a close frame.
+        }
+        break;
+      }
+      case WebSocketEnding::CLIENT_ABANDON:
+        ws = nullptr;
+        httpClient = nullptr;
+        break;
+    }
+
+    // Deliberately still holding `ws` and `httpClient` in the first two cases. Releasing the pin
+    // must follow from the *session* ending, not from us dropping the objects that own it -- the
+    // same distinction as tunnel-closed versus socket-dropped on the connect() path. Bounded by
+    // event-loop turns so the teardown can propagate.
+    for (uint i = 0; i < 100 && tracker->isActive(); ++i) {
+      co_await kj::evalLater([]() {});
+    }
+    KJ_EXPECT(!tracker->isActive(), "the pin must be released when the session ends");
+  });
+
+  KJ_EXPECT(connectCount == 1);
+  KJ_EXPECT(hooks.activeCount == (pinned(pinGate) ? 1 : 0));
+  KJ_EXPECT(hooks.inactiveCount == (pinned(pinGate) ? 1 : 0));
+}
+
+KJ_TEST("Container WebSocket unpins the actor after a clean close") {
+  runWebSocketPinTest(ActorPinGate::ENABLED, WebSocketEnding::CLEAN_CLOSE);
+}
+
+KJ_TEST("Container WebSocket unpins the actor when the remote drops abruptly") {
+  runWebSocketPinTest(ActorPinGate::ENABLED, WebSocketEnding::REMOTE_ABRUPT);
+}
+
+KJ_TEST("Container WebSocket unpins the actor when the client abandons it") {
+  runWebSocketPinTest(ActorPinGate::ENABLED, WebSocketEnding::CLIENT_ABANDON);
+}
+
+KJ_TEST("Container WebSocket does not pin when gated off") {
+  runWebSocketPinTest(ActorPinGate::DISABLED, WebSocketEnding::CLEAN_CLOSE);
 }
 
 }  // namespace

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -1334,9 +1334,11 @@ class Container::TcpPortWorkerInterface final: public WorkerInterface {
  public:
   TcpPortWorkerInterface(kj::EntropySource& entropySource,
       const kj::HttpHeaderTable& headerTable,
+      kj::Maybe<kj::Own<Worker::Actor>> actorPin,
       kj::Rc<TcpPortState> portState)
       : entropySource(entropySource),
         headerTable(headerTable),
+        actorPin(kj::mv(actorPin)),
         portState(kj::mv(portState)) {}
 
   // Implements fetch(), i.e., HTTP requests. We form a TCP connection, then run HTTP over it
@@ -1346,6 +1348,11 @@ class Container::TcpPortWorkerInterface final: public WorkerInterface {
       const kj::HttpHeaders& headers,
       kj::AsyncInputStream& requestBody,
       kj::HttpService::Response& response) override {
+    // Held for the whole exchange, then released at co_return. kj's HttpService-over-HttpClient
+    // adapter keeps this promise outstanding until the response body has been pumped, and for an
+    // upgrade until the WebSocket pump ends, so this covers the full session either way.
+    auto pin = kj::mv(actorPin);
+
     // URLs should have been validated earlier in the stack, so parsing the URL should succeed.
     auto parsedUrl = KJ_REQUIRE_NONNULL(kj::Url::tryParse(url, kj::Url::Context::HTTP_PROXY_REQUEST,
                                             {.percentDecode = false, .allowEmpty = true}),
@@ -1387,7 +1394,8 @@ class Container::TcpPortWorkerInterface final: public WorkerInterface {
         "Connecting to a container using TLS is not currently supported. It is unnecessary "
         "anyway, as the connection is already secure by default.");
 
-    auto promise = connectImpl(kj::Own<kj::AsyncIoStream>(&connection, kj::NullDisposer::instance));
+    auto promise = connectImpl(
+        kj::Own<kj::AsyncIoStream>(&connection, kj::NullDisposer::instance), kj::mv(actorPin));
 
     kj::HttpHeaders responseHeaders(headerTable);
     response.accept(200, "OK", responseHeaders);
@@ -1415,26 +1423,41 @@ class Container::TcpPortWorkerInterface final: public WorkerInterface {
  private:
   kj::EntropySource& entropySource;
   const kj::HttpHeaderTable& headerTable;
+
+  // Keeps the owning actor alive for the connection's duration; null when there is no actor or the
+  // pin is gated off. Deferred proxying releases the IncomingRequest once the response headers are
+  // through, so without this the actor can hibernate while a connection is still open -- which the
+  // tunnel does not survive, because the Fetcher getTcpPort() returns and the state behind it are
+  // IoOwn'd to the actor's IoContext. This Own carries a RequestTracker::ActiveRequest, the same
+  // handle an inbound request holds via WorkerEntrypoint.
+  //
+  // request() and connect() move it into a coroutine local, so release follows the connection
+  // ending rather than this object's destruction -- on the connect() path this interface is owned
+  // by the JS Socket, so tying release here would wait for GC.
+  kj::Maybe<kj::Own<Worker::Actor>> actorPin;
+
   kj::Rc<TcpPortState> portState;
 
   // Connect to the port and pump bytes to/from `connection`.
-  kj::Promise<void> connectImpl(kj::Own<kj::AsyncIoStream> connection) {
+  //
+  // `pinParam` becomes a local because coroutine parameters live until the frame is destroyed,
+  // while locals are destroyed at co_return -- and the frame outlives the pump here.
+  kj::Promise<void> connectImpl(
+      kj::Own<kj::AsyncIoStream> connection, kj::Maybe<kj::Own<Worker::Actor>> pinParam) {
+    auto pin = kj::mv(pinParam);
+
     auto portConnection = portState->connectForRawSocket();
     auto& portStream = *portConnection;
 
-    auto downPumpTask =
-        portConnection->pumpTo(*connection).then([&connection](uint64_t) -> kj::Promise<void> {
+    auto downPumpTask = portConnection->pumpTo(*connection).then([&connection](uint64_t) {
       connection->shutdownWrite();
-      return kj::NEVER_DONE;
     });
-    auto upPumpTask = connection->pumpTo(*portConnection)
-                          .then([&portStream](uint64_t) {
+    auto upPumpTask = connection->pumpTo(*portConnection).then([&portStream](uint64_t) {
       return portStream.endWrite();
-    }).then([]() -> kj::Promise<void> { return kj::NEVER_DONE; });
-    auto disconnected = portStream.rejectWhenDisconnected();
+    });
 
-    co_await kj::joinPromisesFailFast(
-        kj::arr(kj::mv(upPumpTask), kj::mv(downPumpTask), kj::mv(disconnected)));
+    auto cleanClose = kj::joinPromisesFailFast(kj::arr(kj::mv(upPumpTask), kj::mv(downPumpTask)));
+    co_await cleanClose.exclusiveJoin(portStream.rejectWhenDisconnected());
   }
 };
 
@@ -1451,11 +1474,20 @@ class Container::TcpPortOutgoingFactory final: public Fetcher::OutgoingFactory {
 
   Result newSingleUseClient(
       kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) override {
+    // Take the actor reference here, where an IoContext is definitely current. request() and
+    // connect() can be invoked from KJ continuations that are no longer inside a context, so they
+    // must not reach for IoContext::current() themselves.
+    kj::Maybe<kj::Own<Worker::Actor>> actorPin;
+    if (util::Autogate::isEnabled(util::AutogateKey::CONTAINER_PORT_ACTOR_PIN)) {
+      actorPin = IoContext::current().getActor().map([](Worker::Actor& a) { return a.addRef(); });
+    }
+
     // At present we have no use for `cfStr`. This factory creates no operation span.
     auto client = IoContext::current().getSubrequestNoChecks(
         [&](auto& tracing, auto& channelFactory) -> kj::Own<WorkerInterface> {
       makeUserSpanParent(tracing);
-      return kj::heap<TcpPortWorkerInterface>(entropySource, headerTable, portState.addRef());
+      return kj::heap<TcpPortWorkerInterface>(
+          entropySource, headerTable, kj::mv(actorPin), portState.addRef());
     }, {.inHouse = false, .wrapMetrics = false});
     return {.client = kj::mv(client), .spanParents = kj::none};
   }

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -397,6 +397,7 @@ TestFixture::TestFixture(SetupParams&& params)
     } else {
       savedActorLoopback = kj::refcounted<MockActorLoopback>();
     }
+    actorRequestTracker = params.actorRequestTracker;
     actor = makeActor(kj::mv(id));
   }
 }
@@ -422,7 +423,7 @@ jsg::Ref<api::DurableObjectStorage> storageFactory(
 
 kj::Own<Worker::Actor> TestFixture::makeActor(Worker::Actor::Id id) {
   auto& loopback = KJ_ASSERT_NONNULL(savedActorLoopback);
-  return kj::refcounted<Worker::Actor>(*worker, /*tracker=*/kj::none, kj::mv(id),
+  return kj::refcounted<Worker::Actor>(*worker, actorRequestTracker, kj::mv(id),
       /*hasTransient=*/false, actorCacheFactory, /*classname=*/kj::none,
       /*props=*/Frankenvalue(), storageFactory, loopback->addRef(), *timerChannel,
       kj::refcounted<ActorObserver>(), kj::none, kj::none);

--- a/src/workerd/tests/test-fixture.h
+++ b/src/workerd/tests/test-fixture.h
@@ -51,6 +51,11 @@ struct TestFixture {
     // to it) via actor.getLoopback(). This way the actor and the HibernationManager share a
     // single Loopback, mirroring production.
     kj::Maybe<kj::Own<Worker::Actor::Loopback>> actorLoopback;
+    // If set, the actor is created with this RequestTracker (only meaningful when actorId is set).
+    // Lets tests observe the active()/inactive() transitions that drive hibernation. Without one,
+    // Worker::Actor::addRef() returns a bare reference that carries no ActiveRequest, so those
+    // transitions never fire. The tracker must outlive the fixture.
+    kj::Maybe<RequestTracker&> actorRequestTracker;
     // If set, called to create the RequestObserver for each IncomingRequest instead of the default
     // no-op base RequestObserver. Lets tests observe metrics hooks (e.g. recording the values
     // passed to setNextSubrequestBodyRewindable()).
@@ -251,6 +256,8 @@ struct TestFixture {
   // where the namespace's Loopback outlives any single actor instance). Held via addRef so we
   // can hand fresh refs to actors as we reconstruct them.
   kj::Maybe<kj::Own<Worker::Actor::Loopback>> savedActorLoopback;
+  // Saved so resetActor() reconstructs the actor with the same tracker. Owned by the caller.
+  kj::Maybe<RequestTracker&> actorRequestTracker;
   capnp::ByteStreamFactory byteStreamFactory;
   kj::HttpHeaderTable::Builder headerTableBuilder;
   ThreadContext::HeaderIdBundle threadContextHeaderBundle;

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -103,6 +103,11 @@ namespace workerd::util {
   V(NODEJS_EXCEPTIONS_RUST)                                                                        \
   /* Reuse HTTP/1.1 tunnels opened by Container.getTcpPort().fetch(). */                           \
   V(CONTAINER_TUNNEL_REUSE)                                                                        \
+  /* Keep the owning Durable Object actor active for as long as a Container.getTcpPort()           \
+     connection is open, so that hibernation cannot destroy the tunnel mid-stream. Gated because   \
+     it makes actors stay resident (and therefore billable) for the life of a container            \
+     connection. When disabled, such a connection could break silently mid-stream. */              \
+  V(CONTAINER_PORT_ACTOR_PIN)                                                                      \
   /* Allow a Socket to be transferred over JS RPC. When disabled, serializing a Socket fails as    \
      though the type were not serializable at all, and an incoming transferred Socket is           \
      rejected. */                                                                                  \


### PR DESCRIPTION
Keep's DO active when a connection to container is being proxied via the DO. 