### PR TITLE
Fix Node global declarations in workers types

### DIFF
--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -483,9 +483,9 @@ declare const scheduler: Scheduler;
 declare const performance: Performance;
 declare const Cloudflare: Cloudflare;
 declare const origin: string;
-declare const Buffer: any;
-declare const process: any;
-declare const global: ServiceWorkerGlobalScope;
+declare var Buffer: any;
+declare var process: any;
+declare var global: ServiceWorkerGlobalScope;
 declare function setImmediate(
   $function: (...param0: any[]) => void,
   ...args: any[]

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -485,9 +485,9 @@ export declare const scheduler: Scheduler;
 export declare const performance: Performance;
 export declare const Cloudflare: Cloudflare;
 export declare const origin: string;
-export declare const Buffer: any;
-export declare const process: any;
-export declare const global: ServiceWorkerGlobalScope;
+export declare var Buffer: any;
+export declare var process: any;
+export declare var global: ServiceWorkerGlobalScope;
 export declare function setImmediate(
   $function: (...param0: any[]) => void,
   ...args: any[]

--- a/types/src/transforms/globals.ts
+++ b/types/src/transforms/globals.ts
@@ -5,6 +5,14 @@
 import assert from "node:assert";
 import ts from "typescript";
 
+// These globals are also declared with `var` by @types/node, so matching that
+// declaration kind allows TypeScript to merge the declarations.
+const NODE_JS_GLOBAL_VAR_DECLARATIONS = new Set([
+  "Buffer",
+  "process",
+  "global",
+]);
+
 // Copies all properties of `ServiceWorkerGlobalScope` and its superclasses into
 // the global scope:
 //
@@ -74,7 +82,8 @@ function createInlineVisitor(
 export function maybeExtractGlobalNode(
   ctx: ts.TransformationContext,
   node: ts.Node,
-  modifiers?: readonly ts.ModifierLike[]
+  modifiers?: readonly ts.ModifierLike[],
+  varDeclarationNames?: ReadonlySet<string>
 ): ts.Statement | undefined {
   if (
     (ts.isMethodSignature(node) || ts.isMethodDeclaration(node)) &&
@@ -106,7 +115,9 @@ export function maybeExtractGlobalNode(
       );
       const varDeclarationList = ctx.factory.createVariableDeclarationList(
         [varDeclaration],
-        ts.NodeFlags.Const // Use `const` instead of `var`
+        varDeclarationNames?.has(node.name.text)
+          ? ts.NodeFlags.None
+          : ts.NodeFlags.Const
       );
       return ctx.factory.createVariableStatement(modifiers, varDeclarationList);
     }
@@ -176,7 +187,12 @@ function createGlobalScopeVisitor(
       ctx.factory.createToken(ts.SyntaxKind.DeclareKeyword),
     ];
     for (const member of node.members) {
-      const maybeNode = maybeExtractGlobalNode(ctx, member, modifiers);
+      const maybeNode = maybeExtractGlobalNode(
+        ctx,
+        member,
+        modifiers,
+        NODE_JS_GLOBAL_VAR_DECLARATIONS
+      );
       if (maybeNode !== undefined) {
         nodes.push(ts.visitNode(maybeNode, inlineVisitor));
       }

--- a/types/test/transforms/globals.spec.ts
+++ b/types/test/transforms/globals.spec.ts
@@ -101,3 +101,38 @@ declare class ServiceWorkerGlobalScope extends B<string> {
 `
   );
 });
+
+test("createGlobalScopeTransformer: emits Node.js globals as var declarations", () => {
+  const source = `declare abstract class Crypto {
+}
+interface ServiceWorkerGlobalScope {
+    Buffer: any;
+    process: any;
+    global: ServiceWorkerGlobalScope;
+    crypto: Crypto;
+}
+`;
+
+  const sourcePath = "/source.ts";
+  const sources = new Map([[sourcePath, source]]);
+  const program = createMemoryProgram(sources);
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(sourcePath);
+  assert(sourceFile !== undefined);
+
+  const result = ts.transform(sourceFile, [
+    createGlobalScopeTransformer(checker),
+  ]);
+  assert.strictEqual(result.transformed.length, 1);
+
+  const output = printer.printFile(result.transformed[0]);
+  assert.strictEqual(
+    output,
+    source +
+      `declare var Buffer: any;
+declare var process: any;
+declare var global: ServiceWorkerGlobalScope;
+declare const crypto: Crypto;
+`
+  );
+});


### PR DESCRIPTION
Fixes #7026

Buffer, process, and global are also declared by @types/node using the var declaration kind. Emit the same declaration kind for those three names so TypeScript can merge the declarations, while preserving const for Workers and DOM globals.

Adds a transformer regression test covering the three Node globals and a non-Node control.

Testing:
- Targeted transformer regression test: 1 passed, 0 failed
- Linux types generator build: passed
- Generated snapshot matches the Linux generator artifact