### PR TITLE
Tag SQLite errors with SENTRY_DO

### DIFF
--- a/src/workerd/io/actor-sqlite-test.c++
+++ b/src/workerd/io/actor-sqlite-test.c++
@@ -2602,6 +2602,7 @@ KJ_TEST("sync() throws after critical error in explicit transaction") {
     KJ_FAIL_ASSERT("Query should have failed with SQLITE_NOMEM");
   } catch (kj::Exception& e) {
     // Expected: out of memory error. We catch and ignore this to continue the test.
+    KJ_ASSERT(e.getDescription().contains("SENTRY_DO"));
     KJ_ASSERT(e.getDescription().contains("out of memory"));
   }
 

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+#include "sentry.h"
 #include "sqlite.h"
 
 #include <fcntl.h>
@@ -1613,6 +1614,21 @@ class ErrorInjectableDirectory final: public kj::Directory, public kj::AtomicRef
   }
 };
 
+void expectDoSentryDisposition(const kj::Exception& exception) {
+  auto disposition = KJ_ASSERT_NONNULL(exception.getDetail(SENTRY_TAG_DETAIL_ID));
+  KJ_EXPECT(disposition.asChars() == "SENTRY_DO"_kj, exception);
+}
+
+KJ_TEST("SQLite open errors are tagged for DO Sentry") {
+  auto dir = kj::newInMemoryDirectory(kj::nullClock());
+  SqliteDatabase::Vfs vfs(*dir);
+  auto exception = KJ_ASSERT_NONNULL(
+      kj::runCatchingExceptions([&]() { SqliteDatabase(vfs, kj::Path({"missing"}), kj::none); }));
+  KJ_EXPECT(exception.getDescription().contains("unable to open database file: SQLITE_CANTOPEN"),
+      exception);
+  expectDoSentryDisposition(exception);
+}
+
 KJ_TEST("SQLite memory metering enforces SQLITE_NOMEM when limit is exceeded") {
   auto dir = kj::newInMemoryDirectory(kj::nullClock());
   SqliteDatabase::Vfs vfs(*dir);
@@ -1683,10 +1699,13 @@ KJ_TEST("I/O exceptions pass through SQLite") {
   KJ_ASSERT_NONNULL(dir->dbFile)->error = KJ_EXCEPTION(FAILED, "test-vfs-error");
 
   // It should pass through.
-  KJ_EXPECT_THROW_MESSAGE(
-      "test-vfs-error", db.run({.regulator = SqliteDatabase::TRUSTED}, kj::str(R"(
+  auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
+    db.run({.regulator = SqliteDatabase::TRUSTED}, kj::str(R"(
     INSERT INTO things(value) VALUES (456);
-  )")));
+  )"));
+  }));
+  KJ_EXPECT(exception.getDescription() == "test-vfs-error", exception);
+  expectDoSentryDisposition(exception);
 }
 
 void testCriticalError(const char* expectedErrorMessage,

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -190,6 +190,17 @@ kj::String dbErrorMessage(int errorCode, sqlite3* db) {
 // exceptions through SQLite.
 static thread_local kj::Maybe<kj::Exception>* vfsErrorListener = nullptr;
 
+void tagDoSentry(kj::Exception& e) {
+  if (e.getDetail(SENTRY_TAG_DETAIL_ID) == kj::none) {
+    e.setDetail(SENTRY_TAG_DETAIL_ID, kj::heapArray("SENTRY_DO"_kj.asBytes()));
+  }
+}
+
+[[noreturn]] void throwDoSentryException(kj::Exception&& e) {
+  tagDoSentry(e);
+  kj::throwFatalException(kj::mv(e));
+}
+
 // Report that in a sqlite VFS callback, an exception was caught, and SQLITE_IOERROR is being
 // returned to SQLite.
 //
@@ -198,6 +209,7 @@ static thread_local kj::Maybe<kj::Exception>* vfsErrorListener = nullptr;
 // only the frames between the throw and the catch. We actually want to retain the full trace
 // through SQLite.
 void reportVfsErrorCaught(kj::Exception&& e) {
+  tagDoSentry(e);
   if (vfsErrorListener != nullptr) {
     // Only capture the first error; assume subsequent errors are side effects.
     if (*vfsErrorListener == kj::none) {
@@ -258,8 +270,10 @@ class SqliteCallScope {
 #define SQLITE_CALL_NODB(code, ...)                                                                \
   do {                                                                                             \
     int _ec = code;                                                                                \
-    KJ_ASSERT(                                                                                     \
-        _ec == SQLITE_OK, kj::str(sqlite3_errstr(_ec), ": ", namedErrorCode(_ec)), ##__VA_ARGS__); \
+    if (_ec != SQLITE_OK) {                                                                        \
+      throwDoSentryException(KJ_EXCEPTION(                                                         \
+          FAILED, kj::str(sqlite3_errstr(_ec), ": ", namedErrorCode(_ec)), ##__VA_ARGS__));        \
+    }                                                                                              \
   } while (false)
 
 // This version requires the scope to contain a variable named `db` which is of type sqlite3*, or


### PR DESCRIPTION
Prefix existing SQLite open and VFS exception descriptions so they are routed to the Durable Objects Sentry project without changing exception control flow.