### PR TITLE
Route zstd consumers through the compression-rs autogated router

### DIFF
--- a/build/deps/deps.jsonc
+++ b/build/deps/deps.jsonc
@@ -25,7 +25,10 @@
     },
     {
       "name": "zstd",
-      "type": "bazel_dep"
+      "type": "bazel_dep",
+      "patches": [
+        "//:patches/zstd/0001-Split-zstd-into-a-prefixed-impl-and-a-routed-consumer.patch"
+      ]
     },
     {
       "name": "tcmalloc",

--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -162,3 +162,10 @@ git_override(
 
 # zstd
 bazel_dep(name = "zstd", version = "1.5.7.bcr.1")
+single_version_override(
+    module_name = "zstd",
+    patch_strip = 1,
+    patches = [
+        "//:patches/zstd/0001-Split-zstd-into-a-prefixed-impl-and-a-routed-consumer.patch",
+    ],
+)

--- a/deps/rust/Cargo.lock
+++ b/deps/rust/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_python_parser",
  "rustversion",
+ "ruzstd",
  "scratch",
  "serde",
  "serde_json",
@@ -1437,6 +1438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ruzstd"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2104,12 @@ dependencies = [
  "serde",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typenum"

--- a/deps/rust/Cargo.toml
+++ b/deps/rust/Cargo.toml
@@ -49,6 +49,9 @@ lol_html_c_api = { git = "https://github.com/cloudflare/lol-html" }
 hashlink = "0"
 nix = "0"
 pico-args = "0"
+# Pure-Rust zstd decoder, exposed to C++ under zstd_rs_-prefixed symbols by
+# src/rust/zstd-rs. hash enables content checksum verification.
+ruzstd = { version = "0.9", default-features = false, features = ["std", "hash"] }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.12.1" }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.12.1" }
 # param_extractor depends on unbounded_depth feature

--- a/patches/zstd/0001-Split-zstd-into-a-prefixed-impl-and-a-routed-consumer.patch
+++ b/patches/zstd/0001-Split-zstd-into-a-prefixed-impl-and-a-routed-consumer.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Guy Bedford <gbedford@cloudflare.com>
+Date: Wed, 26 Aug 2026 00:00:00 -0700
+Subject: Split zstd into a prefixed zstd_c_ impl and a routed consumer target
+
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 21da376..457d865 100755
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -39,8 +39,14 @@ filegroup(
+     ]),
+ )
+ 
++# The C zstd implementation, compiled with every routed ZSTD_* entry point renamed to its
++# zstd_c_-prefixed spelling. ZSTD_isError cannot be renamed on the command line (zstd_internal.h
++# redefines and zstd_common.c undefs it), so its definition site is renamed via the dedicated
++# ZSTD_ISERROR_RENAME hook in zstd_common.c; internal callers inline ERR_isError and emit no
++# reference to the symbol. Consumers never link this directly; they go through the unprefixed
++# routing layer below.
+ cc_library(
+-    name = "zstd",
++    name = "zstd_impl",
+     srcs = [
+         ":common_sources",
+         ":compress_sources",
+@@ -63,12 +69,41 @@ cc_library(
+         "ZSTD_MULTITHREAD",
+         "ZSTD_BUILD_SHARED=OFF",
+         "ZSTD_BUILD_STATIC=ON",
++        "ZSTD_createCCtx=zstd_c_ZSTD_createCCtx",
++        "ZSTD_freeCCtx=zstd_c_ZSTD_freeCCtx",
++        "ZSTD_CCtx_reset=zstd_c_ZSTD_CCtx_reset",
++        "ZSTD_CCtx_setParameter=zstd_c_ZSTD_CCtx_setParameter",
++        "ZSTD_CCtx_setPledgedSrcSize=zstd_c_ZSTD_CCtx_setPledgedSrcSize",
++        "ZSTD_compressStream2=zstd_c_ZSTD_compressStream2",
++        "ZSTD_createDCtx=zstd_c_ZSTD_createDCtx",
++        "ZSTD_freeDCtx=zstd_c_ZSTD_freeDCtx",
++        "ZSTD_DCtx_reset=zstd_c_ZSTD_DCtx_reset",
++        "ZSTD_DCtx_setParameter=zstd_c_ZSTD_DCtx_setParameter",
++        "ZSTD_decompressStream=zstd_c_ZSTD_decompressStream",
++        "ZSTD_ISERROR_RENAME=zstd_c_ZSTD_isError",
++        "ZSTD_getErrorCode=zstd_c_ZSTD_getErrorCode",
++        "ZSTD_getErrorName=zstd_c_ZSTD_getErrorName",
++        "ZSTD_getErrorString=zstd_c_ZSTD_getErrorString",
+     ] + select({
+         "@platforms//os:windows": ["ZSTD_DISABLE_ASM"],
+         "//conditions:default": [],
+     }),
+ )
+ 
++# The zstd consumed by everything in the build: the standard headers over the routing layer,
++# which forwards each routed call to the C implementation (zstd_c_*, above) or the Rust one
++# (zstd_rs_*), selected at process level by the compression-rs autogate.
++cc_library(
++    name = "zstd",
++    hdrs = [
++        "lib/zdict.h",
++        "lib/zstd.h",
++        "lib/zstd_errors.h",
++    ],
++    includes = ["lib"],
++    deps = ["@@//src/workerd/util:zstd-router"],
++)
++
+ cc_binary(
+     name = "zstd_cli",
+     srcs = glob(
+diff --git a/lib/common/zstd_common.c b/lib/common/zstd_common.c
+index 3f04c22..dec6b03 100644
+--- a/lib/common/zstd_common.c
++++ b/lib/common/zstd_common.c
+@@ -30,6 +30,9 @@ const char* ZSTD_versionString(void) { return ZSTD_VERSION_STRING; }
+ *  ZSTD Error Management
+ ******************************************/
+ #undef ZSTD_isError   /* defined within zstd_internal.h */
++#ifdef ZSTD_ISERROR_RENAME
++#define ZSTD_isError ZSTD_ISERROR_RENAME
++#endif
+ /*! ZSTD_isError() :
+  *  tells if a return value is an error code
+  *  symbol is required for external callers */

--- a/src/rust/zstd-rs/BUILD.bazel
+++ b/src/rust/zstd-rs/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//:build/wd_rust_crate.bzl", "wd_rust_crate")
+
+wd_rust_crate(
+    name = "zstd-rs",
+    visibility = ["//visibility:public"],
+    deps = ["@crates_vendor//:ruzstd"],
+)

--- a/src/rust/zstd-rs/lib.rs
+++ b/src/rust/zstd-rs/lib.rs
@@ -1,0 +1,366 @@
+// Exposes ruzstd (the memory-safe pure-Rust zstd decoder) to C++ under
+// zstd_rs_-prefixed C symbols implementing the ZSTD_decompressStream contract.
+// The unprefixed ZSTD_* names are owned by the routing layer
+// (src/workerd/util/zstd-router.c++), which forwards decompression to these or
+// to the C implementation (zstd_c_*) based on the compression-rs autogate.
+// Compression is not implemented here; the router keeps it on the C
+// implementation on both sides of the gate.
+#![allow(non_snake_case, non_camel_case_types)]
+// FFI layer over ruzstd: each entry point has exactly the safety contract of
+// the libzstd function it replaces.
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::undocumented_unsafe_blocks)]
+
+use core::ffi::c_int;
+use core::ffi::c_void;
+use std::io::Read;
+
+use ruzstd::decoding::FrameDecoder;
+use ruzstd::decoding::errors::FrameDecoderError;
+use ruzstd::decoding::errors::FrameHeaderError;
+use ruzstd::decoding::errors::ReadFrameHeaderError;
+
+// Matches the public ZSTD_inBuffer/ZSTD_outBuffer ABI from zstd.h.
+#[repr(C)]
+pub struct ZSTD_inBuffer {
+    pub src: *const c_void,
+    pub size: usize,
+    pub pos: usize,
+}
+
+#[repr(C)]
+pub struct ZSTD_outBuffer {
+    pub dst: *mut c_void,
+    pub size: usize,
+    pub pos: usize,
+}
+
+// Error results use the standard libzstd encoding, (size_t)-ZSTD_ErrorCode, so
+// the routed ZSTD_isError/ZSTD_getErrorCode/ZSTD_getErrorName (always served
+// by the C implementation) interpret them identically on both sides of the
+// gate.
+const ZSTD_ERROR_GENERIC: usize = 1;
+const ZSTD_ERROR_PREFIX_UNKNOWN: usize = 10;
+const ZSTD_ERROR_FRAME_PARAMETER_UNSUPPORTED: usize = 14;
+const ZSTD_ERROR_FRAME_PARAMETER_WINDOW_TOO_LARGE: usize = 16;
+const ZSTD_ERROR_CORRUPTION_DETECTED: usize = 20;
+const ZSTD_ERROR_CHECKSUM_WRONG: usize = 22;
+const ZSTD_ERROR_DICTIONARY_WRONG: usize = 32;
+const ZSTD_ERROR_PARAMETER_UNSUPPORTED: usize = 40;
+const ZSTD_ERROR_PARAMETER_OUT_OF_BOUND: usize = 42;
+
+const ZSTD_RESET_SESSION_ONLY: c_int = 1;
+const ZSTD_RESET_PARAMETERS: c_int = 2;
+const ZSTD_RESET_SESSION_AND_PARAMETERS: c_int = 3;
+
+const ZSTD_D_WINDOW_LOG_MAX: c_int = 100;
+const ZSTD_WINDOWLOG_MIN: c_int = 10;
+const ZSTD_WINDOWLOG_MAX: c_int = 31;
+// libzstd's ZSTD_WINDOWLOG_LIMIT_DEFAULT.
+const DEFAULT_WINDOW_LOG_MAX: c_int = 27;
+
+// Suggested-more-input hint; callers only distinguish 0 / error / other.
+const HINT: usize = 1;
+
+// Largest input slice fed to the decoder per step: max block content (128K)
+// plus block and frame header slack. This bounds how much data is decoded
+// ahead of the output buffer in a single step.
+const INPUT_STEP: usize = 128 * 1024 + 32;
+
+// A frame header is at most magic(4) + descriptor(1) + window(1) + dictID(4)
+// + contentSize(8) bytes; a header read that fails with more than this
+// buffered is corruption rather than a short read.
+const MAX_FRAME_HEADER_SIZE: usize = 18;
+
+const fn err(code: usize) -> usize {
+    code.wrapping_neg()
+}
+
+struct Dctx {
+    decoder: FrameDecoder,
+    // Unconsumed input: bytes handed to us are taken eagerly (modulo the
+    // hostage byte below) and buffered here until decodable.
+    buf: Vec<u8>,
+    frame_active: bool,
+    // Mirrors libzstd's hostage byte: whenever the output buffer fills before
+    // the stream is fully flushed, one already-buffered input byte is reported
+    // unconsumed so that callers tracking availIn re-offer it, guaranteeing
+    // the call that finally returns 0 sees a non-empty input. The byte is
+    // dropped when offered again.
+    hostage: bool,
+    sticky_error: usize,
+    window_log_max: c_int,
+}
+
+impl Dctx {
+    fn new() -> Self {
+        let mut dctx = Self {
+            decoder: FrameDecoder::new(),
+            buf: Vec::new(),
+            frame_active: false,
+            hostage: false,
+            sticky_error: 0,
+            window_log_max: 0,
+        };
+        dctx.apply_window_log_max();
+        dctx
+    }
+
+    fn apply_window_log_max(&mut self) {
+        let log = if self.window_log_max == 0 {
+            DEFAULT_WINDOW_LOG_MAX
+        } else {
+            self.window_log_max
+        };
+        self.decoder.set_max_window_size(1u64 << log);
+    }
+
+    fn reset_session(&mut self) {
+        self.buf.clear();
+        self.frame_active = false;
+        self.hostage = false;
+        self.sticky_error = 0;
+        // Drop any half-decoded frame state; the next init() rebuilds it.
+        self.decoder = FrameDecoder::new();
+        self.apply_window_log_max();
+    }
+
+    fn fail(&mut self, code: usize) -> usize {
+        self.sticky_error = err(code);
+        self.sticky_error
+    }
+
+    // Runs header parsing, block decoding, and draining over the buffered
+    // input until the output fills or no further progress is possible.
+    // Returns (result, bytes written, whether the output filled).
+    fn pump(&mut self, out_slice: &mut [u8]) -> (usize, usize, bool) {
+        let mut written_total = 0usize;
+        let mut out_full = false;
+
+        let result = 'stream: loop {
+            if !self.frame_active {
+                if self.buf.is_empty() {
+                    break 'stream HINT;
+                }
+                let mut cursor: &[u8] = &self.buf;
+                match self.decoder.init(&mut cursor) {
+                    Ok(()) => {
+                        let consumed = self.decoder.bytes_read_from_source() as usize;
+                        self.buf.drain(..consumed);
+                        self.frame_active = true;
+                    }
+                    Err(FrameDecoderError::ReadFrameHeaderError(
+                        ReadFrameHeaderError::SkipFrame { length, .. },
+                    )) => {
+                        let total = 8 + length as usize;
+                        if self.buf.len() < total {
+                            break 'stream HINT;
+                        }
+                        self.buf.drain(..total);
+                    }
+                    Err(e) => match header_error_code(&e, self.buf.len()) {
+                        Some(code) => break 'stream self.fail(code),
+                        None => break 'stream HINT,
+                    },
+                }
+                continue;
+            }
+
+            let step = self.buf.len().min(INPUT_STEP);
+            let (read, written) = match self
+                .decoder
+                .decode_from_to(&self.buf[..step], &mut out_slice[written_total..])
+            {
+                Ok(progress) => progress,
+                Err(e) => break 'stream self.fail(decode_error_code(&e)),
+            };
+            let (read, written) = if read > step {
+                // ruzstd's decode_from_to claims the 4 checksum bytes as read even
+                // when fewer are available; nothing was consumed in that case, but
+                // finished output can still be drained directly.
+                match self.decoder.read(&mut out_slice[written_total..]) {
+                    Ok(w) => (0, w),
+                    Err(_) => break 'stream self.fail(ZSTD_ERROR_GENERIC),
+                }
+            } else {
+                (read, written)
+            };
+            self.buf.drain(..read);
+            written_total += written;
+
+            if self.decoder.is_finished() && self.decoder.can_collect() == 0 {
+                if let (Some(from_data), Some(calculated)) = (
+                    self.decoder.get_checksum_from_data(),
+                    self.decoder.get_calculated_checksum(),
+                ) && from_data != calculated
+                {
+                    break 'stream self.fail(ZSTD_ERROR_CHECKSUM_WRONG);
+                }
+                self.frame_active = false;
+                if self.buf.is_empty() {
+                    break 'stream 0;
+                }
+                continue;
+            }
+
+            if written_total == out_slice.len() && !out_slice.is_empty() {
+                out_full = true;
+                break 'stream HINT;
+            }
+
+            if read == 0 && written == 0 {
+                break 'stream HINT;
+            }
+        };
+
+        (result, written_total, out_full)
+    }
+}
+
+// None means the header is still incomplete and more input is needed.
+fn header_error_code(e: &FrameDecoderError, buffered: usize) -> Option<usize> {
+    match e {
+        FrameDecoderError::ReadFrameHeaderError(re) => match re {
+            ReadFrameHeaderError::BadMagicNumber(_) => Some(ZSTD_ERROR_PREFIX_UNKNOWN),
+            ReadFrameHeaderError::InvalidFrameDescriptor(_) => {
+                Some(ZSTD_ERROR_FRAME_PARAMETER_UNSUPPORTED)
+            }
+            _ => (buffered >= MAX_FRAME_HEADER_SIZE).then_some(ZSTD_ERROR_CORRUPTION_DETECTED),
+        },
+        FrameDecoderError::FrameHeaderError(he) => match he {
+            FrameHeaderError::WindowTooBig { .. } => {
+                Some(ZSTD_ERROR_FRAME_PARAMETER_WINDOW_TOO_LARGE)
+            }
+            _ => Some(ZSTD_ERROR_FRAME_PARAMETER_UNSUPPORTED),
+        },
+        FrameDecoderError::WindowSizeTooBig { .. } => {
+            Some(ZSTD_ERROR_FRAME_PARAMETER_WINDOW_TOO_LARGE)
+        }
+        FrameDecoderError::DictNotProvided { .. } => Some(ZSTD_ERROR_DICTIONARY_WRONG),
+        _ => Some(ZSTD_ERROR_GENERIC),
+    }
+}
+
+fn decode_error_code(e: &FrameDecoderError) -> usize {
+    match e {
+        FrameDecoderError::FailedToReadBlockHeader(_)
+        | FrameDecoderError::FailedToReadBlockBody(_)
+        | FrameDecoderError::FailedToReadChecksum(_) => ZSTD_ERROR_CORRUPTION_DETECTED,
+        _ => ZSTD_ERROR_GENERIC,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn zstd_rs_ZSTD_createDCtx() -> *mut c_void {
+    Box::into_raw(Box::new(Dctx::new())).cast::<c_void>()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zstd_rs_ZSTD_freeDCtx(dctx: *mut c_void) -> usize {
+    if !dctx.is_null() {
+        drop(unsafe { Box::from_raw(dctx.cast::<Dctx>()) });
+    }
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zstd_rs_ZSTD_DCtx_reset(dctx: *mut c_void, directive: c_int) -> usize {
+    let Some(dctx) = (unsafe { dctx.cast::<Dctx>().as_mut() }) else {
+        return err(ZSTD_ERROR_GENERIC);
+    };
+    match directive {
+        ZSTD_RESET_SESSION_ONLY => dctx.reset_session(),
+        ZSTD_RESET_PARAMETERS => {
+            dctx.window_log_max = 0;
+            dctx.apply_window_log_max();
+        }
+        ZSTD_RESET_SESSION_AND_PARAMETERS => {
+            dctx.reset_session();
+            dctx.window_log_max = 0;
+            dctx.apply_window_log_max();
+        }
+        _ => return err(ZSTD_ERROR_PARAMETER_OUT_OF_BOUND),
+    }
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zstd_rs_ZSTD_DCtx_setParameter(
+    dctx: *mut c_void,
+    param: c_int,
+    value: c_int,
+) -> usize {
+    let Some(dctx) = (unsafe { dctx.cast::<Dctx>().as_mut() }) else {
+        return err(ZSTD_ERROR_GENERIC);
+    };
+    if param != ZSTD_D_WINDOW_LOG_MAX {
+        return err(ZSTD_ERROR_PARAMETER_UNSUPPORTED);
+    }
+    if value != 0 && !(ZSTD_WINDOWLOG_MIN..=ZSTD_WINDOWLOG_MAX).contains(&value) {
+        return err(ZSTD_ERROR_PARAMETER_OUT_OF_BOUND);
+    }
+    dctx.window_log_max = value;
+    dctx.apply_window_log_max();
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zstd_rs_ZSTD_decompressStream(
+    dctx: *mut c_void,
+    output: *mut ZSTD_outBuffer,
+    input: *mut ZSTD_inBuffer,
+) -> usize {
+    let Some(dctx) = (unsafe { dctx.cast::<Dctx>().as_mut() }) else {
+        return err(ZSTD_ERROR_GENERIC);
+    };
+    let (Some(output), Some(input)) = (unsafe { output.as_mut() }, unsafe { input.as_mut() })
+    else {
+        return err(ZSTD_ERROR_GENERIC);
+    };
+    if input.pos > input.size || output.pos > output.size {
+        return err(ZSTD_ERROR_GENERIC);
+    }
+    if dctx.sticky_error != 0 {
+        return dctx.sticky_error;
+    }
+
+    let offered = input.size - input.pos;
+    let mut avail_in = unsafe {
+        if offered > 0 {
+            core::slice::from_raw_parts(input.src.cast::<u8>().add(input.pos), offered)
+        } else {
+            &[]
+        }
+    };
+    if dctx.hostage && !avail_in.is_empty() {
+        // The first offered byte was already consumed when it was taken
+        // hostage; it may be re-held below if the output fills again.
+        avail_in = &avail_in[1..];
+        dctx.hostage = false;
+    }
+    dctx.buf.extend_from_slice(avail_in);
+    input.pos = input.size;
+
+    let out_slice = unsafe {
+        if output.size > output.pos {
+            core::slice::from_raw_parts_mut(
+                output.dst.cast::<u8>().add(output.pos),
+                output.size - output.pos,
+            )
+        } else {
+            &mut []
+        }
+    };
+    let (result, written_total, out_full) = dctx.pump(out_slice);
+
+    output.pos += written_total;
+
+    if result == HINT && out_full && offered > 0 {
+        // Not fully flushed: hold one byte hostage so the flush-completing
+        // call still sees input (see the field comment).
+        dctx.hostage = true;
+        input.pos = input.size - 1;
+    }
+
+    result
+}

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -111,6 +111,15 @@ wd_cc_benchmark(
 )
 
 wd_cc_benchmark(
+    name = "bench-zstd",
+    srcs = ["bench-zstd.c++"],
+    deps = [
+        "//src/rust/zstd-rs",
+        "@zstd",
+    ],
+)
+
+wd_cc_benchmark(
     name = "bench-util",
     srcs = ["bench-util.c++"],
     deps = [

--- a/src/workerd/tests/bench-zstd.c++
+++ b/src/workerd/tests/bench-zstd.c++
@@ -1,0 +1,160 @@
+// Benchmarks native (C) zstd against the Rust decoder (ruzstd) on the
+// node:zlib zstd streaming workload: 1MB of compressible data in 16KB chunks
+// with the default compression level. Only decompression is routed to Rust, so
+// compression is measured on the native implementation only.
+
+#include <workerd/tests/bench-tools.h>
+
+#include <zstd.h>
+
+#include <kj/array.h>
+#include <kj/debug.h>
+
+// The Rust decoder, exported under the zstd_rs_ prefix by src/rust/zstd-rs. The unprefixed names
+// belong to the routing layer, so the benchmark calls the Rust side directly through these.
+extern "C" {
+void* zstd_rs_ZSTD_createDCtx(void);
+size_t zstd_rs_ZSTD_freeDCtx(void* dctx);
+size_t zstd_rs_ZSTD_decompressStream(void* dctx, void* output, void* input);
+}
+
+namespace workerd {
+namespace {
+
+constexpr size_t DATA_SIZE = 1 << 20;
+constexpr size_t CHUNK = 16 * 1024;
+
+kj::Array<kj::byte> makeCompressibleData() {
+  static constexpr kj::StringPtr words[] = {"the "_kj, "quick "_kj, "compression "_kj, "of "_kj,
+    "zstd "_kj, "streaming "_kj, "workers "_kj, "runtime "_kj};
+  auto data = kj::heapArray<kj::byte>(DATA_SIZE);
+  uint32_t s = 0x12345678;
+  size_t pos = 0;
+  while (pos < data.size()) {
+    s = s * 1664525 + 1013904223;
+    auto w = words[(s >> 24) & 7].asBytes();
+    size_t n = kj::min(w.size(), data.size() - pos);
+    memcpy(data.begin() + pos, w.begin(), n);
+    pos += n;
+  }
+  return data;
+}
+
+const kj::Array<kj::byte>& sourceData() {
+  static const kj::Array<kj::byte> data = makeCompressibleData();
+  return data;
+}
+
+kj::Array<kj::byte> compressedData() {
+  auto& src = sourceData();
+  auto out = kj::heapArray<kj::byte>(ZSTD_compressBound(src.size()));
+  auto* cctx = ZSTD_createCCtx();
+  KJ_REQUIRE(cctx != nullptr);
+  KJ_DEFER(ZSTD_freeCCtx(cctx));
+  ZSTD_inBuffer in{src.begin(), src.size(), 0};
+  ZSTD_outBuffer zout{out.begin(), out.size(), 0};
+  KJ_REQUIRE(ZSTD_compressStream2(cctx, &zout, &in, ZSTD_e_end) == 0);
+  return kj::heapArray<kj::byte>(out.first(zout.pos));
+}
+
+size_t compressNative(kj::ArrayPtr<const kj::byte> data) {
+  static kj::byte out[CHUNK];
+  auto* cctx = ZSTD_createCCtx();
+  KJ_REQUIRE(cctx != nullptr);
+  KJ_DEFER(ZSTD_freeCCtx(cctx));
+  size_t total = 0;
+  for (size_t offset = 0; offset < data.size(); offset += CHUNK) {
+    size_t n = kj::min(CHUNK, data.size() - offset);
+    bool last = offset + n == data.size();
+    ZSTD_inBuffer in{data.begin() + offset, n, 0};
+    size_t result;
+    do {
+      ZSTD_outBuffer zout{out, sizeof(out), 0};
+      result = ZSTD_compressStream2(cctx, &zout, &in, last ? ZSTD_e_end : ZSTD_e_continue);
+      KJ_REQUIRE(!ZSTD_isError(result));
+      total += zout.pos;
+    } while (in.pos < in.size || (last && result != 0));
+  }
+  return total;
+}
+
+// Streaming via a generic stream-call shape shared by both backends.
+template <typename Fns>
+size_t streamDecompress(const Fns& fns, kj::ArrayPtr<const kj::byte> data) {
+  static kj::byte out[CHUNK];
+  auto* dctx = fns.create();
+  KJ_REQUIRE(dctx != nullptr);
+  KJ_DEFER(fns.free(dctx));
+  size_t total = 0;
+  size_t result = 1;
+  for (size_t offset = 0; offset < data.size(); offset += CHUNK) {
+    size_t n = kj::min(CHUNK, data.size() - offset);
+    bool last = offset + n == data.size();
+    ZSTD_inBuffer in{data.begin() + offset, n, 0};
+    do {
+      ZSTD_outBuffer zout{out, sizeof(out), 0};
+      result = fns.decompress(dctx, &zout, &in);
+      KJ_REQUIRE(!ZSTD_isError(result));
+      total += zout.pos;
+    } while (in.pos < in.size || (last && result != 0));
+  }
+  KJ_REQUIRE(result == 0, "stream did not end");
+  return total;
+}
+
+struct NativeFns {
+  void* create() const {
+    return ZSTD_createDCtx();
+  }
+  size_t free(void* dctx) const {
+    return ZSTD_freeDCtx(reinterpret_cast<ZSTD_DCtx*>(dctx));
+  }
+  size_t decompress(void* dctx, ZSTD_outBuffer* output, ZSTD_inBuffer* input) const {
+    return ZSTD_decompressStream(reinterpret_cast<ZSTD_DCtx*>(dctx), output, input);
+  }
+};
+
+struct ZstdRsFns {
+  void* create() const {
+    return zstd_rs_ZSTD_createDCtx();
+  }
+  size_t free(void* dctx) const {
+    return zstd_rs_ZSTD_freeDCtx(dctx);
+  }
+  size_t decompress(void* dctx, ZSTD_outBuffer* output, ZSTD_inBuffer* input) const {
+    return zstd_rs_ZSTD_decompressStream(dctx, output, input);
+  }
+};
+
+void Zstd_Compress_Native(benchmark::State& state) {
+  auto& src = sourceData();
+  for (auto _: state) {
+    benchmark::DoNotOptimize(compressNative(src));
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * src.size());
+}
+
+void Zstd_Decompress_Native(benchmark::State& state) {
+  auto& src = sourceData();
+  auto compressed = compressedData();
+  for (auto _: state) {
+    KJ_ASSERT(streamDecompress(NativeFns{}, compressed) == src.size());
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * src.size());
+}
+
+void Zstd_Decompress_ZstdRs(benchmark::State& state) {
+  auto& src = sourceData();
+  auto compressed = compressedData();
+  for (auto _: state) {
+    KJ_ASSERT(streamDecompress(ZstdRsFns{}, compressed) == src.size());
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * src.size());
+}
+
+WD_BENCHMARK(Zstd_Compress_Native)->Name("Zstd::Compress::Native");
+WD_BENCHMARK(Zstd_Decompress_Native)->Name("Zstd::Decompress::Native");
+WD_BENCHMARK(Zstd_Decompress_ZstdRs)->Name("Zstd::Decompress::ZstdRs");
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -34,6 +34,19 @@ wd_cc_library(
     ],
 )
 
+# The routing layer owning the unprefixed ZSTD_* symbol names; @zstd//:zstd depends on this, so
+# every zstd consumer links it. Deliberately kj/capnp-free (see zstd-router.c++).
+wd_cc_library(
+    name = "zstd-router",
+    srcs = ["zstd-router.c++"],
+    hdrs = ["zstd-router.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/rust/zstd-rs",
+        "@zstd//:zstd_impl",
+    ],
+)
+
 wd_cc_library(
     name = "perfetto",
     srcs = ["perfetto-tracing.c++"],
@@ -304,6 +317,7 @@ wd_cc_library(
         ":sentry",
         ":strong-bool",
         ":zlib-router",
+        ":zstd-router",
         "@capnp-cpp//src/capnp",
         "@capnp-cpp//src/kj",
     ],
@@ -463,6 +477,14 @@ kj_test(
     deps = [
         ":autogate",
         "@zlib",
+    ],
+)
+
+kj_test(
+    src = "zstd-router-test.c++",
+    deps = [
+        ":autogate",
+        "@zstd",
     ],
 )
 

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -5,6 +5,7 @@
 
 #include <workerd/util/sentry.h>
 #include <workerd/util/zlib-router.h>
+#include <workerd/util/zstd-router.h>
 
 #include <stdlib.h>
 
@@ -19,14 +20,16 @@ kj::Maybe<Autogate> globalAutogate;
 namespace {
 constexpr auto WORKERD_PREFIX = "workerd-autogate-"_kj;
 
-// Propagates the COMPRESSION_RS gate to the zlib routing layer, which cannot depend on autogate
-// itself. Called whenever the global gate state changes; also run at static init so that
+// Propagates the COMPRESSION_RS gate to the zlib and zstd routing layers, which cannot depend on
+// autogate itself. Called whenever the global gate state changes; also run at static init so that
 // processes that never call initAutogate() (e.g. kj_test binaries under WORKERD_ALL_AUTOGATES)
 // still route accordingly.
-void syncZlibRouter() {
-  workerd_zlib_router_set_rs(Autogate::isEnabled(AutogateKey::COMPRESSION_RS));
+void syncCompressionRouters() {
+  bool enable = Autogate::isEnabled(AutogateKey::COMPRESSION_RS);
+  workerd_zlib_router_set_rs(enable);
+  workerd_zstd_router_set_rs(enable);
 }
-[[maybe_unused]] const bool zlibRouterInitialSync = (syncZlibRouter(), true);
+[[maybe_unused]] const bool compressionRoutersInitialSync = (syncCompressionRouters(), true);
 
 // Converts a SCREAMING_SNAKE_CASE string to kebab-case at compile time.
 template <size_t N>
@@ -114,12 +117,12 @@ void Autogate::initAutogate(
     return initAllAutogates();
   }
   globalAutogate = Autogate(gates);
-  syncZlibRouter();
+  syncCompressionRouters();
 }
 
 void Autogate::deinitAutogate() {
   globalAutogate = kj::none;
-  syncZlibRouter();
+  syncCompressionRouters();
 }
 
 void Autogate::initAllAutogates() {
@@ -128,7 +131,7 @@ void Autogate::initAllAutogates() {
     autogate.gates[autogateToIndex(key)] = true;
   }
   globalAutogate = kj::mv(autogate);
-  syncZlibRouter();
+  syncCompressionRouters();
 }
 
 void Autogate::initAutogateNamesForTest(
@@ -159,7 +162,7 @@ void Autogate::initAutogateForTest(std::initializer_list<AutogateKey> keys) {
     autogate.gates[autogateToIndex(key)] = true;
   }
   globalAutogate = kj::mv(autogate);
-  syncZlibRouter();
+  syncCompressionRouters();
 }
 
 }  // namespace workerd::util

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -116,11 +116,13 @@ namespace workerd::util {
      existed; the typescript_implemented_streams compat flag requires this gate to receive         \
      streams over RPC (that combination is rejected, not degraded). */                             \
   V(RPC_EXTERNALS_HYDRATION)                                                                       \
-  /* Route all zlib usage in the process to zlib-rs (libz-rs-sys), the memory-safe Rust          \
-     implementation, instead of chromium zlib. The unprefixed zlib symbols are owned by the      \
-     routing layer in util/zlib-router.c++, so this covers every consumer: node:zlib, web        \
-     CompressionStream, crypto crc32, kj-gzip/http (fetch and WebSocket compression), and V8's   \
-     compression utils. Chromium zlib remains the default. */                                    \
+  /* Route all zlib usage in the process to zlib-rs (libz-rs-sys) and all zstd decompression to  \
+     ruzstd, the memory-safe Rust implementations, instead of the C libraries. The unprefixed    \
+     symbols are owned by the routing layers in util/zlib-router.c++ and util/zstd-router.c++,   \
+     so this covers every consumer: node:zlib (including zstd modes), web CompressionStream,     \
+     crypto crc32, kj-gzip/http (fetch and WebSocket compression), and V8's compression utils.   \
+     zstd compression stays on the C implementation on both sides (no credible pure-Rust         \
+     encoder exists). The C implementations remain the default. */                               \
   V(COMPRESSION_RS)                                                                                 \
   /* Enables per-call JSRPC tracing, trace-context propagation, and related Fetcher spans. */       \
   V(JSRPC_TRACING)                                                                                  \

--- a/src/workerd/util/zstd-router-test.c++
+++ b/src/workerd/util/zstd-router-test.c++
@@ -1,0 +1,175 @@
+#include <workerd/util/autogate.h>
+
+#include <zstd.h>
+
+#include <kj/array.h>
+#include <kj/test.h>
+
+// Direct entry points into the two implementations behind the router, for comparing against the
+// routed (unprefixed) API declared by zstd.h. Only decompression branches on the gate, so only
+// the decompression context entry points exist in both spellings.
+extern "C" {
+void* zstd_c_ZSTD_createDCtx(void);
+size_t zstd_c_ZSTD_freeDCtx(void* dctx);
+size_t zstd_c_ZSTD_DCtx_setParameter(void* dctx, int param, int value);
+size_t zstd_c_ZSTD_decompressStream(void* dctx, void* output, void* input);
+void* zstd_rs_ZSTD_createDCtx(void);
+size_t zstd_rs_ZSTD_freeDCtx(void* dctx);
+size_t zstd_rs_ZSTD_DCtx_setParameter(void* dctx, int param, int value);
+size_t zstd_rs_ZSTD_decompressStream(void* dctx, void* output, void* input);
+}
+
+namespace workerd::util {
+namespace {
+
+// ZSTD_d_format, an experimental parameter the C implementation accepts and the Rust decoder
+// rejects; used to observe which implementation the router selected.
+constexpr int ZSTD_D_FORMAT = 1000;
+
+struct DctxFns {
+  void* (*create)();
+  size_t (*free)(void* dctx);
+  size_t (*setParameter)(void* dctx, int param, int value);
+  size_t (*decompressStream)(void* dctx, void* output, void* input);
+};
+
+// The routed API, adapted to the hand-declared opaque-pointer shapes above.
+const DctxFns routedFns{
+  []() -> void* { return ZSTD_createDCtx(); },
+  [](void* dctx) { return ZSTD_freeDCtx(reinterpret_cast<ZSTD_DCtx*>(dctx)); },
+  [](void* dctx, int param, int value) {
+  return ZSTD_DCtx_setParameter(
+      reinterpret_cast<ZSTD_DCtx*>(dctx), static_cast<ZSTD_dParameter>(param), value);
+},
+  [](void* dctx, void* output, void* input) {
+  return ZSTD_decompressStream(reinterpret_cast<ZSTD_DCtx*>(dctx),
+      reinterpret_cast<ZSTD_outBuffer*>(output), reinterpret_cast<ZSTD_inBuffer*>(input));
+},
+};
+
+const DctxFns cFns{
+  zstd_c_ZSTD_createDCtx,
+  zstd_c_ZSTD_freeDCtx,
+  zstd_c_ZSTD_DCtx_setParameter,
+  zstd_c_ZSTD_decompressStream,
+};
+
+const DctxFns rsFns{
+  zstd_rs_ZSTD_createDCtx,
+  zstd_rs_ZSTD_freeDCtx,
+  zstd_rs_ZSTD_DCtx_setParameter,
+  zstd_rs_ZSTD_decompressStream,
+};
+
+kj::Array<kj::byte> makeInput() {
+  constexpr kj::StringPtr chunk = "the quick compression of zstd streaming workers runtime "_kj;
+  auto data = kj::heapArray<kj::byte>(256 * 1024);
+  for (size_t pos = 0; pos < data.size(); pos += chunk.size()) {
+    memcpy(data.begin() + pos, chunk.begin(), kj::min(chunk.size(), data.size() - pos));
+  }
+  return data;
+}
+
+kj::Array<kj::byte> compressRouted(kj::ArrayPtr<const kj::byte> input, bool checksum = false) {
+  auto* cctx = ZSTD_createCCtx();
+  KJ_REQUIRE(cctx != nullptr);
+  KJ_DEFER(ZSTD_freeCCtx(cctx));
+  if (checksum) {
+    KJ_REQUIRE(!ZSTD_isError(ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 1)));
+  }
+  auto dest = kj::heapArray<kj::byte>(input.size() + 1024);
+  ZSTD_inBuffer in{input.begin(), input.size(), 0};
+  ZSTD_outBuffer out{dest.begin(), dest.size(), 0};
+  size_t result = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
+  KJ_REQUIRE(result == 0 && !ZSTD_isError(result));
+  return kj::heapArray<kj::byte>(dest.first(out.pos));
+}
+
+// Streaming decompression through the given entry points, in 4KB input and 4KB output steps.
+kj::Array<kj::byte> decompressWith(const DctxFns& fns, kj::ArrayPtr<const kj::byte> compressed) {
+  auto* dctx = fns.create();
+  KJ_REQUIRE(dctx != nullptr);
+  KJ_DEFER(fns.free(dctx));
+
+  kj::Vector<kj::byte> result;
+  kj::byte chunk[4096];
+  size_t offset = 0;
+  size_t lastResult = 1;
+  while (true) {
+    size_t n = kj::min(sizeof(chunk), compressed.size() - offset);
+    ZSTD_inBuffer in{compressed.begin() + offset, n, 0};
+    do {
+      ZSTD_outBuffer out{chunk, sizeof(chunk), 0};
+      lastResult = fns.decompressStream(dctx, &out, &in);
+      KJ_REQUIRE(!ZSTD_isError(lastResult), ZSTD_getErrorName(lastResult));
+      result.addAll(kj::arrayPtr(chunk, out.pos));
+    } while (in.pos < in.size || (lastResult != 0 && offset + n == compressed.size()));
+    offset += n;
+    if (offset == compressed.size()) break;
+  }
+  KJ_REQUIRE(lastResult == 0, "stream did not end");
+  return result.releaseAsArray();
+}
+
+bool acceptsDFormatParam(const DctxFns& fns) {
+  auto* dctx = fns.create();
+  KJ_REQUIRE(dctx != nullptr);
+  KJ_DEFER(fns.free(dctx));
+  return !ZSTD_isError(fns.setParameter(dctx, ZSTD_D_FORMAT, 0));
+}
+
+KJ_TEST("zstd router uses the C implementation with the compression-rs gate off") {
+  Autogate::initAutogateNamesForTest(
+      kj::ArrayPtr<const kj::StringPtr>(), IgnoreAllAutogatesEnv::YES);
+  KJ_DEFER(Autogate::deinitAutogate());
+
+  // The premise of the routing probe: the two implementations observably differ on the
+  // experimental ZSTD_d_format parameter.
+  KJ_EXPECT(acceptsDFormatParam(cFns));
+  KJ_EXPECT(!acceptsDFormatParam(rsFns));
+  KJ_EXPECT(acceptsDFormatParam(routedFns));
+
+  auto input = makeInput();
+  auto compressed = compressRouted(input);
+  KJ_EXPECT(decompressWith(routedFns, compressed) == input);
+  KJ_EXPECT(decompressWith(cFns, compressed) == input);
+  KJ_EXPECT(decompressWith(rsFns, compressed) == input);
+}
+
+KJ_TEST("zstd router uses the Rust decoder with the compression-rs gate on") {
+  Autogate::initAutogateForTest({AutogateKey::COMPRESSION_RS});
+  KJ_DEFER(Autogate::deinitAutogate());
+
+  KJ_EXPECT(!acceptsDFormatParam(routedFns));
+  KJ_EXPECT(acceptsDFormatParam(cFns));
+
+  auto input = makeInput();
+  // Compression is not routed: it must keep working with the gate on.
+  auto compressed = compressRouted(input);
+  KJ_EXPECT(decompressWith(routedFns, compressed) == input);
+  KJ_EXPECT(decompressWith(rsFns, compressed) == input);
+  KJ_EXPECT(decompressWith(cFns, compressed) == input);
+
+  // Checksummed frames verify on the Rust side.
+  auto checksummed = compressRouted(input, true);
+  KJ_EXPECT(decompressWith(routedFns, checksummed) == input);
+
+  // Corruption is reported through the standard error code encoding.
+  {
+    auto corrupted = kj::heapArray<kj::byte>(checksummed);
+    corrupted[corrupted.size() / 2] ^= 0xff;
+    auto* dctx = routedFns.create();
+    KJ_DEFER(routedFns.free(dctx));
+    kj::byte chunk[4096];
+    ZSTD_inBuffer in{corrupted.begin(), corrupted.size(), 0};
+    size_t result = 0;
+    do {
+      ZSTD_outBuffer out{chunk, sizeof(chunk), 0};
+      result = routedFns.decompressStream(dctx, &out, &in);
+    } while (!ZSTD_isError(result) && result != 0 && in.pos < in.size);
+    KJ_EXPECT(ZSTD_isError(result));
+  }
+}
+
+}  // namespace
+}  // namespace workerd::util

--- a/src/workerd/util/zstd-router.c++
+++ b/src/workerd/util/zstd-router.c++
@@ -1,0 +1,81 @@
+#include "zstd-router.h"
+
+#include <stddef.h>
+
+#include <atomic>
+
+// This translation unit defines the unprefixed spellings of every ZSTD_* function consumed in
+// the build and forwards each call to one of the two implementations linked into the binary:
+//
+//   - the C implementation, rebuilt with its routed entry points renamed to zstd_c_* by
+//     @zstd//:zstd_impl, and
+//   - the Rust decoder (ruzstd), exported under zstd_rs_* by src/rust/zstd-rs.
+//
+// The Rust side implements decompression only (no credible pure-Rust encoder exists), so just
+// the decompression context entry points branch on the gate; compression always goes to the C
+// implementation. The error helpers are pure functions over the standard error code encoding,
+// which the Rust decoder also produces, so they too always go to the C implementation. It cannot
+// include zstd.h: the consumer headers declare the unprefixed spellings defined here, so the
+// prototypes for both implementations are hand-declared with opaque pointers. This target
+// deliberately has no kj/capnp dependencies.
+
+extern "C" {
+
+// Always forwarded to the C implementation.
+#define ZSTD_ROUTER_C_API(V)                                                                       \
+  V(void*, ZSTD_createCCtx, (void), ())                                                            \
+  V(size_t, ZSTD_freeCCtx, (void* cctx), (cctx))                                                   \
+  V(size_t, ZSTD_CCtx_reset, (void* cctx, int reset), (cctx, reset))                               \
+  V(size_t, ZSTD_CCtx_setParameter, (void* cctx, int param, int value), (cctx, param, value))      \
+  V(size_t, ZSTD_CCtx_setPledgedSrcSize, (void* cctx, unsigned long long pledgedSrcSize),          \
+      (cctx, pledgedSrcSize))                                                                      \
+  V(size_t, ZSTD_compressStream2, (void* cctx, void* output, void* input, int endOp),              \
+      (cctx, output, input, endOp))                                                                \
+  V(unsigned, ZSTD_isError, (size_t code), (code))                                                 \
+  V(int, ZSTD_getErrorCode, (size_t code), (code))                                                 \
+  V(const char*, ZSTD_getErrorName, (size_t code), (code))                                         \
+  V(const char*, ZSTD_getErrorString, (int code), (code))
+
+// Branches on the gate.
+#define ZSTD_ROUTER_D_API(V)                                                                       \
+  V(void*, ZSTD_createDCtx, (void), ())                                                            \
+  V(size_t, ZSTD_freeDCtx, (void* dctx), (dctx))                                                   \
+  V(size_t, ZSTD_DCtx_reset, (void* dctx, int reset), (dctx, reset))                               \
+  V(size_t, ZSTD_DCtx_setParameter, (void* dctx, int param, int value), (dctx, param, value))      \
+  V(size_t, ZSTD_decompressStream, (void* dctx, void* output, void* input), (dctx, output, input))
+
+#define V(ret, name, params, args) ret zstd_c_##name params;
+ZSTD_ROUTER_C_API(V)
+ZSTD_ROUTER_D_API(V)
+#undef V
+#define V(ret, name, params, args) ret zstd_rs_##name params;
+ZSTD_ROUTER_D_API(V)
+#undef V
+
+}  // extern "C"
+
+namespace {
+std::atomic<bool> useZstdRs{false};
+}  // namespace
+
+extern "C" {
+
+void workerd_zstd_router_set_rs(bool enable) {
+  useZstdRs.store(enable, std::memory_order_relaxed);
+}
+
+#define V(ret, name, params, args)                                                                 \
+  ret name params {                                                                                \
+    return zstd_c_##name args;                                                                     \
+  }
+ZSTD_ROUTER_C_API(V)
+#undef V
+
+#define V(ret, name, params, args)                                                                 \
+  ret name params {                                                                                \
+    return useZstdRs.load(std::memory_order_relaxed) ? zstd_rs_##name args : zstd_c_##name args;   \
+  }
+ZSTD_ROUTER_D_API(V)
+#undef V
+
+}  // extern "C"

--- a/src/workerd/util/zstd-router.h
+++ b/src/workerd/util/zstd-router.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// Routing layer owning the unprefixed spellings of every ZSTD_* symbol consumed in the build.
+// zstd consumers resolve to these definitions (see zstd-router.c++), which forward each call to
+// either the C implementation (zstd_c_*) or the Rust decoder (zstd_rs_*).
+
+extern "C" {
+
+// Selects the Rust decoder as the backing implementation for all subsequent zstd decompression
+// calls; compression stays on the C implementation on both sides. Set at process startup from
+// the compression-rs autogate (see Autogate::initAutogate()); a decompression context must be
+// created, run, and freed by a single implementation, so this must not be toggled while any
+// context is live.
+void workerd_zstd_router_set_rs(bool enable);
+
+}  // extern "C"


### PR DESCRIPTION
This extends the compression-rs autogated router introduced in #7132 to zstd.

_As posted, this should not land, due to the 3x slowdown. But updating this PR as Rust zstd improves can allow us to track when this might become viable in future._

The unprefixed ZSTD_* symbol names consumed in the build (the streaming compression/decompression context entry points and the error helpers) are now owned by a compiled routing layer, `src/workerd/util/zstd-router.c++`, which forwards each call to one of the two implementations linked into the binary, selected by the same process-global atomic set from the compression-rs autogate as the zlib router. This covers node:zlib's zstd modes universally (the only zstd consumer in the build).

No credible pure-Rust zstd encoder exists today (ruzstd's encoder only supports the fastest strategy, with no level selection, streaming flush control, or dictionaries), so only decompression is routed: the gate switches `ZSTD_decompressStream` and the DCtx entry points to ruzstd, while compression stays on the C implementation on both sides of the gate. The error helpers also stay on the C implementation; the Rust side returns errors in the standard `(size_t)-ZSTD_ErrorCode` encoding so they interpret results from either implementation.

* The C implementation is rebuilt with its routed entry points renamed to `zstd_c_*` as `@zstd//:zstd_impl`, via a `single_version_override` patch to the BCR zstd module's BUILD (mirroring how `build/BUILD.zlib` does `zlib_impl`); `@zstd//:zstd` becomes the standard headers over the routing layer. One source-line guard is needed in `zstd_common.c`, which `#undef`s `ZSTD_isError`.
* The new `src/rust/zstd-rs` crate implements the `ZSTD_decompressStream` contract over ruzstd's `FrameDecoder`: push-style input buffering with bounded decode steps, frame-boundary and skippable-frame handling, `ZSTD_d_windowLogMax` enforcement, content checksum verification, and libzstd's hostage-byte protocol at frame end so node:zlib's availIn/availOut bookkeeping and truncation detection behave identically on both sides of the gate.
* The gate is propagated from the existing sync point in `autogate.c++`.
* A new kj_test verifies the router selects the matching implementation on both sides of the gate (observed via the experimental `ZSTD_d_format` parameter, which only the C implementation accepts) and that both implementations decode each other's output, including checksummed frames and corruption errors.
* A `bench-zstd` benchmark measures the node:zlib streaming workload (1MB compressible data, 16KB chunks) against both decoders.

Benchmark results:

| Benchmark | Throughput |
|---|---|
| Zstd::Compress::Native (C, both sides of gate) | 472 MiB/s |
| Zstd::Decompress::Native (C, gate off) | 1.38 GiB/s |
| Zstd::Decompress::ZstdRs (ruzstd, gate on) | 485 MiB/s (~2.9x slower) |

Compression output is gate-independent (always the C encoder); representative ratios with decode verified byte-exact through both decoders:

| Input (1MB) | L1 | L3 (default) | L19 |
|---|---|---|---|
| repetitive text | 163 B | 162 B | 148 B |
| JSON records | 14.11% | 13.79% | 11.49% |
| random | 100% | 100% | 100% |
| zeros | 51 B | 50 B | 49 B |

Test coverage: the new router kj_test, zlib-zstd-nodejs-test across all variants (`@all-autogates` exercises the ruzstd path end-to-end, including streaming, truncation, and maxOutputLength cases), and the full `//src/workerd/...` + `//src/rust/...` suites.
