### PR TITLE
Route brotli through the compression-rs autogated router

### DIFF
--- a/build/BUILD.brotli
+++ b/build/BUILD.brotli
@@ -1,0 +1,93 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# The brotli C API functions our consumers call. The C implementation below is compiled with
+# these renamed to brotli_c_*; the standard names are owned by the routing layer
+# (src/workerd/util/brotli-router.c++), which forwards each call to either the C implementation
+# or rust-brotli (brotli_rs_*), selected at process level by the compression-rs autogate.
+ROUTED_FUNCTIONS = [
+    "BrotliEncoderCreateInstance",
+    "BrotliEncoderDestroyInstance",
+    "BrotliEncoderSetParameter",
+    "BrotliEncoderCompressStream",
+    "BrotliEncoderIsFinished",
+    "BrotliEncoderHasMoreOutput",
+    "BrotliEncoderCompress",
+    "BrotliEncoderMaxCompressedSize",
+    "BrotliDecoderCreateInstance",
+    "BrotliDecoderDestroyInstance",
+    "BrotliDecoderSetParameter",
+    "BrotliDecoderDecompressStream",
+    "BrotliDecoderHasMoreOutput",
+    "BrotliDecoderGetErrorCode",
+    "BrotliDecoderErrorString",
+    "BrotliDecoderDecompress",
+]
+
+config_setting(
+    name = "clang-cl",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "clang-cl",
+    },
+)
+
+config_setting(
+    name = "msvc",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
+    },
+)
+
+cc_library(
+    name = "brotli_inc",
+    hdrs = glob(["c/include/brotli/*.h"]),
+    strip_include_prefix = "c/include",
+    visibility = ["//visibility:public"],
+)
+
+# The C brotli implementation, compiled with the routed entry points renamed to brotli_c_*.
+# Consumers never link this directly; they go through the unprefixed routing layer.
+cc_library(
+    name = "brotli_impl",
+    srcs = glob([
+        "c/common/*.c",
+        "c/common/*.h",
+        "c/dec/*.c",
+        "c/dec/*.h",
+        "c/enc/*.c",
+        "c/enc/*.h",
+    ]),
+    linkopts = select({
+        ":clang-cl": [],
+        ":msvc": [],
+        "//conditions:default": ["-lm"],
+    }),
+    local_defines = ["%s=brotli_c_%s" % (f, f) for f in ROUTED_FUNCTIONS],
+    visibility = ["//visibility:public"],
+    deps = [":brotli_inc"],
+)
+
+# The brotli consumed by everything in the build: the public headers declare the standard
+# unprefixed symbol names, which are defined by the routing layer.
+cc_library(
+    name = "brotlicommon",
+    visibility = ["//visibility:public"],
+    deps = [":brotli_inc"],
+)
+
+cc_library(
+    name = "brotlidec",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":brotli_inc",
+        "@@//src/workerd/util:brotli-router",
+    ],
+)
+
+cc_library(
+    name = "brotlienc",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":brotli_inc",
+        "@@//src/workerd/util:brotli-router",
+    ],
+)

--- a/build/deps/deps.jsonc
+++ b/build/deps/deps.jsonc
@@ -19,9 +19,20 @@
         "//:patches/boringssl/0001-Expose-libdecrepit-so-NodeJS-can-use-it-for-ncrypto.patch"
       ]
     },
+    // Built from our own build file (rather than the upstream BUILD) so the C implementation can
+    // be compiled under prefixed symbol names, with the standard names owned by the routing layer
+    // in src/workerd/util/brotli-router.c++.
     {
       "name": "brotli",
-      "type": "bazel_dep"
+      "type": "github_release",
+      "use_bazel_dep": true,
+      "owner": "google",
+      "repo": "brotli",
+      "freeze_version": "v1.2.0",
+      "build_file": "//:build/BUILD.brotli",
+      "patches": [
+        "//:patches/brotli/0001-Add-dummy-MODULE.bazel.patch"
+      ]
     },
     {
       "name": "zstd",

--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -22,7 +22,19 @@ archive_override(
 )
 
 # brotli
-bazel_dep(name = "brotli", version = "1.2.0.bcr.1")
+bazel_dep(name = "brotli")
+archive_override(
+    module_name = "brotli",
+    build_file = "//:build/BUILD.brotli",
+    patch_strip = 1,
+    patches = [
+        "//:patches/brotli/0001-Add-dummy-MODULE.bazel.patch",
+    ],
+    sha256 = "eb5f7dadf215d0670665fd81566e1fe2dfdc154d983f09142de7299df4c182e6",
+    strip_prefix = "google-brotli-028fb5a",
+    type = "tgz",
+    url = "https://api.github.com/repos/google/brotli/tarball/v1.2.0",
+)
 
 # capnp-cpp
 http.archive(

--- a/deps/rust/Cargo.lock
+++ b/deps/rust/Cargo.lock
@@ -41,6 +41,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +157,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -444,6 +480,8 @@ dependencies = [
  "ada-url",
  "anyhow",
  "async-trait",
+ "brotli",
+ "brotli-decompressor",
  "bytes",
  "capnp",
  "capnp-rpc",

--- a/deps/rust/Cargo.toml
+++ b/deps/rust/Cargo.toml
@@ -32,6 +32,11 @@ syn = { version = "2", features = ["full"] }
 ada-url = { version = "4", default-features = false, features = ["std"] }
 anyhow = "1"
 async-trait = { version = "0", default-features = false }
+# Memory-safe Rust implementation of brotli, exposed to C++ under brotli_rs_-prefixed
+# symbols by src/rust/brotli-rs. The ffi-api feature stays off: it would export the
+# standard unprefixed C symbols, which are owned by the routing layer.
+brotli = { version = "8", default-features = false, features = ["std"] }
+brotli-decompressor = { version = "5", default-features = false, features = ["std"] }
 bytes = { version = "1", default-features = false }
 capnp = "0"
 capnpc = "0"

--- a/patches/brotli/0001-Add-dummy-MODULE.bazel.patch
+++ b/patches/brotli/0001-Add-dummy-MODULE.bazel.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Guy Bedford <gbedford@cloudflare.com>
+Date: Wed, 26 Aug 2026 12:00:00 -0700
+Subject: Add dummy MODULE.bazel
+
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000000000000000000000000000000000000..0000000000000000000000000000000000000001
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,8 @@
++# dummy file used to support bzlmod
++module(
++    name = "brotli",
++    version = "1.2.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/src/rust/brotli-rs/BUILD.bazel
+++ b/src/rust/brotli-rs/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//:build/wd_rust_crate.bzl", "wd_rust_crate")
+
+wd_rust_crate(
+    name = "brotli-rs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates_vendor//:brotli",
+        "@crates_vendor//:brotli-decompressor",
+    ],
+)

--- a/src/rust/brotli-rs/lib.rs
+++ b/src/rust/brotli-rs/lib.rs
@@ -1,0 +1,400 @@
+// Exposes rust-brotli (the memory-safe Rust implementation of brotli) to C++
+// under brotli_rs_-prefixed C symbols matching the brotli C API. The standard
+// unprefixed names are owned by the routing layer
+// (src/workerd/util/brotli-router.c++), which forwards to these or to the C
+// implementation (brotli_c_*) based on the compression-rs autogate.
+//
+// Allocation uses the Rust global allocator; the custom allocator callbacks
+// accepted by the create functions are ignored, mirroring zlib-rs' rust-allocator
+// configuration. The crate's ffi-api feature stays off since it would export the
+// unprefixed names.
+#![allow(non_snake_case)]
+// Thin forwarders over the rust-brotli streaming API: each wrapper has exactly the safety
+// contract of the brotli C API function it implements.
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::undocumented_unsafe_blocks)]
+
+use core::ffi::c_char;
+use core::ffi::c_int;
+use core::ffi::c_void;
+use core::slice;
+
+use brotli::enc::StandardAlloc;
+use brotli::enc::encode::BrotliEncoderDestroyInstance;
+use brotli::enc::encode::BrotliEncoderMaxCompressedSize;
+use brotli::enc::encode::BrotliEncoderOperation;
+use brotli::enc::encode::BrotliEncoderParameter;
+use brotli::enc::encode::BrotliEncoderStateStruct;
+use brotli_decompressor::BrotliDecoderHasMoreOutput;
+use brotli_decompressor::BrotliDecompressStream;
+use brotli_decompressor::BrotliResult;
+use brotli_decompressor::BrotliState;
+
+type EncoderState = BrotliEncoderStateStruct<StandardAlloc>;
+type DecoderState = BrotliState<StandardAlloc, StandardAlloc, StandardAlloc>;
+
+// The custom allocator callback types from the C API; accepted for signature
+// compatibility and ignored.
+type BrotliAllocFunc = Option<unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void>;
+type BrotliFreeFunc = Option<unsafe extern "C" fn(*mut c_void, *mut c_void)>;
+
+// BrotliDecoderResult values.
+const BROTLI_DECODER_RESULT_ERROR: c_int = 0;
+const BROTLI_DECODER_RESULT_SUCCESS: c_int = 1;
+const BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT: c_int = 2;
+const BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT: c_int = 3;
+
+fn decoder_result(result: &BrotliResult) -> c_int {
+    match result {
+        BrotliResult::ResultSuccess => BROTLI_DECODER_RESULT_SUCCESS,
+        BrotliResult::NeedsMoreInput => BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT,
+        BrotliResult::NeedsMoreOutput => BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT,
+        BrotliResult::ResultFailure => BROTLI_DECODER_RESULT_ERROR,
+    }
+}
+
+unsafe fn slice_or_nil<'a>(data: *const u8, len: usize) -> &'a [u8] {
+    if len == 0 {
+        return &[];
+    }
+    unsafe { slice::from_raw_parts(data, len) }
+}
+
+unsafe fn slice_or_nil_mut<'a>(data: *mut u8, len: usize) -> &'a mut [u8] {
+    if len == 0 {
+        return &mut [];
+    }
+    unsafe { slice::from_raw_parts_mut(data, len) }
+}
+
+fn encoder_parameter(param: c_int) -> Option<BrotliEncoderParameter> {
+    use BrotliEncoderParameter as P;
+    Some(match param {
+        0 => P::BROTLI_PARAM_MODE,
+        1 => P::BROTLI_PARAM_QUALITY,
+        2 => P::BROTLI_PARAM_LGWIN,
+        3 => P::BROTLI_PARAM_LGBLOCK,
+        4 => P::BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING,
+        5 => P::BROTLI_PARAM_SIZE_HINT,
+        6 => P::BROTLI_PARAM_LARGE_WINDOW,
+        _ => return None,
+    })
+}
+
+fn encoder_operation(op: c_int) -> Option<BrotliEncoderOperation> {
+    use BrotliEncoderOperation as Op;
+    Some(match op {
+        0 => Op::BROTLI_OPERATION_PROCESS,
+        1 => Op::BROTLI_OPERATION_FLUSH,
+        2 => Op::BROTLI_OPERATION_FINISH,
+        3 => Op::BROTLI_OPERATION_EMIT_METADATA,
+        _ => return None,
+    })
+}
+
+// =======================================================================================
+// Encoder
+
+#[unsafe(no_mangle)]
+pub extern "C" fn brotli_rs_BrotliEncoderCreateInstance(
+    _alloc_func: BrotliAllocFunc,
+    _free_func: BrotliFreeFunc,
+    _opaque: *mut c_void,
+) -> *mut EncoderState {
+    Box::into_raw(Box::new(BrotliEncoderStateStruct::new(
+        StandardAlloc::default(),
+    )))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliEncoderDestroyInstance(state: *mut EncoderState) {
+    if state.is_null() {
+        return;
+    }
+    let mut boxed = unsafe { Box::from_raw(state) };
+    BrotliEncoderDestroyInstance(&mut boxed);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliEncoderSetParameter(
+    state: *mut EncoderState,
+    param: c_int,
+    value: u32,
+) -> c_int {
+    let Some(param) = encoder_parameter(param) else {
+        return 0;
+    };
+    unsafe { c_int::from((*state).set_parameter(param, value)) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliEncoderCompressStream(
+    state: *mut EncoderState,
+    op: c_int,
+    available_in: *mut usize,
+    next_in: *mut *const u8,
+    available_out: *mut usize,
+    next_out: *mut *mut u8,
+    total_out: *mut usize,
+) -> c_int {
+    let Some(op) = encoder_operation(op) else {
+        return 0;
+    };
+    unsafe {
+        let input = slice_or_nil(*next_in, *available_in);
+        let output = slice_or_nil_mut(*next_out, *available_out);
+        let mut input_offset = 0usize;
+        let mut output_offset = 0usize;
+        let mut to = Some(0usize);
+        let result = (*state).compress_stream(
+            op,
+            &mut *available_in,
+            input,
+            &mut input_offset,
+            &mut *available_out,
+            output,
+            &mut output_offset,
+            &mut to,
+            &mut |_a, _b, _c, _d| (),
+        );
+        if !total_out.is_null() {
+            *total_out = to.unwrap_or(0);
+        }
+        *next_in = (*next_in).add(input_offset);
+        *next_out = (*next_out).add(output_offset);
+        c_int::from(result)
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliEncoderIsFinished(state: *mut EncoderState) -> c_int {
+    unsafe { c_int::from((*state).is_finished()) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliEncoderHasMoreOutput(state: *mut EncoderState) -> c_int {
+    unsafe { c_int::from((*state).has_more_output()) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn brotli_rs_BrotliEncoderMaxCompressedSize(input_size: usize) -> usize {
+    BrotliEncoderMaxCompressedSize(input_size)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliEncoderCompress(
+    quality: c_int,
+    lgwin: c_int,
+    mode: c_int,
+    input_size: usize,
+    input_buffer: *const u8,
+    encoded_size: *mut usize,
+    encoded_buffer: *mut u8,
+) -> c_int {
+    unsafe {
+        let mut state = BrotliEncoderStateStruct::new(StandardAlloc::default());
+        state.set_parameter(
+            BrotliEncoderParameter::BROTLI_PARAM_QUALITY,
+            quality.cast_unsigned(),
+        );
+        state.set_parameter(
+            BrotliEncoderParameter::BROTLI_PARAM_LGWIN,
+            lgwin.cast_unsigned(),
+        );
+        state.set_parameter(
+            BrotliEncoderParameter::BROTLI_PARAM_MODE,
+            mode.cast_unsigned(),
+        );
+        state.set_parameter(
+            BrotliEncoderParameter::BROTLI_PARAM_SIZE_HINT,
+            input_size as u32,
+        );
+        let input = slice_or_nil(input_buffer, input_size);
+        let output = slice_or_nil_mut(encoded_buffer, *encoded_size);
+        let mut available_in = input_size;
+        let mut input_offset = 0usize;
+        let mut available_out = *encoded_size;
+        let mut output_offset = 0usize;
+        let mut to = Some(0usize);
+        let result = state.compress_stream(
+            BrotliEncoderOperation::BROTLI_OPERATION_FINISH,
+            &mut available_in,
+            input,
+            &mut input_offset,
+            &mut available_out,
+            output,
+            &mut output_offset,
+            &mut to,
+            &mut |_a, _b, _c, _d| (),
+        );
+        let ok = result && state.is_finished();
+        BrotliEncoderDestroyInstance(&mut state);
+        if !ok {
+            return 0;
+        }
+        *encoded_size = output_offset;
+        1
+    }
+}
+
+// =======================================================================================
+// Decoder
+
+#[unsafe(no_mangle)]
+pub extern "C" fn brotli_rs_BrotliDecoderCreateInstance(
+    _alloc_func: BrotliAllocFunc,
+    _free_func: BrotliFreeFunc,
+    _opaque: *mut c_void,
+) -> *mut DecoderState {
+    Box::into_raw(Box::new(BrotliState::new(
+        StandardAlloc::default(),
+        StandardAlloc::default(),
+        StandardAlloc::default(),
+    )))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliDecoderDestroyInstance(state: *mut DecoderState) {
+    if state.is_null() {
+        return;
+    }
+    drop(unsafe { Box::from_raw(state) });
+}
+
+// The Rust decoder has no equivalent of the C decoder parameters
+// (disable-ring-buffer-reallocation and large-window are internal to it); accept
+// and ignore them.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliDecoderSetParameter(
+    _state: *mut DecoderState,
+    _param: c_int,
+    _value: u32,
+) -> c_int {
+    1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliDecoderDecompressStream(
+    state: *mut DecoderState,
+    available_in: *mut usize,
+    next_in: *mut *const u8,
+    available_out: *mut usize,
+    next_out: *mut *mut u8,
+    total_out: *mut usize,
+) -> c_int {
+    unsafe {
+        let input = slice_or_nil(*next_in, *available_in);
+        let output = slice_or_nil_mut(*next_out, *available_out);
+        let mut input_offset = 0usize;
+        let mut output_offset = 0usize;
+        let mut fallback_total_out = 0usize;
+        let total_out = if total_out.is_null() {
+            &mut fallback_total_out
+        } else {
+            &mut *total_out
+        };
+        let result = BrotliDecompressStream(
+            &mut *available_in,
+            &mut input_offset,
+            input,
+            &mut *available_out,
+            &mut output_offset,
+            output,
+            total_out,
+            &mut *state,
+        );
+        *next_in = (*next_in).add(input_offset);
+        *next_out = (*next_out).add(output_offset);
+        decoder_result(&result)
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliDecoderHasMoreOutput(state: *const DecoderState) -> c_int {
+    unsafe { c_int::from(BrotliDecoderHasMoreOutput(&*state)) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliDecoderGetErrorCode(state: *const DecoderState) -> c_int {
+    unsafe { (*state).error_code as c_int }
+}
+
+// Matches the strings produced by the C implementation's BrotliDecoderErrorString
+// (see BROTLI_DECODER_ERROR_CODES_LIST in brotli/decode.h).
+#[unsafe(no_mangle)]
+pub extern "C" fn brotli_rs_BrotliDecoderErrorString(code: c_int) -> *const c_char {
+    let name: &'static str = match code {
+        0 => "_NO_ERROR\0",
+        1 => "_SUCCESS\0",
+        2 => "_NEEDS_MORE_INPUT\0",
+        3 => "_NEEDS_MORE_OUTPUT\0",
+        -1 => "_ERROR_FORMAT_EXUBERANT_NIBBLE\0",
+        -2 => "_ERROR_FORMAT_RESERVED\0",
+        -3 => "_ERROR_FORMAT_EXUBERANT_META_NIBBLE\0",
+        -4 => "_ERROR_FORMAT_SIMPLE_HUFFMAN_ALPHABET\0",
+        -5 => "_ERROR_FORMAT_SIMPLE_HUFFMAN_SAME\0",
+        -6 => "_ERROR_FORMAT_CL_SPACE\0",
+        -7 => "_ERROR_FORMAT_HUFFMAN_SPACE\0",
+        -8 => "_ERROR_FORMAT_CONTEXT_MAP_REPEAT\0",
+        -9 => "_ERROR_FORMAT_BLOCK_LENGTH_1\0",
+        -10 => "_ERROR_FORMAT_BLOCK_LENGTH_2\0",
+        -11 => "_ERROR_FORMAT_TRANSFORM\0",
+        -12 => "_ERROR_FORMAT_DICTIONARY\0",
+        -13 => "_ERROR_FORMAT_WINDOW_BITS\0",
+        -14 => "_ERROR_FORMAT_PADDING_1\0",
+        -15 => "_ERROR_FORMAT_PADDING_2\0",
+        -16 => "_ERROR_FORMAT_DISTANCE\0",
+        -18 => "_ERROR_COMPOUND_DICTIONARY\0",
+        -19 => "_ERROR_DICTIONARY_NOT_SET\0",
+        -20 => "_ERROR_INVALID_ARGUMENTS\0",
+        -21 => "_ERROR_ALLOC_CONTEXT_MODES\0",
+        -22 => "_ERROR_ALLOC_TREE_GROUPS\0",
+        -25 => "_ERROR_ALLOC_CONTEXT_MAP\0",
+        -26 => "_ERROR_ALLOC_RING_BUFFER_1\0",
+        -27 => "_ERROR_ALLOC_RING_BUFFER_2\0",
+        -30 => "_ERROR_ALLOC_BLOCK_TYPE_TREES\0",
+        -31 => "_ERROR_UNREACHABLE\0",
+        _ => "INVALID\0",
+    };
+    name.as_ptr().cast()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn brotli_rs_BrotliDecoderDecompress(
+    encoded_size: usize,
+    encoded_buffer: *const u8,
+    decoded_size: *mut usize,
+    decoded_buffer: *mut u8,
+) -> c_int {
+    unsafe {
+        let mut state = BrotliState::new(
+            StandardAlloc::default(),
+            StandardAlloc::default(),
+            StandardAlloc::default(),
+        );
+        let input = slice_or_nil(encoded_buffer, encoded_size);
+        let output = slice_or_nil_mut(decoded_buffer, *decoded_size);
+        let mut available_in = encoded_size;
+        let mut input_offset = 0usize;
+        let mut available_out = *decoded_size;
+        let mut output_offset = 0usize;
+        let mut total_out = 0usize;
+        let result = BrotliDecompressStream(
+            &mut available_in,
+            &mut input_offset,
+            input,
+            &mut available_out,
+            &mut output_offset,
+            output,
+            &mut total_out,
+            &mut state,
+        );
+        match result {
+            BrotliResult::ResultSuccess => {
+                *decoded_size = output_offset;
+                BROTLI_DECODER_RESULT_SUCCESS
+            }
+            _ => BROTLI_DECODER_RESULT_ERROR,
+        }
+    }
+}

--- a/src/rust/brotli-rs/lib.rs
+++ b/src/rust/brotli-rs/lib.rs
@@ -160,8 +160,12 @@ pub unsafe extern "C" fn brotli_rs_BrotliEncoderCompressStream(
         if !total_out.is_null() {
             *total_out = to.unwrap_or(0);
         }
-        *next_in = (*next_in).add(input_offset);
-        *next_out = (*next_out).add(output_offset);
+        if input_offset != 0 {
+            *next_in = (*next_in).add(input_offset);
+        }
+        if output_offset != 0 {
+            *next_out = (*next_out).add(output_offset);
+        }
         c_int::from(result)
     }
 }
@@ -303,8 +307,12 @@ pub unsafe extern "C" fn brotli_rs_BrotliDecoderDecompressStream(
             total_out,
             &mut *state,
         );
-        *next_in = (*next_in).add(input_offset);
-        *next_out = (*next_out).add(output_offset);
+        if input_offset != 0 {
+            *next_in = (*next_in).add(input_offset);
+        }
+        if output_offset != 0 {
+            *next_out = (*next_out).add(output_offset);
+        }
         decoder_result(&result)
     }
 }

--- a/src/workerd/tests/BUILD.bazel
+++ b/src/workerd/tests/BUILD.bazel
@@ -111,6 +111,16 @@ wd_cc_benchmark(
 )
 
 wd_cc_benchmark(
+    name = "bench-brotli",
+    srcs = ["bench-brotli.c++"],
+    deps = [
+        "//src/rust/brotli-rs",
+        "@brotli//:brotlidec",
+        "@brotli//:brotlienc",
+    ],
+)
+
+wd_cc_benchmark(
     name = "bench-util",
     srcs = ["bench-util.c++"],
     deps = [

--- a/src/workerd/tests/bench-brotli.c++
+++ b/src/workerd/tests/bench-brotli.c++
@@ -1,0 +1,197 @@
+// Benchmarks the native (C) brotli against rust-brotli on the kj-http content-encoding
+// streaming workload: 1MB of compressible data in 16KB chunks with kj's default parameters
+// (quality 5, lgwin 19). The native arm goes through the unprefixed (routed) API, which
+// resolves to the C implementation since benchmarks run with the compression-rs autogate off;
+// the rust arm calls rust-brotli directly through its brotli_rs_* symbols.
+
+#include <workerd/tests/bench-tools.h>
+
+#include <brotli/decode.h>
+#include <brotli/encode.h>
+
+#include <kj/array.h>
+#include <kj/debug.h>
+
+extern "C" {
+void* brotli_rs_BrotliEncoderCreateInstance(void*, void*, void*);
+void brotli_rs_BrotliEncoderDestroyInstance(void* state);
+int brotli_rs_BrotliEncoderSetParameter(void* state, int param, uint32_t value);
+int brotli_rs_BrotliEncoderCompressStream(void* state,
+    int op,
+    size_t* availableIn,
+    const uint8_t** nextIn,
+    size_t* availableOut,
+    uint8_t** nextOut,
+    size_t* totalOut);
+int brotli_rs_BrotliEncoderIsFinished(void* state);
+void* brotli_rs_BrotliDecoderCreateInstance(void*, void*, void*);
+void brotli_rs_BrotliDecoderDestroyInstance(void* state);
+int brotli_rs_BrotliDecoderDecompressStream(void* state,
+    size_t* availableIn,
+    const uint8_t** nextIn,
+    size_t* availableOut,
+    uint8_t** nextOut,
+    size_t* totalOut);
+}
+
+namespace workerd {
+namespace {
+
+constexpr size_t DATA_SIZE = 1 << 20;
+constexpr size_t CHUNK = 16 * 1024;
+constexpr int QUALITY = 5;
+constexpr int LGWIN = 19;
+
+kj::Array<kj::byte> makeCompressibleData() {
+  static constexpr kj::StringPtr words[] = {"the "_kj, "quick "_kj, "compression "_kj, "of "_kj,
+    "brotli "_kj, "streaming "_kj, "workers "_kj, "runtime "_kj};
+  auto data = kj::heapArray<kj::byte>(DATA_SIZE);
+  uint32_t s = 0x12345678;
+  size_t pos = 0;
+  while (pos < data.size()) {
+    s = s * 1664525 + 1013904223;
+    auto w = words[(s >> 24) & 7].asBytes();
+    size_t n = kj::min(w.size(), data.size() - pos);
+    memcpy(data.begin() + pos, w.begin(), n);
+    pos += n;
+  }
+  return data;
+}
+
+const kj::Array<kj::byte>& sourceData() {
+  static const kj::Array<kj::byte> data = makeCompressibleData();
+  return data;
+}
+
+// Streaming via a generic stream-call shape shared by both backends. The run callback returns
+// whether the stream is finished.
+template <typename RunFn>
+size_t streamAll(kj::ArrayPtr<const kj::byte> data, RunFn&& run) {
+  static kj::byte out[CHUNK];
+  size_t total = 0;
+  size_t offset = 0;
+  while (offset < data.size()) {
+    size_t n = kj::min(CHUNK, data.size() - offset);
+    bool last = offset + n == data.size();
+    const kj::byte* nextIn = data.begin() + offset;
+    size_t availIn = n;
+    offset += n;
+    do {
+      kj::byte* nextOut = out;
+      size_t availOut = sizeof(out);
+      bool done = run(&nextIn, &availIn, &nextOut, &availOut, last);
+      total += sizeof(out) - availOut;
+      if (done) return total;
+    } while (availIn > 0 || last);
+  }
+  return total;
+}
+
+size_t compressNative(kj::ArrayPtr<const kj::byte> data) {
+  BrotliEncoderState* ctx = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
+  KJ_REQUIRE(ctx != nullptr);
+  KJ_DEFER(BrotliEncoderDestroyInstance(ctx));
+  KJ_REQUIRE(BrotliEncoderSetParameter(ctx, BROTLI_PARAM_QUALITY, QUALITY) == BROTLI_TRUE);
+  KJ_REQUIRE(BrotliEncoderSetParameter(ctx, BROTLI_PARAM_LGWIN, LGWIN) == BROTLI_TRUE);
+  return streamAll(data,
+      [&](const kj::byte** nextIn, size_t* availIn, kj::byte** nextOut, size_t* availOut,
+          bool last) {
+    KJ_REQUIRE(
+        BrotliEncoderCompressStream(ctx, last ? BROTLI_OPERATION_FINISH : BROTLI_OPERATION_PROCESS,
+            availIn, nextIn, availOut, nextOut, nullptr) == BROTLI_TRUE);
+    return BrotliEncoderIsFinished(ctx) == BROTLI_TRUE;
+  });
+}
+
+size_t compressBrotliRs(kj::ArrayPtr<const kj::byte> data) {
+  void* ctx = brotli_rs_BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
+  KJ_REQUIRE(ctx != nullptr);
+  KJ_DEFER(brotli_rs_BrotliEncoderDestroyInstance(ctx));
+  KJ_REQUIRE(brotli_rs_BrotliEncoderSetParameter(ctx, BROTLI_PARAM_QUALITY, QUALITY) == 1);
+  KJ_REQUIRE(brotli_rs_BrotliEncoderSetParameter(ctx, BROTLI_PARAM_LGWIN, LGWIN) == 1);
+  return streamAll(data,
+      [&](const kj::byte** nextIn, size_t* availIn, kj::byte** nextOut, size_t* availOut,
+          bool last) {
+    KJ_REQUIRE(brotli_rs_BrotliEncoderCompressStream(ctx,
+                   last ? BROTLI_OPERATION_FINISH : BROTLI_OPERATION_PROCESS, availIn, nextIn,
+                   availOut, nextOut, nullptr) == 1);
+    return brotli_rs_BrotliEncoderIsFinished(ctx) == 1;
+  });
+}
+
+size_t decompressNative(kj::ArrayPtr<const kj::byte> data) {
+  BrotliDecoderState* ctx = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
+  KJ_REQUIRE(ctx != nullptr);
+  KJ_DEFER(BrotliDecoderDestroyInstance(ctx));
+  return streamAll(data,
+      [&](const kj::byte** nextIn, size_t* availIn, kj::byte** nextOut, size_t* availOut, bool) {
+    BrotliDecoderResult result =
+        BrotliDecoderDecompressStream(ctx, availIn, nextIn, availOut, nextOut, nullptr);
+    KJ_REQUIRE(result != BROTLI_DECODER_RESULT_ERROR);
+    return result == BROTLI_DECODER_RESULT_SUCCESS;
+  });
+}
+
+size_t decompressBrotliRs(kj::ArrayPtr<const kj::byte> data) {
+  void* ctx = brotli_rs_BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
+  KJ_REQUIRE(ctx != nullptr);
+  KJ_DEFER(brotli_rs_BrotliDecoderDestroyInstance(ctx));
+  return streamAll(data,
+      [&](const kj::byte** nextIn, size_t* availIn, kj::byte** nextOut, size_t* availOut, bool) {
+    int result =
+        brotli_rs_BrotliDecoderDecompressStream(ctx, availIn, nextIn, availOut, nextOut, nullptr);
+    KJ_REQUIRE(result != BROTLI_DECODER_RESULT_ERROR);
+    return result == BROTLI_DECODER_RESULT_SUCCESS;
+  });
+}
+
+kj::Array<kj::byte> compressedData() {
+  auto& src = sourceData();
+  size_t destLen = BrotliEncoderMaxCompressedSize(src.size());
+  auto dest = kj::heapArray<kj::byte>(destLen);
+  KJ_REQUIRE(BrotliEncoderCompress(QUALITY, LGWIN, BROTLI_MODE_GENERIC, src.size(), src.begin(),
+                 &destLen, dest.begin()) == BROTLI_TRUE);
+  return kj::heapArray<kj::byte>(dest.first(destLen));
+}
+
+void Brotli_Compress_Native(benchmark::State& state) {
+  auto& src = sourceData();
+  for (auto _: state) {
+    benchmark::DoNotOptimize(compressNative(src));
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * src.size());
+}
+
+void Brotli_Compress_BrotliRs(benchmark::State& state) {
+  auto& src = sourceData();
+  for (auto _: state) {
+    benchmark::DoNotOptimize(compressBrotliRs(src));
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * src.size());
+}
+
+void Brotli_Decompress_Native(benchmark::State& state) {
+  auto& src = sourceData();
+  auto compressed = compressedData();
+  for (auto _: state) {
+    KJ_ASSERT(decompressNative(compressed) == src.size());
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * src.size());
+}
+
+void Brotli_Decompress_BrotliRs(benchmark::State& state) {
+  auto& src = sourceData();
+  auto compressed = compressedData();
+  for (auto _: state) {
+    KJ_ASSERT(decompressBrotliRs(compressed) == src.size());
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * src.size());
+}
+
+WD_BENCHMARK(Brotli_Compress_Native)->Name("Brotli::Compress::Native");
+WD_BENCHMARK(Brotli_Compress_BrotliRs)->Name("Brotli::Compress::BrotliRs");
+WD_BENCHMARK(Brotli_Decompress_Native)->Name("Brotli::Decompress::Native");
+WD_BENCHMARK(Brotli_Decompress_BrotliRs)->Name("Brotli::Decompress::BrotliRs");
+
+}  // namespace
+}  // namespace workerd

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -34,6 +34,20 @@ wd_cc_library(
     ],
 )
 
+# The routing layer owning the unprefixed brotli symbol names; @brotli//:brotlienc and
+# @brotli//:brotlidec depend on this, so every brotli consumer links it. Deliberately
+# kj/capnp-free (see brotli-router.c++).
+wd_cc_library(
+    name = "brotli-router",
+    srcs = ["brotli-router.c++"],
+    hdrs = ["brotli-router.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/rust/brotli-rs",
+        "@brotli//:brotli_impl",
+    ],
+)
+
 wd_cc_library(
     name = "perfetto",
     srcs = ["perfetto-tracing.c++"],
@@ -301,6 +315,7 @@ wd_cc_library(
     copts = ["-Werror=switch"],
     visibility = ["//visibility:public"],
     deps = [
+        ":brotli-router",
         ":sentry",
         ":strong-bool",
         ":zlib-router",
@@ -463,6 +478,15 @@ kj_test(
     deps = [
         ":autogate",
         "@zlib",
+    ],
+)
+
+kj_test(
+    src = "brotli-router-test.c++",
+    deps = [
+        ":autogate",
+        "@brotli//:brotlidec",
+        "@brotli//:brotlienc",
     ],
 )
 

--- a/src/workerd/util/autogate.c++
+++ b/src/workerd/util/autogate.c++
@@ -3,6 +3,7 @@
 //     https://opensource.org/licenses/Apache-2.0
 #include "autogate.h"
 
+#include <workerd/util/brotli-router.h>
 #include <workerd/util/sentry.h>
 #include <workerd/util/zlib-router.h>
 
@@ -19,14 +20,16 @@ kj::Maybe<Autogate> globalAutogate;
 namespace {
 constexpr auto WORKERD_PREFIX = "workerd-autogate-"_kj;
 
-// Propagates the COMPRESSION_RS gate to the zlib routing layer, which cannot depend on autogate
-// itself. Called whenever the global gate state changes; also run at static init so that
-// processes that never call initAutogate() (e.g. kj_test binaries under WORKERD_ALL_AUTOGATES)
-// still route accordingly.
-void syncZlibRouter() {
-  workerd_zlib_router_set_rs(Autogate::isEnabled(AutogateKey::COMPRESSION_RS));
+// Propagates the COMPRESSION_RS gate to the zlib and brotli routing layers, which cannot depend
+// on autogate themselves. Called whenever the global gate state changes; also run at static init
+// so that processes that never call initAutogate() (e.g. kj_test binaries under
+// WORKERD_ALL_AUTOGATES) still route accordingly.
+void syncCompressionRouters() {
+  bool enable = Autogate::isEnabled(AutogateKey::COMPRESSION_RS);
+  workerd_zlib_router_set_rs(enable);
+  workerd_brotli_router_set_rs(enable);
 }
-[[maybe_unused]] const bool zlibRouterInitialSync = (syncZlibRouter(), true);
+[[maybe_unused]] const bool compressionRoutersInitialSync = (syncCompressionRouters(), true);
 
 // Converts a SCREAMING_SNAKE_CASE string to kebab-case at compile time.
 template <size_t N>
@@ -114,12 +117,12 @@ void Autogate::initAutogate(
     return initAllAutogates();
   }
   globalAutogate = Autogate(gates);
-  syncZlibRouter();
+  syncCompressionRouters();
 }
 
 void Autogate::deinitAutogate() {
   globalAutogate = kj::none;
-  syncZlibRouter();
+  syncCompressionRouters();
 }
 
 void Autogate::initAllAutogates() {
@@ -128,7 +131,7 @@ void Autogate::initAllAutogates() {
     autogate.gates[autogateToIndex(key)] = true;
   }
   globalAutogate = kj::mv(autogate);
-  syncZlibRouter();
+  syncCompressionRouters();
 }
 
 void Autogate::initAutogateNamesForTest(
@@ -159,7 +162,7 @@ void Autogate::initAutogateForTest(std::initializer_list<AutogateKey> keys) {
     autogate.gates[autogateToIndex(key)] = true;
   }
   globalAutogate = kj::mv(autogate);
-  syncZlibRouter();
+  syncCompressionRouters();
 }
 
 }  // namespace workerd::util

--- a/src/workerd/util/autogate.h
+++ b/src/workerd/util/autogate.h
@@ -116,11 +116,12 @@ namespace workerd::util {
      existed; the typescript_implemented_streams compat flag requires this gate to receive         \
      streams over RPC (that combination is rejected, not degraded). */                             \
   V(RPC_EXTERNALS_HYDRATION)                                                                       \
-  /* Route all zlib usage in the process to zlib-rs (libz-rs-sys), the memory-safe Rust          \
-     implementation, instead of chromium zlib. The unprefixed zlib symbols are owned by the      \
-     routing layer in util/zlib-router.c++, so this covers every consumer: node:zlib, web        \
-     CompressionStream, crypto crc32, kj-gzip/http (fetch and WebSocket compression), and V8's   \
-     compression utils. Chromium zlib remains the default. */                                    \
+  /* Route all zlib and brotli usage in the process to the memory-safe Rust implementations     \
+     (zlib-rs and rust-brotli) instead of the native C libraries. The unprefixed symbols are    \
+     owned by the routing layers in util/zlib-router.c++ and util/brotli-router.c++, so this    \
+     covers every consumer: node:zlib, web CompressionStream, crypto crc32, kj-gzip/kj-brotli/  \
+     kj-http (fetch and WebSocket compression), and V8's compression utils. The C               \
+     implementations remain the default. */                                                     \
   V(COMPRESSION_RS)                                                                                 \
   /* Enables per-call JSRPC tracing, trace-context propagation, and related Fetcher spans. */       \
   V(JSRPC_TRACING)                                                                                  \

--- a/src/workerd/util/brotli-router-test.c++
+++ b/src/workerd/util/brotli-router-test.c++
@@ -1,0 +1,132 @@
+#include <workerd/util/autogate.h>
+
+#include <brotli/decode.h>
+#include <brotli/encode.h>
+
+#include <kj/array.h>
+#include <kj/test.h>
+
+// Direct entry points into the two implementations behind the router, for comparing against the
+// routed (unprefixed) API. The unprefixed spelling comes from the brotli headers; these must be
+// hand-declared since the renames in build/BUILD.brotli only apply to the C implementation's own
+// compilation.
+extern "C" {
+int brotli_c_BrotliEncoderCompress(int quality,
+    int lgwin,
+    int mode,
+    size_t inputSize,
+    const unsigned char* inputBuffer,
+    size_t* encodedSize,
+    unsigned char* encodedBuffer);
+int brotli_rs_BrotliEncoderCompress(int quality,
+    int lgwin,
+    int mode,
+    size_t inputSize,
+    const unsigned char* inputBuffer,
+    size_t* encodedSize,
+    unsigned char* encodedBuffer);
+const char* brotli_c_BrotliDecoderErrorString(int code);
+const char* brotli_rs_BrotliDecoderErrorString(int code);
+}
+
+namespace workerd::util {
+namespace {
+
+using CompressFn = int (*)(int, int, int, size_t, const unsigned char*, size_t*, unsigned char*);
+
+// Adapter over the header-declared routed API (whose mode parameter is the
+// BrotliEncoderMode enum) to the common signature used by the prefixed entry points.
+int routedCompress(int quality,
+    int lgwin,
+    int mode,
+    size_t inputSize,
+    const unsigned char* inputBuffer,
+    size_t* encodedSize,
+    unsigned char* encodedBuffer) {
+  return BrotliEncoderCompress(quality, lgwin, static_cast<BrotliEncoderMode>(mode), inputSize,
+      inputBuffer, encodedSize, encodedBuffer);
+}
+
+// Quality 4 chosen because the two implementations' hashing heuristics observably diverge
+// there for this input; at some other qualities the port produces byte-identical streams.
+constexpr int QUALITY = 4;
+constexpr int LGWIN = 22;
+
+kj::Array<kj::byte> makeInput() {
+  static constexpr kj::StringPtr words[] = {"the "_kj, "quick "_kj, "compression "_kj, "of "_kj,
+    "brotli "_kj, "streaming "_kj, "workers "_kj, "runtime "_kj};
+  auto data = kj::heapArray<kj::byte>(64 * 1024);
+  uint32_t s = 0x12345678;
+  size_t pos = 0;
+  while (pos < data.size()) {
+    s = s * 1664525 + 1013904223;
+    auto w = words[(s >> 24) & 7].asBytes();
+    size_t n = kj::min(w.size(), data.size() - pos);
+    memcpy(data.begin() + pos, w.begin(), n);
+    pos += n;
+  }
+  return data;
+}
+
+kj::Array<kj::byte> compressWith(CompressFn fn, kj::ArrayPtr<const kj::byte> input) {
+  size_t destLen = BrotliEncoderMaxCompressedSize(input.size());
+  auto dest = kj::heapArray<kj::byte>(destLen);
+  KJ_REQUIRE(fn(QUALITY, LGWIN, BROTLI_MODE_GENERIC, input.size(), input.begin(), &destLen,
+                 dest.begin()) == BROTLI_TRUE);
+  return kj::heapArray<kj::byte>(dest.first(destLen));
+}
+
+void expectRoundtrip(kj::ArrayPtr<const kj::byte> compressed, kj::ArrayPtr<const kj::byte> input) {
+  size_t destLen = input.size();
+  auto dest = kj::heapArray<kj::byte>(destLen);
+  KJ_EXPECT(BrotliDecoderDecompress(compressed.size(), compressed.begin(), &destLen,
+                dest.begin()) == BROTLI_DECODER_RESULT_SUCCESS);
+  KJ_EXPECT(dest.first(destLen) == input);
+}
+
+KJ_TEST("brotli router uses the C implementation with the compression-rs gate off") {
+  Autogate::initAutogateNamesForTest(
+      kj::ArrayPtr<const kj::StringPtr>(), IgnoreAllAutogatesEnv::YES);
+  KJ_DEFER(Autogate::deinitAutogate());
+
+  KJ_EXPECT(BrotliDecoderErrorString(BROTLI_DECODER_ERROR_FORMAT_PADDING_1) ==
+      brotli_c_BrotliDecoderErrorString(BROTLI_DECODER_ERROR_FORMAT_PADDING_1));
+
+  auto input = makeInput();
+  auto routed = compressWith(&routedCompress, input);
+  auto native = compressWith(&brotli_c_BrotliEncoderCompress, input);
+  auto rs = compressWith(&brotli_rs_BrotliEncoderCompress, input);
+
+  KJ_EXPECT(routed == native);
+  // The premise of the routing test: the two implementations produce observably different
+  // streams for this input.
+  KJ_EXPECT(routed != rs);
+  expectRoundtrip(routed, input);
+}
+
+KJ_TEST("brotli router uses rust-brotli with the compression-rs gate on") {
+  Autogate::initAutogateForTest({AutogateKey::COMPRESSION_RS});
+  KJ_DEFER(Autogate::deinitAutogate());
+
+  KJ_EXPECT(BrotliDecoderErrorString(BROTLI_DECODER_ERROR_FORMAT_PADDING_1) ==
+      brotli_rs_BrotliDecoderErrorString(BROTLI_DECODER_ERROR_FORMAT_PADDING_1));
+  // The Rust implementation's error strings match the C implementation's.
+  KJ_EXPECT(
+      kj::StringPtr(brotli_rs_BrotliDecoderErrorString(BROTLI_DECODER_ERROR_FORMAT_PADDING_1)) ==
+      kj::StringPtr(brotli_c_BrotliDecoderErrorString(BROTLI_DECODER_ERROR_FORMAT_PADDING_1)));
+
+  auto input = makeInput();
+  auto routed = compressWith(&routedCompress, input);
+  auto native = compressWith(&brotli_c_BrotliEncoderCompress, input);
+  auto rs = compressWith(&brotli_rs_BrotliEncoderCompress, input);
+
+  KJ_EXPECT(routed == rs);
+  KJ_EXPECT(routed != native);
+  // rust-brotli output decoded by whichever implementation the router selects; also decode the
+  // C implementation's stream to cover cross-implementation compatibility.
+  expectRoundtrip(routed, input);
+  expectRoundtrip(native, input);
+}
+
+}  // namespace
+}  // namespace workerd::util

--- a/src/workerd/util/brotli-router.c++
+++ b/src/workerd/util/brotli-router.c++
@@ -1,0 +1,88 @@
+#include "brotli-router.h"
+
+#include <stddef.h>
+
+#include <atomic>
+
+// This translation unit defines the brotli C API entry points our consumers use and forwards
+// each call to one of the two implementations linked into the binary:
+//
+//   - the C implementation, compiled with these functions renamed to brotli_c_* (see
+//     build/BUILD.brotli), and
+//   - rust-brotli, exported under brotli_rs_* by src/rust/brotli-rs.
+//
+// It does not include the brotli headers: the renames in build/BUILD.brotli only apply to the
+// implementation's own compilation, so the prototypes are hand-declared here with the encoder and
+// decoder states passed through as opaque pointers. Enum parameters and results travel as int.
+// This target deliberately has no kj/capnp dependencies so that anything linking @brotli stays
+// lean.
+
+extern "C" {
+
+typedef void* (*brotli_alloc_func)(void* opaque, size_t size);
+typedef void (*brotli_free_func)(void* opaque, void* address);
+
+#define BROTLI_ROUTER_API(V)                                                                       \
+  V(void*, BrotliEncoderCreateInstance,                                                            \
+      (brotli_alloc_func alloc_func, brotli_free_func free_func, void* opaque),                    \
+      (alloc_func, free_func, opaque))                                                             \
+  V(void, BrotliEncoderDestroyInstance, (void* state), (state))                                    \
+  V(int, BrotliEncoderSetParameter, (void* state, int param, unsigned int value),                  \
+      (state, param, value))                                                                       \
+  V(int, BrotliEncoderCompressStream,                                                              \
+      (void* state, int op, size_t* availableIn, const unsigned char** nextIn,                     \
+          size_t* availableOut, unsigned char** nextOut, size_t* totalOut),                        \
+      (state, op, availableIn, nextIn, availableOut, nextOut, totalOut))                           \
+  V(int, BrotliEncoderIsFinished, (void* state), (state))                                          \
+  V(int, BrotliEncoderHasMoreOutput, (void* state), (state))                                       \
+  V(size_t, BrotliEncoderMaxCompressedSize, (size_t inputSize), (inputSize))                       \
+  V(int, BrotliEncoderCompress,                                                                    \
+      (int quality, int lgwin, int mode, size_t inputSize, const unsigned char* inputBuffer,       \
+          size_t* encodedSize, unsigned char* encodedBuffer),                                      \
+      (quality, lgwin, mode, inputSize, inputBuffer, encodedSize, encodedBuffer))                  \
+  V(void*, BrotliDecoderCreateInstance,                                                            \
+      (brotli_alloc_func alloc_func, brotli_free_func free_func, void* opaque),                    \
+      (alloc_func, free_func, opaque))                                                             \
+  V(void, BrotliDecoderDestroyInstance, (void* state), (state))                                    \
+  V(int, BrotliDecoderSetParameter, (void* state, int param, unsigned int value),                  \
+      (state, param, value))                                                                       \
+  V(int, BrotliDecoderDecompressStream,                                                            \
+      (void* state, size_t* availableIn, const unsigned char** nextIn, size_t* availableOut,       \
+          unsigned char** nextOut, size_t* totalOut),                                              \
+      (state, availableIn, nextIn, availableOut, nextOut, totalOut))                               \
+  V(int, BrotliDecoderHasMoreOutput, (const void* state), (state))                                 \
+  V(int, BrotliDecoderGetErrorCode, (const void* state), (state))                                  \
+  V(const char*, BrotliDecoderErrorString, (int code), (code))                                     \
+  V(int, BrotliDecoderDecompress,                                                                  \
+      (size_t encodedSize, const unsigned char* encodedBuffer, size_t* decodedSize,                \
+          unsigned char* decodedBuffer),                                                           \
+      (encodedSize, encodedBuffer, decodedSize, decodedBuffer))
+
+// Prototypes for both implementations.
+#define V(ret, name, params, args)                                                                 \
+  ret brotli_c_##name params;                                                                      \
+  ret brotli_rs_##name params;
+BROTLI_ROUTER_API(V)
+#undef V
+
+}  // extern "C"
+
+namespace {
+std::atomic<bool> useBrotliRs{false};
+}  // namespace
+
+extern "C" {
+
+void workerd_brotli_router_set_rs(bool enable) {
+  useBrotliRs.store(enable, std::memory_order_relaxed);
+}
+
+#define V(ret, name, params, args)                                                                 \
+  ret name params {                                                                                \
+    return useBrotliRs.load(std::memory_order_relaxed) ? brotli_rs_##name args                     \
+                                                       : brotli_c_##name args;                     \
+  }
+BROTLI_ROUTER_API(V)
+#undef V
+
+}  // extern "C"

--- a/src/workerd/util/brotli-router.c++
+++ b/src/workerd/util/brotli-router.c++
@@ -19,8 +19,8 @@
 
 extern "C" {
 
-typedef void* (*brotli_alloc_func)(void* opaque, size_t size);
-typedef void (*brotli_free_func)(void* opaque, void* address);
+using brotli_alloc_func = void* (*)(void* opaque, size_t size);
+using brotli_free_func = void (*)(void* opaque, void* address);
 
 #define BROTLI_ROUTER_API(V)                                                                       \
   V(void*, BrotliEncoderCreateInstance,                                                            \

--- a/src/workerd/util/brotli-router.h
+++ b/src/workerd/util/brotli-router.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// Routing layer owning the standard unprefixed brotli symbol names
+// (BrotliEncoderCompressStream, BrotliDecoderDecompressStream, ...). Every brotli consumer in the
+// build resolves the declarations in brotli/encode.h and brotli/decode.h to these definitions
+// (see brotli-router.c++), which forward each call to either the C implementation (brotli_c_*)
+// or rust-brotli (brotli_rs_*).
+
+extern "C" {
+
+// Selects rust-brotli as the backing implementation for all subsequent brotli calls. Set at
+// process startup from the compression-rs autogate (see Autogate::initAutogate()); an encoder or
+// decoder state must be created, run, and destroyed by a single implementation, so this must not
+// be toggled while any state is live.
+void workerd_brotli_router_set_rs(bool enable);
+
+}  // extern "C"


### PR DESCRIPTION
This extends the compression-rs autogate from zlib to brotli, using the same routing module technique in #7132.

This results in both the `Content-Encoding: br` configuration, and Node.js usage delegating to the Rust version when the autogate is enabled.

Headline numbers, measuring the fetch `Content-Encoding: br` configuration (quality 5, lgwin 19, 1MB compressible data in 16KB chunks, opt build):

| workload | C brotli | rust-brotli | delta |
|---|---|---|---|
| compress | 90.5 MiB/s | 69.0 MiB/s | -24% |
| decompress | 999 MiB/s | 671 MiB/s | -33% |

With the latest Rust nightly and SIMD features of the Rust brotli implementation (not yet included in this PR) we get:

| workload | nightly + simd |
|---|---|
| compress | -22% |
| decompress | -25% |

_The main question here is thus whether we are okay with a 25-30% slowdown, with the SIMD and newer nightly Rust / LLVM closer to 20%. Hopefully that improves further over time as well._

For node:zlib the gap depends on quality: at node's default q11 the one-shot compress measures ~10-18% slower on 1MB inputs, with the q4/q5 range matching the streaming numbers above. Compressed output sizes match the C library within noise at all measured qualities (worst case +2.7% at q5 on one input; q11 outputs effectively identical). The NPOSTFIX/NDIRECT encoder params are not supported by rust-brotli's encoder and report failure under the gate; decoder params are accepted and ignored.

The unprefixed `BrotliEncoder*`/`BrotliDecoder*` symbol names are now owned by a compiled routing layer, `src/workerd/util/brotli-router.c++`, which forwards each call to one of the two implementations linked into the binary: the C brotli library (rebuilt with the routed entry points renamed to `brotli_c_*` by `build/BUILD.brotli`) or rust-brotli (exported under `brotli_rs_*` prefixes by `src/rust/brotli-rs`). The branch is set process-globally from the compression-rs autogate alongside the existing zlib router.

Every consumer resolves the `brotli/encode.h` / `brotli/decode.h` declarations to the routing layer, so the gate covers fetch `Content-Encoding: br` encoding/decoding and response-stream observation (kj-brotli), and node:zlib's brotli modes (the shared `Brotli{Encoder,Decoder}Context` machinery).

* `@brotli` moves from the BCR module to the upstream release archive with our own build file so the C implementation can be compiled under prefixed names, mirroring `build/BUILD.zlib`
* `src/rust/brotli-rs` implements the routed C API subset over the `brotli`/`brotli-decompressor` crates: allocation uses the Rust global allocator (the C allocator callbacks are accepted and ignored), decoder error strings are byte-identical to the C library's, and the crates' ffi-api feature stays off since it would export the unprefixed names
* a new kj_test verifies the router selects the matching implementation on both sides of the gate
* a new bench-brotli benchmark measures the two implementations on the kj-http streaming workload

The router test, node:zlib brotli tests, compression stream tests, and the full test suite pass in both gate states.