### PR TITLE
Use dynamic_cast to avoid type confusion

### DIFF
--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1390,6 +1390,10 @@ class Object: private Wrappable {
   // to explicitly declare the default constructor.
   Object() = default;
 
+  inline Object* jsgTryGetObject() override {
+    return this;
+  }
+
   inline void jsgVisitForGc(GcVisitor& visitor) override {}
 
   // Subclasses should override these to provide appropriate information for
@@ -1454,6 +1458,16 @@ class Object: private Wrappable {
   template <typename>
   friend class WeakRef;
 };
+
+// Declared in wrappable.h; see there for why this check exists.
+template <typename T>
+T& downcastObject(Object& object) {
+  T* result = dynamic_cast<T*>(&object);
+  if (result == nullptr) {
+    reportWrapperTypeMismatch(typeid(T), typeid(object));
+  }
+  return *result;
+}
 
 // Ref<T> is a reference to a resource type (a type with a JSG_RESOURCE_TYPE block) living on
 // the V8 heap.

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -755,13 +755,21 @@ class JsObject final: public JsBase<v8::Object, JsObject> {
  public:
   template <typename T>
   bool isInstanceOf(Lock& js) {
-    return js.getInstance(inner, typeid(T)) != kj::none;
+    KJ_IF_SOME(instance, js.getInstance(inner, typeid(T))) {
+      // getInstance() checks the prototype chain, but the wrapper may be
+      // pointing at the wrong object after a V8 sandbox corruption, so defense
+      // in depth means we need to confirm the type before answering yes.
+      downcastObject<T>(instance);
+      return true;
+    } else {
+      return false;
+    }
   }
 
   template <typename T>
   kj::Maybe<jsg::Ref<T>> tryUnwrapAs(Lock& js) {
-    KJ_IF_SOME(ins, js.getInstance(inner, typeid(T))) {
-      return _jsgThis(static_cast<T*>(&ins));
+    KJ_IF_SOME(instance, js.getInstance(inner, typeid(T))) {
+      return _jsgThis(&downcastObject<T>(instance));
     } else {
       return kj::none;
     }

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -312,14 +312,11 @@ v8::Maybe<bool> Serializer::WriteHostObject(v8::Isolate* isolate, v8::Local<v8::
         object->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
             static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX)));
 
-    // HACK: Although we don't technically know yet that `wrappable` is an `Object`, we know that
-    //   only subclasses of `Object` register serializers. So *if* a serializer is found, then this
-    //   cast is valid, and the pointer won't be accessed otherwise. We can't do a dynamic_cast
-    //   here since `Wrappable` is privately inherited by `Object` and anyway we don't want the
-    //   overhead of dynamic_cast.
-    // TODO(cleanup): Probably `Wrappable` should contain a bool indicating if it is an `Object`
-    //   or not?
-    Object* obj = reinterpret_cast<jsg::Object*>(wrappable);
+    // Only subclasses of `Object` register serializers, so anything else is not serializable.
+    Object* obj = wrappable->jsgTryGetObject();
+    if (obj == nullptr) {
+      throwDataCloneErrorForObject(js, object);
+    }
 
     if (!IsolateBase::from(isolate).serialize(
             Lock::from(isolate), typeid(*wrappable), *obj, *this)) {

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -1048,9 +1048,19 @@ class Isolate: public IsolateBase {
       if (instance.IsEmpty()) {
         return kj::none;
       } else {
-        return *reinterpret_cast<Object*>(
+        // Finding `type`'s template in the prototype chain says nothing about
+        // what the internal field points at (sandbox corruption defense in
+        // depth), so this establishes only that the pointer is *some*
+        // `Wrappable`. The caller, which knows the type statically, is
+        // responsible for the rest -- see JsObject::tryUnwrapAs().
+        auto& wrappable = *reinterpret_cast<Wrappable*>(
             instance->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
                 static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX)));
+        Object* object = wrappable.jsgTryGetObject();
+        if (object == nullptr) {
+          reportWrapperTypeMismatch(type, typeid(wrappable));
+        }
+        return *object;
       }
     }
 

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -15,6 +15,8 @@
 
 #include <kj/async.h>
 #include <kj/debug.h>
+
+#include <cstdlib>
 #if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
 #include <sanitizer/asan_interface.h>
 #endif
@@ -443,6 +445,15 @@ kj::Maybe<Wrappable&> Wrappable::tryUnwrapOpaque(
   }
 
   return kj::none;
+}
+
+void reportWrapperTypeMismatch(const std::type_info& expected, const std::type_info& actual) {
+  // Only reachable if the wrapper's internal field has been made to point at an object of the
+  // wrong type, which means memory outside this process's control has already been corrupted.
+  // Abort: edgeworker's crash handler turns this into an abrupt shutdown of the isolate.
+  KJ_LOG(FATAL, "JS wrapper's C++ object is not of the expected type", typeName(expected),
+      typeName(actual));
+  abort();
 }
 
 void Wrappable::jsgVisitForGc(GcVisitor& visitor) {

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -19,6 +19,7 @@
 #include <kj/vector.h>
 
 #include <atomic>
+#include <typeinfo>
 
 // Niche value optimization for v8::TracedReference<T>. This teaches kj::Maybe to use
 // TracedReference's built-in empty state (IsEmpty()) as the "none" representation, eliminating
@@ -88,6 +89,7 @@ using kj::uint;
 
 class GcVisitor;
 class HeapTracer;
+class Object;
 class Wrappable;  // Forward declaration for WeakRefAnchor.
 
 // Shared alive/dead flag for weak references to Wrappable objects. Allocated lazily in
@@ -246,6 +248,14 @@ class Wrappable: public kj::Refcounted {
   // If `handle` was originally returned by attachOpaqueWrapper(), return the Wrappable it wraps.
   // Otherwise, return nullptr.
   static kj::Maybe<Wrappable&> tryUnwrapOpaque(v8::Isolate* isolate, v8::Local<v8::Value> handle);
+
+  // If this is a `jsg::Object`, return it, otherwise null. `Object` inherits `Wrappable`
+  // privately, which makes it impossible to `dynamic_cast` from a `Wrappable` to an `Object` (or
+  // to any of its subclasses); this hands the caller a pointer it can cast from. Named with the
+  // `jsg` prefix because it pollutes the namespace of JSG_RESOURCE types.
+  virtual Object* jsgTryGetObject() {
+    return nullptr;
+  }
 
   // Perform GC visitation. This is named with the `jsg` prefix because it pollutes the
   // namespace of JSG_RESOURCE types.
@@ -497,6 +507,51 @@ inline bool Wrappable::wasTracedInLastGc() const {
 // TODO(soon):
 // - Track memory usage of native objects.
 
+// Log the types involved in a failed downcast and abort.  Out-of-line and not
+// templated, to keep the code that unwrappers inline as small as possible.
+[[noreturn]] void reportWrapperTypeMismatch(
+    const std::type_info& expected, const std::type_info& actual);
+
+// Cast an `Object` that came from a wrapper to the type the callsite expects,
+// aborting if the object is not of that type.
+//
+// In-sandbox corruption may allow an attacker to confuse types.  An object's
+// RTTI lives outside the V8 sandbox, out of reach of such a substitution, so
+// use that to confirm the type instead.
+//
+// Defined in jsg.h, where `Object` is complete.
+template <typename T>
+T& downcastObject(Object& object);
+
+// Cast a `Wrappable` taken from a wrapper's internal field to the type the
+// callsite expects, aborting if the object is not of that type.
+template <typename T>
+T& downcastWrappable(Wrappable& wrappable) {
+  if constexpr (kj::canConvert<T&, Object&>()) {
+    // A `dynamic_cast` cannot start from `Wrappable`: the runtime check is
+    // specified to succeed only through a public base, so a
+    // privately-inherited one fails regardless of what access the callsite
+    // has. Every resource type reaches `T` through the public `Object` base,
+    // so start from there. This also lands on the correct address for a `T`
+    // that inherits `Object` at a non-zero offset, which a `reinterpret_cast`
+    // would not.
+    Object* object = wrappable.jsgTryGetObject();
+    if (object == nullptr) {
+      reportWrapperTypeMismatch(typeid(T), typeid(wrappable));
+    }
+    return downcastObject<T>(*object);
+  } else {
+    // Wrappables that are not `Object`s -- `WrappableFunction` and
+    // `OpaqueWrappable` -- inherit `Wrappable` publicly, so they can be cast
+    // directly.
+    T* result = dynamic_cast<T*>(&wrappable);
+    if (result == nullptr) {
+      reportWrapperTypeMismatch(typeid(T), typeid(wrappable));
+    }
+    return *result;
+  }
+}
+
 // Given a handle to a resource type, extract the raw C++ object pointer.
 template <typename T, bool isContext>
 T& extractInternalPointer(
@@ -516,7 +571,7 @@ T& extractInternalPointer(
     auto* ptr = object->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
         static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX));
     KJ_ASSERT(ptr != nullptr, "EPT type-tag mismatch: internal field returned nullptr");
-    return *reinterpret_cast<T*>(ptr);
+    return downcastWrappable<T>(*reinterpret_cast<Wrappable*>(ptr));
   }
 }
 


### PR DESCRIPTION
Merging from upstream.

When getting JSG objects from external pointers of JS objects we use the vtable to guard against type confusion. If the V8 sandbox is corrupted, external pointer table indeces can be swapped. This is a defence in depth against that.