### PR TITLE
Retain hibernatable WebSockets during active pumps

### DIFF
--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -880,12 +880,12 @@ void ServiceWorkerGlobalScope::sendHibernatableWebSocketClose(IoContext& context
 
   // Even if no handler is exported, we need to claim the websocket so it's removed from the map.
   //
-  // We won't be dispatching any further events because we've received a close, so we return the
-  // owned websocket back to the api::WebSocket.
+  // We won't be dispatching any further events because we've received a close, so copy the
+  // websocket's tags before the manager drops them.
   auto releasePackage = event->prepareForRelease(lock, websocketId);
   auto websocket = kj::mv(releasePackage.webSocketRef);
-  websocket->initiateHibernatableRelease(lock, kj::mv(releasePackage.ownedWebSocket),
-      kj::mv(releasePackage.tags), api::WebSocket::HibernatableReleaseState::CLOSE);
+  websocket->initiateHibernatableRelease(
+      lock, kj::mv(releasePackage.tags), api::WebSocket::HibernatableReleaseState::CLOSE);
   KJ_IF_SOME(h, exportedHandler) {
     KJ_IF_SOME(handler, h.webSocketClose) {
       event->waitUntil(setHibernatableEventTimeout(
@@ -912,12 +912,12 @@ void ServiceWorkerGlobalScope::sendHibernatableWebSocketError(IoContext& context
 
   // Even if no handler is exported, we need to claim the websocket so it's removed from the map.
   //
-  // We won't be dispatching any further events because we've encountered an error, so we return
-  // the owned websocket back to the api::WebSocket.
+  // We won't be dispatching any further events because we've encountered an error, so copy the
+  // websocket's tags before the manager drops them.
   auto releasePackage = event->prepareForRelease(lock, websocketId);
   auto& websocket = releasePackage.webSocketRef;
-  websocket->initiateHibernatableRelease(lock, kj::mv(releasePackage.ownedWebSocket),
-      kj::mv(releasePackage.tags), WebSocket::HibernatableReleaseState::ERROR);
+  websocket->initiateHibernatableRelease(
+      lock, kj::mv(releasePackage.tags), WebSocket::HibernatableReleaseState::ERROR);
 
   KJ_IF_SOME(h, exportedHandler) {
     KJ_IF_SOME(handler, h.webSocketError) {

--- a/src/workerd/api/hibernatable-adapter.c++
+++ b/src/workerd/api/hibernatable-adapter.c++
@@ -11,14 +11,14 @@ namespace workerd::api {
 HibernatableWebSocketAdapter::HibernatableWebSocketAdapter(jsg::Lock& js,
     WebSocket& shellParam,
     IoContext& ioContext,
-    kj::WebSocket& ws,
+    kj::Rc<kj::WebSocket> ws,
     WebSocket::HibernationPackage package)
     : shell(shellParam) {
   KJ_UNIMPLEMENTED("EW-10817: HibernatableWebSocketAdapter revival ctor not yet implemented");
 }
 
 HibernatableWebSocketAdapter::HibernatableWebSocketAdapter(
-    WebSocket& shellParam, kj::WebSocket& ws, kj::Array<kj::String> tags)
+    WebSocket& shellParam, kj::Rc<kj::WebSocket> ws, kj::Array<kj::String> tags)
     : shell(shellParam) {
   KJ_UNIMPLEMENTED("EW-10817: HibernatableWebSocketAdapter transition ctor not yet implemented");
 }
@@ -109,14 +109,12 @@ bool HibernatableWebSocketAdapter::isAwaitingCoupling() {
   return false;
 }
 
-kj::Own<kj::WebSocket> HibernatableWebSocketAdapter::acceptAsHibernatable(kj::Array<kj::String>) {
+kj::Rc<kj::WebSocket> HibernatableWebSocketAdapter::acceptAsHibernatable(kj::Array<kj::String>) {
   unimplemented();
 }
 
-void HibernatableWebSocketAdapter::initiateHibernatableRelease(jsg::Lock&,
-    kj::Own<kj::WebSocket>,
-    kj::Array<kj::String>,
-    WebSocket::HibernatableReleaseState) {
+void HibernatableWebSocketAdapter::initiateHibernatableRelease(
+    jsg::Lock&, kj::Array<kj::String>, WebSocket::HibernatableReleaseState) {
   unimplemented();
 }
 

--- a/src/workerd/api/hibernatable-adapter.h
+++ b/src/workerd/api/hibernatable-adapter.h
@@ -22,20 +22,20 @@ class HibernatableWebSocketAdapter final: public WebSocketAdapter {
   HibernatableWebSocketAdapter(jsg::Lock& js,
       WebSocket& shell,
       IoContext& ioContext,
-      kj::WebSocket& ws,
+      kj::Rc<kj::WebSocket> ws,
       WebSocket::HibernationPackage package);
 
   // Transition constructor — invoked from `WebSocket::acceptAsHibernatable` when the
   // autogate is on, after the kj::WebSocket has been extracted from the legacy adapter.
-  // Receives the surviving identity from the legacy adapter together with a reference to
-  // the kj::WebSocket (which is being transferred to the HibernationManager and lives there
-  // for the rest of the connection).
+  // Receives the surviving identity from the legacy adapter together with shared ownership
+  // of the kj::WebSocket.
   //
   // Does not take a `jsg::Lock&` because the call site in the shell does not have one
   // available (`HibernationManager::acceptWebSocket` does not currently plumb one through).
   // When the implementation actually needs JS state, it can grab the lock from the ambient
   // IoContext.
-  HibernatableWebSocketAdapter(WebSocket& shell, kj::WebSocket& ws, kj::Array<kj::String> tags);
+  HibernatableWebSocketAdapter(
+      WebSocket& shell, kj::Rc<kj::WebSocket> ws, kj::Array<kj::String> tags);
 
   ~HibernatableWebSocketAdapter() noexcept(false);
 
@@ -67,9 +67,8 @@ class HibernatableWebSocketAdapter final: public WebSocketAdapter {
   bool isHibernatable() override;
   void setObserver(kj::Own<WebSocketObserver> observer) override;
 
-  kj::Own<kj::WebSocket> acceptAsHibernatable(kj::Array<kj::String> tags) override;
+  kj::Rc<kj::WebSocket> acceptAsHibernatable(kj::Array<kj::String> tags) override;
   void initiateHibernatableRelease(jsg::Lock& js,
-      kj::Own<kj::WebSocket> ws,
       kj::Array<kj::String> tags,
       WebSocket::HibernatableReleaseState releaseState) override;
   bool awaitingHibernatableError() override;

--- a/src/workerd/api/hibernatable-web-socket.c++
+++ b/src/workerd/api/hibernatable-web-socket.c++
@@ -40,13 +40,12 @@ HibernatableWebSocketEvent::ItemsForRelease HibernatableWebSocketEvent::prepareF
   // Note that we don't call `claimWebSocket()` to get this, since we would lose our reference to
   // the HibernatableWebSocket (it removes it from `webSocketsForEventHandler`).
   auto websocketRef = hibernatableWebSocket.value->getActiveOrUnhibernate(lock);
-  auto ownedWebSocket = kj::mv(KJ_REQUIRE_NONNULL(hibernatableWebSocket.value->ws));
   auto tags = hibernatableWebSocket.value->getTags();
 
   // Now that we've obtained the websocket for the event, let's free up the slots we had allocated.
   manager.webSocketsForEventHandler.erase(hibernatableWebSocket);
 
-  return ItemsForRelease(kj::mv(websocketRef), kj::mv(ownedWebSocket), kj::mv(tags));
+  return ItemsForRelease(kj::mv(websocketRef), kj::mv(tags));
 }
 
 jsg::Ref<WebSocket> HibernatableWebSocketEvent::claimWebSocket(
@@ -192,9 +191,8 @@ kj::Promise<WorkerInterface::CustomEvent::Result> HibernatableWebSocketCustomEve
 }
 
 HibernatableWebSocketEvent::ItemsForRelease::ItemsForRelease(
-    jsg::Ref<WebSocket> ref, kj::Own<kj::WebSocket> owned, kj::Array<kj::String> tags)
+    jsg::Ref<WebSocket> ref, kj::Array<kj::String> tags)
     : webSocketRef(kj::mv(ref)),
-      ownedWebSocket(kj::mv(owned)),
       tags(kj::mv(tags)) {}
 
 HibernatableWebSocketCustomEvent::HibernatableWebSocketCustomEvent(uint16_t typeId,

--- a/src/workerd/api/hibernatable-web-socket.h
+++ b/src/workerd/api/hibernatable-web-socket.h
@@ -24,24 +24,16 @@ class HibernatableWebSocketEvent final: public ExtendableEvent {
 
   static jsg::Ref<HibernatableWebSocketEvent> constructor(kj::String type) = delete;
 
-  // When we call a close or error event, we need to move the owned websocket and the tags back into
-  // the api::WebSocket to extend their lifetimes. This is because the HibernatableWebSocket, which
-  // has owned these things for the entire duration of the connection, is free to go away after we
-  // dispatch the final event. JS may still want to access the underlying kj::WebSocket or the tags,
-  // so we have to transfer ownership to JS-land.
+  // The manager's tags are free to go away after the final close or error event is dispatched, so
+  // copy them into the api::WebSocket that receives the event.
   struct ItemsForRelease {
     jsg::Ref<WebSocket> webSocketRef;
-    kj::Own<kj::WebSocket> ownedWebSocket;
     kj::Array<kj::String> tags;
 
-    explicit ItemsForRelease(
-        jsg::Ref<WebSocket> ref, kj::Own<kj::WebSocket> owned, kj::Array<kj::String> tags);
+    explicit ItemsForRelease(jsg::Ref<WebSocket> ref, kj::Array<kj::String> tags);
   };
 
-  // Call this when transferring ownership of the kj::WebSocket and tags to the api::WebSocket.
-  //
-  // Gets a reference to the api::WebSocket, and moves the owned kj::WebSocket out of the
-  // HibernatableWebSocket whose event we are currently delivering.
+  // Gets a reference to the api::WebSocket and clones the tags owned by the HibernationManager.
   ItemsForRelease prepareForRelease(jsg::Lock& lock, kj::StringPtr websocketId);
 
   // Should only be called once per event, see definition for details.

--- a/src/workerd/api/web-socket.c++
+++ b/src/workerd/api/web-socket.c++
@@ -94,12 +94,13 @@ kj::StringPtr KJ_STRINGIFY(const LegacyWebSocketAdapter::NativeState& state) {
 // kj::Own<WebSocketAdapter> makeAdapterForHibernationRevival(jsg::Lock& js,
 //     WebSocket& shell,
 //     IoContext& ioContext,
-//     kj::WebSocket& ws,
+//     kj::Rc<kj::WebSocket> ws,
 //     WebSocket::HibernationPackage package) {
 //   if (util::Autogate::isEnabled(util::AutogateKey::HIBERNATABLE_WEBSOCKET_REFACTOR)) {
-//     return kj::heap<HibernatableWebSocketAdapter>(js, shell, ioContext, ws, kj::mv(package));
+//     return kj::heap<HibernatableWebSocketAdapter>(
+//         js, shell, ioContext, kj::mv(ws), kj::mv(package));
 //   }
-//   return kj::heap<LegacyWebSocketAdapter>(js, shell, ioContext, ws, kj::mv(package));
+//   return kj::heap<LegacyWebSocketAdapter>(js, shell, ioContext, kj::mv(ws), kj::mv(package));
 // }
 //
 // }  // namespace
@@ -110,12 +111,12 @@ kj::StringPtr KJ_STRINGIFY(const LegacyWebSocketAdapter::NativeState& state) {
 // =============================================================================
 
 WebSocket::WebSocket(
-    jsg::Lock& js, IoContext& ioContext, kj::WebSocket& ws, HibernationPackage package)
-    : impl(kj::heap<LegacyWebSocketAdapter>(js, *this, ioContext, ws, kj::mv(package))) {}
+    jsg::Lock& js, IoContext& ioContext, kj::Rc<kj::WebSocket> ws, HibernationPackage package)
+    : impl(kj::heap<LegacyWebSocketAdapter>(js, *this, ioContext, kj::mv(ws), kj::mv(package))) {}
 
 jsg::Ref<WebSocket> WebSocket::hibernatableFromNative(
-    jsg::Lock& js, kj::WebSocket& ws, HibernationPackage package) {
-  return js.alloc<WebSocket>(js, IoContext::current(), ws, kj::mv(package));
+    jsg::Lock& js, kj::Rc<kj::WebSocket> ws, HibernationPackage package) {
+  return js.alloc<WebSocket>(js, IoContext::current(), kj::mv(ws), kj::mv(package));
 }
 
 WebSocket::WebSocket(jsg::Lock& js, kj::Own<kj::WebSocket> native)
@@ -202,26 +203,24 @@ void WebSocket::setObserver(kj::Own<WebSocketObserver> observer) {
   impl->setObserver(kj::mv(observer));
 }
 
-kj::Own<kj::WebSocket> WebSocket::acceptAsHibernatable(kj::Array<kj::String> tags) {
+kj::Rc<kj::WebSocket> WebSocket::acceptAsHibernatable(kj::Array<kj::String> tags) {
   // TODO(EW-10817): When the HibernatableWebSocketAdapter path is functional, re-enable the
   // autogate-driven swap below — extract the kj::WebSocket from the legacy adapter (via
   // `LegacyWebSocketAdapter::extractForHibernatableTransition`, also commented out today)
   // and atomically replace `impl` with a fresh `HibernatableWebSocketAdapter`.
   //
   // if (util::Autogate::isEnabled(util::AutogateKey::HIBERNATABLE_WEBSOCKET_REFACTOR)) {
-  //   auto& legacy = kj::downcast<LegacyWebSocketAdapter>(*impl);
-  //   auto ws = legacy.extractForHibernatableTransition();
-  //   impl = kj::heap<HibernatableWebSocketAdapter>(*this, *ws, kj::mv(tags));
-  //   return kj::mv(ws);
+  //   auto ws = kj::Rc<kj::WebSocket>(
+  //       kj::downcast<LegacyWebSocketAdapter>(*impl).extractForHibernatableTransition());
+  //   impl = kj::heap<HibernatableWebSocketAdapter>(*this, ws.addRef(), kj::mv(tags));
+  //   return ws;
   // }
   return impl->acceptAsHibernatable(kj::mv(tags));
 }
 
-void WebSocket::initiateHibernatableRelease(jsg::Lock& js,
-    kj::Own<kj::WebSocket> ws,
-    kj::Array<kj::String> tags,
-    WebSocket::HibernatableReleaseState releaseState) {
-  impl->initiateHibernatableRelease(js, kj::mv(ws), kj::mv(tags), releaseState);
+void WebSocket::initiateHibernatableRelease(
+    jsg::Lock& js, kj::Array<kj::String> tags, WebSocket::HibernatableReleaseState releaseState) {
+  impl->initiateHibernatableRelease(js, kj::mv(tags), releaseState);
 }
 
 bool WebSocket::awaitingHibernatableError() {
@@ -277,11 +276,13 @@ void WebSocket::visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
 // LegacyWebSocketAdapter — operational implementation.
 // =============================================================================
 
-IoOwn<LegacyWebSocketAdapter::Native> LegacyWebSocketAdapter::initNative(
-    IoContext& ioContext, kj::WebSocket& ws, kj::Array<kj::String> tags, bool closedOutgoingConn) {
+IoOwn<LegacyWebSocketAdapter::Native> LegacyWebSocketAdapter::initNative(IoContext& ioContext,
+    kj::Rc<kj::WebSocket> ws,
+    kj::Array<kj::String> tags,
+    bool closedOutgoingConn) {
   auto nativeObj = kj::heap<Native>();
   nativeObj->state.init<Accepted>(
-      Accepted::Hibernatable{.ws = ws, .tags = kj::mv(tags)}, *nativeObj, ioContext);
+      Accepted::Hibernatable{.ws = kj::mv(ws), .tags = kj::mv(tags)}, *nativeObj, ioContext);
   // We might have called `close()` when this WebSocket was previously active.
   // If so, we want to prevent any future calls to `send()`.
   nativeObj->closedOutgoing = closedOutgoingConn;
@@ -291,7 +292,7 @@ IoOwn<LegacyWebSocketAdapter::Native> LegacyWebSocketAdapter::initNative(
 LegacyWebSocketAdapter::LegacyWebSocketAdapter(jsg::Lock& js,
     WebSocket& shell,
     IoContext& ioContext,
-    kj::WebSocket& ws,
+    kj::Rc<kj::WebSocket> ws,
     WebSocket::HibernationPackage package)
     : shell(shell),
       url(kj::mv(package.url)),
@@ -302,7 +303,7 @@ LegacyWebSocketAdapter::LegacyWebSocketAdapter(jsg::Lock& js,
       serializedAttachment(kj::mv(package.serializedAttachment)),
       allowHalfOpen(package.allowHalfOpen),
       farNative(initNative(ioContext,
-          ws,
+          kj::mv(ws),
           kj::mv(KJ_REQUIRE_NONNULL(package.maybeTags)),
           package.closedOutgoingConnection)),
       outgoingMessages(ioContext.createObject<OutgoingMessagesMap>()),
@@ -1266,18 +1267,9 @@ kj::Promise<void> LegacyWebSocketAdapter::pump(IoContext& context,
         co_await promise;
       }
 
-      // If a DO constructor throws after sending data to a websocket, the `kj::WebSocket& ws` may already
-      // have been freed by the hibernation manager, so we must stop the pump loop and not touch `ws`.
-      //
-      // A constructor failure aborts the IoContext, so we use that as an early-return condition.
-      // Message sent from constructor always wait for an output gate, so by the time that await
-      // returns, this is the first line that runs after the constructor completes, regardless of its
-      // outcome.
-      //
-      // Note that `ws` can be freed during the pump loop only when the constructor throws. In all other
-      // cases the coroutine is canceled normally — for example, when we call send from
-      // `blockConcurrencyWhile()` inside the constructor, which then throws, or when the DO waits on
-      // `ws.send()` to deliver the data while another event handler calls `ctx.abort()`.
+      // A constructor failure aborts the IoContext. Messages sent from a constructor always wait
+      // for an output gate, so this is the first line that runs after the constructor completes.
+      // Do not send its queued messages after it fails.
       if (context.getAbortReason() != kj::none) {
         co_return;
       }
@@ -1519,15 +1511,13 @@ void LegacyWebSocketAdapter::setPeer(jsg::WeakRef<WebSocket> other) {
   peer = kj::mv(other);
 }
 
-kj::Own<kj::WebSocket> LegacyWebSocketAdapter::acceptAsHibernatable(kj::Array<kj::String> tags) {
+kj::Rc<kj::WebSocket> LegacyWebSocketAdapter::acceptAsHibernatable(kj::Array<kj::String> tags) {
   KJ_IF_SOME(hibernatable, farNative->state.tryGet<AwaitingAcceptanceOrCoupling>()) {
     // We can only request hibernation if we have not called accept.
-    auto ws = kj::mv(hibernatable.ws);
-    // We pass a reference to the kj::WebSocket for the api::WebSocket to refer to when calling
-    // `send()` or `close()`.
-    farNative->state.init<Accepted>(
-        Accepted::Hibernatable{.ws = *ws, .tags = kj::mv(tags)}, *farNative, IoContext::current());
-    return kj::mv(ws);
+    auto ws = kj::Rc<kj::WebSocket>(kj::mv(hibernatable.ws));
+    farNative->state.init<Accepted>(Accepted::Hibernatable{.ws = ws.addRef(), .tags = kj::mv(tags)},
+        *farNative, IoContext::current());
+    return ws;
   }
   JSG_FAIL_REQUIRE(TypeError,
       "Tried to make an api::WebSocket hibernatable when it was in an incompatible state.");
@@ -1547,16 +1537,14 @@ kj::Own<kj::WebSocket> LegacyWebSocketAdapter::acceptAsHibernatable(kj::Array<kj
 //       "Tried to make an api::WebSocket hibernatable when it was in an incompatible state.");
 // }
 
-void LegacyWebSocketAdapter::initiateHibernatableRelease(jsg::Lock& js,
-    kj::Own<kj::WebSocket> ws,
-    kj::Array<kj::String> tags,
-    WebSocket::HibernatableReleaseState releaseState) {
+void LegacyWebSocketAdapter::initiateHibernatableRelease(
+    jsg::Lock& js, kj::Array<kj::String> tags, WebSocket::HibernatableReleaseState releaseState) {
   // TODO(soon): We probably want this to be an assert, since this is meant to be called once
   // at the end of a websocket connection>
   KJ_IF_SOME(state, farNative->state.tryGet<Accepted>()) {
     KJ_REQUIRE(state.isHibernatable(),
         "tried to initiate hibernatable release but websocket wasn't hibernatable");
-    state.ws.initiateHibernatableRelease(js, kj::mv(ws), kj::mv(tags), releaseState);
+    state.ws.initiateHibernatableRelease(js, kj::mv(tags), releaseState);
     farNative->closedIncoming = true;
   } else {
     KJ_LOG(WARNING, "Unexpected Hibernatable WebSocket state on release", farNative->state);
@@ -1614,7 +1602,7 @@ kj::WebSocket* LegacyWebSocketAdapter::Accepted::WrappedWebSocket::operator->() 
       return owned.get();
     }
     KJ_CASE_ONEOF(hibernatable, Hibernatable) {
-      return &hibernatable.ws;
+      return hibernatable.ws.get();
     }
   }
   KJ_UNREACHABLE;
@@ -1626,7 +1614,7 @@ kj::WebSocket& LegacyWebSocketAdapter::Accepted::WrappedWebSocket::operator*() {
       return *owned;
     }
     KJ_CASE_ONEOF(hibernatable, Hibernatable) {
-      return hibernatable.ws;
+      return *hibernatable.ws;
     }
   }
   KJ_UNREACHABLE;
@@ -1654,14 +1642,10 @@ kj::Array<kj::StringPtr> LegacyWebSocketAdapter::Accepted::WrappedWebSocket::get
   return result;
 }
 
-void LegacyWebSocketAdapter::Accepted::WrappedWebSocket::initiateHibernatableRelease(jsg::Lock& js,
-    kj::Own<kj::WebSocket> ws,
-    kj::Array<kj::String> tags,
-    WebSocket::HibernatableReleaseState state) {
+void LegacyWebSocketAdapter::Accepted::WrappedWebSocket::initiateHibernatableRelease(
+    jsg::Lock& js, kj::Array<kj::String> tags, WebSocket::HibernatableReleaseState state) {
   auto& hibernatable = KJ_REQUIRE_NONNULL(getIfHibernatable());
   hibernatable.releaseState = state;
-  // Note that we move the owned kj::WebSocket here.
-  hibernatable.attachedForClose = kj::mv(ws);
   hibernatable.tags = kj::mv(tags);
 }
 

--- a/src/workerd/api/web-socket.h
+++ b/src/workerd/api/web-socket.h
@@ -14,6 +14,7 @@
 #include <workerd/util/strong-bool.h>
 
 #include <kj/compat/http.h>
+#include <kj/refcount.h>
 
 #include <cstdlib>
 #include <list>
@@ -226,12 +227,13 @@ class WebSocket: public EventTarget {
   // This WebSocket constructor is only used when WebSockets wake up from hibernation.
   // It will immediately set the `state` to `Accepted`, but it limits the behavior by specifying it
   // as `Hibernatable` -- thereby making most api::WebSocket methods inaccessible.
-  WebSocket(jsg::Lock& js, IoContext& ioContext, kj::WebSocket& ws, HibernationPackage package);
+  WebSocket(
+      jsg::Lock& js, IoContext& ioContext, kj::Rc<kj::WebSocket> ws, HibernationPackage package);
 
   // Similar to how the JS `constructor()` creates a WebSocket, when waking from hibernation
   // we want to be able to recreate WebSockets from C++ that will be delivered to JS code.
   static jsg::Ref<WebSocket> hibernatableFromNative(
-      jsg::Lock& js, kj::WebSocket& ws, HibernationPackage package);
+      jsg::Lock& js, kj::Rc<kj::WebSocket> ws, HibernationPackage package);
 
   // The JS WebSocket constructor needs to initiate a connection, but we need to return the
   // WebSocket object to the caller in Javascript immediately. We will defer the connection logic
@@ -255,9 +257,9 @@ class WebSocket: public EventTarget {
   kj::Promise<DeferredProxy<void>> couple(
       jsg::Lock& js, kj::Own<kj::WebSocket> other, RequestObserver& request);
 
-  // Extract the kj::WebSocket from this api::WebSocket (if applicable). The kj::WebSocket will be
-  // owned elsewhere, but the api::WebSocket will retain a reference.
-  kj::Own<kj::WebSocket> acceptAsHibernatable(kj::Array<kj::String> tags);
+  // The kj::WebSocket is shared with the HibernationManager so both it and this api::WebSocket
+  // retain ownership.
+  kj::Rc<kj::WebSocket> acceptAsHibernatable(kj::Array<kj::String> tags);
 
   // Accesses the tags of the hibernatable websocket.
   kj::Array<kj::StringPtr> getHibernatableTags();
@@ -272,10 +274,8 @@ class WebSocket: public EventTarget {
 
   // Called when a Hibernatable WebSocket wants to dispatch a close/error event, this modifies
   // our `Accepted` state to prepare the state to transition to `Released`.
-  void initiateHibernatableRelease(jsg::Lock& js,
-      kj::Own<kj::WebSocket> ws,
-      kj::Array<kj::String> tags,
-      HibernatableReleaseState releaseState);
+  void initiateHibernatableRelease(
+      jsg::Lock& js, kj::Array<kj::String> tags, HibernatableReleaseState releaseState);
 
   bool awaitingHibernatableError();
 
@@ -519,14 +519,12 @@ class WebSocketAdapter {
   // peer end when the local end is terminating in this worker.
   virtual void setObserver(kj::Own<WebSocketObserver> observer) = 0;
 
-  // Hibernation transitions: extracts the kj::WebSocket so the HibernationManager can
-  // assume ownership; the adapter retains a bare reference for sends.
-  virtual kj::Own<kj::WebSocket> acceptAsHibernatable(kj::Array<kj::String> tags) = 0;
+  // Hibernation transitions: shares ownership of the kj::WebSocket with the HibernationManager.
+  virtual kj::Rc<kj::WebSocket> acceptAsHibernatable(kj::Array<kj::String> tags) = 0;
 
   // HibernationManager coordination: signals that the underlying connection is winding
   // down and the adapter should arrange to deliver its terminal close/error event.
   virtual void initiateHibernatableRelease(jsg::Lock& js,
-      kj::Own<kj::WebSocket> ws,
       kj::Array<kj::String> tags,
       WebSocket::HibernatableReleaseState releaseState) = 0;
   virtual bool awaitingHibernatableError() = 0;
@@ -589,7 +587,7 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
   LegacyWebSocketAdapter(jsg::Lock& js,
       WebSocket& shell,
       IoContext& ioContext,
-      kj::WebSocket& ws,
+      kj::Rc<kj::WebSocket> ws,
       WebSocket::HibernationPackage package);
 
   // ---------------------------------------------------------------------------
@@ -619,9 +617,8 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
   bool isHibernatable() override;
   void setObserver(kj::Own<WebSocketObserver> observer) override;
 
-  kj::Own<kj::WebSocket> acceptAsHibernatable(kj::Array<kj::String> tags) override;
+  kj::Rc<kj::WebSocket> acceptAsHibernatable(kj::Array<kj::String> tags) override;
   void initiateHibernatableRelease(jsg::Lock& js,
-      kj::Own<kj::WebSocket> ws,
       kj::Array<kj::String> tags,
       WebSocket::HibernatableReleaseState releaseState) override;
   bool awaitingHibernatableError() override;
@@ -670,12 +667,7 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
     // A `Hibernatable` WebSocket shares a sub-set of behavior that's already implemented for
     // an `Accepted` WebSocket, so we can think of it a sub-state.
     struct Hibernatable {
-      kj::WebSocket& ws;
-      // If we have initiated a hibernatable error/close event, we need to take back ownership
-      // of the kj::WebSocket so any final queued messages will deliver. We store this owned
-      // websocket in `attachedForClose`. Since the `ws` reference is still valid, we prevent
-      // usage of `attachedForClose` directly in favor of using `ws` directly.
-      kj::Maybe<kj::Own<void>> attachedForClose;
+      kj::Rc<kj::WebSocket> ws;
 
       // We can't move the state to Released after the Hibernatable Close/Error event runs,
       // since we don't have a request on the thread by the time the event completes. If we
@@ -708,10 +700,8 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
 
       // Transitions our Hibernatable websocket to a "Releasing" state. The websocket will
       // transition to `Released` when convenient.
-      void initiateHibernatableRelease(jsg::Lock& js,
-          kj::Own<kj::WebSocket> ws,
-          kj::Array<kj::String> tags,
-          WebSocket::HibernatableReleaseState state);
+      void initiateHibernatableRelease(
+          jsg::Lock& js, kj::Array<kj::String> tags, WebSocket::HibernatableReleaseState state);
 
       bool isAwaitingRelease();
       bool isAwaitingError();
@@ -799,8 +789,10 @@ class LegacyWebSocketAdapter final: public WebSocketAdapter {
 
   // Creates a fresh `Native` set up in the Accepted-Hibernatable state. Used by the
   // hibernation-revival constructor.
-  IoOwn<Native> initNative(
-      IoContext& ioContext, kj::WebSocket& ws, kj::Array<kj::String> tags, bool closedOutgoingConn);
+  IoOwn<Native> initNative(IoContext& ioContext,
+      kj::Rc<kj::WebSocket> ws,
+      kj::Array<kj::String> tags,
+      bool closedOutgoingConn);
 
   void dispatchOpen(jsg::Lock& js);
   void ensurePumping(jsg::Lock& js);

--- a/src/workerd/io/hibernation-manager-test.c++
+++ b/src/workerd/io/hibernation-manager-test.c++
@@ -1289,5 +1289,123 @@ KJ_TEST("HibernationManager: GC collects WebSocket with in-flight auto-response"
   fixture.drainAndDestroy(kj::mv(request));
 }
 
+KJ_TEST("HibernationManager: running pump retains socket after manager removal") {
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("pump-socket-lifetime")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm, "socket"_kj);
+
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
+
+  // The pump borrows the native socket and suspends on the output gate.
+  sendFromDo(fixture, *request, *hm, "pending"_kj);
+
+  // Rejecting an inbound event makes the manager remove its socket entry.
+  stats.rejectCustomEvents = true;
+  end1->send("terminate"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+
+  KJ_ASSERT(stats.customEventCalls == 2, stats.customEventCalls);
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    KJ_ASSERT(hm->getWebSockets(env.js, kj::none).size() == 0);
+    KJ_ASSERT(hm->getWebSockets(env.js, "socket"_kj).size() == 0);
+  });
+
+  // Without the ownership fix, this resumes into ws.send() using the
+  // manager's destroyed socket.
+  paf.fulfiller->fulfill();
+
+  auto message = end1->receive().wait(fixture.getWaitScope());
+  KJ_ASSERT(message.is<kj::String>());
+  KJ_ASSERT(message.get<kj::String>() == "pending"_kj);
+
+  blocker.wait(fixture.getWaitScope());
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST(
+    "HibernationManager: failed termination dispatch retains socket under a gate-blocked pump") {
+  // A failed event dispatch removes the manager entry while the API pump is blocked on the output
+  // gate. The adapter keeps the native socket alive until the queued operation completes.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("failed-termination-gated-pump")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  // Lock the output gate so the pump parks at its `co_await gatedMessage.outputLock`.
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
+
+  sendFromDo(fixture, *request, *hm, "gated"_kj);
+  auto receivePromise = end1->receive();
+  fixture.pollEventLoop();
+  KJ_ASSERT(!receivePromise.poll(fixture.getWaitScope()), "pump should be parked on the gate");
+
+  // The eyeball sends a message, but the DO is too overloaded to accept either it or the error
+  // event that follows, so the HibernationManager removes its entry.
+  stats.rejectCustomEvents = true;
+  end1->send("message"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+  KJ_ASSERT(stats.customEventCalls == 2, stats.customEventCalls);
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    KJ_ASSERT(hm->getWebSockets(env.js, kj::none).size() == 0);
+  });
+
+  // The adapter still owns the socket, so the pump can deliver the queued message.
+  paf.fulfiller->fulfill();
+  auto message = receivePromise.wait(fixture.getWaitScope());
+  KJ_ASSERT(message.is<kj::String>());
+  KJ_ASSERT(message.get<kj::String>() == "gated"_kj);
+
+  blocker.wait(fixture.getWaitScope());
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
+KJ_TEST(
+    "HibernationManager: failed termination dispatch retains socket under a gate-blocked close") {
+  // Companion to the test above for the Close branch of the pump's send loop.
+  DispatchStats stats;
+  TestFixture fixture(stubLoopbackParams(stats, kj::str("failed-termination-gated-close")));
+  auto hm = makeTestHm(fixture);
+  auto request = fixture.newIncomingRequest();
+  auto end1 = acceptNewWebSocket(fixture, *request, *hm);
+
+  auto paf = kj::newPromiseAndFulfiller<void>();
+  auto blocker = fixture.getActor().getOutputGate().lockWhile(kj::mv(paf.promise), nullptr);
+
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    auto& js = env.js;
+    auto websockets = hm->getWebSockets(js, kj::none);
+    KJ_ASSERT(websockets.size() == 1);
+    websockets[0]->close(js, 1001, jsg::USVString(kj::str("gated-bye")));
+  });
+
+  auto receivePromise = end1->receive();
+  fixture.pollEventLoop();
+  KJ_ASSERT(!receivePromise.poll(fixture.getWaitScope()), "pump should be parked on the gate");
+
+  stats.rejectCustomEvents = true;
+  end1->send("message"_kj).wait(fixture.getWaitScope());
+  fixture.pollEventLoop();
+  KJ_ASSERT(stats.customEventCalls == 2, stats.customEventCalls);
+  fixture.enterContext(*request, [&](const TestFixture::Environment& env) {
+    KJ_ASSERT(hm->getWebSockets(env.js, kj::none).size() == 0);
+  });
+
+  // The adapter still owns the socket, so the pump can deliver the queued close.
+  paf.fulfiller->fulfill();
+  auto message = receivePromise.wait(fixture.getWaitScope());
+  KJ_ASSERT(message.is<kj::WebSocket::Close>());
+  auto& close = message.get<kj::WebSocket::Close>();
+  KJ_ASSERT(close.code == 1001, close.code);
+  KJ_ASSERT(close.reason == "gated-bye"_kj, close.reason);
+
+  blocker.wait(fixture.getWaitScope());
+  fixture.drainAndDestroy(kj::mv(request));
+}
+
 }  // namespace
 }  // namespace workerd

--- a/src/workerd/io/legacy-hibernation-manager.c++
+++ b/src/workerd/io/legacy-hibernation-manager.c++
@@ -18,8 +18,8 @@ LegacyHibernationManagerImpl::HibernatableWebSocket::HibernatableWebSocket(
     : tagItems(kj::heapArray<TagListItem>(tags.size())),
       activeOrPackage(kj::mv(websocket)),
       // The `ws` starts off empty because we need to set up our tagging infrastructure before
-      // calling api::WebSocket::acceptAsHibernatable(). We will transfer ownership of the
-      // kj::WebSocket prior to starting the readLoop.
+      // calling api::WebSocket::acceptAsHibernatable(). We will share ownership of the
+      // kj::WebSocket before starting the readLoop.
       ws(kj::none),
       manager(manager) {}
 
@@ -66,8 +66,8 @@ jsg::Ref<api::WebSocket> LegacyHibernationManagerImpl::HibernatableWebSocket::
       autoResponsePromise = promise.addBranch();
     }
     activeOrPackage
-        .init<jsg::Ref<api::WebSocket>>(
-            api::WebSocket::hibernatableFromNative(js, *KJ_REQUIRE_NONNULL(ws), kj::mv(package)))
+        .init<jsg::Ref<api::WebSocket>>(api::WebSocket::hibernatableFromNative(
+            js, KJ_REQUIRE_NONNULL(ws).addRef(), kj::mv(package)))
         ->setAutoResponseStatus(autoResponseTimestamp, kj::mv(autoResponsePromise));
   }
   return activeOrPackage.get<jsg::Ref<api::WebSocket>>().addRef();
@@ -145,8 +145,8 @@ void LegacyHibernationManagerImpl::acceptWebSocket(
     tagListItem.list = *list.get();
   }
 
-  // Before starting the readLoop, we need to move the kj::Own<kj::WebSocket> from the
-  // api::WebSocket into the HibernatableWebSocket and accept the api::WebSocket as "hibernatable".
+  // Before starting the readLoop, share ownership of the kj::WebSocket with the
+  // HibernatableWebSocket and accept the api::WebSocket as hibernatable.
   refToHibernatable.ws =
       refToHibernatable.activeOrPackage.get<jsg::Ref<api::WebSocket>>()->acceptAsHibernatable(
           refToHibernatable.getTags());

--- a/src/workerd/io/legacy-hibernation-manager.h
+++ b/src/workerd/io/legacy-hibernation-manager.h
@@ -105,11 +105,9 @@ class LegacyHibernationManagerImpl final: public Worker::Actor::HibernationManag
     // the websocket's properties in a HibernationPackage until it's time to wake up.
     kj::OneOf<jsg::Ref<api::WebSocket>, api::WebSocket::HibernationPackage> activeOrPackage;
 
-    // This is an owned websocket that we extract from the api::WebSocket after accepting as
-    // hibernatable. It becomes null once we dispatch a close or error event because we want its
-    // lifetime to be managed by IoContext's DeleteQueue. This helps prevent a situation where the
-    // HibernationManager drops the websocket before all queued messages have sent.
-    kj::Maybe<kj::Own<kj::WebSocket>> ws;
+    // This is the manager's strong reference to the websocket shared with api::WebSocket after
+    // accepting as hibernatable.
+    kj::Maybe<kj::Rc<kj::WebSocket>> ws;
 
     LegacyHibernationManagerImpl& manager;
     // TODO(someday): We (currently) only use the LegacyHibernationManagerImpl reference to refer to


### PR DESCRIPTION
Merging from upstream.

Share strong ownership of native hibernatable WebSockets between the manager and API adapter. Remove release-time ownership transfer and verify gated sends and closes survive manager removal.