### PR TITLE
Use shims to find wrappables

### DIFF
--- a/src/rust/jsg/ffi.c++
+++ b/src/rust/jsg/ffi.c++
@@ -619,7 +619,8 @@ Local wrap_resource(Isolate* isolate, kj::Rc<Wrappable> wrappable, const Global&
       local_tmpl->InstanceTemplate()->NewInstance(isolate->GetCurrentContext()));
 
   // attachWrapper sets up CppgcShim, TracedReference, internal fields, etc.
-  wrappable->attachWrapper(isolate, object, true);
+  wrappable->attachWrapper(isolate, object, true,
+      static_cast<v8::CppHeapPointerTag>(::workerd::jsg::kNonResourceWrappableTag));
 
   // Override tag to identify as Rust object for unwrapping
   auto tagAddress = const_cast<uint16_t*>(&::workerd::jsg::Wrappable::WORKERD_RUST_WRAPPABLE_TAG);
@@ -635,7 +636,8 @@ void wrappable_attach_wrapper(kj::Rc<Wrappable> wrappable, FunctionCallbackInfo&
   auto object = args.This();
 
   // attachWrapper sets up CppgcShim, TracedReference, internal fields, etc.
-  wrappable->attachWrapper(isolate, object, true);
+  wrappable->attachWrapper(isolate, object, true,
+      static_cast<v8::CppHeapPointerTag>(::workerd::jsg::kNonResourceWrappableTag));
 
   // Override tag to identify as Rust object for unwrapping
   auto tagAddress = const_cast<uint16_t*>(&::workerd::jsg::Wrappable::WORKERD_RUST_WRAPPABLE_TAG);
@@ -711,11 +713,15 @@ kj::Maybe<kj::Rc<Wrappable>> unwrap_resource(Isolate* isolate, Local value) {
           const_cast<uint16_t*>(&::workerd::jsg::Wrappable::WORKERD_RUST_WRAPPABLE_TAG)) {
     return kj::none;
   }
-  auto* ptr = static_cast<Wrappable*>(
-      reinterpret_cast<::workerd::jsg::Wrappable*>(v8_obj->GetAlignedPointerFromInternalField(
-          ::workerd::jsg::Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
-          static_cast<v8::EmbedderDataTypeTag>(
-              ::workerd::jsg::Wrappable::WRAPPED_OBJECT_FIELD_INDEX))));
+  // The WORKERD_RUST_WRAPPABLE_TAG marker check above established that this is one of our Rust
+  // wrappables, so the pointer can be taken directly through the shim.
+  auto* wrappable = ::workerd::jsg::Wrappable::unwrapFromShimAnyType(isolate, v8_obj);
+  if (wrappable == nullptr) {
+    // unwrapFromShimAnyType() returning null is a sign of in-sandbox corruption.
+    KJ_LOG(FATAL, "wrapper type mismatch: marked object's CppHeap handle resolves to no wrappable");
+    abort();
+  }
+  auto* ptr = static_cast<Wrappable*>(reinterpret_cast<::workerd::jsg::Wrappable*>(wrappable));
   return ptr->toRc();
 }
 

--- a/src/workerd/api/basics.c++
+++ b/src/workerd/api/basics.c++
@@ -673,8 +673,8 @@ jsg::Ref<AbortSignal> AbortSignal::timeout(jsg::Lock& js, double delay) {
 
   auto context = js.v8Context();
 
-  auto& global =
-      jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(context, context->Global());
+  auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
+      js.v8Isolate, context, context->Global(), jsg::kNonResourceWrappableTagRange);
 
   // It's worth noting that the setTimeout holds a strong pointer to the AbortSignal,
   // keeping it from being garbage collected before the timer fires or until the request
@@ -1346,8 +1346,8 @@ kj::Promise<void> Scheduler::wait(
 
   auto context = js.v8Context();
 
-  auto& global =
-      jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(context, context->Global());
+  auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
+      js.v8Isolate, context, context->Global(), jsg::kNonResourceWrappableTagRange);
   auto timeoutId = global.setTimeoutInternal(
       [fulfiller = IoContext::current().addObject(kj::mv(paf.fulfiller))](jsg::Lock& lock) mutable {
     fulfiller->fulfill();

--- a/src/workerd/api/capnp.h
+++ b/src/workerd/api/capnp.h
@@ -114,7 +114,7 @@ class CapnpTypeWrapper: private CapnpTypeWrapperBase {
     auto tmpl = getCapnpTemplate(js, client.getSchema());
     auto obj = jsg::check(tmpl->InstanceTemplate()->NewInstance(context));
     auto ref = js.alloc<CapnpCapability>(kj::mv(client));
-    ref.attachWrapper(js.v8Isolate, obj);
+    ref.attachWrapper(js.v8Isolate, obj, TypeWrapper::template wrappableTag<CapnpCapability>());
     KJ_IF_SOME(r, refToInitialize) {
       r = kj::mv(ref);
     }
@@ -357,7 +357,7 @@ class CapnpTypeWrapper: private CapnpTypeWrapperBase {
               jsg::V8Ref<v8::Object>(js.v8Isolate, arg.As<v8::Object>()), wrapper));
       auto ptr = js.alloc<CapnpCapability>(kj::mv(client));
 
-      ptr.attachWrapper(js.v8Isolate, obj);
+      ptr.attachWrapper(js.v8Isolate, obj, TypeWrapper::template wrappableTag<CapnpCapability>());
     });
   }
 
@@ -371,7 +371,8 @@ class CapnpTypeWrapper: private CapnpTypeWrapperBase {
       auto& js = jsg::Lock::from(args.GetIsolate());
       auto obj = args.This();
       auto& wrapper = TypeWrapper::from(js.v8Isolate);
-      auto& self = jsg::extractInternalPointer<CapnpCapability, false>(js.v8Context(), obj);
+      auto& self = jsg::extractInternalPointerFor<TypeWrapper, CapnpCapability, false>(
+          js.v8Isolate, js.v8Context(), obj);
 
       return wrapper.wrap(js, js.v8Context(), obj, self.call(js, method, args[0], wrapper));
     });

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -1272,8 +1272,8 @@ jsg::Ref<StorageManager> Navigator::getStorage(jsg::Lock& js) {
 bool Navigator::sendBeacon(jsg::Lock& js, kj::String url, jsg::Optional<Body::Initializer> body) {
   KJ_IF_SOME(context, IoContext::tryCurrent()) {
     auto v8Context = js.v8Context();
-    auto& global =
-        jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(v8Context, v8Context->Global());
+    auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
+        js.v8Isolate, v8Context, v8Context->Global(), jsg::kNonResourceWrappableTagRange);
     auto promise = global.fetch(js, kj::mv(url),
         Request::InitializerDict{
           .method = kj::str("POST"),

--- a/src/workerd/api/node/timers.c++
+++ b/src/workerd/api/node/timers.c++
@@ -13,15 +13,15 @@ jsg::Ref<Immediate> TimersUtil::setImmediate(jsg::Lock& js,
     jsg::Function<void(jsg::Arguments<jsg::Value>)> function,
     jsg::Arguments<jsg::Value> args) {
   auto context = js.v8Context();
-  auto& global =
-      jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(context, context->Global());
+  auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
+      js.v8Isolate, context, context->Global(), jsg::kNonResourceWrappableTagRange);
   return global.setImmediate(js, kj::mv(function), kj::mv(args));
 }
 
 void TimersUtil::clearImmediate(jsg::Lock& js, kj::Maybe<jsg::Ref<Immediate>> maybeImmediate) {
   auto context = js.v8Context();
-  auto& global =
-      jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(context, context->Global());
+  auto& global = jsg::extractInternalPointer<ServiceWorkerGlobalScope, true>(
+      js.v8Isolate, context, context->Global(), jsg::kNonResourceWrappableTagRange);
   global.clearImmediate(kj::mv(maybeImmediate));
 }
 }  // namespace workerd::api::node

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -107,6 +107,7 @@ wd_cc_library(
         "v8-platform-wrapper.h",
         "web-idl.h",
         "wrappable.h",
+        "wrappable-tag.h",
     ],
     # Some JSG headers can't be compiled on their own
     features = ["-parse_headers"],

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -86,7 +86,7 @@ struct FunctorCallback<TypeWrapper, Ret(Args...), kj::_::Indexes<indexes...>> {
       auto& js = Lock::from(isolate);
       auto& wrapper = TypeWrapper::from(isolate);
       auto& func = extractInternalPointer<WrappableFunction<Ret(Args...)>, false>(
-          context, args.Data().As<v8::Object>());
+          isolate, context, args.Data().As<v8::Object>(), kNonResourceWrappableTagRange);
 
       auto unwrapped = _::unwrapArgs<Args...>(wrapper, js, context, args,
           []<size_t i>() { return TypeErrorContext::callbackArgument(i); });
@@ -115,7 +115,7 @@ struct FunctorCallback<TypeWrapper,
       auto& js = Lock::from(isolate);
       auto& func = extractInternalPointer<
           WrappableFunction<Ret(const v8::FunctionCallbackInfo<v8::Value>&, Args...)>, false>(
-          context, args.Data().As<v8::Object>());
+          isolate, context, args.Data().As<v8::Object>(), kNonResourceWrappableTagRange);
 
       auto unwrapped = _::unwrapArgs<Args...>(wrapper, js, context, args,
           []<size_t i>() { return TypeErrorContext::callbackArgument(i); });

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -59,7 +59,7 @@ namespace workerd::jsg {
 
 #define JSG_RESOURCE_TYPE(Type, ...)                                                               \
   static constexpr ::workerd::jsg::JsgKind JSG_KIND KJ_UNUSED = ::workerd::jsg::JsgKind::RESOURCE; \
-  using jsgSuper = jsgThis;                                                                        \
+  using jsgSuper = typename Type::jsgThis;                                                         \
   using jsgThis = Type;                                                                            \
   inline kj::StringPtr jsgGetMemoryName() const override {                                         \
     return #Type##_kjc;                                                                            \
@@ -1574,8 +1574,12 @@ class Ref {
   //
   // It is an error to attach a wrapper when another wrapper is already attached. Hence,
   // typically this should only be called on a newly-allocated object.
-  void attachWrapper(v8::Isolate* isolate, v8::Local<v8::Object> object) {
-    inner->Wrappable::attachWrapper(isolate, object, resourceNeedsGcTracing<T>());
+  // `tag` is the per-type CppHeapPointerTag for T, computed by the caller via
+  // TypeWrapper::wrappableTag<T>() (the caller has the TypeWrapper and thus the full type list
+  // needed to number T; Ref<T> does not).
+  void attachWrapper(
+      v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTag tag) {
+    inner->Wrappable::attachWrapper(isolate, object, resourceNeedsGcTracing<T>(), tag);
   }
 
   // Obtain a weak reference to the referenced object. The weak reference does not keep the

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -122,7 +122,7 @@ struct ConstructorCallback<TypeWrapper, T, Ref<T>(Args...), kj::_::Indexes<index
       if constexpr (T::jsgHasReflection) {
         ptr->jsgInitReflection(wrapper);
       }
-      ptr.attachWrapper(isolate, obj);
+      ptr.attachWrapper(isolate, obj, TypeWrapper::template wrappableTag<T>());
     });
   }
 };
@@ -150,7 +150,7 @@ struct ConstructorCallback<TypeWrapper, T, Ref<T>(Lock&, Args...), kj::_::Indexe
       if constexpr (T::jsgHasReflection) {
         ptr->jsgInitReflection(wrapper);
       }
-      ptr.attachWrapper(isolate, obj);
+      ptr.attachWrapper(isolate, obj, TypeWrapper::template wrappableTag<T>());
     });
   }
 };
@@ -182,7 +182,7 @@ struct ConstructorCallback<TypeWrapper,
       if constexpr (T::jsgHasReflection) {
         ptr->jsgInitReflection(wrapper);
       }
-      ptr.attachWrapper(isolate, obj);
+      ptr.attachWrapper(isolate, obj, TypeWrapper::template wrappableTag<T>());
     });
   }
 };
@@ -232,7 +232,7 @@ struct MethodCallback<TypeWrapper,
       auto obj = args.This();
       auto& wrapper = TypeWrapper::from(isolate);
       auto& lock = Lock::from(isolate);
-      auto& self = extractInternalPointer<T, isContext>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);
       auto unwrapped = _::unwrapArgs<Args...>(wrapper, lock, context, args,
           []<size_t i>() { return TypeErrorContext::methodArgument(typeid(T), methodName, i); });
       if constexpr (isVoid<Ret>()) {
@@ -255,7 +255,7 @@ struct MethodCallback<TypeWrapper,
     v8::HandleScope handleScope(isolate);
     auto context = isolate->GetCurrentContext();
     auto& js = Lock::from(isolate);
-    auto& self = extractInternalPointer<T, isContext>(context, receiver);
+    auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, receiver);
     auto& wrapper = TypeWrapper::from(isolate);
 
     return liftKj<Ret>(isolate, [&]() {
@@ -295,7 +295,7 @@ struct MethodCallback<TypeWrapper,
       auto context = isolate->GetCurrentContext();
       auto obj = args.This();
       auto& wrapper = TypeWrapper::from(isolate);
-      auto& self = extractInternalPointer<T, isContext>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);
       auto& lock = Lock::from(isolate);
       auto unwrapped = _::unwrapArgs<Args...>(wrapper, lock, context, args,
           []<size_t i>() { return TypeErrorContext::methodArgument(typeid(T), methodName, i); });
@@ -318,7 +318,7 @@ struct MethodCallback<TypeWrapper,
     auto isolate = options.isolate;
     v8::HandleScope handleScope(isolate);
     auto context = isolate->GetCurrentContext();
-    auto& self = extractInternalPointer<T, isContext>(context, receiver);
+    auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, receiver);
     auto& lock = Lock::from(isolate);
     auto& wrapper = TypeWrapper::from(isolate);
 
@@ -356,7 +356,7 @@ struct MethodCallback<TypeWrapper,
       auto obj = args.This();
       auto& wrapper = TypeWrapper::from(isolate);
       auto& lock = Lock::from(isolate);
-      auto& self = extractInternalPointer<T, isContext>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);
       auto unwrapped = _::unwrapArgs<Args...>(wrapper, lock, context, args,
           []<size_t i>() { return TypeErrorContext::methodArgument(typeid(T), methodName, i); });
       if constexpr (isVoid<Ret>()) {
@@ -650,7 +650,7 @@ struct GetterCallback;
             !wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {           \
           throwTypeError(isolate, kIllegalInvocation);                                             \
         }                                                                                          \
-        auto& self = extractInternalPointer<T, isContext>(context, obj);                           \
+        auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);  \
         return wrapper.wrap(js, context, obj,                                                      \
             (self.*method)(                                                                        \
                 wrapper.unwrap(js, context, static_cast<kj::Decay<Args>*>(nullptr))...));          \
@@ -666,7 +666,8 @@ struct GetterCallback;
       v8::HandleScope handleScope(isolate);                                                        \
       auto context = isolate->GetCurrentContext();                                                 \
       auto& lock = Lock::from(isolate);                                                            \
-      auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
+      auto& self =                                                                                 \
+          extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, receiver);        \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
       return liftKj<ReturnType>(isolate, [&]() {                                                   \
         return (self.*method)(wrapper.template unwrapFastApi<Args>(                                \
@@ -696,7 +697,7 @@ struct GetterCallback;
             !wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {           \
           throwTypeError(isolate, kIllegalInvocation);                                             \
         }                                                                                          \
-        auto& self = extractInternalPointer<T, isContext>(context, obj);                           \
+        auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);  \
         return wrapper.wrap(js, context, obj,                                                      \
             (self.*method)(                                                                        \
                 js, wrapper.unwrap(js, context, static_cast<kj::Decay<Args>*>(nullptr))...));      \
@@ -712,7 +713,8 @@ struct GetterCallback;
       v8::HandleScope handleScope(isolate);                                                        \
       auto context = isolate->GetCurrentContext();                                                 \
       auto& js = Lock::from(isolate);                                                              \
-      auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
+      auto& self =                                                                                 \
+          extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, receiver);        \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
       return liftKj<ReturnType>(isolate, [&]() {                                                   \
         return (self.*method)(js,                                                                  \
@@ -773,7 +775,7 @@ struct PropertyGetterCallback;
             !wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {           \
           throwTypeError(isolate, kIllegalInvocation);                                             \
         }                                                                                          \
-        auto& self = extractInternalPointer<T, isContext>(context, obj);                           \
+        auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);  \
         return wrapper.wrap(js, context, obj,                                                      \
             (self.*method)(                                                                        \
                 wrapper.unwrap(js, context, static_cast<kj::Decay<Args>*>(nullptr))...));          \
@@ -788,7 +790,8 @@ struct PropertyGetterCallback;
       auto isolate = options.isolate;                                                              \
       v8::HandleScope handleScope(isolate);                                                        \
       auto context = isolate->GetCurrentContext();                                                 \
-      auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
+      auto& self =                                                                                 \
+          extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, receiver);        \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
       auto& js = Lock::from(isolate);                                                              \
                                                                                                    \
@@ -820,7 +823,7 @@ struct PropertyGetterCallback;
             !wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {           \
           throwTypeError(isolate, kIllegalInvocation);                                             \
         }                                                                                          \
-        auto& self = extractInternalPointer<T, isContext>(context, obj);                           \
+        auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);  \
         return wrapper.wrap(js, context, obj,                                                      \
             (self.*method)(                                                                        \
                 js, wrapper.unwrap(js, context, static_cast<kj::Decay<Args>*>(nullptr))...));      \
@@ -835,7 +838,8 @@ struct PropertyGetterCallback;
       auto isolate = options.isolate;                                                              \
       v8::HandleScope handleScope(isolate);                                                        \
       auto context = isolate->GetCurrentContext();                                                 \
-      auto& self = extractInternalPointer<T, isContext>(context, receiver);                        \
+      auto& self =                                                                                 \
+          extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, receiver);        \
       auto& js = Lock::from(isolate);                                                              \
       auto& wrapper = TypeWrapper::from(isolate);                                                  \
                                                                                                    \
@@ -894,7 +898,7 @@ struct SetterCallback<TypeWrapper, methodName, void (T::*)(Arg), method, isConte
       if (!isContext && !wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {
         throwTypeError(isolate, kIllegalInvocation);
       }
-      auto& self = extractInternalPointer<T, isContext>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);
       (self.*method)(wrapper.template unwrap<Arg>(
           js, context, value, TypeErrorContext::setterArgument(typeid(T), methodName)));
     });
@@ -921,7 +925,7 @@ struct SetterCallback<TypeWrapper, methodName, void (T::*)(Lock&, Arg), method, 
       if (!isContext && !wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {
         throwTypeError(isolate, kIllegalInvocation);
       }
-      auto& self = extractInternalPointer<T, isContext>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);
       auto& js = Lock::from(isolate);
       (self.*method)(js,
           wrapper.template unwrap<Arg>(
@@ -958,7 +962,7 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Arg), method,
       if (!isContext && !wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {
         throwTypeError(isolate, kIllegalInvocation);
       }
-      auto& self = extractInternalPointer<T, isContext>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);
       (self.*method)(wrapper.template unwrap<Arg>(
           js, context, info[0], TypeErrorContext::setterArgument(typeid(T), methodName)));
     });
@@ -975,7 +979,7 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Arg), method,
     v8::HandleScope handleScope(isolate);
     auto context = isolate->GetCurrentContext();
     auto& js = Lock::from(isolate);
-    auto& self = extractInternalPointer<T, isContext>(context, receiver);
+    auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, receiver);
     auto& wrapper = TypeWrapper::from(isolate);
 
     liftKj<void>(isolate, [&]() -> void {
@@ -1006,7 +1010,7 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Lock&, Arg), 
       if (!isContext && !wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {
         throwTypeError(isolate, kIllegalInvocation);
       }
-      auto& self = extractInternalPointer<T, isContext>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, obj);
       auto& js = Lock::from(isolate);
       (self.*method)(js,
           wrapper.template unwrap<Arg>(
@@ -1024,7 +1028,7 @@ struct PropertySetterCallback<TypeWrapper, methodName, void (T::*)(Lock&, Arg), 
     auto isolate = options.isolate;
     v8::HandleScope handleScope(isolate);
     auto context = isolate->GetCurrentContext();
-    auto& self = extractInternalPointer<T, isContext>(context, receiver);
+    auto& self = extractInternalPointerFor<TypeWrapper, T, isContext>(isolate, context, receiver);
     auto& lock = Lock::from(isolate);
     auto& wrapper = TypeWrapper::from(isolate);
 
@@ -1121,6 +1125,14 @@ class DynamicResourceTypeMap {
   struct DynamicTypeInfo {
     v8::Local<v8::FunctionTemplate> tmpl;
     kj::Maybe<ReflectionInitializer&> reflectionInitializer;
+    // The CppHeapPointerTag for this exact (dynamic) type. Used when wrapping a Ref<T> whose
+    // runtime type is a subclass of T: the wrapper must be tagged with the subclass's tag, not
+    // T's, so that unwrapping at a subclass-typed method site accepts it.
+    v8::CppHeapPointerTag tag;
+    // The tag range accepted for this type (this type and its subclasses). Used by getInstance()
+    // to tag-check a wrapper when unwrapping it by runtime type_info, where no static type is
+    // available to compute the range from.
+    v8::CppHeapPointerTagRange tagRange;
   };
 
   DynamicTypeInfo getDynamicTypeInfo(v8::Isolate* isolate, const std::type_info& type) {
@@ -1218,7 +1230,7 @@ struct WildcardPropertyCallbacks<TypeWrapper,
       if (!wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {
         throwTypeError(isolate, kIllegalInvocation);
       }
-      auto& self = extractInternalPointer<T, false>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, false>(isolate, context, obj);
       auto& lock = Lock::from(isolate);
       if ((self.*getNamedMethod)(lock, kj::str(name.As<v8::String>())) != kj::none) {
         result = v8::Intercepted::kYes;
@@ -1245,7 +1257,7 @@ struct WildcardPropertyCallbacks<TypeWrapper,
       if (!wrapper.getTemplate(isolate, static_cast<T*>(nullptr))->HasInstance(obj)) {
         throwTypeError(isolate, kIllegalInvocation);
       }
-      auto& self = extractInternalPointer<T, false>(context, obj);
+      auto& self = extractInternalPointerFor<TypeWrapper, T, false>(isolate, context, obj);
       auto& lock = Lock::from(isolate);
       KJ_IF_SOME(value, (self.*getNamedMethod)(lock, kj::str(name.As<v8::String>()))) {
         result = v8::Intercepted::kYes;
@@ -1819,7 +1831,8 @@ class ResourceWrapper {
           static_cast<T&>(object).jsgInitReflection(wrapper);
         };
       }
-      return {wrapper.getTemplate(isolate, static_cast<T*>(nullptr)), rinit};
+      return {wrapper.getTemplate(isolate, static_cast<T*>(nullptr)), rinit,
+        TypeWrapper::template wrappableTag<T>(), TypeWrapper::template wrappableTagRange<T>()};
     });
 
     if constexpr (static_cast<uint>(T::jsgSerializeLevel) !=
@@ -1885,20 +1898,24 @@ class ResourceWrapper {
       // Check if *value is actually a subclass of T. If so, we need to dynamically look up the
       // correct wrapper. But in the common case that it's exactly T, we can skip the lookup.
       v8::Local<v8::FunctionTemplate> tmpl;
+      v8::CppHeapPointerTag tag;
       if (type == typeid(T)) {
         tmpl = getTemplate(isolate, nullptr);
+        tag = TypeWrapper::template wrappableTag<T>();
         if constexpr (T::jsgHasReflection) {
           value->jsgInitReflection(wrapper);
         }
       } else {
+        // The runtime type is a subclass of T; tag the wrapper with the subclass's own tag.
         auto info = wrapper.getDynamicTypeInfo(isolate, type);
         tmpl = info.tmpl;
+        tag = info.tag;
         KJ_IF_SOME(i, info.reflectionInitializer) {
           i(*value, wrapper);
         }
       }
       v8::Local<v8::Object> object = check(tmpl->InstanceTemplate()->NewInstance(context));
-      value.attachWrapper(isolate, object);
+      value.attachWrapper(isolate, object, tag);
       return object;
     }
   }
@@ -1931,7 +1948,7 @@ class ResourceWrapper {
     if constexpr (T::jsgHasReflection) {
       ptr->jsgInitReflection(static_cast<TypeWrapper&>(*this));
     }
-    ptr.attachWrapper(isolate, global);
+    ptr.attachWrapper(isolate, global, TypeWrapper::template wrappableTag<T>());
 
     // Disable `eval(code)` and `new Function(code)`. (Actually, setting this to `false` really
     // means "call the callback registered on the isolate to check" -- setting it to `true` means
@@ -2003,7 +2020,14 @@ class ResourceWrapper {
           v8::Local<v8::Object>::Cast(handle)->FindInstanceInPrototypeChain(
               getTemplate(js.v8Isolate, nullptr));
       if (!instance.IsEmpty()) {
-        return extractInternalPointer<T, false>(context, instance);
+        // The prototype-chain check above already accepts exactly the genuine wrappers of T (or a
+        // subclass), whose tags all lie in T's range, so a tag outside it means a wrapper whose
+        // CppHeap handle was redirected while its prototype chain was left intact -- an in-sandbox
+        // memory-safety violation, which aborts. (An ordinary wrong-type argument is rejected by the
+        // prototype-chain check, not here, and yields the kj::none below.)
+        Wrappable* wrappable = Wrappable::unwrapFromShimInRangeOrAbort(
+            js.v8Isolate, instance, TypeWrapper::template wrappableTagRange<T>());
+        return *reinterpret_cast<T*>(wrappable);
       }
     }
 
@@ -2159,7 +2183,7 @@ class ObjectWrapper {
         i(*value, wrapper);
       }
       v8::Local<v8::Object> object = check(tmpl->InstanceTemplate()->NewInstance(context));
-      value.attachWrapper(isolate, object);
+      value.attachWrapper(isolate, object, info.tag);
       return object;
     }
   }

--- a/src/workerd/jsg/ser.c++
+++ b/src/workerd/jsg/ser.c++
@@ -308,9 +308,17 @@ v8::Maybe<bool> Serializer::WriteHostObject(v8::Isolate* isolate, v8::Local<v8::
       throwDataCloneErrorForObject(js, object);
     }
 
-    Wrappable* wrappable = reinterpret_cast<Wrappable*>(
-        object->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
-            static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX)));
+    // The InternalFieldCount + isWorkerdApiObject() checks above established that this is one of
+    // our wrapped objects; the serializer is then selected by the object's dynamic type, so we
+    // only need the pointer here.
+    Wrappable* wrappable = Wrappable::unwrapFromShimAnyType(js.v8Isolate, object);
+    if (wrappable == nullptr) {
+      // The object carries our marker (isWorkerdApiObject() passed) yet its CppHeap handle resolves
+      // to no live wrappable. That is an in-sandbox corruption signal.
+      KJ_LOG(
+          FATAL, "wrapper type mismatch: marked object's CppHeap handle resolves to no wrappable");
+      abort();
+    }
 
     // Only subclasses of `Object` register serializers, so anything else is not serializable.
     Object* obj = wrappable->jsgTryGetObject();

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -365,16 +365,32 @@ void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
   // V8 calls this to tell us when our wrapper can be dropped. See comment about droppable
   // references in Wrappable::attachWrapper() for details.
   v8::HandleScope scope(isolate);
-  auto& wrappable = *static_cast<Wrappable*>(
-      handle.As<v8::Object>().Get(isolate)->GetAlignedPointerFromInternalField(
-          Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
-          static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX)));
+
+  // V8 can only hand this polymorphic callback  an object that is in one of
+  // the sandbox-external tables, so it's genuinely one of our objects.  But
+  // sandbox-internal corruption can cause it to pick us the wrong object and
+  // since it is polymorphic we can't use a tag check.  Instead check that
+  // the wrappable points back at the object being dropped.
+  auto object = handle.As<v8::Object>().Get(isolate);
+  // unwrapFromShimAnyType() returning null is a sign of in-sandbox corruption.
+  Wrappable* wrappablePtr = Wrappable::unwrapFromShimAnyType(isolate, object);
+  if (wrappablePtr == nullptr) {
+    KJ_LOG(
+        FATAL, "wrapper type mismatch: dropped object's CppHeap handle resolves to no wrappable");
+    abort();
+  }
+  auto& wrappable = *wrappablePtr;
+  auto& backReference = KJ_ASSERT_NONNULL(wrappable.wrapper);
+  if (backReference.Get(isolate) != object) {
+    KJ_LOG(FATAL, "wrapper type mismatch: dropped object's CppHeap handle names another wrappable");
+    abort();
+  }
 
   // V8 gets angry if we do not EXPLICITLY call `Reset()` on the wrapper. If we merely destroy it
   // (which is what `detachWrapper()` will do) it is not satisfied, and will come back and try to
   // visit the reference again, but it will DCHECK-fail on that second attempt because the
   // reference is in an inconsistent state at that point.
-  KJ_ASSERT_NONNULL(wrappable.wrapper).Reset();
+  backReference.Reset();
 
   // We don't want to call `detachWrapper()` now because it may create new handles (specifically,
   // if the wrappable has strong references, which means that its outgoing references need to be

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -888,7 +888,7 @@ class Isolate: public IsolateBase {
         }
 
         auto de = alloc<DOMException>(kj::mv(message), kj::mv(name));
-        de.attachWrapper(v8Isolate, obj);
+        de.attachWrapper(v8Isolate, obj, TypeWrapper::template wrappableTag<DOMException>());
 
         return kj::mv(de);
       });
@@ -1043,22 +1043,23 @@ class Isolate: public IsolateBase {
 
     virtual kj::Maybe<Object&> getInstance(
         v8::Local<v8::Object> obj, const std::type_info& type) override {
-      auto instance = v8::Local<v8::Object>(obj)->FindInstanceInPrototypeChain(
-          jsgIsolate.getWrapperByContext(*this)->getDynamicTypeInfo(v8Isolate, type).tmpl);
+      auto info = jsgIsolate.getWrapperByContext(*this)->getDynamicTypeInfo(v8Isolate, type);
+      auto instance = v8::Local<v8::Object>(obj)->FindInstanceInPrototypeChain(info.tmpl);
       if (instance.IsEmpty()) {
         return kj::none;
       } else {
-        // Finding `type`'s template in the prototype chain says nothing about
-        // what the internal field points at (sandbox corruption defense in
-        // depth), so this establishes only that the pointer is *some*
-        // `Wrappable`. The caller, which knows the type statically, is
-        // responsible for the rest -- see JsObject::tryUnwrapAs().
-        auto& wrappable = *reinterpret_cast<Wrappable*>(
-            instance->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
-                static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX)));
-        Object* object = wrappable.jsgTryGetObject();
+        // Tag-check the wrapper against the requested type's range. The prototype-chain check above
+        // already accepts exactly the genuine wrappers of `type` (or a subclass), whose tags all lie
+        // in the range, so a tag outside it means a wrapper whose CppHeap handle was redirected while
+        // its prototype chain was left intact -- an in-sandbox memory-safety violation, which aborts.
+        Wrappable* wrappable =
+            Wrappable::unwrapFromShimInRangeOrAbort(v8Isolate, instance, info.tagRange);
+        // Even after checking the tags we use the vtable check to confirm the type
+        // matches our expectations. This should never fail unless we have an attacker
+        // that has somehow got around the tag check.
+        Object* object = wrappable->jsgTryGetObject();
         if (object == nullptr) {
-          reportWrapperTypeMismatch(type, typeid(wrappable));
+          reportWrapperTypeMismatch(type, typeid(*wrappable));
         }
         return *object;
       }

--- a/src/workerd/jsg/type-wrapper.h
+++ b/src/workerd/jsg/type-wrapper.h
@@ -17,6 +17,7 @@
 #include <workerd/jsg/util.h>
 #include <workerd/jsg/value.h>
 #include <workerd/jsg/web-idl.h>
+#include <workerd/jsg/wrappable-tag.h>
 #include <workerd/jsg/wrappable.h>
 
 #include <v8-wasm.h>
@@ -616,6 +617,164 @@ class TypeWrapper: public DynamicResourceTypeMap<Self>,
       func(typeid(TypeHandler<Ref<U>>),
           static_cast<const TypeHandler<Ref<U>>*>(&TYPE_HANDLER_INSTANCE<Ref<U>>));
     }
+  }
+
+  // === Per-type CppHeapPointerTag numbering ===================================================
+  //
+  // Assign every resource type registered with this isolate a dense id via DFS pre-order over the
+  // JSG_INHERIT forest, so that a type and all its subclasses occupy a contiguous id interval.
+  // `wrappableTag<U>()` is U's own tag (used at Wrap time); `wrappableTagRange<U>()` is the
+  // [U, last-subclass-of-U] interval (used at Unwrap time to accept U or any subclass).
+  //
+  // Only resource types (JSG_KIND == RESOURCE) are numbered. Non-resource wrappables share
+  // kNonResourceWrappableTag and are handled separately by their unwrap sites.
+  //
+  // The whole assignment is computed in a single consteval pass over a per-type metadata table,
+  // rather than as a web of recursive templates: extracting each type's parent and kind is O(N)
+  // instantiations, and all the DFS arithmetic then runs inside one interpreted constexpr loop with
+  // no further instantiation (we have to be careful about workers-api.c++ compile times).
+
+  static constexpr size_t kNumTypes = sizeof...(T);
+
+  // Position of U in the pack T..., or kNumTypes if U is not in the pack (e.g. Object, which is the
+  // forest root and is never itself wrapped).
+  template <typename U>
+  static consteval size_t typeIndex() {
+    size_t index = kNumTypes;
+    size_t i = 0;
+    ((kj::isSameType<U, T>() ? (index = i, void()) : void(), ++i), ...);
+    return index;
+  }
+
+  // Per-type metadata, one entry per pack member, used by the numbering pass.
+  struct TypeMeta {
+    // Index into the pack of this type's JSG superclass, or kNumTypes if the parent is Object (a
+    // forest root) or this type is not a resource.
+    size_t parentIndex = 0;
+    bool isResource = false;
+  };
+
+  // Metadata for every pack member. Building this is the only per-type template work: each entry
+  // reads the type's JSG_KIND and, for resources, locates its jsgSuper in the pack.
+  static constexpr auto kTypeMeta = []() {
+    kj::FixedArray<TypeMeta, kNumTypes> meta{};
+    size_t i = 0;
+    ([&]<typename U>() {
+      if constexpr (U::JSG_KIND == JsgKind::RESOURCE) {
+        using Parent = U::jsgSuper;
+        if constexpr (kj::isSameType<Parent, Object>()) {
+          // A forest root: Object is never itself wrapped, so it has no index in the pack.
+          meta[i] = TypeMeta{.parentIndex = kNumTypes, .isResource = true};
+        } else {
+          // typeIndex() also returns kNumTypes for a type that is simply absent from the pack, so
+          // without this check an unregistered JSG superclass would be indistinguishable from
+          // Object and silently make this type a forest root. Its tag would then fall outside the
+          // subtree range of every registered ancestor, and the first inherited method dispatched
+          // through one of them would abort at runtime.
+          static_assert(typeIndex<Parent>() < kNumTypes,
+              "this JSG resource type's superclass (its jsgSuper, i.e. the JSG_RESOURCE_TYPE of "
+              "its C++ base class) is not registered in this isolate's JSG_DECLARE_ISOLATE_TYPE "
+              "list; register it, or correct the type's inheritance");
+          meta[i] = TypeMeta{.parentIndex = typeIndex<Parent>(), .isResource = true};
+        }
+      } else {
+        meta[i] = TypeMeta{.parentIndex = kNumTypes, .isResource = false};
+      }
+      ++i;
+    }.template operator()<T>(), ...);
+    return meta;
+  }();
+
+  // DFS pre-order ids and subtree sizes for every resource type, computed in one pass over
+  // kTypeMeta. Non-resource entries are left at zero and never consulted.
+  struct Numbering {
+    kj::FixedArray<uint16_t, kNumTypes> preorderId;
+    kj::FixedArray<uint16_t, kNumTypes> subtreeSize;
+  };
+
+  static constexpr Numbering kNumbering = []() {
+    Numbering n{};
+
+    // The pack order (JSG_DECLARE_ISOLATE_TYPE registration order) is arbitrary: a resource's JSG
+    // superclass may appear either before or after it. So neither pass below may assume a parent
+    // precedes its children in index order. Both instead process resources in order of increasing
+    // depth in the jsgSuper forest, which guarantees every parent is handled before its children
+    // regardless of pack order. Depth is bounded by the inheritance depth (small), so the passes
+    // are O(kNumTypes * maxDepth) with no fixed-point iteration.
+    kj::FixedArray<uint16_t, kNumTypes> depth{};
+    uint16_t maxDepth = 0;
+    for (size_t i = 0; i < kNumTypes; ++i) {
+      if (!kTypeMeta[i].isResource) continue;
+      uint16_t d = 0;
+      for (size_t p = kTypeMeta[i].parentIndex; p != kNumTypes; p = kTypeMeta[p].parentIndex) {
+        ++d;
+      }
+      depth[i] = d;
+      if (d > maxDepth) maxDepth = d;
+    }
+
+    // subtreeSize(U) = 1 + sum of subtreeSize over direct resource children of U. Fold deepest
+    // resources into their parents first, so a parent's total is complete before it is itself folded
+    // into its own parent.
+    for (size_t i = 0; i < kNumTypes; ++i) {
+      n.subtreeSize[i] = kTypeMeta[i].isResource ? 1 : 0;
+    }
+    for (size_t level = maxDepth; level-- > 0;) {
+      for (size_t i = 0; i < kNumTypes; ++i) {
+        if (!kTypeMeta[i].isResource || depth[i] != level + 1) continue;
+        size_t parent = kTypeMeta[i].parentIndex;
+        n.subtreeSize[parent] = static_cast<uint16_t>(n.subtreeSize[parent] + n.subtreeSize[i]);
+      }
+    }
+
+    // preorder(U) = preorder(parent) + 1 + (subtree space of earlier siblings), where siblings are
+    // resources with the same parent; roots (parent == Object) start at base 0. Assigning by
+    // increasing depth ensures preorder(parent) is set before any child reads it. Sibling order is
+    // pack order among nodes sharing a parent, tracked by the per-parent cursor `nextChildOffset`.
+    kj::FixedArray<uint16_t, kNumTypes> nextChildOffset{};  // per-parent accumulated sibling space
+    uint16_t nextRootOffset = 0;                            // sibling space among forest roots
+    for (size_t level = 0; level <= maxDepth; ++level) {
+      for (size_t i = 0; i < kNumTypes; ++i) {
+        if (!kTypeMeta[i].isResource || depth[i] != level) continue;
+        size_t parent = kTypeMeta[i].parentIndex;
+        if (parent == kNumTypes) {
+          n.preorderId[i] = nextRootOffset;
+          nextRootOffset = static_cast<uint16_t>(nextRootOffset + n.subtreeSize[i]);
+        } else {
+          n.preorderId[i] =
+              static_cast<uint16_t>(n.preorderId[parent] + 1 + nextChildOffset[parent]);
+          nextChildOffset[parent] =
+              static_cast<uint16_t>(nextChildOffset[parent] + n.subtreeSize[i]);
+        }
+      }
+    }
+
+    return n;
+  }();
+
+  // U's own tag: its pre-order id offset past the reserved non-resource tag.
+  template <typename U>
+  static consteval v8::CppHeapPointerTag wrappableTag() {
+    static_assert(U::JSG_KIND == JsgKind::RESOURCE);
+    constexpr uint16_t tag = kFirstResourceTag + kNumbering.preorderId[typeIndex<U>()];
+    // If this fires, this isolate registers more wrappable types than the freelist bucket array in
+    // HeapTracer can index. Raise kMaxWrappableTags in wrappable-tag.h; see the comment there.
+    static_assert(wrappableTagBucketIndex(tag) < kMaxWrappableTags,
+        "too many JSG resource types for this isolate; raise kMaxWrappableTags");
+    return static_cast<v8::CppHeapPointerTag>(tag);
+  }
+
+  // The tag range accepted when unwrapping into a receiver of static type U: U itself through the
+  // last id in U's subtree. subtreeSize includes U, so the last id is preorder(U) +
+  // subtreeSize(U) - 1.
+  template <typename U>
+  static consteval v8::CppHeapPointerTagRange wrappableTagRange() {
+    static_assert(U::JSG_KIND == JsgKind::RESOURCE);
+    constexpr size_t idx = typeIndex<U>();
+    uint16_t first = kFirstResourceTag + kNumbering.preorderId[idx];
+    uint16_t last = first + kNumbering.subtreeSize[idx] - 1;
+    return v8::CppHeapPointerTagRange(
+        static_cast<v8::CppHeapPointerTag>(first), static_cast<v8::CppHeapPointerTag>(last));
   }
 
   template <typename U>

--- a/src/workerd/jsg/wrappable-tag.h
+++ b/src/workerd/jsg/wrappable-tag.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+// INTERNAL IMPLEMENTATION FILE
+//
+// Compile-time assignment of per-type CppHeapPointerTags to JSG resource types, so that
+// unwrapping a JS wrapper into its C++ object can range-check the type through V8's CppHeap
+// pointer table. See ept-tagging design notes.
+//
+// The scheme mirrors what V8's CppHeapPointerTag enum documents: assign every resource type a
+// dense id via a DFS pre-order over the JSG_INHERIT forest, so that the ids of a type and all of
+// its (transitive) subclasses form a contiguous interval. A method receiver of static type T then
+// accepts any wrapper whose tag lies in T's subtree interval -- i.e. T or any subclass -- and
+// rejects everything else.
+
+#include <workerd/jsg/util.h>  // JsgKind
+
+#include <v8-sandbox.h>  // CppHeapPointerTag, CppHeapPointerTagRange
+
+#include <cstdint>
+
+namespace workerd::jsg {
+
+// The tag reserved for wrappables that are not JSG resource types: WrappableFunction<Sig> (the
+// backing object of a jsg::Function) and opaque wrappers. Resource types receive their own
+// per-type tags, numbered starting immediately after this one.
+//
+// This single shared tag does not by itself pin down a concrete C++ type -- it
+// only distinguishes "non-resource wrappable" from "resource". Polymorphic
+// unwrap sites that use it will typically follow up with a dynamic_cast or other
+// vtable-backed techniques that pin down the exact type based on non-sandbox data.
+constexpr uint16_t kNonResourceWrappableTag =
+    static_cast<uint16_t>(v8::CppHeapPointerTag::kFirstObjectWrappableTag);
+
+// The dense id of the first resource type. Resource ids are offset past the non-resource tag so
+// that the two spaces never collide within kObjectWrappableTagRange.
+constexpr uint16_t kFirstResourceTag = kNonResourceWrappableTag + 1;
+
+// Upper bound on the number of distinct wrappable tags any single isolate type may use: one
+// catch-all tag plus one per registered resource type. It sizes the freelist bucket array in
+// HeapTracer (a small fixed array, indexed by tag) and is enforced at compile time by a
+// static_assert in TypeWrapper::wrappableTag<T>().
+//
+// To grow it: just raise this number. The only cost is a slightly larger fixed array per isolate
+// (kMaxWrappableTags pointers). There is no correctness subtlety -- the bound exists solely so the
+// runtime array can be statically sized rather than grown on demand. Real isolates use on the
+// order of ~270 tags today.
+constexpr uint16_t kMaxWrappableTags = 310;
+
+// Index of a tag within the freelist bucket array: tags are dense starting at
+// kFirstObjectWrappableTag (the catch-all), so the offset is a compact array index.
+constexpr uint16_t wrappableTagBucketIndex(uint16_t tag) {
+  return tag - kNonResourceWrappableTag;
+}
+
+// The single-tag range used to unwrap non-resource wrappables (functions, opaque wrappers), which
+// all share kNonResourceWrappableTag.
+constexpr v8::CppHeapPointerTagRange kNonResourceWrappableTagRange(
+    static_cast<v8::CppHeapPointerTag>(kNonResourceWrappableTag),
+    static_cast<v8::CppHeapPointerTag>(kNonResourceWrappableTag));
+
+}  // namespace workerd::jsg

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -87,7 +87,9 @@ using JSGWrappable = workerd::jsg::Wrappable;
 // condemned after that point and will be deleted shortly thereafter.
 class Wrappable::CppgcShim final: public v8::Object::Wrappable {
  public:
-  CppgcShim(JSGWrappable& wrappable): state(Active{kj::addRef(wrappable)}) {
+  CppgcShim(JSGWrappable& wrappable, v8::CppHeapPointerTag tag)
+      : tag(tag),
+        state(Active{kj::addRef(wrappable)}) {
     KJ_DASSERT(wrappable.cppgcShim == kj::none);
     wrappable.cppgcShim = *this;
   }
@@ -166,30 +168,49 @@ class Wrappable::CppgcShim final: public v8::Object::Wrappable {
     return false;
   }
 
+  // The per-type CppHeapPointerTag this shim was Wrapped with. A shim is only ever reused for the
+  // same tag (see HeapTracer::freelistedShimsByTag), so this value is fixed for the shim's whole
+  // lifetime and identifies which freelist bucket it belongs to.
+  v8::CppHeapPointerTag tag;
+
   mutable kj::OneOf<Active, Freelisted, Dead> state;
   // This is `mutable` because `Trace()` is const. We configure V8 to perform traces atomically in
   // the main thread so concurrency is not a concern.
 };
 
+kj::Maybe<JSGWrappable::CppgcShim&>& HeapTracer::freelistHeadFor(v8::CppHeapPointerTag tag) {
+  auto index = wrappableTagBucketIndex(static_cast<uint16_t>(tag));
+  // Guaranteed in range by the static_assert in TypeWrapper::wrappableTag<T>() at every wrap site;
+  // this is a defensive backstop for the non-resource catch-all and any future direct callers.
+  KJ_ASSERT(index < kMaxWrappableTags);
+  return freelistedShimsByTag[index];
+}
+
 void HeapTracer::addToFreelist(JSGWrappable::CppgcShim& shim) {
+  auto& head = freelistHeadFor(shim.tag);
   auto& freelisted = shim.state.init<JSGWrappable::CppgcShim::Freelisted>();
-  freelisted.next = freelistedShims;
+  freelisted.next = head;
   KJ_IF_SOME(next, freelisted.next) {
     next.state.get<JSGWrappable::CppgcShim::Freelisted>().prev = &freelisted.next;
   }
-  freelisted.prev = &freelistedShims;
-  freelistedShims = shim;
+  freelisted.prev = &head;
+  head = shim;
 }
 
-JSGWrappable::CppgcShim* HeapTracer::allocateShim(JSGWrappable& wrappable) {
+JSGWrappable::CppgcShim* HeapTracer::allocateShim(
+    JSGWrappable& wrappable, v8::CppHeapPointerTag tag) {
   // Under gc-stress (either turn-boundary or alloc mode), skip freelist reuse so each freed shim
   // keeps a unique address and ASAN poisoning sticks, giving cleaner use-after-free reports.
   if (!isGcStressModeForTest() && !isAllocGcStressModeForTest()) {
-    KJ_IF_SOME(shim, freelistedShims) {
-      freelistedShims = shim.state.get<JSGWrappable::CppgcShim::Freelisted>().next;
-      KJ_IF_SOME(next, freelistedShims) {
-        next.state.get<JSGWrappable::CppgcShim::Freelisted>().prev = &freelistedShims;
+    // Only reuse a shim from the bucket for this exact tag, so a recycled shim's table-entry tag
+    // never changes and a stale wrapper handle can't be confused across types.
+    auto& head = freelistHeadFor(tag);
+    KJ_IF_SOME(shim, head) {
+      head = shim.state.get<JSGWrappable::CppgcShim::Freelisted>().next;
+      KJ_IF_SOME(next, head) {
+        next.state.get<JSGWrappable::CppgcShim::Freelisted>().prev = &head;
       }
+      KJ_DASSERT(shim.tag == tag);
       shim.state = JSGWrappable::CppgcShim::Active{kj::addRef(wrappable)};
       KJ_DASSERT(wrappable.cppgcShim == kj::none);
       wrappable.cppgcShim = shim;
@@ -197,17 +218,20 @@ JSGWrappable::CppgcShim* HeapTracer::allocateShim(JSGWrappable& wrappable) {
     }
   }
   auto& cppgcAllocHandle = isolate->GetCppHeap()->GetAllocationHandle();
-  auto* shim = cppgc::MakeGarbageCollected<JSGWrappable::CppgcShim>(cppgcAllocHandle, wrappable);
+  auto* shim =
+      cppgc::MakeGarbageCollected<JSGWrappable::CppgcShim>(cppgcAllocHandle, wrappable, tag);
   return shim;
 }
 
 void HeapTracer::clearFreelistedShims() {
-  for (;;) {
-    KJ_IF_SOME(shim, freelistedShims) {
-      freelistedShims = shim.state.get<JSGWrappable::CppgcShim::Freelisted>().next;
-      shim.state = JSGWrappable::CppgcShim::Dead{};
-    } else {
-      break;
+  for (auto& head: freelistedShimsByTag) {
+    for (;;) {
+      KJ_IF_SOME(shim, head) {
+        head = shim.state.get<JSGWrappable::CppgcShim::Freelisted>().next;
+        shim.state = JSGWrappable::CppgcShim::Dead{};
+      } else {
+        break;
+      }
     }
   }
 }
@@ -217,6 +241,54 @@ void HeapTracer::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
     tracker.trackField("wrapper", wrapper);
   }
   // TODO(soon): Track the other fields here?
+}
+
+Wrappable* Wrappable::unwrapFromShim(
+    v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTagRange tagRange) {
+  // Read the CppgcShim out of V8's CppHeap pointer table, requiring the stored tag to fall within
+  // `tagRange`. If the object was never wrapped, or its tag is outside the range (a type-confused
+  // or forged handle), Unwrap returns nullptr.
+  auto* shim =
+      static_cast<CppgcShim*>(v8::Object::Unwrap<v8::Object::Wrappable>(isolate, object, tagRange));
+  if (shim == nullptr) {
+    return nullptr;
+  }
+
+  // Dispatch through the shim's owning reference, which is the lifetime-correct pointer: it is a
+  // kj::Own<Wrappable> that keeps the object alive for as long as the shim is Active. A minor-GC'd
+  // (Freelisted) or dead shim can never be reached here, because its table entry is only ever
+  // populated while Active (attachWrapper/allocateShim write it) and per-type freelisting keeps a
+  // recycled shim's tag constant, so a stale handle either misses the range or resolves to a live
+  // object of the same type.
+  KJ_IF_SOME(active, shim->state.tryGet<CppgcShim::Active>()) {
+    return active.wrappable.get();
+  }
+  return nullptr;
+}
+
+Wrappable* Wrappable::unwrapFromShimAnyType(v8::Isolate* isolate, v8::Local<v8::Object> object) {
+  return unwrapFromShim(isolate, object, v8::kObjectWrappableTagRange);
+}
+
+Wrappable* Wrappable::unwrapFromShimInRangeOrAbort(
+    v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTagRange tagRange) {
+  // Unwrap with the wide wrappable range so Object::Unwrap never faults, then range-check the shim's
+  // own tag ourselves. See the header for why the check can't be delegated to Object::Unwrap, and
+  // why an out-of-range tag here is a memory-safety violation that must abort.
+  auto* shim = static_cast<CppgcShim*>(
+      v8::Object::Unwrap<v8::Object::Wrappable>(isolate, object, v8::kObjectWrappableTagRange));
+  if (shim != nullptr) {
+    auto tag = static_cast<uint16_t>(shim->tag);
+    if (tag >= static_cast<uint16_t>(tagRange.first) &&
+        tag <= static_cast<uint16_t>(tagRange.last)) {
+      KJ_IF_SOME(active, shim->state.tryGet<CppgcShim::Active>()) {
+        return active.wrappable.get();
+      }
+    }
+  }
+
+  KJ_LOG(FATAL, "wrapper type mismatch: object's tag is outside the expected range");
+  abort();
 }
 
 kj::Own<JSGWrappable> JSGWrappable::detachWrapper(bool shouldFreelistShim) {
@@ -341,8 +413,10 @@ void Wrappable::traceFromV8(cppgc::Visitor& cppgcVisitor) {
   jsgVisitForGc(visitor);
 }
 
-void Wrappable::attachWrapper(
-    v8::Isolate* isolate, v8::Local<v8::Object> object, bool needsGcTracing) {
+void Wrappable::attachWrapper(v8::Isolate* isolate,
+    v8::Local<v8::Object> object,
+    bool needsGcTracing,
+    v8::CppHeapPointerTag tag) {
   auto& tracer = HeapTracer::getTracer(isolate);
 
   KJ_REQUIRE(wrapper == kj::none);
@@ -391,17 +465,19 @@ void Wrappable::attachWrapper(
 
   // Set up internal fields for a newly-allocated object.
   KJ_REQUIRE(object->InternalFieldCount() == Wrappable::INTERNAL_FIELD_COUNT);
-  // The third argument is the type tag, a small integer that should be
-  // different for every pointer type to avoid type confusion attacks.  We just
-  // use the slot index for now, since we have a different pointer type for
-  // each slot.
+  // Internal field 0 holds a marker identifying this as a workerd API object; see
+  // isWorkerdApiObject(). The marker's address is a small integer type-tagged by slot index.
   auto tagAddress = const_cast<uint16_t*>(&WORKERD_WRAPPABLE_TAG);
   object->SetAlignedPointerInInternalField(WRAPPABLE_TAG_FIELD_INDEX, tagAddress,
       static_cast<v8::EmbedderDataTypeTag>(WRAPPABLE_TAG_FIELD_INDEX));
-  object->SetAlignedPointerInInternalField(WRAPPED_OBJECT_FIELD_INDEX, this,
-      static_cast<v8::EmbedderDataTypeTag>(WRAPPED_OBJECT_FIELD_INDEX));
 
-  v8::Object::Wrap<WRAPPABLE_TAG>(isolate, object, tracer.allocateShim(*this));
+  // The C++ object is reached only through the CppgcShim, stored in V8's CppHeap pointer table
+  // with a per-type tag. There is deliberately no second, independently-corruptible pointer to
+  // the object in an internal field: a single tagged handle means dispatch and GC lifetime can
+  // never be driven by different pointers, closing the wrapper type-confusion / use-after-free
+  // class of bugs. The shim carries the same tag so it lands in the matching freelist bucket.
+  auto* shim = tracer.allocateShim(*this, tag);
+  v8::Object::Wrap(isolate, object, shim, tag);
 
   if (strongRefcount > 0) {
     strongWrapper.Reset(isolate, object);
@@ -427,7 +503,8 @@ v8::Local<v8::Object> Wrappable::attachOpaqueWrapper(
   // Null prototype: opaque wrappers flow through v8::Promise::Resolver::Resolve(), whose thenable
   // check does Get(value, "then"). A null prototype keeps that lookup off Object.prototype.
   jsg::check(object->SetPrototype(context, v8::Null(isolate)));
-  attachWrapper(isolate, object, needsGcTracing);
+  attachWrapper(isolate, object, needsGcTracing,
+      static_cast<v8::CppHeapPointerTag>(kNonResourceWrappableTag));
   return object;
 }
 
@@ -438,9 +515,12 @@ kj::Maybe<Wrappable&> Wrappable::tryUnwrapOpaque(
         v8::Local<v8::Object>::Cast(handle)->FindInstanceInPrototypeChain(
             IsolateBase::getOpaqueTemplate(isolate));
     if (!instance.IsEmpty()) {
-      return *reinterpret_cast<Wrappable*>(
-          instance->GetAlignedPointerFromInternalField(WRAPPED_OBJECT_FIELD_INDEX,
-              static_cast<v8::EmbedderDataTypeTag>(WRAPPED_OBJECT_FIELD_INDEX)));
+      // The prototype-chain check above accepts exactly our opaque wrappers, which all carry
+      // kNonResourceWrappableTag. A tag outside that range therefore means the object's CppHeap
+      // handle was redirected to an unrelated type while its prototype chain was left intact -- an
+      // in-sandbox memory-safety violation, which aborts (matching the resource unwrap sites)
+      // rather than returning a mistyped pointer for a downstream dynamic_cast to catch.
+      return *unwrapFromShimInRangeOrAbort(isolate, instance, kNonResourceWrappableTagRange);
     }
   }
 

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -8,6 +8,8 @@
 // This file defines basic helpers involved in wrapping C++ objects for JavaScript consumption,
 // including garbage-collecting those objects.
 
+#include <workerd/jsg/wrappable-tag.h>
+
 #include <v8-context.h>
 #include <v8-object.h>
 #include <v8-version.h>
@@ -152,10 +154,12 @@ class Wrappable: public kj::Refcounted {
     // tag that helps us to identify a v8 API object as one of our own.
     WRAPPABLE_TAG_FIELD_INDEX,
 
-    // Index of the internal field that points back to the `Wrappable`.
-    WRAPPED_OBJECT_FIELD_INDEX,
-
     // Number of internal fields in a wrapper object.
+    //
+    // The pointer back to the C++ Wrappable is NOT stored in an internal field: it lives only in
+    // V8's CppHeap pointer table, reached via the CppgcShim (see attachWrapper / unwrapFromShim).
+    // Keeping a single tagged handle -- rather than a second, independently-corruptible internal
+    // field -- is what prevents wrapper type-confusion and use-after-free.
     INTERNAL_FIELD_COUNT,
   };
 
@@ -231,16 +235,22 @@ class Wrappable: public kj::Refcounted {
   // Attach to a JavaScript object. This increments the Wrappable's refcount until `object`
   // is garbage-collected (or unlink() is called).
   //
-  // The object MUST have exactly 2 internal field slots, which will be initialized by this
-  // call as follows:
-  // - Internal field 0 is special and is used by the GC tracing implementation.
-  // - Internal field 1 is set to a pointer to the Wrappable. It can be used to unwrap the
-  //   object.
+  // The object MUST have exactly INTERNAL_FIELD_COUNT internal field slots. Internal field 0 holds
+  // the workerd-API marker (see isWorkerdApiObject); the C++ object pointer itself is stored in
+  // V8's CppHeap pointer table rather than an internal field.
   //
   // If `needsGcTracing` is true, then the virtual method jsgVisitForGc() will be called to
   // perform GC tracing. If false, the method is never called (may be more efficient, if the
   // method does nothing anyway).
-  void attachWrapper(v8::Isolate* isolate, v8::Local<v8::Object> object, bool needsGcTracing);
+  //
+  // `tag` is the per-type CppHeapPointerTag identifying the wrapped object's type. It is stored
+  // in V8's CppHeap pointer table (via Object::Wrap) and range-checked at unwrap time to reject
+  // type-confused handles. Resource types pass their own tag (TypeWrapper::wrappableTag<T>());
+  // non-resource wrappables (functions, opaque wrappers) pass kNonResourceWrappableTag.
+  void attachWrapper(v8::Isolate* isolate,
+      v8::Local<v8::Object> object,
+      bool needsGcTracing,
+      v8::CppHeapPointerTag tag);
 
   // Attach an empty, null-prototype object as the wrapper.
   v8::Local<v8::Object> attachOpaqueWrapper(v8::Local<v8::Context> context, bool needsGcTracing);
@@ -287,6 +297,37 @@ class Wrappable: public kj::Refcounted {
   // Detaches the wrapper from V8 and returns the reference that V8 had previously held.
   // (Typically, the caller will ignore the return value, thus dropping the reference.)
   kj::Own<Wrappable> detachWrapper(bool shouldFreelistShim);
+
+  // Given a JS wrapper object, unwrap it back to its Wrappable, requiring that the object's tag
+  // (stored in V8's CppHeap pointer table by attachWrapper) lies within `tagRange`. Returns
+  // nullptr if the object was never wrapped or its tag is outside the range (i.e. a type-confused
+  // or forged handle). Dispatch goes through the CppgcShim's owning reference, so the pointer
+  // returned is always the lifetime-correct one.
+  static Wrappable* unwrapFromShim(
+      v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTagRange tagRange);
+
+  // Like unwrapFromShim(), but accepts any wrappable tag. For call sites that have already
+  // established the object's type by another means (a prototype-chain check, or an
+  // isWorkerdApiObject() marker check plus a dynamic-type lookup) and only need the pointer.
+  // Returns nullptr if the object was never wrapped.
+  static Wrappable* unwrapFromShimAnyType(v8::Isolate* isolate, v8::Local<v8::Object> object);
+
+  // Unwrap an object already known to be one of our wrappers (the caller has done a prototype-chain
+  // check for `tagRange`'s type), requiring its stored tag to fall within `tagRange`, and abort if
+  // it does not.
+  //
+  // The prototype-chain check the caller performed accepts exactly the objects whose own map was
+  // built from this type's template -- i.e. genuine, JSG-wrapped instances of the type or a
+  // subclass, all of whose tags fall in `tagRange`. The only way to reach here with an out-of-range
+  // tag is therefore a wrapper whose CppHeap handle or shim tag was corrupted in-sandbox, which is a
+  // memory-safety violation. We abort so it is surfaced rather than silently ignored; returning a
+  // pointer would risk type confusion, and returning "not found" would hide the attack.
+  //
+  // The range check is done in C++ (via a wide-range unwrap) rather than by passing `tagRange` to
+  // Object::Unwrap, because a checked V8 build turns a narrow-range miss into its own fatal DCHECK
+  // before returning, producing a different (and less informative) crash than the abort here.
+  static Wrappable* unwrapFromShimInRangeOrAbort(
+      v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTagRange tagRange);
 
   // Called by HeapTracer when V8 tells us that it found a reference to this object.
   void traceFromV8(cppgc::Visitor& cppgcVisitor);
@@ -389,9 +430,15 @@ class HeapTracer: public v8::EmbedderRootsHandler {
   void clearWrappers();
 
   void addToFreelist(Wrappable::CppgcShim& shim);
-  Wrappable::CppgcShim* allocateShim(Wrappable& wrappable);
+  Wrappable::CppgcShim* allocateShim(Wrappable& wrappable, v8::CppHeapPointerTag tag);
   void clearFreelistedShims();
 
+ private:
+  // Returns the head slot of the intrusive freelist for `tag`. The slot has a stable address (it
+  // lives in the fixed-size freelistedShimsByTag array), so freelisted shims may point back to it.
+  kj::Maybe<Wrappable::CppgcShim&>& freelistHeadFor(v8::CppHeapPointerTag tag);
+
+ public:
   // The epoch of the currently active (possibly in-flight) major GC cycle. Advanced once
   // per cycle in whichever prologue fires first (incremental-marking start or the
   // mark-compact prologue). Wrappable::traceFromV8() stamps this value into
@@ -452,9 +499,22 @@ class HeapTracer: public v8::EmbedderRootsHandler {
   // List of all Wrappables for which a JavaScript wrapper exists.
   kj::List<Wrappable, &Wrappable::link> wrappers;
 
-  // List of shim objects for wrappers that were collected during a minor GC. The shim objects
-  // can be reused for future allocations.
-  kj::Maybe<Wrappable::CppgcShim&> freelistedShims;
+  // Freelists of shim objects for wrappers that were collected during a minor GC. The shim
+  // objects can be reused for future allocations before the next major GC.
+  //
+  // A shim's single CppHeap-pointer-table entry carries its object's per-type tag, written once at
+  // Wrap time. When a shim is recycled it is re-Wrapped, which would rewrite that tag -- so a shim
+  // must only ever be reused for the same type across its whole lifetime, or a stale wrapper
+  // handle for an old occupant could pass the tag check against a new occupant of a different
+  // type. We therefore partition the freelist by tag: each bucket only ever holds shims that last
+  // served (and will next serve) that tag.
+  //
+  // A fixed-size array indexed by dense bucket index (wrappableTagBucketIndex(tag)). Each element
+  // is the head of an intrusive LIFO list; freelisted shims store a raw pointer back to their head
+  // slot, so the array elements must have stable addresses -- hence a plain array rather than a
+  // grown-on-demand vector. Sized by kMaxWrappableTags, which is enforced at wrap time by a
+  // static_assert in TypeWrapper::wrappableTag<T>().
+  kj::Maybe<Wrappable::CppgcShim&> freelistedShimsByTag[kMaxWrappableTags] = {};
 
   // Major GC epoch counters; see getActiveGcEpoch()/getCompletedGcEpoch(). The two are equal
   // exactly when no major cycle is in flight (the mark-compact epilogue restores equality),
@@ -553,26 +613,48 @@ T& downcastWrappable(Wrappable& wrappable) {
 }
 
 // Given a handle to a resource type, extract the raw C++ object pointer.
+//
+// `tagRange` is the set of CppHeapPointerTags that the receiver's static type accepts: the
+// receiver type's own tag through the tags of all its subclasses. If the wrapper's tag is outside
+// this range -- i.e. the handle names an object of an unrelated type -- unwrapping fails,
+// signalling a type-confusion attempt. Callers compute the range via
+// TypeWrapper::wrappableTagRange<T>() (resource types) or kNonResourceWrappableTag (functions and
+// opaque wrappers).
 template <typename T, bool isContext>
-T& extractInternalPointer(
-    const v8::Local<v8::Context>& context, const v8::Local<v8::Object>& object) {
+T& extractInternalPointer(v8::Isolate* isolate,
+    const v8::Local<v8::Context>& context,
+    const v8::Local<v8::Object>& object,
+    v8::CppHeapPointerTagRange tagRange) {
   // Due to bugs in V8, we can't use internal fields on the global object:
   //   https://groups.google.com/d/msg/v8-users/RET5b3KOa5E/3EvpRBzwAQAJ
   //
   // So, when wrapping a global object, we store the pointer in the "embedder data" of the context
-  // instead of the internal fields of the object.
+  // instead of the internal fields of the object. The global is a per-context singleton and is
+  // not reached through the tagged CppHeap-pointer path, so the tag range does not apply to it.
 
   if constexpr (isContext) {
     // V8 docs say EmbedderData slot 0 is special, so we use slot 1. (See comments in newContext().)
     return KJ_ASSERT_NONNULL(
         getAlignedPointerFromEmbedderData<T>(context, ContextPointerSlot::GLOBAL_WRAPPER));
   } else {
-    KJ_ASSERT(object->InternalFieldCount() == Wrappable::INTERNAL_FIELD_COUNT);
-    auto* ptr = object->GetAlignedPointerFromInternalField(Wrappable::WRAPPED_OBJECT_FIELD_INDEX,
-        static_cast<v8::EmbedderDataTypeTag>(Wrappable::WRAPPED_OBJECT_FIELD_INDEX));
-    KJ_ASSERT(ptr != nullptr, "EPT type-tag mismatch: internal field returned nullptr");
-    return downcastWrappable<T>(*reinterpret_cast<Wrappable*>(ptr));
+    // A tag outside the range for the type this dispatch site expects is a memory-safety violation
+    // (an object whose CppHeap handle has been redirected to an unrelated type), so this aborts
+    // rather than throwing, which JSG would catch and turn into a recoverable JS exception.
+    Wrappable* ptr = Wrappable::unwrapFromShimInRangeOrAbort(isolate, object, tagRange);
+    return downcastWrappable<T>(*ptr);
   }
+}
+
+// Convenience wrapper around extractInternalPointer for resource types, filling in the accepted
+// tag range from TypeWrapper::wrappableTagRange<T>() so dispatch sites don't each repeat it. The
+// range is an isolate-wide value that only TypeWrapper can compute, so it can't be a default
+// argument on extractInternalPointer itself (which lives here, where TypeWrapper is not visible).
+template <typename TypeWrapper, typename T, bool isContext>
+T& extractInternalPointerFor(v8::Isolate* isolate,
+    const v8::Local<v8::Context>& context,
+    const v8::Local<v8::Object>& object) {
+  return extractInternalPointer<T, isContext>(
+      isolate, context, object, TypeWrapper::template wrappableTagRange<T>());
 }
 
 }  // namespace workerd::jsg

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -174,6 +174,8 @@ wd_cc_library(
         ":set_use_transpiler": ["WORKERD_USE_TRANSPILER"],
         "//conditions:default": [],
     }),
+    # TODO(soon): This is temporarily disabled because it takes a lifetime to complete.
+    tags = ["no-clang-tidy"],
     visibility = ["//visibility:public"],
     deps = [
         ":actor-id-impl",


### PR DESCRIPTION
Merging from upstream.

We previously kept a wrappable alive via the shims in the cppgc heap, but an attacker with an in-sandbox corruption exploit can manipulate the in-sandbox indeces into the cppgc table so that the shims are freed and thus the wrappables, but the JS objects still have a reference to the freed wrappables in the external pointer table. This means an attacker can escalate from an in-sandbox V8 bug to a use-after-free.

With this change we access the wrappable from a field in the cppgc shim, thus aligning the lifetimes and closing this avenue. As an extra benefit we tag the entries in the cppgc table with type tags so that we can verify that an in-sandbox corruption is not leading to a type confusion attack. This lines up with the way Chromium does it. We have more tagging bits in the cppgc table than in the external pointer table, which makes this simpler.

The aim is that type test failures in the bindings that can be caused by a programmer error should throw, but failing type tests that we think can only be called by in-sandbox corruption/attacks should abort().