### PR TITLE
fix(streams): Cancel internal stream pumps before releasing their source

### DIFF
--- a/src/workerd/api/streams/internal-test.c++
+++ b/src/workerd/api/streams/internal-test.c++
@@ -1041,5 +1041,70 @@ KJ_TEST("Writing SharedArrayBuffer works") {
   });
 }
 
+KJ_TEST("internal pipe force-cancel drops pending read before destroying source") {
+  class PendingReadSource final: public ReadableStreamSource {
+   public:
+    PendingReadSource(kj::Promise<size_t> readPromise, kj::Vector<kj::String>& events)
+        : readPromise(kj::mv(readPromise)),
+          events(events) {}
+
+    ~PendingReadSource() noexcept(false) {
+      events.add(kj::str("source destroyed"));
+    }
+
+    kj::Promise<size_t> tryRead(void* buffer, size_t minBytes, size_t maxBytes) override {
+      KJ_ASSERT(minBytes <= 1);
+      KJ_ASSERT(maxBytes >= 1);
+
+      static_cast<kj::byte*>(buffer)[0] = 1;
+      events.add(kj::str("read started"));
+
+      return kj::mv(readPromise).attach(kj::defer([&events = events] {
+        events.add(kj::str("read promise dropped"));
+      }));
+    }
+
+    void cancel(kj::Exception reason) override {
+      events.add(kj::str("source canceled"));
+    }
+
+   private:
+    kj::Promise<size_t> readPromise;
+    kj::Vector<kj::String>& events;
+  };
+
+  auto fixture = makeStreamTestFixture();
+  kj::Vector<kj::String> events;
+  bool pipeRejected = false;
+
+  fixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
+    auto read = kj::newPromiseAndFulfiller<size_t>();
+
+    auto source = env.js.alloc<ReadableStream>(
+        env.context, kj::heap<PendingReadSource>(kj::mv(read.promise), events));
+    auto destination = env.js.alloc<WritableStream>(env.context, kj::heap<NoopSink>(), kj::none);
+
+    auto pipe = source->pipeTo(env.js, destination.addRef(), PipeToOptions{})
+                    .catch_(env.js, [&](jsg::Lock&, jsg::Value) { pipeRejected = true; });
+
+    KJ_ASSERT(events.size() == 1);
+    KJ_ASSERT(events[0] == "read started");
+
+    // Bypass the pipe lock like JsReadableStream::forceCancel().
+    source->getController().cancel(env.js, kj::none);
+
+    // The fix must synchronously cancel the pending read before freeing its source.
+    KJ_ASSERT(events.size() == 4);
+    KJ_ASSERT(events[1] == "read promise dropped");
+    KJ_ASSERT(events[2] == "source canceled");
+    KJ_ASSERT(events[3] == "source destroyed");
+
+    // Without the fix, this resumes pumpTo() with a dangling source pointer.
+    read.fulfiller->fulfill(1);
+
+    return env.context.awaitJs(env.js, kj::mv(pipe)).then([&] { KJ_ASSERT(pipeRejected); });
+  });
+}
+
 }  // namespace
 }  // namespace workerd::api

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -845,6 +845,9 @@ jsg::Promise<void> ReadableStreamInternalController::cancel(
 void ReadableStreamInternalController::doCancel(
     jsg::Lock& js, jsg::Optional<jsg::JsValue> maybeReason) {
   auto exception = reasonToException(js, maybeReason);
+  KJ_IF_SOME(locked, readState.tryGetUnsafe<PipeLocked>()) {
+    locked.cancelPump(exception);
+  }
   KJ_IF_SOME(locked, readState.tryGetUnsafe<ReaderLocked>()) {
     KJ_IF_SOME(canceler, locked.getCanceler()) {
       canceler->cancel(exception.clone());
@@ -2507,7 +2510,10 @@ kj::Maybe<kj::Ptr<ReadableStreamController::PipeController>> ReadableStreamInter
   if (isLockedToReader()) {
     return kj::none;
   }
-  return readState.transitionTo<PipeLocked>(addPtrToThis()).getPtr();
+  return readState
+      .transitionTo<PipeLocked>(
+          addPtrToThis(), IoContext::current().addObject(kj::heap<kj::Canceler>()))
+      .getPtr();
 }
 
 bool ReadableStreamInternalController::PipeLocked::isClosed() {
@@ -2547,7 +2553,8 @@ kj::Maybe<kj::Promise<void>> ReadableStreamInternalController::PipeLocked::tryPu
   // This is safe because the caller should have already checked isClosed and tryGetErrored
   // and handled those before calling tryPumpTo.
   auto& readable = KJ_ASSERT_NONNULL(inner->state.tryGetUnsafe<Readable>());
-  return IoContext::current().waitForDeferredProxy(readable->pumpTo(kj::mv(sink), end));
+  return pumpCanceler->wrap(
+      IoContext::current().waitForDeferredProxy(readable->pumpTo(kj::mv(sink), end)));
 }
 
 jsg::Promise<ReadResult> ReadableStreamInternalController::PipeLocked::read(jsg::Lock& js) {

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -132,7 +132,9 @@ class ReadableStreamInternalController: public ReadableStreamController, public 
   class PipeLocked: public PipeController {
    public:
     static constexpr kj::StringPtr NAME KJ_UNUSED = "pipe-locked"_kj;
-    PipeLocked(kj::Ptr<ReadableStreamInternalController> inner): inner(kj::mv(inner)) {}
+    PipeLocked(kj::Ptr<ReadableStreamInternalController> inner, IoOwn<kj::Canceler> pumpCanceler)
+        : inner(kj::mv(inner)),
+          pumpCanceler(kj::mv(pumpCanceler)) {}
 
     bool isClosed() override;
 
@@ -144,6 +146,10 @@ class ReadableStreamInternalController: public ReadableStreamController, public 
 
     kj::Maybe<kj::Promise<void>> tryPumpTo(kj::Ptr<WritableStreamSink> sink, bool end) override;
 
+    void cancelPump(const kj::Exception& reason) {
+      pumpCanceler->cancel(reason);
+    }
+
     jsg::Promise<ReadResult> read(jsg::Lock& js) override;
 
     kj::Ptr<PipeController> getPtr() override {
@@ -152,6 +158,7 @@ class ReadableStreamInternalController: public ReadableStreamController, public 
 
    private:
     kj::Ptr<ReadableStreamInternalController> inner;
+    IoOwn<kj::Canceler> pumpCanceler;
   };
 
   kj::Weak<ReadableStream> owner;


### PR DESCRIPTION
Merging from upstream.

This prevents pumpTo() from resuming with a dangling ReadableStreamSource pointer after forceCancel().