### PR TITLE
Re-enable clang-tidy for the `workerd-api` library

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,7 +60,10 @@ Checks: >
   readability-enum-initial-value,
   readability-redundant-*,
   -readability-redundant-inline-specifier,
+  -readability-redundant-lambda-parameter-list,
+  -readability-redundant-nested-if,
   -readability-redundant-parentheses,
+  -readability-redundant-qualified-alias,
   -readability-redundant-smartptr-get,
   readability-reference-to-constructed-temporary,
   readability-static-accessed-through-instance,
@@ -82,6 +85,7 @@ Checks: >
 # modernize-use-override
 # modernize-use-ranges
 # readability-avoid-return-with-void-value
+# readability-redundant-qualified-alias
 # modernize-avoid-variadic-functions
 # readability-convert-member-functions-to-static
 # readability-redundant-smartptr-get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,7 @@ jobs:
   lint:
     uses: ./.github/workflows/_bazel.yml
     with:
+      image: ubuntu-24.04
       extra_bazel_args: '--config=lint --config=ci-test --config=ci-linux-common'
       run_tests: false
       parse_headers: true

--- a/build/deps/build_deps.jsonc
+++ b/build/deps/build_deps.jsonc
@@ -121,7 +121,7 @@
       "repo": "workerd-tools",
       "file_regex": "llvm-.*-linux-amd64-clang-tidy$",
       "file_type": "executable",
-      "freeze_version": "clang-tidy-22.1.5"
+      "freeze_version": "clang-tidy-23.1.0"
     },
     {
       "name": "clang_tidy_linux_arm64",
@@ -130,7 +130,7 @@
       "repo": "workerd-tools",
       "file_regex": "llvm-.*-linux-arm64-clang-tidy$",
       "file_type": "executable",
-      "freeze_version": "clang-tidy-22.1.5"
+      "freeze_version": "clang-tidy-23.1.0"
     },
     {
       "name": "clang_tidy_darwin_arm64",
@@ -139,7 +139,7 @@
       "repo": "workerd-tools",
       "file_regex": "llvm-.*-darwin-arm64-clang-tidy$",
       "file_type": "executable",
-      "freeze_version": "clang-tidy-22.1.5"
+      "freeze_version": "clang-tidy-23.1.0"
     },
     {
       // Clang/LLVM headers needed to build the workerd-lint clang-tidy
@@ -153,7 +153,7 @@
       "repo": "workerd-tools",
       "file_regex": "llvm-.*-linux-amd64-clang-tidy-dev\\.tar\\.xz$",
       "build_file": "@workerd//tools/clang-tidy:BUILD.headers",
-      "freeze_version": "clang-tidy-22.1.5"
+      "freeze_version": "clang-tidy-23.1.0"
     }
   ]
 }

--- a/build/deps/gen/build_deps.MODULE.bazel
+++ b/build/deps/gen/build_deps.MODULE.bazel
@@ -29,8 +29,8 @@ bazel_dep(name = "bazel_skylib", version = "1.9.2")
 http.file(
     name = "clang_tidy_darwin_arm64",
     executable = True,
-    sha256 = "c499cb9cbcb3af9e7bce2da5d42fe3bfa957928620c73a435f5918e00cf08d6a",
-    url = "https://github.com/cloudflare/workerd-tools/releases/download/clang-tidy-22.1.5/llvm-22.1.5-darwin-arm64-clang-tidy",
+    sha256 = "07a59b3c0f9b6b2b57940f3895818c7a7dfa87c0e7612c8d7d340e6b430ed988",
+    url = "https://github.com/cloudflare/workerd-tools/releases/download/clang-tidy-23.1.0/llvm-23.1.0-darwin-arm64-clang-tidy",
 )
 use_repo(http, "clang_tidy_darwin_arm64")
 
@@ -38,10 +38,10 @@ use_repo(http, "clang_tidy_darwin_arm64")
 http.archive(
     name = "clang_tidy_dev_headers",
     build_file = "@workerd//tools/clang-tidy:BUILD.headers",
-    sha256 = "8c8f3e5abd3e48d2570bdbba9de6a6aa96f01c489ad4ccddeb0449b3a857d706",
-    strip_prefix = "llvm-22.1.5-linux-amd64-clang-tidy-dev",
+    sha256 = "e0d13e8e55c058827ac9b594ceb79653c7961f81470345eae745600f69ce8ffe",
+    strip_prefix = "llvm-23.1.0-linux-amd64-clang-tidy-dev",
     type = "tar.xz",
-    url = "https://github.com/cloudflare/workerd-tools/releases/download/clang-tidy-22.1.5/llvm-22.1.5-linux-amd64-clang-tidy-dev.tar.xz",
+    url = "https://github.com/cloudflare/workerd-tools/releases/download/clang-tidy-23.1.0/llvm-23.1.0-linux-amd64-clang-tidy-dev.tar.xz",
 )
 use_repo(http, "clang_tidy_dev_headers")
 
@@ -49,8 +49,8 @@ use_repo(http, "clang_tidy_dev_headers")
 http.file(
     name = "clang_tidy_linux_amd64",
     executable = True,
-    sha256 = "ef023eeeafba064d4f182ce130b306202a21f23632ad4253687ed10b7df493da",
-    url = "https://github.com/cloudflare/workerd-tools/releases/download/clang-tidy-22.1.5/llvm-22.1.5-linux-amd64-clang-tidy",
+    sha256 = "c8eb1978d063e59aa65e55e519a6f2ce466a15847dcca34f6afaed5b72430ee7",
+    url = "https://github.com/cloudflare/workerd-tools/releases/download/clang-tidy-23.1.0/llvm-23.1.0-linux-amd64-clang-tidy",
 )
 use_repo(http, "clang_tidy_linux_amd64")
 
@@ -58,8 +58,8 @@ use_repo(http, "clang_tidy_linux_amd64")
 http.file(
     name = "clang_tidy_linux_arm64",
     executable = True,
-    sha256 = "59a52ec78d370141667022fe33dd12b17568f3c1a466641c5df52790a570556d",
-    url = "https://github.com/cloudflare/workerd-tools/releases/download/clang-tidy-22.1.5/llvm-22.1.5-linux-arm64-clang-tidy",
+    sha256 = "2942de1667eef4a08e94c8f130149dee2b6ec6ca7eab41365c4b799a24e03bc2",
+    url = "https://github.com/cloudflare/workerd-tools/releases/download/clang-tidy-23.1.0/llvm-23.1.0-linux-arm64-clang-tidy",
 )
 use_repo(http, "clang_tidy_linux_arm64")
 

--- a/src/workerd/server/BUILD.bazel
+++ b/src/workerd/server/BUILD.bazel
@@ -174,8 +174,6 @@ wd_cc_library(
         ":set_use_transpiler": ["WORKERD_USE_TRANSPILER"],
         "//conditions:default": [],
     }),
-    # TODO(soon): This is temporarily disabled because it takes a lifetime to complete.
-    tags = ["no-clang-tidy"],
     visibility = ["//visibility:public"],
     deps = [
         ":actor-id-impl",


### PR DESCRIPTION
Draft because broken