### PR TITLE
fix: preserve unknown RPC return types

### DIFF
--- a/types/defines/rpc.d.ts
+++ b/types/defines/rpc.d.ts
@@ -36,6 +36,7 @@ declare namespace Rpc {
   //   cloneable composite types. This allows types defined with the "interface" keyword to pass the
   //   serializable check as well. Otherwise, only types defined with the "type" keyword would pass.
   type Serializable<T> =
+    | (unknown extends T ? unknown : never)
     // Structured cloneables
     | BaseType
     // Structured cloneable composites

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -132,6 +132,12 @@ class TestEntrypoint extends WorkerEntrypoint<Env, Props> {
   method() {
     return null;
   }
+  unknownMethod(): unknown {
+    return null;
+  }
+  unknownArrayObjectMethod(): { bar: unknown[] } {
+    return { bar: [] };
+  }
   async asyncMethod() {
     return true;
   }
@@ -540,6 +546,10 @@ export default <ExportedHandler<Env>>{
       s[symbolMethod];
 
       expectTypeOf(s.method()).toEqualTypeOf<Promise<null>>(); // (always async)
+      expectTypeOf(s.unknownMethod()).toEqualTypeOf<Promise<unknown>>();
+      const unknownArrayObject = await s.unknownArrayObjectMethod();
+      expectTypeOf(unknownArrayObject).not.toBeNever();
+      expectTypeOf(unknownArrayObject.bar).toEqualTypeOf<unknown[]>();
       expectTypeOf(await s.asyncMethod()).toEqualTypeOf<boolean>();
 
       expectTypeOf(s.voidMethod).toEqualTypeOf<(x?: number) => Promise<void>>(); // (always async)


### PR DESCRIPTION
## Summary

Fixes #5200.

`Rpc.Result<R>` currently falls through to `never` when `R` is `unknown`. The same failure affects concrete object types containing unknown fields, such as `{ bar: unknown[] }`, even though those values can be carried over the RPC boundary.

This adds an `unknown extends T` branch to `Serializable<T>`. The guard accepts `unknown` only when it is the type being checked; known types continue through the existing recursive serializability checks. Existing rejection of known non-serializable values, including `ReadableStream<string>`, is preserved. Type-level coverage now exercises both the top-level and nested-unknown cases.

## Verification

- `git diff --check`
- Focused TypeScript sanity checks against the exact RPC definitions, covering unknown acceptance and `ReadableStream<string>` rejection.
- The full Bazel type target was not run because this checkout environment has no Bazel binary or installed repository dependencies.
