### PR TITLE
Increase timeouts for slow integration tests

### DIFF
--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -732,6 +732,7 @@ wd_test(
 )
 
 wd_test(
+    size = "large",
     src = "scheduler-test.wd-test",
     args = ["--experimental"],
     data = ["scheduler-test.js"],
@@ -1232,7 +1233,7 @@ wd_test(
 )
 
 wd_test(
-    size = "large",
+    size = "enormous",
     src = "worker-loader-test.wd-test",
     args = ["--experimental"],
     data = ["worker-loader-test.js"],

--- a/src/wpt/BUILD.bazel
+++ b/src/wpt/BUILD.bazel
@@ -118,6 +118,7 @@ wpt_test(
 
 wpt_test(
     name = "compression-ts",
+    size = "large",
     autogates = ["workerd-autogate-per-isolate-javascript-bootstrap"],
     compat_flags = ["typescript_implemented_streams"],
     config = "compression-test-ts.ts",


### PR DESCRIPTION
The scheduler, worker loader, and TypeScript compression tests can run close to their Bazel size-class timeouts under CI load. Move each to the next size class so load does not turn successful test execution into flaky timeouts.

Part of deflake effort.