### PR TITLE
Add console.trace() output to worker logs

### DIFF
--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -70,6 +70,8 @@ namespace workerd {
 
 namespace {
 
+enum class ConsoleMethodKind { STANDARD, TRACE };
+
 constexpr kj::StringPtr logLevelToString(LogLevel level) {
   switch (level) {
     case LogLevel::DEBUG_:
@@ -401,6 +403,13 @@ void reportStartupError(kj::StringPtr id,
 #undef LOG_AND_SET_PERM_EXCEPTION
   }
 }
+
+void handleLogImpl(jsg::Lock& js,
+    const Worker::LoggingOptions& loggingOptions,
+    LogLevel level,
+    const v8::Global<v8::Function>& original,
+    const v8::FunctionCallbackInfo<v8::Value>& info,
+    ConsoleMethodKind methodKind);
 
 uint64_t getCurrentThreadId() {
 #if __linux__
@@ -1786,24 +1795,29 @@ void Worker::setupContext(
   auto consoleStr = jsg::v8StrIntern(lock.v8Isolate, "console");
   auto console = jsg::check(global->Get(context, consoleStr)).As<v8::Object>();
 
-  auto setHandler = [&](const char* method, LogLevel level) {
+  auto setHandler = [&](const char* method, LogLevel level, ConsoleMethodKind methodKind) {
     auto methodStr = jsg::v8StrIntern(lock.v8Isolate, method);
     v8::Global<v8::Function> original(
         lock.v8Isolate, jsg::check(console->Get(context, methodStr)).As<v8::Function>());
 
     auto f = lock.wrapSimpleFunction(context,
-        [loggingOptions, level, original = kj::mv(original)](
+        [loggingOptions, level, methodKind, original = kj::mv(original)](
             jsg::Lock& js, const v8::FunctionCallbackInfo<v8::Value>& info) {
-      handleLog(js, loggingOptions, level, original, info);
+      if (methodKind == ConsoleMethodKind::TRACE) {
+        handleLogImpl(js, loggingOptions, level, original, info, ConsoleMethodKind::TRACE);
+      } else {
+        handleLog(js, loggingOptions, level, original, info);
+      }
     });
     jsg::check(console->Set(context, methodStr, f));
   };
 
-  setHandler("debug", LogLevel::DEBUG_);
-  setHandler("error", LogLevel::ERROR);
-  setHandler("info", LogLevel::INFO);
-  setHandler("log", LogLevel::LOG);
-  setHandler("warn", LogLevel::WARN);
+  setHandler("debug", LogLevel::DEBUG_, ConsoleMethodKind::STANDARD);
+  setHandler("error", LogLevel::ERROR, ConsoleMethodKind::STANDARD);
+  setHandler("info", LogLevel::INFO, ConsoleMethodKind::STANDARD);
+  setHandler("log", LogLevel::LOG, ConsoleMethodKind::STANDARD);
+  setHandler("trace", LogLevel::LOG, ConsoleMethodKind::TRACE);
+  setHandler("warn", LogLevel::WARN, ConsoleMethodKind::STANDARD);
 }
 
 void Worker::setupContextInternalScripts(jsg::Lock& lock, v8::Local<v8::Context> context) {
@@ -2169,20 +2183,58 @@ void Worker::processEntrypointClass(jsg::Lock& js,
   });
 }
 
-void Worker::handleLog(jsg::Lock& js,
-    const LoggingOptions& loggingOptions,
+namespace {
+
+kj::String getConsoleTrace(jsg::Lock& js) {
+  static constexpr auto addLineCol = [](kj::StringTree str, int line, int col) {
+    if (line != v8::Message::kNoLineNumberInfo) {
+      str = kj::strTree(kj::mv(str), ":", line);
+      if (col != v8::Message::kNoColumnInfo) {
+        str = kj::strTree(kj::mv(str), ":", col);
+      }
+    }
+    return str;
+  };
+
+  auto trace = v8::StackTrace::CurrentStackTrace(js.v8Isolate, 10);
+  kj::Vector<kj::String> lines(trace->GetFrameCount());
+  for (auto i: kj::zeroTo(trace->GetFrameCount())) {
+    auto frame = trace->GetFrame(js.v8Isolate, i);
+    auto scriptName = frame->GetScriptName();
+    auto location = scriptName.IsEmpty() || scriptName->Length() == 0
+        ? kj::strTree("  at worker.js")
+        : kj::strTree("  at ", scriptName);
+    location = addLineCol(kj::mv(location), frame->GetLineNumber(), frame->GetColumn());
+
+    auto functionName = frame->GetFunctionName();
+    if (!functionName.IsEmpty() && functionName->Length() != 0) {
+      location = kj::strTree(kj::mv(location), " in ", functionName);
+    }
+    lines.add(location.flatten());
+  }
+  return kj::str("\n", kj::delimited(lines, "\n"_kj));
+}
+
+void handleLogImpl(jsg::Lock& js,
+    const Worker::LoggingOptions& loggingOptions,
     LogLevel level,
     const v8::Global<v8::Function>& original,
-    const v8::FunctionCallbackInfo<v8::Value>& info) {
+    const v8::FunctionCallbackInfo<v8::Value>& info,
+    ConsoleMethodKind methodKind) {
   // Call original V8 implementation so messages sent to connected inspector if any
   auto context = js.v8Context();
-  int length = info.Length();
+  int originalLength = info.Length();
   // to pass additional arguments from this function to js' `formatLog` we add arguments to the end
   // of the arguments vector, then in formatLog we `pop` these from the vector.
   // 3 is just the number of args we currently pass.
-  v8::LocalVector<v8::Value> args(js.v8Isolate, length + 3);
-  for (auto i: kj::zeroTo(length)) args[i] = info[i];
-  jsg::check(original.Get(js.v8Isolate)->Call(context, info.This(), length, args.data()));
+  v8::LocalVector<v8::Value> args(js.v8Isolate, originalLength + 3);
+  for (auto i: kj::zeroTo(originalLength)) args[i] = info[i];
+  jsg::check(original.Get(js.v8Isolate)->Call(context, info.This(), originalLength, args.data()));
+
+  kj::String traceStack;
+  if (methodKind == ConsoleMethodKind::TRACE) {
+    traceStack = getConsoleTrace(js);
+  }
 
   // The TryCatch is initialized here to catch cases where the v8 isolate's execution is
   // terminating, usually as a result of an infinite loop. We need to perform the initialization
@@ -2190,9 +2242,27 @@ void Worker::handleLog(jsg::Lock& js,
   v8::TryCatch tryCatch(js.v8Isolate);
 
   auto message = [&]() {
-    int length = info.Length();
+    int length = methodKind == ConsoleMethodKind::TRACE && originalLength == 0 ? 1 : originalLength;
     kj::Vector<kj::String> stringified(length);
     for (auto i: kj::zeroTo(length)) {
+      if (methodKind == ConsoleMethodKind::TRACE && i == 0) {
+        if (!tryCatch.CanContinue()) {
+          stringified.add(kj::str("{}"));
+          break;
+        }
+        js.withinHandleScope([&] {
+          if (kj::runCatchingExceptions([&]() {
+            auto first = originalLength == 0
+                ? kj::str("Trace", traceStack)
+                : kj::str("Trace: ", js.toString(jsg::check(info[0]->ToString(js.v8Context()))),
+                      traceStack);
+            stringified.add(js.serializeJson(js.str(first)));
+          }) != kj::none) {
+            stringified.add(kj::str("{}"));
+          }
+        });
+        continue;
+      }
       auto arg = info[i];
       // serializeJson and v8::Value::ToString can throw JS exceptions
       // (e.g. for recursive objects) so we eat them here, to ensure logging and non-logging code
@@ -2277,7 +2347,7 @@ void Worker::handleLog(jsg::Lock& js,
             ioContext.getWorker().getIsolate().getApi().getErrorInterfaceTypeHandler(js);
         kj::Array<kj::Maybe<tracing::ErrorInfo>> slots;
         bool anyError = false;
-        for (auto i: kj::zeroTo(length)) {
+        for (auto i: kj::zeroTo(originalLength)) {
           if (!tryCatch.CanContinue()) break;
           auto arg = info[i];
           if (!arg->IsNativeError()) continue;
@@ -2304,7 +2374,7 @@ void Worker::handleLog(jsg::Lock& js,
 
           KJ_IF_SOME(e, extracted) {
             if (!anyError) {
-              slots = kj::heapArray<kj::Maybe<tracing::ErrorInfo>>(length);
+              slots = kj::heapArray<kj::Maybe<tracing::ErrorInfo>>(originalLength);
               anyError = true;
             }
             slots[i] = kj::mv(e);
@@ -2352,14 +2422,39 @@ void Worker::handleLog(jsg::Lock& js,
     auto formatLog = formatLogVal.As<v8::Function>();
 
     auto levelStr = logLevelToString(level);
-    args[length] = js.boolean(colors);
-    args[length + 1] = js.boolean(loggingOptions.structuredLogging.toBool());
-    args[length + 2] = js.strIntern(levelStr);
-    auto formatted = js.toString(
-        jsg::check(formatLog->Call(context, js.v8Undefined(), length + 3, args.data())));
+    auto formatMessage = [&](v8::LocalVector<v8::Value>& formatArgs, int length,
+                             StructuredLogging structuredLogging) {
+      formatArgs[length] = js.boolean(colors);
+      formatArgs[length + 1] = js.boolean(structuredLogging.toBool());
+      formatArgs[length + 2] = js.strIntern(levelStr);
+      return js.toString(
+          jsg::check(formatLog->Call(context, js.v8Undefined(), length + 3, formatArgs.data())));
+    };
+
+    auto formatted = [&]() {
+      if (methodKind == ConsoleMethodKind::TRACE) {
+        auto rawMessage = formatMessage(args, originalLength, StructuredLogging::NO);
+        auto traceMessage = originalLength == 0 ? kj::str("Trace", traceStack)
+                                                : kj::str("Trace: ", rawMessage, traceStack);
+        v8::LocalVector<v8::Value> traceArgs(js.v8Isolate, 4);
+        traceArgs[0] = js.str(traceMessage);
+        return formatMessage(traceArgs, 1, loggingOptions.structuredLogging);
+      }
+      return formatMessage(args, originalLength, loggingOptions.structuredLogging);
+    }();
     fprintf(fd, "%s\n", formatted.cStr());
     fflush(fd);
   }
+}
+
+}  // namespace
+
+void Worker::handleLog(jsg::Lock& js,
+    const LoggingOptions& loggingOptions,
+    LogLevel level,
+    const v8::Global<v8::Function>& original,
+    const v8::FunctionCallbackInfo<v8::Value>& info) {
+  handleLogImpl(js, loggingOptions, level, original, info, ConsoleMethodKind::STANDARD);
 }
 
 Worker::Lock::TakeSynchronously::TakeSynchronously(kj::Maybe<RequestObserver&> requestParam) {

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -3807,10 +3807,17 @@ KJ_TEST("Server: tail workers") {
           modules = [
             ( name = "main.js",
               esModule =
+                `function traceFromHelper() {
+                `  console.trace("trace message");
+                `}
                 `export default {
                 `  async fetch(req, env, ctx) {
                 `    console.log("foo", "bar");
                 `    console.log("baz");
+                `    traceFromHelper();
+                `    console.trace();
+                `    console.trace(new Error("trace error"));
+                `    console.trace("context", new TypeError("trace context"));
                 `    return new Response("OK");
                 `  }
                 `}
@@ -3827,9 +3834,36 @@ KJ_TEST("Server: tail workers") {
               esModule =
                 `export default {
                 `  async tail(req, env, ctx) {
+                `    const logs = req[0].logs;
+                `    const trace = logs[2];
+                `    const noArgs = logs[3];
+                `    const error = logs[4];
+                `    const context = logs[5];
+                `    const firstFrame = trace?.message[0]?.split("\n")[1];
                 `    await fetch("http://tail", {
                 `      method: "POST",
-                `      body: JSON.stringify(req[0].logs.map(log => log.message))
+                `      body: JSON.stringify({
+                `        messages: logs.slice(0, 2).map(log => log.message),
+                `        length: logs.length,
+                `        level: trace?.level,
+                `        trace: trace?.message.length === 1 &&
+                `          trace.message[0].startsWith("Trace: trace message\n"),
+                `        stack: firstFrame?.includes("main.js:") &&
+                `          firstFrame.includes("in traceFromHelper"),
+                `        noArgs: noArgs?.message.length === 1 &&
+                `          noArgs.message[0].startsWith("Trace\n  at "),
+                `        noErrorInfo: trace?.errorInfo === undefined && noArgs?.errorInfo === undefined,
+                `        error: error?.message.length === 1 &&
+                `          error.message[0].startsWith("Trace: Error: trace error\n") &&
+                `          error.errorInfo?.length === 1 && error.errorInfo[0]?.name === "Error" &&
+                `          error.errorInfo[0].message === "trace error",
+                `        context: context?.message.length === 2 &&
+                `          context.message[0].startsWith("Trace: context\n") &&
+                `          context.message[1] === "TypeError: trace context" &&
+                `          context.errorInfo?.length === 2 && context.errorInfo[0] === null &&
+                `          context.errorInfo[1]?.name === "TypeError" &&
+                `          context.errorInfo[1].message === "trace context"
+                `      })
                 `    });
                 `  }
                 `}
@@ -3869,15 +3903,15 @@ KJ_TEST("Server: tail workers") {
   auto subreq = test.receiveInternetSubrequest("tail");
   subreq.recv(R"(
     POST / HTTP/1.1
-    Content-Length: 23
+    Content-Length: 148
     Host: tail
     Content-Type: text/plain;charset=UTF-8
 
-    [["foo","bar"],["baz"]])"_blockquote);
+    {"messages":[["foo","bar"],["baz"]],"length":6,"level":"log","trace":true,"stack":true,"noArgs":true,"noErrorInfo":true,"error":true,"context":true})"_blockquote);
 
   auto subreq2 = test.receiveInternetSubrequest("tail2");
   subreq2.recv(R"(
-    GET /2 HTTP/1.1
+    GET /6 HTTP/1.1
     Host: tail2
 
     )"_blockquote);
@@ -6594,6 +6628,7 @@ KJ_TEST("Server: structured logging with console methods") {
                 `    console.error("This is an error message");
                 `    console.debug("This is a debug message");
                 `    console.debug({a: 1});
+                `    console.trace("This is a %s", "trace message");
                 `
                 `    process.stdout.write("stdout");
                 `    process.stdout.write("stdout with\nmultiple\nnewlines\nlog");
@@ -6678,6 +6713,13 @@ KJ_TEST("Server: structured logging with console methods") {
     KJ_ASSERT(logline.contains(R"("message":"{ a: 1 }")"), logline);
   });
 
+  expectLogLine(interceptorPipe.output.get(), [](kj::StringPtr logline) {
+    KJ_ASSERT(logline.contains(R"("level":"log")"), logline);
+    KJ_ASSERT(logline.contains(R"("message":"Trace: This is a trace message\n  at )"), logline);
+    KJ_ASSERT(logline.contains("main.js:"_kj), logline);
+    KJ_ASSERT(logline.contains("in fetch"_kj), logline);
+  });
+
   // process.stdout should be logs split by newline
   expectLogLine(interceptorPipe.output.get(), [](kj::StringPtr logline) {
     KJ_ASSERT(logline.contains(R"("level":"log")"), logline);
@@ -6715,7 +6757,7 @@ KJ_TEST("Server: structured logging with console methods") {
         logline.contains(
             R"_("message":"Error: Test exception for structured logging\n    at Object.fetch ()_"),
         logline);
-    KJ_ASSERT(logline.contains(R"_(main.js:18:13)")_"), logline);
+    KJ_ASSERT(logline.contains(R"_(main.js:19:13)")_"), logline);
   });
 
   expectLogLine(interceptorPipe.output.get(), [](kj::StringPtr logline) {


### PR DESCRIPTION
Fixes #2278.

Trace calls reach V8's inspector but not worker log output. This change also
routes them through the existing console logging path and captures up to 10 V8
stack frames.

The original arguments are still sent to the inspector unchanged. Tail messages
keep their existing slots, and `errorInfo` remains aligned with those slots.
The first log message includes the `Trace:` prefix and captured stack. Calls
without arguments emit a single trace message.

Tests:

- Server tail worker and structured logging tests with default settings
- The same server tests with all autogates
- Tail and stop-the-world error info tests
