### PR TITLE
Instrument LOG_EXCEPTION to observe a new Sentry disposition exception detail

### DIFF
--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -387,11 +387,8 @@ v8::Local<v8::Value> exceptionToJs(
           .internalErrorId = shouldLogWithInternalId ? tunneledException.internalErrorId : kj::none,
         });
     if (shouldLogWithInternalId) {
-      // LOG_EXCEPTION("jsgInternalError", ...), but with internal error ID:
-      auto& e = exception;
-      constexpr auto sentryErrorContext = "jsgInternalError";
       auto& wdErrId = KJ_ASSERT_NONNULL(tunneledException.internalErrorId);
-      KJ_LOG(ERROR, e, sentryErrorContext, wdErrId);
+      LOG_EXCEPTION_WITH_ID("jsgInternalError", exception, wdErrId);
     } else {
       KJ_LOG(INFO, exception);  // Run with --verbose to see exception logs.
     }

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -421,6 +421,13 @@ kj_test(
 )
 
 kj_test(
+    src = "sentry-test.c++",
+    deps = [
+        ":sentry",
+    ],
+)
+
+kj_test(
     size = "large",
     src = "sqlite-test.c++",
     deps = [

--- a/src/workerd/util/sentry-test.c++
+++ b/src/workerd/util/sentry-test.c++
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "sentry.h"
+
+#include <kj/test.h>
+
+namespace {
+
+void expectSentryTag(kj::StringPtr tag) {
+  auto exception = KJ_EXCEPTION(FAILED, "test-error");
+  exception.setDetail(workerd::SENTRY_TAG_DETAIL_ID, kj::heapArray(tag.asBytes()));
+
+  KJ_EXPECT_LOG(ERROR, tag);
+  LOG_EXCEPTION("sentryTagTest", exception);
+  KJ_EXPECT_LOG(ERROR, tag);
+  auto wdErrId = workerd::makeInternalErrorId();
+  LOG_EXCEPTION_WITH_ID("sentryTagWithIdTest", exception, wdErrId);
+  KJ_EXPECT(exception.getDescription() == "test-error", exception);
+}
+
+KJ_TEST("Sentry tags are applied only when logging") {
+  expectSentryTag("SENTRY_DO"_kj);
+  expectSentryTag("SENTRY_RT"_kj);
+  expectSentryTag("NOSENTRY"_kj);
+}
+
+}  // namespace

--- a/src/workerd/util/sentry.h
+++ b/src/workerd/util/sentry.h
@@ -16,6 +16,8 @@
 
 namespace workerd {
 
+constexpr kj::Exception::DetailTypeId SENTRY_TAG_DETAIL_ID = 0xd3b1bbd08ecf715ull;
+
 // For internal errors, we generate an ID to include when rendering user-facing "internal error"
 // exceptions and writing internal exception logs, to make it easier to search for logs
 // corresponding to "internal error" exceptions reported by users.
@@ -36,14 +38,29 @@ InternalErrorId makeInternalErrorId();
 #define LOG_EXCEPTION(context, exception)                                                          \
   [&](const kj::Exception& e) {                                                                    \
     constexpr auto sentryErrorContext = context;                                                   \
+    KJ_IF_SOME(d, e.getDetail(::workerd::SENTRY_TAG_DETAIL_ID)) {                                  \
+      auto sentryTag = d.asChars();                                                                \
+      if (sentryTag.size() > 0) {                                                                  \
+        KJ_LOG(ERROR, e, sentryErrorContext, sentryTag);                                           \
+        return;                                                                                    \
+      }                                                                                            \
+    }                                                                                              \
     KJ_LOG(ERROR, e, sentryErrorContext);                                                          \
   }(exception)
 
+// This is just log LOG_EXCEPTION, except it also records id specifically as wdErrId.
 #define LOG_EXCEPTION_WITH_ID(context, exception, id)                                              \
-  [&](const kj::Exception& e) {                                                                    \
+  [&](const kj::Exception& e, const ::workerd::InternalErrorId& wdErrId) {                         \
     constexpr auto sentryErrorContext = context;                                                   \
-    KJ_LOG(ERROR, e, sentryErrorContext, id);                                                      \
-  }(exception)
+    KJ_IF_SOME(d, e.getDetail(::workerd::SENTRY_TAG_DETAIL_ID)) {                                  \
+      auto sentryTag = d.asChars();                                                                \
+      if (sentryTag.size() > 0) {                                                                  \
+        KJ_LOG(ERROR, e, sentryErrorContext, wdErrId, sentryTag);                                  \
+        return;                                                                                    \
+      }                                                                                            \
+    }                                                                                              \
+    KJ_LOG(ERROR, e, sentryErrorContext, wdErrId);                                                 \
+  }(exception, id)
 
 #define ACTOR_STORAGE_OP_PREFIX "; actorStorageOp = "
 


### PR DESCRIPTION
This will allow us to set NOSENTRY or SENTRY_DO or SENTRY_RT or similar on specific messages, designating how we handle these errors or what development team they go to, without adding strings to exception messages.

Also tie wdErrId fields more directly to the appropriate name.