### PR TITLE
CC-8364 Expose configured container images to Durable Objects

### DIFF
--- a/src/workerd/api/actor-state.c++
+++ b/src/workerd/api/actor-state.c++
@@ -1149,6 +1149,7 @@ DurableObjectState::DurableObjectState(jsg::Lock& js,
     kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
     kj::Maybe<rpc::Container::Client> container,
     bool containerRunning,
+    jsg::Dict<kj::String> containerImages,
     kj::Maybe<Worker::Actor::FacetManager&> facetManager,
     kj::Maybe<ActorVersion> version)
     : id(kj::mv(actorId)),
@@ -1156,7 +1157,7 @@ DurableObjectState::DurableObjectState(jsg::Lock& js,
       props(js, props),
       storage(kj::mv(storage)),
       container(container.map([&](rpc::Container::Client& cap) {
-        return js.alloc<Container>(kj::mv(cap), containerRunning);
+        return js.alloc<Container>(kj::mv(cap), containerRunning, kj::mv(containerImages));
       })),
       facetManager(facetManager.map(
           [](Worker::Actor::FacetManager& ref) { return IoContext::current().addObject(ref); })),

--- a/src/workerd/api/actor-state.h
+++ b/src/workerd/api/actor-state.h
@@ -592,6 +592,7 @@ class DurableObjectState: public jsg::Object {
       kj::Maybe<jsg::Ref<DurableObjectStorage>> storage,
       kj::Maybe<rpc::Container::Client> container,
       bool containerRunning,
+      jsg::Dict<kj::String> containerImages,
       kj::Maybe<Worker::Actor::FacetManager&> facetManager,
       kj::Maybe<ActorVersion> version = kj::none);
 

--- a/src/workerd/api/container-test.c++
+++ b/src/workerd/api/container-test.c++
@@ -659,6 +659,45 @@ KJ_TEST("Container::start monitors a container that exits immediately") {
   });
 }
 
+KJ_TEST("Container::images returns configured images without exposing mutable state") {
+  auto fixture = makeFixture();
+  fixture.runInIoContext([](const TestFixture::Environment& env) {
+    auto images = kj::heapArrayBuilder<jsg::Dict<kj::String>::Field>(2);
+    images.add(jsg::Dict<kj::String>::Field{
+      .name = kj::str("api"),
+      .value = kj::str("registry.example.com/api@sha256:111"),
+    });
+    images.add(jsg::Dict<kj::String>::Field{
+      .name = kj::str("worker"),
+      .value = kj::str("registry.example.com/worker@sha256:222"),
+    });
+
+    auto container =
+        env.js.alloc<Container>(rpc::Container::Client(kj::heap<RestartContainerServer>()), false,
+            jsg::Dict<kj::String>{.fields = images.finish()});
+
+    auto first = container->getImages();
+    KJ_EXPECT(first.fields.size() == 2);
+    KJ_EXPECT(first.fields[0].name == "api");
+    KJ_EXPECT(first.fields[0].value == "registry.example.com/api@sha256:111");
+    KJ_EXPECT(first.fields[1].name == "worker");
+    KJ_EXPECT(first.fields[1].value == "registry.example.com/worker@sha256:222");
+
+    first.fields[0].value = kj::str("changed");
+    auto second = container->getImages();
+    KJ_EXPECT(second.fields[0].value == "registry.example.com/api@sha256:111");
+  });
+}
+
+KJ_TEST("Container::images is empty when no images are configured") {
+  auto fixture = makeFixture();
+  fixture.runInIoContext([](const TestFixture::Environment& env) {
+    auto container =
+        env.js.alloc<Container>(rpc::Container::Client(kj::heap<RestartContainerServer>()), false);
+    KJ_EXPECT(container->getImages().fields.size() == 0);
+  });
+}
+
 KJ_TEST("Container::destroy updates running before restart and clears the old reason") {
   auto fixture = makeFixture();
   fixture.runInIoContext([](const TestFixture::Environment& env) -> kj::Promise<void> {

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -298,8 +298,9 @@ void ExecProcess::resize(jsg::Lock& js, int cols, int rows) {
 // =======================================================================================
 // Basic lifecycle methods
 
-Container::Container(rpc::Container::Client rpcClient, bool running)
-    : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))) {
+Container::Container(rpc::Container::Client rpcClient, bool running, jsg::Dict<kj::String> images)
+    : rpcClient(IoContext::current().addObject(kj::heap(kj::mv(rpcClient)))),
+      images(kj::mv(images)) {
   if (running) startMonitor();
 }
 
@@ -320,6 +321,18 @@ bool Container::getRunning() {
     return monitor->running;
   }
   return false;
+}
+
+jsg::Dict<kj::String> Container::getImages() const {
+  return jsg::Dict<kj::String>{
+    .fields =
+        KJ_MAP(field, images.fields) {
+    return jsg::Dict<kj::String>::Field{
+      .name = kj::str(field.name),
+      .value = kj::str(field.value),
+    };
+  },
+  };
 }
 
 bool Container::isCurrentMonitor(uint64_t generation) {

--- a/src/workerd/api/container.h
+++ b/src/workerd/api/container.h
@@ -196,7 +196,9 @@ class ExecProcess: public jsg::Object {
 // etc.
 class Container: public jsg::Object {
  public:
-  Container(rpc::Container::Client rpcClient, bool running);
+  Container(rpc::Container::Client rpcClient,
+      bool running,
+      jsg::Dict<kj::String> images = jsg::Dict<kj::String>{});
 
   struct DirectorySnapshot {
     kj::String id;
@@ -329,6 +331,7 @@ class Container: public jsg::Object {
   };
 
   bool getRunning();
+  jsg::Dict<kj::String> getImages() const;
 
   // Methods correspond closely to the RPC interface in `container.capnp`.
   void start(jsg::Lock& js, jsg::Optional<StartupOptions> options);
@@ -358,6 +361,7 @@ class Container: public jsg::Object {
 
   JSG_RESOURCE_TYPE(Container, CompatibilityFlags::Reader flags) {
     JSG_READONLY_PROTOTYPE_PROPERTY(running, getRunning);
+    JSG_READONLY_PROTOTYPE_PROPERTY(images, getImages);
     JSG_METHOD(start);
     JSG_METHOD(monitor);
     JSG_METHOD(destroy);
@@ -380,10 +384,12 @@ class Container: public jsg::Object {
 
   void visitForMemoryInfo(jsg::MemoryTracker& tracker) const {
     tracker.trackField("destroyReason", destroyReason);
+    tracker.trackField("images", images);
   }
 
  private:
   IoOwn<rpc::Container::Client> rpcClient;
+  jsg::Dict<kj::String> images;
 
   struct Monitor final {
     Monitor(kj::ForkedPromise<int32_t> promise, uint64_t generation);

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -3682,6 +3682,7 @@ struct Worker::Actor::Impl {
   kj::Maybe<jsg::JsRef<jsg::JsObject>> ctxObject;
 
   kj::Maybe<rpc::Container::Client> container;
+  jsg::Dict<kj::String> containerImages;
   kj::Maybe<FacetManager&> facetManager;
   kj::Maybe<ActorVersion> version;
 
@@ -3855,6 +3856,7 @@ struct Worker::Actor::Impl {
       kj::Maybe<kj::Own<HibernationManager>> manager,
       kj::Maybe<uint16_t>& hibernationEventType,
       kj::Maybe<rpc::Container::Client> container,
+      jsg::Dict<kj::String> containerImages,
       kj::Maybe<FacetManager&> facetManager,
       kj::PromiseFulfillerPair<void> paf = kj::newPromiseAndFulfiller<void>())
       : actorId(kj::mv(actorId)),
@@ -3863,6 +3865,7 @@ struct Worker::Actor::Impl {
         metrics(kj::mv(metricsParam)),
         transient(hasTransient),
         container(kj::mv(container)),
+        containerImages(kj::mv(containerImages)),
         facetManager(facetManager),
         hooks(loopback->addRef(), timerChannel, *metrics),
         inputGate(hooks),
@@ -3913,6 +3916,7 @@ Worker::Actor::Actor(const Worker& worker,
     kj::Maybe<kj::Own<HibernationManager>> manager,
     kj::Maybe<uint16_t> hibernationEventType,
     kj::Maybe<rpc::Container::Client> container,
+    jsg::Dict<kj::String> containerImages,
     kj::Maybe<FacetManager&> facetManager,
     kj::Maybe<ActorVersion> version,
     kj::Maybe<uint64_t> holderToken)
@@ -3920,7 +3924,7 @@ Worker::Actor::Actor(const Worker& worker,
       tracker(tracker.map([](RequestTracker& tracker) { return tracker.addRef(); })) {
   impl = kj::heap<Impl>(*this, kj::mv(actorId), hasTransient, kj::mv(makeActorCache), kj::mv(props),
       kj::mv(makeStorage), kj::mv(loopback), timerChannel, kj::mv(metrics), kj::mv(manager),
-      hibernationEventType, kj::mv(container), facetManager);
+      hibernationEventType, kj::mv(container), kj::mv(containerImages), facetManager);
   impl->version = kj::mv(version);
   impl->holderToken = holderToken;
 
@@ -3998,10 +4002,21 @@ kj::Promise<void> Worker::Actor::ensureConstructedImpl(IoContext& context, Actor
         storage = impl->makeStorage(lock, worker->getIsolate().getApi(), *c);
       }
 
+      auto containerImages = jsg::Dict<kj::String>{
+        .fields =
+            KJ_MAP(field, impl->containerImages.fields) {
+        return jsg::Dict<kj::String>::Field{
+          .name = kj::str(field.name),
+          .value = kj::str(field.value),
+        };
+      },
+      };
+
       auto ctx = js.alloc<api::DurableObjectState>(js, cloneId(),
           jsg::JsValue(KJ_ASSERT_NONNULL(lock.getWorker().impl->ctxExports).getHandle(js)),
           impl->props.toJs(js), kj::mv(storage), kj::mv(impl->container), containerRunning,
-          impl->facetManager, impl->version.map([](ActorVersion& v) { return v.clone(); }));
+          kj::mv(containerImages), impl->facetManager,
+          impl->version.map([](ActorVersion& v) { return v.clone(); }));
 
       auto handler =
           info.cls(lock, ctx.addRef(), KJ_ASSERT_NONNULL(lock.getWorker().impl->env).addRef(js));

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -974,6 +974,7 @@ class Worker::Actor final: public kj::Refcounted {
       kj::Maybe<kj::Own<HibernationManager>> manager,
       kj::Maybe<uint16_t> hibernationEventType,
       kj::Maybe<rpc::Container::Client> container = kj::none,
+      jsg::Dict<kj::String> containerImages = jsg::Dict<kj::String>{},
       kj::Maybe<FacetManager&> facetManager = kj::none,
       kj::Maybe<ActorVersion> version = kj::none,
       kj::Maybe<uint64_t> holderToken = kj::none);

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -318,6 +318,7 @@ class Server::ActorClass: public IoChannelFactory::ActorClassChannel {
       kj::Own<Worker::Actor::Loopback> loopback,
       kj::Maybe<kj::Own<Worker::Actor::HibernationManager>> manager,
       kj::Maybe<rpc::Container::Client> container,
+      jsg::Dict<kj::String> containerImages,
       kj::Maybe<Worker::Actor::FacetManager&> facetManager) = 0;
 
   // Start a request on the actor. (The actor must have been created using newActor().)
@@ -1320,9 +1321,16 @@ class Server::ActorNamespace final {
       auto loopback = kj::refcounted<Loopback>(*this);
 
       kj::Maybe<rpc::Container::Client> container = kj::none;
+      jsg::Dict<kj::String> containerImages;
       KJ_IF_SOME(config, containerOptions) {
         KJ_ASSERT(config.hasImageName(), "Image name is required");
         auto imageName = config.getImageName();
+        containerImages.fields = KJ_MAP(image, config.getImages()) {
+          return jsg::Dict<kj::String>::Field{
+            .name = kj::str(image.getName()),
+            .value = kj::str(image.getImage()),
+          };
+        };
         auto privilegeConfig = config.getPrivileges();
         auto capabilities =
             kj::heapArrayBuilder<kj::String>(privilegeConfig.getCapabilities().size());
@@ -1363,9 +1371,9 @@ class Server::ActorNamespace final {
             kj::mv(privileges));
       }
 
-      auto actor =
-          actorClass->newActor(getTracker(), Worker::Actor::cloneId(id), kj::mv(makeActorCache),
-              kj::mv(makeStorage), kj::mv(loopback), tryGetManagerRef(), kj::mv(container), *this);
+      auto actor = actorClass->newActor(getTracker(), Worker::Actor::cloneId(id),
+          kj::mv(makeActorCache), kj::mv(makeStorage), kj::mv(loopback), tryGetManagerRef(),
+          kj::mv(container), kj::mv(containerImages), *this);
       onBrokenTask = monitorOnBroken(*actor);
       this->actor = kj::mv(actor);
     }
@@ -2023,6 +2031,7 @@ class Server::InvalidConfigActorClass final: public ActorClass {
       kj::Own<Worker::Actor::Loopback> loopback,
       kj::Maybe<kj::Own<Worker::Actor::HibernationManager>> manager,
       kj::Maybe<rpc::Container::Client> container,
+      jsg::Dict<kj::String> containerImages,
       kj::Maybe<Worker::Actor::FacetManager&> facetManager) override {
     JSG_FAIL_REQUIRE(
         Error, "Cannot instantiate Durable Object class because its config is invalid.");
@@ -4123,6 +4132,7 @@ class Server::WorkerService final: public Service,
         kj::Own<Worker::Actor::Loopback> loopback,
         kj::Maybe<kj::Own<Worker::Actor::HibernationManager>> manager,
         kj::Maybe<rpc::Container::Client> container,
+        jsg::Dict<kj::String> containerImages,
         kj::Maybe<Worker::Actor::FacetManager&> facetManager) override {
       TimerChannel& timerChannel = *service;
 
@@ -4140,7 +4150,7 @@ class Server::WorkerService final: public Service,
       return kj::refcounted<Worker::Actor>(*service->worker, tracker, kj::mv(actorId), true,
           kj::mv(makeActorCache), className, kj::mv(props), kj::mv(makeStorage), kj::mv(loopback),
           timerChannel, kj::refcounted<ActorObserver>(), kj::mv(manager), hibernationEventTypeId,
-          kj::mv(container), facetManager);
+          kj::mv(container), kj::mv(containerImages), facetManager);
     }
 
     kj::Own<WorkerInterface> startRequest(
@@ -5486,10 +5496,11 @@ class Server::WorkerLoaderNamespace: public kj::Refcounted, private kj::TaskSet:
           kj::Own<Worker::Actor::Loopback> loopback,
           kj::Maybe<kj::Own<Worker::Actor::HibernationManager>> manager,
           kj::Maybe<rpc::Container::Client> container,
+          jsg::Dict<kj::String> containerImages,
           kj::Maybe<Worker::Actor::FacetManager&> facetManager) override {
         return getInner().newActor(tracker, kj::mv(actorId), kj::mv(makeActorCache),
             kj::mv(makeStorage), kj::mv(loopback), kj::mv(manager), kj::mv(container),
-            facetManager);
+            kj::mv(containerImages), facetManager);
       }
 
       kj::Own<WorkerInterface> startRequest(

--- a/src/workerd/server/tests/container-client/container-client.wd-test
+++ b/src/workerd/server/tests/container-client/container-client.wd-test
@@ -13,10 +13,30 @@ const unitTests :Workerd.Config = (
         durableObjectNamespaces = [
           ( className = "DurableObjectExample",
             uniqueKey = "container-client-test-DurableObjectExample",
-            container = (imageName = "cloudflare/workerd/container-client-test") ),
+            container = (
+              imageName = "cloudflare/workerd/container-client-test",
+              images = [
+                (
+                  name = "api",
+                  image = "registry.example.com/api@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                ),
+                (
+                  name = "worker",
+                  image = "registry.example.com/worker@sha256:2222222222222222222222222222222222222222222222222222222222222222",
+                ),
+              ],
+            ) ),
           ( className = "DurableObjectExample2",
             uniqueKey = "container-client-test-DurableObjectExample2",
-            container = (imageName = "cloudflare/workerd/container-client-test") ),
+            container = (
+              imageName = "cloudflare/workerd/container-client-test",
+              images = [
+                (
+                  name = "tools",
+                  image = "registry.example.com/tools@sha256:3333333333333333333333333333333333333333333333333333333333333333",
+                ),
+              ],
+            ) ),
         ],
         durableObjectStorage = (localDisk = "TEST_TMPDIR"),
         bindings = [

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -22,6 +22,10 @@ function getRandomDurableObjectName(name) {
 // before testing the behaviour with your container.
 //
 export class DurableObjectExample extends DurableObject {
+  testImages(expected) {
+    assert.deepStrictEqual(this.ctx.container.images, expected);
+  }
+
   async testExitCode() {
     const container = this.ctx.container;
     if (container.running) {
@@ -2893,6 +2897,31 @@ export class TestService extends WorkerEntrypoint {
 }
 
 export class DurableObjectExample2 extends DurableObjectExample {}
+
+export const testImages = {
+  async test(_ctrl, env) {
+    const cases = [
+      [
+        env.MY_CONTAINER,
+        {
+          api: 'registry.example.com/api@sha256:' + '1'.repeat(64),
+          worker: 'registry.example.com/worker@sha256:' + '2'.repeat(64),
+        },
+      ],
+      [
+        env.MY_DUPLICATE_CONTAINER,
+        {
+          tools: 'registry.example.com/tools@sha256:' + '3'.repeat(64),
+        },
+      ],
+    ];
+
+    for (const [namespace, expected] of cases) {
+      const id = namespace.idFromName(getRandomDurableObjectName('testImages'));
+      await namespace.get(id).testImages(expected);
+    }
+  },
+};
 
 // Test basic container status
 export const testStatus = {

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -676,6 +676,15 @@ struct Worker {
       # they can expose arbitrary host devices, disable security profiles, or grant capabilities
       # such as CAP_SYS_ADMIN that may provide host-level access. Only use trusted configuration.
 
+      images @2 :List(NamedImage);
+      # Named image references exposed to the Durable Object through ctx.container.images.
+      # These do not change imageName, which remains the default when start() omits an image.
+
+      struct NamedImage {
+        name @0 :Text;
+        image @1 :Text;
+      }
+
       struct ContainerPrivileges {
         capabilities @0 :List(Text);
         # Docker HostConfig.CapAdd values.

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -440,7 +440,8 @@ kj::Own<Worker::Actor> TestFixture::makeActor(Worker::Actor::Id id) {
       kj::refcounted<ActorObserver>(),
       savedHibernationManager.map(
           [](kj::Own<Worker::Actor::HibernationManager>& m) { return m->addRef(); }),
-      /*hibernationEventType=*/kj::none, /*container=*/kj::none, /*facetManager=*/kj::none,
+      /*hibernationEventType=*/kj::none, /*container=*/kj::none,
+      /*containerImages=*/jsg::Dict<kj::String>{}, /*facetManager=*/kj::none,
       /*version=*/kj::none, savedHolderToken);
 }
 

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -4070,6 +4070,7 @@ interface ExecProcess {
 }
 interface Container {
   get running(): boolean;
+  get images(): Record<string, string>;
   start(options?: ContainerStartupOptions): void;
   monitor(): Promise<void>;
   destroy(error?: any): Promise<void>;

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -4079,6 +4079,7 @@ export interface ExecProcess {
 }
 export interface Container {
   get running(): boolean;
+  get images(): Record<string, string>;
   start(options?: ContainerStartupOptions): void;
   monitor(): Promise<void>;
   destroy(error?: any): Promise<void>;

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -3983,6 +3983,7 @@ interface ExecProcess {
 }
 interface Container {
   get running(): boolean;
+  get images(): Record<string, string>;
   start(options?: ContainerStartupOptions): void;
   monitor(): Promise<void>;
   destroy(error?: any): Promise<void>;

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -3992,6 +3992,7 @@ export interface ExecProcess {
 }
 export interface Container {
   get running(): boolean;
+  get images(): Record<string, string>;
   start(options?: ContainerStartupOptions): void;
   monitor(): Promise<void>;
   destroy(error?: any): Promise<void>;


### PR DESCRIPTION
Carry class-scoped image references into Durable Object actor construction and expose them through the read-only ctx.container.images property. Return a fresh dictionary on each access so Worker code cannot mutate the runtime configuration.