### PR TITLE
Fix dynamic library loading into base snapshot for Pyodide 3.14.x

### DIFF
--- a/src/pyodide/create_vendor_zip.py
+++ b/src/pyodide/create_vendor_zip.py
@@ -70,6 +70,7 @@ def install_packages(package_names: list[str], python: PyVer, work_dir: Path) ->
     venv_path = work_dir / "pyodide-venv"
     interp_name = get_interp_name(python)
     pyodide_index = get_pyodide_index(python)
+    site_packages = venv_path / "lib" / f"python{python}" / "site-packages"
 
     print(f"Creating Pyodide venv with {interp_name}...")
     run_uv(["venv", str(venv_path), "--python", interp_name])
@@ -81,6 +82,10 @@ def install_packages(package_names: list[str], python: PyVer, work_dir: Path) ->
         [
             "pip",
             "install",
+            "--python",
+            venv_path / "bin" / "python",
+            "--target",
+            site_packages,
             "--extra-index-url",
             pyodide_index,
             "--index-strategy",
@@ -91,8 +96,6 @@ def install_packages(package_names: list[str], python: PyVer, work_dir: Path) ->
         env=env,
     )
 
-    major_minor = python
-    site_packages = venv_path / "lib" / f"python{major_minor}" / "site-packages"
     if not site_packages.exists():
         print(f"Error: site-packages not found at {site_packages}")
         sys.exit(1)

--- a/src/pyodide/internal/snapshot.ts
+++ b/src/pyodide/internal/snapshot.ts
@@ -359,7 +359,13 @@ function preloadDynamicLibs026(Module: Module): void {
  * pointers that point into the dylib symbols work correctly.
  * Load the dynamic libraries in loadOrder. Mostly logic dealing with paths.
  */
-function preloadDynamicLibsMain(Module: Module, loadOrder: string[]): void {
+function preloadDynamicLibsMain(
+  Module: Module,
+  loadOrder: string[] | undefined
+): void {
+  if (!loadOrder) {
+    return;
+  }
   const sitePackages = Module.FS.sessionSitePackages + '/';
   const sitePackagesRoot = VIRTUALIZED_DIR.getSitePackagesRoot();
   const dynlibRoot = VIRTUALIZED_DIR.getDynlibRoot();
@@ -392,17 +398,16 @@ function preloadDynamicLibsMain(Module: Module, loadOrder: string[]): void {
   }
 }
 
-function preloadDynamicLibs(Module: Module): void {
-  if (Module.API.version === PyodideVersion.V0_26_0a2) {
-    // In 0.26.0a2 we need to preload dynamic libraries even if we aren't restoring a snapshot.
-    preloadDynamicLibs026(Module);
-    return;
-  }
-  //
-  const loadOrder = LOADED_SNAPSHOT_META?.loadOrder;
-  if (!loadOrder) {
-    // In newer versions we only need to do the preloading if there is a snapshot to restore.
-    return;
+function maybeReserveTrampolinePointer(Module: Module): Disposable {
+  // This is only needed for Python 3.13 (Pyodide 0.28.2). For Python 314.0.4
+  // and 314.0.6 it isn't needed but getting rid of it would break snapshot
+  // stability so we have to keep it. In all newer versions do nothing.
+  if (
+    Module.API.version !== PyodideVersion.V0_28_2 &&
+    Module.API.version !== PyodideVersion.V314_0_4 &&
+    Module.API.version !== PyodideVersion.V314_0_6
+  ) {
+    return { [Symbol.dispose](): void {} };
   }
   // In Pyodide 0.28 we switched from using top level EM_JS to initialize the CountArgs function
   // pointer to using an initializer to work around a regression in Emscripten 4.0.3 and 4.0.4. We
@@ -415,8 +420,21 @@ function preloadDynamicLibs(Module: Module): void {
   // CountArgsPointer and after loading dynamic libraries, we put it in the free list so it will be
   // used at the right moment.
   const PyEMCountArgsPtr = Module.getEmptyTableSlot();
-  preloadDynamicLibsMain(Module, loadOrder);
-  Module.freeTableIndexes.push(PyEMCountArgsPtr);
+  return {
+    [Symbol.dispose](): void {
+      Module.freeTableIndexes.push(PyEMCountArgsPtr);
+    },
+  };
+}
+
+function preloadDynamicLibs(Module: Module): void {
+  if (Module.API.version === PyodideVersion.V0_26_0a2) {
+    // In 0.26.0a2 we need to preload dynamic libraries even if we aren't restoring a snapshot.
+    preloadDynamicLibs026(Module);
+    return;
+  }
+  using _reserved = maybeReserveTrampolinePointer(Module);
+  preloadDynamicLibsMain(Module, LOADED_SNAPSHOT_META?.loadOrder);
 }
 
 /**

--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -46,11 +46,16 @@ def _py_wd_test_helper(
         snapshot = version_info[use_snapshot + "_snapshot"]
         data = data + [":python_snapshots"]
         load_snapshot = snapshot or None
+    if make_snapshot and pyodide_version != "0.26.0a2":
+        feature_flags = feature_flags + ["python_dedicated_snapshot"]
 
     if load_snapshot and not make_snapshot:
         args += ["--python-load-snapshot", "load_snapshot.bin"]
 
     flags = _get_enable_flags(python_flag) + feature_flags
+
+    # deduplicate flag list because passing the same flag multiple times fails with "Compatibility flag specified multiple times"
+    flags = list({flag: 1 for flag in flags})
     feature_flags_txt = ",".join(['"{}"'.format(flag) for flag in flags])
 
     expand_template(

--- a/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
@@ -39,7 +39,6 @@ vendored_py_wd_test(
 
 vendored_py_wd_test(
     "shapely",
-    feature_flags = ["python_dedicated_snapshot"],
     make_snapshot = True,
     python_flags = ["0.28.2"],
     use_snapshot = "baseline",


### PR DESCRIPTION
Pyodide 0.28.2 has the deficiency from the point of view of memory snapshots that it calls `addFunction` when initializing the `PyRuntime` object as a part of interpeter intialization. This caused function pointer mismatches, which we dealt with by calling Module.getEmptyTableSlot() and then putting the table slot into the freelist. In Pyodide 314.x, we call `addFunction` before `main()` so we don't need to do this.

Generally, reserving the function pointer in this case is harmless but if there is no snapshot loaded then `LOADED_SNAPSHOT_META.loadOrder` is empty and we return early and don't reserve the slot. If we load any dynamic library into the base snapshot then it will be loaded one too early compared to when we restore it with the slot reserved. Generally we use baseline snapshots which don't have any dynamic libraries loaded into them so we don't notice the problem. But we encountered it in the workers-py test suite.