### PR TITLE
Upstream four patches

### DIFF
--- a/build/deps/v8.MODULE.bazel
+++ b/build/deps/v8.MODULE.bazel
@@ -62,6 +62,7 @@ PATCHES = [
     "0037-Fix-CFunction-MemorySpan-declarations-on-Windows.patch",
     "0038-Properly-depend-on-llvm-libc.patch",
     "0039-wasm-memory.discard-prototype-for-the-memory-control.patch",
+    "0040-cppgc-Add-two-API-calls-for-testing.patch",
 ]
 
 http_archive(

--- a/docs/jsg.md
+++ b/docs/jsg.md
@@ -2241,25 +2241,31 @@ if (jsg::HeapTracer::isInCppgcDestructor()) {
 ### Wrapper Lifecycle
 
 ```
-1. C++ object created (no JS wrapper yet)
+1. Wrappable created (no JS wrapper yet)
          |
-2. Object passed to JavaScript
+2. Wrappable passed to JavaScript
          |
-3. attachWrapper() creates JS wrapper
+3. attachWrapper() attaches the JS wrapper, allocating a cppgc shim
+   (or reusing one from the freelist)
          |
-4. JS wrapper and C++ object linked
+4. wrapper -> shim -> Wrappable:
+   - the wrapper keeps the shim alive, via V8's CppHeap pointer table
+   - the shim holds a strong kj::Own<Wrappable>
+   - so the Wrappable cannot be destroyed while a wrapper exists
          |
-5. GC may collect wrapper if:
+5. GC may collect the wrapper if:
    - No JS references exist
-   - No strong Ref<T>s exist
+   - No strong Ref<T>s exist (one would root the wrapper)
    - Wrapper is "unmodified"
          |
-6. If wrapper collected but C++ object still alive:
-   - New wrapper created on next JS access
+6. detachWrapper() runs when the wrapper goes away, from:
+   - ~CppgcShim, after a major GC collected the wrapper
+   - ResetRoot(), when V8 drops an unmodified droppable wrapper
+   - clearWrappers(), at isolate shutdown
+   It releases the shim's reference to the Wrappable.
          |
-7. When C++ object destroyed:
-   - detachWrapper() called
-   - JS wrapper becomes empty shell
+7. If other C++ references remain, the Wrappable lives on and a new
+   wrapper is created on the next JS access. Otherwise it is destroyed.
 ```
 
 ### Async Destructor Safety

--- a/docs/jsg.md
+++ b/docs/jsg.md
@@ -2199,17 +2199,20 @@ connection between a C++ object and its JavaScript "wrapper" object.
 
 #### Internal Fields
 
-JavaScript wrapper objects have two internal fields:
+JavaScript wrapper objects have one internal marker field:
 
 ```cpp
 enum InternalFields : int {
-  WRAPPABLE_TAG_FIELD_INDEX = 0,    // Contains WORKERD_WRAPPABLE_TAG
-  WRAPPED_OBJECT_FIELD_INDEX = 1,   // Pointer back to the Wrappable
-  INTERNAL_FIELD_COUNT = 2,
+  WRAPPABLE_TAG_FIELD_INDEX = 0,  // Contains WORKERD_WRAPPABLE_TAG
+  INTERNAL_FIELD_COUNT = 1,
 };
 ```
 
 Check if an object is a workerd API object: `jsg::Wrappable::isWorkerdApiObject(object)`
+
+The native `Wrappable` is owned by a cppgc shim reached through V8's tagged CppHeap pointer table.
+Unwrapping validates the resource tag range, exact JavaScript wrapper identity, and native RTTI
+before dispatch.
 
 #### Context Embedder Data Slots
 

--- a/patches/v8/0040-cppgc-Add-two-API-calls-for-testing.patch
+++ b/patches/v8/0040-cppgc-Add-two-API-calls-for-testing.patch
@@ -1,0 +1,107 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Erik Corry <erikcorry@chromium.org>
+Date: Fri, 28 Aug 2026 10:04:26 +0200
+Subject: [cppgc] Add two API calls for testing.
+
+The regular ways to invoke a GC for testing
+will complete the cppgc sweep (and finalizers)
+in the atomic pause. This makes it hard to test
+issues caused by the normal delayed sweep, which
+happens at the event loop. Add a flag to make
+this testing simpler.
+
+diff --git a/include/v8-cppgc.h b/include/v8-cppgc.h
+index 9800d10d03a138ca8bf016517332471551c57877..2bb82aa6f2cdabc4588415256c72c9a44281c762 100644
+--- a/include/v8-cppgc.h
++++ b/include/v8-cppgc.h
+@@ -127,6 +127,28 @@ class V8_EXPORT CppHeap {
+   void CollectGarbageInYoungGenerationForTesting(
+       cppgc::EmbedderStackState stack_state);
+ 
++  /**
++   * Controls whether forced garbage collections sweep atomically.
++   *
++   * A forced garbage collection (including
++   * `Isolate::RequestGarbageCollectionForTesting()`) normally sweeps
++   * atomically, so finalizers have already run by the time the collection
++   * returns. When this is enabled, forced collections instead sweep according
++   * to the heap's sweeping support, leaving finalization deferred as it would
++   * be in a natural garbage collection. This lets a test observe an object in
++   * the window between being discovered unreachable and being finalized.
++   *
++   * Note that sweeping may then be concurrent; pass `--single-threaded-gc` for
++   * sweeping that only makes progress on the main thread, and use
++   * `FinishSweepingForTesting()` to close the window deterministically.
++   */
++  void SetForceIncrementalSweepingForTesting(bool value);
++
++  /**
++   * Finishes any in-progress sweeping, running the finalizers it discovers.
++   */
++  void FinishSweepingForTesting();
++
+  private:
+   CppHeap() = default;
+ 
+diff --git a/src/heap/cppgc-js/cpp-heap.cc b/src/heap/cppgc-js/cpp-heap.cc
+index 9dc25e15d4c10f73f2a5cb9e26a343aac0212af3..120bcce5a11b636bba9559eb5a79b6b74c176145 100644
+--- a/src/heap/cppgc-js/cpp-heap.cc
++++ b/src/heap/cppgc-js/cpp-heap.cc
+@@ -146,6 +146,15 @@ void CppHeap::CollectGarbageInYoungGenerationForTesting(
+       internal::CppHeap::CollectionType::kMinor, stack_state);
+ }
+ 
++void CppHeap::SetForceIncrementalSweepingForTesting(bool value) {
++  return internal::CppHeap::From(this)->SetForceIncrementalSweepingForTesting(
++      value);
++}
++
++void CppHeap::FinishSweepingForTesting() {
++  return internal::CppHeap::From(this)->FinishSweepingIfRunning();
++}
++
+ namespace internal {
+ 
+ namespace {
+@@ -737,7 +746,15 @@ CppHeap::MarkingType CppHeap::SelectMarkingType() const {
+ }
+ 
+ CppHeap::SweepingType CppHeap::SelectSweepingType() const {
+-  if (IsForceGC(current_gc_flags_)) return SweepingType::kAtomic;
++  // A forced GC normally sweeps atomically, which runs finalizers before the
++  // collection returns. Tests that need to observe an object after it has been
++  // found unreachable but before it is finalized opt out via
++  // SetForceIncrementalSweepingForTesting(), which leaves sweeping deferred as
++  // it would be in a natural GC.
++  if (IsForceGC(current_gc_flags_) &&
++      !force_incremental_sweeping_for_testing_) {
++    return SweepingType::kAtomic;
++  }
+ 
+   return sweeping_support();
+ }
+diff --git a/src/heap/cppgc-js/cpp-heap.h b/src/heap/cppgc-js/cpp-heap.h
+index 3af2c9759076d09c54e065461438da3a23f1f5ff..106894d8a74be229c8c9237df6022e2aa110653a 100644
+--- a/src/heap/cppgc-js/cpp-heap.h
++++ b/src/heap/cppgc-js/cpp-heap.h
+@@ -211,6 +211,12 @@ class V8_EXPORT_PRIVATE CppHeap final
+   void EnableDetachedGarbageCollectionsForTesting();
+   void CollectGarbageForTesting(CollectionType, StackState);
+   void UpdateGCCapabilitiesFromFlagsForTesting();
++  // Only meaningful for a heap attached to an isolate: CompactAndSweep()
++  // requires atomic sweeping when there is no isolate.
++  void SetForceIncrementalSweepingForTesting(bool value) {
++    DCHECK_IMPLIES(value, isolate_ != nullptr);
++    force_incremental_sweeping_for_testing_ = value;
++  }
+ 
+   bool CurrentThreadIsHeapThread() const final;
+ 
+@@ -266,6 +272,7 @@ class V8_EXPORT_PRIVATE CppHeap final
+ 
+   bool in_detached_testing_mode_ = false;
+   bool force_incremental_marking_for_testing_ = false;
++  bool force_incremental_sweeping_for_testing_ = false;
+   bool is_in_v8_marking_step_ = false;
+ 
+   // Used size of objects. Reported to V8's regular heap growing strategy.

--- a/src/workerd/api/modules.h
+++ b/src/workerd/api/modules.h
@@ -51,8 +51,9 @@ class EnvModule final: public jsg::Object {
 };
 
 template <class Registry>
-void registerModules(Registry& registry, auto featureFlags) {
-  node::registerNodeJsCompatModules(registry, featureFlags);
+void registerModules(
+    Registry& registry, auto featureFlags, const node::ModuleSource* nodeModuleSource = nullptr) {
+  node::registerNodeJsCompatModules(registry, featureFlags, nodeModuleSource);
   registerUnsafeModules(registry, featureFlags);
   if (featureFlags.getRttiApi()) {
     registerRTTIModule(registry);
@@ -74,9 +75,12 @@ void registerModules(Registry& registry, auto featureFlags) {
 }
 
 template <class TypeWrapper>
-void registerBuiltinModules(jsg::modules::ModuleRegistry::Builder& builder, auto featureFlags) {
-  builder.add(node::getInternalNodeJsCompatModuleBundle<TypeWrapper>(featureFlags));
-  builder.add(node::getExternalNodeJsCompatModuleBundle(featureFlags));
+void registerBuiltinModules(jsg::modules::ModuleRegistry::Builder& builder,
+    auto featureFlags,
+    const node::ModuleSource* nodeModuleSource = nullptr) {
+  builder.add(
+      node::getInternalNodeJsCompatModuleBundle<TypeWrapper>(featureFlags, nodeModuleSource));
+  builder.add(node::getExternalNodeJsCompatModuleBundle(featureFlags, nodeModuleSource));
   builder.add(getInternalSocketModuleBundle<TypeWrapper>(featureFlags));
   builder.add(getInternalBase64ModuleBundle<TypeWrapper>(featureFlags));
   builder.add(getInternalMessageChannelModuleBundle<TypeWrapper>(featureFlags));

--- a/src/workerd/api/node/BUILD.bazel
+++ b/src/workerd/api/node/BUILD.bazel
@@ -52,6 +52,7 @@ wd_cc_library(
         "diagnostics-channel.h",
         "inspector.h",
         "module.h",
+        "module-source.h",
         "node.h",
         "process.h",
         "timers.h",

--- a/src/workerd/api/node/module-source.h
+++ b/src/workerd/api/node/module-source.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <workerd/jsg/util.h>
+
+namespace workerd::api::node {
+
+class ModuleSource {
+ public:
+  virtual ~ModuleSource() noexcept(false) = default;
+
+  virtual jsg::StaticExternalStringSource get(kj::ArrayPtr<const char> embeddedSource) const = 0;
+};
+
+}  // namespace workerd::api::node

--- a/src/workerd/api/node/node.h
+++ b/src/workerd/api/node/node.h
@@ -3,6 +3,7 @@
 #include "crypto.h"
 #include "diagnostics-channel.h"
 #include "inspector.h"
+#include "module-source.h"
 #include "zlib-util.h"
 
 #include <workerd/api/node/async-hooks.h>
@@ -83,7 +84,27 @@ constexpr bool isNodeConsoleModule(kj::StringPtr name) {
 }
 
 template <class Registry>
-void registerNodeJsCompatModules(Registry& registry, auto featureFlags) {
+void addNodeJsCompatModule(
+    Registry& registry, jsg::Module::Reader module, const ModuleSource* moduleSource) {
+  if (moduleSource != nullptr) {
+    if constexpr (requires {
+                    registry.addBuiltinModule(module.getName(),
+                        moduleSource->get(module.getSrc().asChars()), module.getType(),
+                        module.getCompileCache().asBytes());
+                  }) {
+      if (module.which() == jsg::Module::SRC) {
+        registry.addBuiltinModule(module.getName(), moduleSource->get(module.getSrc().asChars()),
+            module.getType(), module.getCompileCache().asBytes());
+        return;
+      }
+    }
+  }
+  registry.addBuiltinModule(module);
+}
+
+template <class Registry>
+void registerNodeJsCompatModules(
+    Registry& registry, auto featureFlags, const ModuleSource* moduleSource = nullptr) {
 #define V(T, N)                                                                                    \
   registry.template addBuiltinModule<T>(N, workerd::jsg::ModuleRegistry::Type::INTERNAL);
 
@@ -213,7 +234,7 @@ void registerNodeJsCompatModules(Registry& registry, auto featureFlags) {
     }
 
     return true;
-  });
+  }, [&](jsg::Module::Reader module) { addNodeJsCompatModule(registry, module, moduleSource); });
 
   // If the `nodejs_compat` flag is off, but the `nodejs_als` flag is on, we
   // need to register the `node:async_hooks` module from the bundle.
@@ -223,7 +244,7 @@ void registerNodeJsCompatModules(Registry& registry, auto featureFlags) {
       auto specifier = module.getName();
       if (specifier == "node:async_hooks") {
         KJ_DASSERT(module.getType() == jsg::ModuleType::BUILTIN);
-        registry.addBuiltinModule(module);
+        addNodeJsCompatModule(registry, module, moduleSource);
       }
     }
   }
@@ -236,7 +257,8 @@ void registerNodeJsCompatModules(Registry& registry, auto featureFlags) {
 }
 
 template <class TypeWrapper>
-kj::Own<jsg::modules::ModuleBundle> getInternalNodeJsCompatModuleBundle(auto featureFlags) {
+kj::Own<jsg::modules::ModuleBundle> getInternalNodeJsCompatModuleBundle(
+    auto featureFlags, const ModuleSource* moduleSource = nullptr) {
   jsg::modules::ModuleBundle::BuiltinBuilder builder(
       jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN_ONLY);
 #define V(M, N)                                                                                    \
@@ -256,7 +278,14 @@ kj::Own<jsg::modules::ModuleBundle> getInternalNodeJsCompatModuleBundle(auto fea
     builder.addObject<UrlUtil, TypeWrapper>(kUrlUtilSpecifier);
   }
 
-  jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(builder, NODE_BUNDLE);
+  if (moduleSource == nullptr) {
+    jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(
+        builder, NODE_BUNDLE, [](jsg::Module::Reader) { return true; });
+  } else {
+    jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(builder, NODE_BUNDLE,
+        [](jsg::Module::Reader) { return true; },
+        [&](jsg::Module::Reader module) { return moduleSource->get(module.getSrc().asChars()); });
+  }
 
   // Register Rust-implemented Node.js modules that declare Internal
   // visibility. The adapter registers only the modules whose declared type
@@ -274,12 +303,12 @@ kj::Own<jsg::modules::ModuleBundle> getInternalNodeJsCompatModuleBundle(auto fea
   return builder.finish();
 }
 
-kj::Own<jsg::modules::ModuleBundle> getExternalNodeJsCompatModuleBundle(auto featureFlags) {
+kj::Own<jsg::modules::ModuleBundle> getExternalNodeJsCompatModuleBundle(
+    auto featureFlags, const ModuleSource* moduleSource = nullptr) {
   jsg::modules::ModuleBundle::BuiltinBuilder builder(
       jsg::modules::ModuleBundle::BuiltinBuilder::Type::BUILTIN);
   if (isNodeJsCompatEnabled(featureFlags)) {
-    jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(
-        builder, NODE_BUNDLE, [&](jsg::Module::Reader module) -> bool {
+    auto filter = [&](jsg::Module::Reader module) -> bool {
       if (isNodeJsCompatFsModule(module.getName())) {
         return featureFlags.getEnableNodeJsFsModule();
       }
@@ -350,7 +379,13 @@ kj::Own<jsg::modules::ModuleBundle> getExternalNodeJsCompatModuleBundle(auto fea
         return featureFlags.getEnableNodeJsSqliteModule();
       }
       return true;
-    });
+    };
+    if (moduleSource == nullptr) {
+      jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(builder, NODE_BUNDLE, kj::mv(filter));
+    } else {
+      jsg::modules::ModuleBundle::getBuiltInBundleFromCapnp(builder, NODE_BUNDLE, kj::mv(filter),
+          [&](jsg::Module::Reader module) { return moduleSource->get(module.getSrc().asChars()); });
+    }
   } else if (featureFlags.getNodeJsAls()) {
     // The AsyncLocalStorage API can be enabled independently of the rest
     // of the nodejs_compat layer.
@@ -361,7 +396,11 @@ kj::Own<jsg::modules::ModuleBundle> getExternalNodeJsCompatModuleBundle(auto fea
         KJ_DASSERT(module.getType() == jsg::ModuleType::BUILTIN);
         KJ_DASSERT(module.which() == workerd::jsg::Module::SRC);
         auto specifier = KJ_ASSERT_NONNULL(jsg::Url::tryParse(module.getName()));
-        builder.addEsm(specifier, module.getSrc().asChars());
+        if (moduleSource == nullptr) {
+          builder.addEsm(specifier, module.getSrc().asChars());
+        } else {
+          builder.addEsm(specifier, moduleSource->get(module.getSrc().asChars()));
+        }
       }
     }
   }

--- a/src/workerd/api/rtti.c++
+++ b/src/workerd/api/rtti.c++
@@ -132,9 +132,15 @@ struct EncoderModuleRegistryImpl {
 
   template <typename Func>
   void addBuiltinBundleFiltered(jsg::Bundle::Reader bundle, Func filter) {
+    addBuiltinBundleFiltered(
+        bundle, kj::mv(filter), [&](jsg::Module::Reader module) { addBuiltinModule(module); });
+  }
+
+  template <typename Filter, typename AddModule>
+  void addBuiltinBundleFiltered(jsg::Bundle::Reader bundle, Filter filter, AddModule addModule) {
     for (auto module: bundle.getModules()) {
       if (filter(module)) {
-        addBuiltinModule(module);
+        addModule(module);
       }
     }
   }

--- a/src/workerd/io/io-channels.c++
+++ b/src/workerd/io/io-channels.c++
@@ -186,9 +186,10 @@ resolveCap(kj::Own<Frankenvalue::CapTableEntry> cap) {
         return kj::implicitCast<kj::Own<Frankenvalue::CapTableEntry>>(kj::mv(channel));
       }
       KJ_CASE_ONEOF(promise, kj::Promise<kj::Own<IoChannelFactory::TokenizableChannel>>) {
-        return promise.then([](kj::Own<IoChannelFactory::TokenizableChannel> channel) {
+        return promise
+            .then([](kj::Own<IoChannelFactory::TokenizableChannel> channel) {
           return kj::implicitCast<kj::Own<Frankenvalue::CapTableEntry>>(kj::mv(channel));
-        });
+        }).attach(kj::mv(cap));
       }
     }
     KJ_UNREACHABLE;

--- a/src/workerd/io/worker-modules.h
+++ b/src/workerd/io/worker-modules.h
@@ -89,7 +89,8 @@ static kj::Arc<jsg::modules::ModuleRegistry> newWorkerModuleRegistry(
     const jsg::Url& bundleBase,
     auto setupForApi,
     jsg::modules::ModuleRegistry::Builder::Options options =
-        jsg::modules::ModuleRegistry::Builder::Options::NONE) {
+        jsg::modules::ModuleRegistry::Builder::Options::NONE,
+    const api::node::ModuleSource* nodeModuleSource = nullptr) {
   jsg::modules::ModuleRegistry::Builder builder(bundleBase, options);
 
   // This callback is used when a module is being loaded to arrange evaluating the
@@ -111,7 +112,7 @@ static kj::Arc<jsg::modules::ModuleRegistry> newWorkerModuleRegistry(
   });
 
   // Add the module bundles that are built into the runtime.
-  api::registerBuiltinModules<TypeWrapper>(builder, featureFlags);
+  api::registerBuiltinModules<TypeWrapper>(builder, featureFlags, nodeModuleSource);
 
   bool hasPythonModules = false;
 

--- a/src/workerd/jsg/BUILD.bazel
+++ b/src/workerd/jsg/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("//:build/js_capnp_library.bzl", "js_capnp_library")
 load("//:build/kj_test.bzl", "kj_test")
+load("//:build/wd_cc_benchmark.bzl", "wd_cc_benchmark")
 load("//:build/wd_cc_capnp_library.bzl", "wd_cc_capnp_library")
 load("//:build/wd_cc_library.bzl", "wd_cc_library")
 
@@ -27,6 +28,13 @@ wd_cc_library(
         "@capnp-cpp//src/kj",
         "@workerd-v8//:v8",
     ],
+)
+
+wd_cc_benchmark(
+    name = "bench-dispatch",
+    srcs = ["bench-dispatch.c++"],
+    local_defines = ["JSG_IMPLEMENTATION"],
+    deps = [":jsg"],
 )
 
 wd_cc_library(

--- a/src/workerd/jsg/bench-dispatch.c++
+++ b/src/workerd/jsg/bench-dispatch.c++
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "jsg-test.h"
+
+#include <workerd/tests/bench-tools.h>
+
+namespace workerd::jsg::test {
+namespace {
+
+class DispatchTarget final: public Object {
+ public:
+  uint32_t call() {
+    return ++value;
+  }
+
+  uint32_t callWith(uint32_t increment) {
+    return value += increment;
+  }
+
+  JSG_RESOURCE_TYPE(DispatchTarget) {
+    JSG_METHOD(call);
+    JSG_METHOD(callWith);
+  }
+
+ private:
+  uint32_t value = 0;
+};
+
+class DispatchContext final: public Object, public ContextGlobal {
+ public:
+  Ref<DispatchTarget> makeTarget(Lock& js) {
+    return js.alloc<DispatchTarget>();
+  }
+
+  JSG_RESOURCE_TYPE(DispatchContext) {
+    JSG_NESTED_TYPE(DispatchTarget);
+    JSG_METHOD(makeTarget);
+  }
+};
+
+JSG_DECLARE_DEBUG_ISOLATE_TYPE(SlowDispatchIsolate, DispatchContext, DispatchTarget);
+JSG_DECLARE_DEBUG_ISOLATE_TYPE(SlowArgDispatchIsolate, DispatchContext, DispatchTarget);
+JSG_DECLARE_DEBUG_ISOLATE_TYPE(FastDispatchIsolate, DispatchContext, DispatchTarget);
+JSG_DECLARE_DEBUG_ISOLATE_TYPE(FastArgDispatchIsolate, DispatchContext, DispatchTarget);
+
+V8System v8System({"--allow-natives-syntax"_kj});
+
+constexpr uint32_t CALLS_PER_BATCH = 10000;
+
+template <typename Isolate, bool WITH_ARGUMENT = false>
+void runDispatchBenchmark(benchmark::State& state, bool fastApiEnabled) {
+  JsgConfig config = {
+    .fastApiEnabled = fastApiEnabled,
+  };
+  Evaluator<DispatchContext, Isolate, JsgConfig> evaluator(v8System, config);
+
+  evaluator.run([&](auto& js) {
+    auto source = WITH_ARGUMENT ? R"(
+      const target = makeTarget();
+      function dispatchBatch(count) {
+        let result;
+        for (let i = 0; i < count; ++i) {
+          result = target.callWith(1);
+        }
+        return result;
+      }
+      %PrepareFunctionForOptimization(dispatchBatch);
+      dispatchBatch(10000);
+      %OptimizeFunctionOnNextCall(dispatchBatch);
+      dispatchBatch(10000);
+      dispatchBatch;
+    )"_kj
+                                : R"(
+      const target = makeTarget();
+      function dispatchBatch(count) {
+        let result;
+        for (let i = 0; i < count; ++i) {
+          result = target.call();
+        }
+        return result;
+      }
+      %PrepareFunctionForOptimization(dispatchBatch);
+      dispatchBatch(10000);
+      %OptimizeFunctionOnNextCall(dispatchBatch);
+      dispatchBatch(10000);
+      dispatchBatch;
+    )"_kj;
+    auto script = check(v8::Script::Compile(js.v8Context(), js.str(source)));
+    auto function = check(script->Run(js.v8Context())).template As<v8::Function>();
+    auto count = v8::Integer::NewFromUnsigned(js.v8Isolate, CALLS_PER_BATCH);
+
+    callCounter.reset();
+    for (auto _: state) {
+      v8::Local<v8::Value> args[] = {count};
+      auto result = check(function->Call(js.v8Context(), js.v8Context()->Global(), 1, args));
+      benchmark::DoNotOptimize(*result);
+    }
+
+    state.SetItemsProcessed(state.iterations() * CALLS_PER_BATCH);
+    if (fastApiEnabled && callCounter.fast == 0) {
+      state.SkipWithError("V8 did not use the Fast API callback");
+    }
+  });
+}
+
+void NativeDispatchSlow(benchmark::State& state) {
+  runDispatchBenchmark<SlowDispatchIsolate>(state, false);
+}
+
+void NativeDispatchSlowArg(benchmark::State& state) {
+  runDispatchBenchmark<SlowArgDispatchIsolate, true>(state, false);
+}
+
+void NativeDispatchFast(benchmark::State& state) {
+  runDispatchBenchmark<FastDispatchIsolate>(state, true);
+}
+
+void NativeDispatchFastArg(benchmark::State& state) {
+  runDispatchBenchmark<FastArgDispatchIsolate, true>(state, true);
+}
+
+WD_BENCHMARK(NativeDispatchSlow);
+WD_BENCHMARK(NativeDispatchSlowArg);
+WD_BENCHMARK(NativeDispatchFast);
+WD_BENCHMARK(NativeDispatchFastArg);
+
+}  // namespace
+}  // namespace workerd::jsg::test

--- a/src/workerd/jsg/condemned-wrapper-test.c++
+++ b/src/workerd/jsg/condemned-wrapper-test.c++
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Tests for the window in which a Wrappable's wrapper has been collected by a major GC but the
+// ~CppgcShim that releases the Wrappable has not run yet. In that window the Wrappable is
+// condemned: it is still addressable, and its WeakRef anchor still reports alive, but promoting a
+// WeakRef to a strong Ref would resurrect a doomed object. See Wrappable::isCondemned().
+//
+// A forced GC normally sweeps atomically and runs ~CppgcShim before returning, so the window never
+// opens. Lock::requestGcWithDeferredSweepForTesting() leaves the sweep pending, which is what a
+// natural major GC does, and makes the window observable without relying on allocation pressure to
+// be handed a GC at the right moment.
+
+#include "jsg-test.h"
+
+namespace workerd::jsg::test {
+namespace {
+
+// A pending sweep stays pending for the rest of the test without any special GC flags, because
+// cppgc only ever runs finalizers on the mutator thread: a concurrent sweep task merely collects
+// unfinalized objects (DeferredFinalizationBuilder) and SweepFinalizer drains that list on the
+// mutator thread. Nothing between requestGcWithDeferredSweepForTesting() and the assertions
+// allocates or pumps the foreground task runner, so ~CppgcShim cannot run until
+// finishDeferredSweepForTesting() asks for it.
+V8System v8System({"--expose-gc"_kj});
+
+class ContextGlobalObject: public Object, public ContextGlobal {};
+
+// Set by DeferredSweepContext::makeBox(). A namespace-scope variable rather than a member because
+// Evaluator::run() does not hand the caller a reference to the context object.
+kj::Maybe<WeakRef<NumberBox>> weakBox;
+
+struct DeferredSweepContext: public ContextGlobalObject {
+  // Allocates a NumberBox and remembers a weak ref to it. Returning the Ref is what gives the
+  // object a JS wrapper, which is the thing the GC later collects.
+  Ref<NumberBox> makeBox(Lock& js) {
+    auto box = js.alloc<NumberBox>(42);
+    weakBox = box.getWeakRef(js);
+    return box;
+  }
+
+  JSG_RESOURCE_TYPE(DeferredSweepContext) {
+    JSG_NESTED_TYPE(NumberBox);
+    JSG_METHOD(makeBox);
+  }
+};
+JSG_DECLARE_ISOLATE_TYPE(DeferredSweepIsolate, DeferredSweepContext, NumberBox);
+
+// Creates a wrapped NumberBox reachable only from JS, then drops the JS reference, leaving the
+// wrapper collectable. The handle scope keeps the script's own handles from rooting it.
+void makeCollectableBox(Lock& js) {
+  js.withinHandleScope([&] {
+    auto source = "let b = makeBox(); b = null;"_kj;
+    auto script = check(v8::Script::Compile(js.v8Context(), js.str(source)));
+    check(script->Run(js.v8Context()));
+  });
+  KJ_ASSERT(weakBox != kj::none);
+}
+
+KJ_TEST("deferred sweep: WeakRef refuses to promote a condemned target") {
+  setPredictableModeForTest();
+  Evaluator<DeferredSweepContext, DeferredSweepIsolate> e(v8System);
+  e.run([](Lock& js) {
+    // Reset even if an assertion fails, so a WeakRef cannot outlive the isolate or
+    // leak into the next test.
+    KJ_DEFER(weakBox = kj::none);
+    auto& tracer = HeapTracer::getTracer(js.v8Isolate);
+    auto countBefore = tracer.getCondemnedWrapperCount();
+
+    makeCollectableBox(js);
+    auto& weak = KJ_ASSERT_NONNULL(weakBox);
+
+    js.requestGcWithDeferredSweepForTesting();
+
+    // The Wrappable is still addressable: ~CppgcShim, which is what drops the shim's owning
+    // reference and runs ~Wrappable, has not been given a chance to run.
+    auto& box = KJ_ASSERT_NONNULL(weak.tryGet());
+    KJ_ASSERT(box.value == 42);
+
+    // Promotion must fail rather than resurrect it, and must record that it did so. The counter
+    // is what establishes that the refusal came from the condemned check: tryAddRef() only bumps
+    // it on the isCondemned() branch, so this is equivalent to asserting isCondemned() directly,
+    // which the test cannot do because Object inherits Wrappable privately.
+    KJ_ASSERT(weak.tryAddRef(js) == kj::none);
+    KJ_ASSERT(tracer.getCondemnedWrapperCount() == countBefore + 1);
+
+    // Having refused once, the anchor is invalidated permanently.
+    KJ_ASSERT(!weak.isAlive());
+
+    js.finishDeferredSweepForTesting();
+  });
+}
+
+KJ_TEST("deferred sweep: finishing the sweep releases the Wrappable") {
+  setPredictableModeForTest();
+  Evaluator<DeferredSweepContext, DeferredSweepIsolate> e(v8System);
+  e.run([](Lock& js) {
+    // Reset even if an assertion fails, so a WeakRef cannot outlive the isolate or
+    // leak into the next test.
+    KJ_DEFER(weakBox = kj::none);
+    makeCollectableBox(js);
+    auto& weak = KJ_ASSERT_NONNULL(weakBox);
+
+    js.requestGcWithDeferredSweepForTesting();
+    KJ_ASSERT(weak.isAlive());
+
+    // Running the deferred ~CppgcShim drops the last reference to the Wrappable, which invalidates
+    // the anchor through ~Wrappable() rather than through the condemned check.
+    js.finishDeferredSweepForTesting();
+    KJ_ASSERT(!weak.isAlive());
+  });
+}
+
+KJ_TEST("deferred sweep: isolate shutdown handles a condemned Wrappable") {
+  setPredictableModeForTest();
+  KJ_DEFER(weakBox = kj::none);
+
+  {
+    DeferredSweepIsolate isolate(v8System, kj::heap<IsolateObserver>());
+    isolate.runInLockScope([&](DeferredSweepIsolate::Lock& lock) {
+      JSG_WITHIN_CONTEXT_SCOPE(
+          lock, lock.newContext<DeferredSweepContext>().getHandle(lock), [&](Lock& js) {
+        makeCollectableBox(js);
+        js.requestGcWithDeferredSweepForTesting();
+        KJ_ASSERT(KJ_ASSERT_NONNULL(weakBox).isAlive());
+      });
+    });
+    // The isolate is destroyed with ~CppgcShim still pending.
+  }
+
+  KJ_ASSERT(!KJ_ASSERT_NONNULL(weakBox).isAlive());
+}
+
+// Contrast with the above: this is the behaviour the deferred-sweep hook exists to change. If this
+// ever starts reporting a condemned wrapper, a forced GC has stopped sweeping atomically and the
+// hook is no longer buying anything.
+KJ_TEST("forced GC sweeps atomically, so the condemned window never opens") {
+  setPredictableModeForTest();
+  Evaluator<DeferredSweepContext, DeferredSweepIsolate> e(v8System);
+  e.run([](Lock& js) {
+    // Reset even if an assertion fails, so a WeakRef cannot outlive the isolate or
+    // leak into the next test.
+    KJ_DEFER(weakBox = kj::none);
+    auto& tracer = HeapTracer::getTracer(js.v8Isolate);
+    auto countBefore = tracer.getCondemnedWrapperCount();
+
+    makeCollectableBox(js);
+    auto& weak = KJ_ASSERT_NONNULL(weakBox);
+
+    js.requestGcForTesting();
+
+    // ~CppgcShim ran inside the collection, so the anchor was invalidated by ~Wrappable() and
+    // there was never a condemned Wrappable for tryAddRef() to catch.
+    KJ_ASSERT(!weak.isAlive());
+    KJ_ASSERT(weak.tryAddRef(js) == kj::none);
+    KJ_ASSERT(tracer.getCondemnedWrapperCount() == countBefore);
+  });
+}
+
+}  // namespace
+}  // namespace workerd::jsg::test

--- a/src/workerd/jsg/fast-api-test.c++
+++ b/src/workerd/jsg/fast-api-test.c++
@@ -2,10 +2,21 @@
 
 #include <workerd/util/autogate.h>
 
+#include <signal.h>
+#ifdef __linux__
+#include <sys/mman.h>
+#endif
+
 namespace workerd::jsg::test {
 namespace {
 
 using jsg::CallCounter;
+
+volatile sig_atomic_t* fastCallbackEntered = nullptr;
+
+void recordFastCallback(int) {
+  *fastCallbackEntered = jsg::callCounter.fast > 0;
+}
 
 struct WrappedInt {
   int32_t i;
@@ -128,6 +139,15 @@ class FastMethodContext: public jsg::Object, public jsg::ContextGlobal {
     return js.alloc<StaticMethodContainer>();
   }
 
+  void substituteCppgcShim(
+      jsg::Lock& js, v8::Local<v8::Object> target, v8::Local<v8::Object> source) {
+    substituteCppgcShimForTest(js.v8Isolate, target, source);
+  }
+
+  void resetCallCounter() {
+    jsg::callCounter.reset();
+  }
+
   JSG_RESOURCE_TYPE(FastMethodContext) {
     JSG_NESTED_TYPE(StaticMethodContainer);
 
@@ -147,11 +167,14 @@ class FastMethodContext: public jsg::Object, public jsg::ContextGlobal {
     JSG_METHOD(unwrapLenientOptional);
 
     JSG_METHOD(newContainer);
+    JSG_METHOD(substituteCppgcShim);
+    JSG_METHOD(resetCallCounter);
   }
 };
 
 JSG_DECLARE_DEBUG_ISOLATE_TYPE(
     FastMethodIsolate, FastMethodContext, WrappedInt, StaticMethodContainer);
+using FastMethodEvaluator = Evaluator<FastMethodContext, FastMethodIsolate, JsgConfig>;
 
 jsg::V8System v8System({"--allow-natives-syntax"});
 
@@ -184,12 +207,52 @@ CallCounter runTest(Test test) {
   return jsg::callCounter;
 }
 
+void runCorruptedFastDispatch() {
+  JsgConfig config = {
+    .fastApiEnabled = true,
+  };
+  FastMethodEvaluator e(v8System, config);
+  e.expectEval(R"(
+    const target = newContainer();
+    const source = newContainer();
+    const fastCall = () => target.value;
+    %PrepareFunctionForOptimization(fastCall);
+    fastCall();
+    %OptimizeFunctionOnNextCall(fastCall);
+    fastCall();
+    substituteCppgcShim(target, source);
+    resetCallCounter();
+    fastCall();
+  )",
+      "number", "42");
+}
+
 KJ_TEST("v8::Local<v8::Value> and v8::Local<v8::Object> as fast method parameters") {
   util::Autogate::initAutogateForTest({util::AutogateKey::V8_FAST_API});
   KJ_ASSERT(runTest({"processValue(42)"_kjc, "number"_kjc, "42"_kjc}) == CallCounter(2, 1));
   KJ_ASSERT(
       runTest({"processObject({test: 123})"_kjc, "number"_kjc, "123"_kjc}) == CallCounter(2, 1));
 }
+
+#ifdef __linux__
+// Needs mmap.
+KJ_TEST("fast dispatch rejects substituted wrapper identity") {
+  util::Autogate::initAutogateForTest({util::AutogateKey::V8_FAST_API});
+  auto* entered = static_cast<volatile sig_atomic_t*>(mmap(
+      nullptr, sizeof(sig_atomic_t), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+  KJ_REQUIRE(entered != MAP_FAILED);
+  *entered = 0;
+  KJ_DEFER(KJ_SYSCALL(munmap(const_cast<sig_atomic_t*>(entered), sizeof(*entered))));
+  fastCallbackEntered = entered;
+  KJ_DEFER(fastCallbackEntered = nullptr);
+
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    signal(SIGABRT, recordFastCallback);
+    runCorruptedFastDispatch();
+  });
+  KJ_EXPECT(*entered == 1, "corrupted invocation did not enter the Fast API callback");
+}
+#endif  // __linux__
 
 KJ_TEST("Lock& as the first parameter in fast method calls") {
   KJ_ASSERT(runTest({"addWithLock(3, 4)"_kjc, "number"_kjc, "7"_kjc}) == CallCounter(2, 1));

--- a/src/workerd/jsg/jsg-test.c++
+++ b/src/workerd/jsg/jsg-test.c++
@@ -4,6 +4,8 @@
 
 #include "jsg-test.h"
 
+#include <signal.h>
+
 namespace workerd::jsg::test {
 namespace {
 
@@ -60,6 +62,29 @@ KJ_TEST("context type is exposed in the global scope") {
 // ========================================================================================
 
 struct InheritContext: public ContextGlobalObject {
+  struct OffsetBase {
+    virtual void anchor() {}
+    uint64_t padding = 0;
+  };
+
+  struct OffsetObject: public OffsetBase, public Object {
+    static Ref<OffsetObject> constructor(jsg::Lock& js, double value) {
+      auto result = js.alloc<OffsetObject>();
+      result->value = value;
+      return result;
+    }
+
+    double getValue() {
+      return value;
+    }
+
+    JSG_RESOURCE_TYPE(OffsetObject) {
+      JSG_METHOD(getValue);
+    }
+
+    double value = 0;
+  };
+
   struct Other: public Object {
     static jsg::Ref<Other> constructor(jsg::Lock& js) {
       return js.alloc<Other>();
@@ -71,16 +96,43 @@ struct InheritContext: public ContextGlobalObject {
     return ExtendedNumberBox::constructor(js, value, kj::mv(text));
   }
 
+  void substituteCppgcShim(
+      jsg::Lock& js, v8::Local<v8::Object> target, v8::Local<v8::Object> source) {
+    substituteCppgcShimForTest(js.v8Isolate, target, source);
+  }
+
+  void detachWrapper(jsg::Lock& js, v8::Local<v8::Object> object) {
+    detachWrapperForTest(js.v8Isolate, object);
+  }
+
+  void resetRoot(jsg::Lock& js, v8::Local<v8::Object> object) {
+    resetRootForTest(js.v8Isolate, object);
+  }
+
+  bool sharesCppgcShim(jsg::Lock& js, v8::Local<v8::Object> first, v8::Local<v8::Object> second) {
+    return sharesCppgcShimForTest(js.v8Isolate, first, second);
+  }
+
   JSG_RESOURCE_TYPE(InheritContext) {
     JSG_NESTED_TYPE(NumberBox);
     JSG_NESTED_TYPE(Other);
+    JSG_NESTED_TYPE(OffsetObject);
     JSG_NESTED_TYPE(ExtendedNumberBox);
 
     JSG_METHOD(newExtendedAsBase);
+    JSG_METHOD(substituteCppgcShim);
+    JSG_METHOD(detachWrapper);
+    JSG_METHOD(resetRoot);
+    JSG_METHOD(sharesCppgcShim);
   }
 };
-JSG_DECLARE_ISOLATE_TYPE(
-    InheritIsolate, InheritContext, NumberBox, InheritContext::Other, ExtendedNumberBox);
+JSG_DECLARE_ISOLATE_TYPE(InheritIsolate,
+    InheritContext,
+    NumberBox,
+    InheritContext::Other,
+    InheritContext::OffsetObject,
+    ExtendedNumberBox);
+using InheritEvaluator = Evaluator<InheritContext, InheritIsolate>;
 
 KJ_TEST("inheritance") {
   Evaluator<InheritContext, InheritIsolate> e(v8System);
@@ -115,6 +167,61 @@ KJ_TEST("inheritance") {
   e.expectEval("newExtendedAsBase(123, 'foo') instanceof NumberBox", "boolean", "true");
 
   e.expectEval("newExtendedAsBase(123, 'foo') instanceof ExtendedNumberBox", "boolean", "true");
+
+  e.expectEval("new OffsetObject(123).getValue()", "number", "123");
+}
+
+KJ_TEST("native dispatch rejects same-type shim substitution") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    InheritEvaluator e(v8System);
+    e.expectEval("let target = new NumberBox(123);"
+                 "let source = new NumberBox(456);"
+                 "substituteCppgcShim(target, source);"
+                 "target.getValue()",
+        "number", "456");
+  });
+}
+
+KJ_TEST("native dispatch rejects inheritance-compatible shim substitution") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    InheritEvaluator e(v8System);
+    e.expectEval("let target = new NumberBox(123);"
+                 "let source = new ExtendedNumberBox(456, 'source');"
+                 "substituteCppgcShim(target, source);"
+                 "target.getValue()",
+        "number", "456");
+  });
+}
+
+KJ_TEST("ResetRoot rejects substituted shim ownership") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    InheritEvaluator e(v8System);
+    e.expectEval(R"(
+      let target = new NumberBox(123);
+      const source = new NumberBox(456);
+      substituteCppgcShim(target, source);
+      resetRoot(target);
+    )",
+        "undefined", "undefined");
+  });
+}
+
+KJ_TEST("native dispatch rejects stale handle after same-tag shim reuse") {
+  KJ_EXPECT_SIGNAL(SIGABRT, {
+    InheritEvaluator e(v8System);
+    e.expectEval(R"(
+      const target = new NumberBox(123);
+      const source = new NumberBox(456);
+      substituteCppgcShim(target, source);
+      detachWrapper(source);
+      const replacement = new NumberBox(789);
+      if (!sharesCppgcShim(target, replacement)) {
+        throw new Error("expected the shim to be reused");
+      }
+      target.getValue();
+    )",
+        "number", "789");
+  });
 }
 
 // ========================================================================================

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -12,6 +12,8 @@
 #include <workerd/jsg/util.h>
 #include <workerd/util/thread-scopes.h>
 
+#include <v8-cppgc.h>
+
 #ifdef V8_ENABLE_SANDBOX
 #include <sys/mman.h>
 #endif
@@ -332,6 +334,29 @@ void Lock::requestGcForTesting() const {
   }
   v8Isolate->RequestGarbageCollectionForTesting(
       v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
+}
+
+void Lock::requestGcWithDeferredSweepForTesting() const {
+  if (!isPredictableModeForTest()) {
+    KJ_LOG(ERROR, "Test GC used while not in a test");
+    return;
+  }
+  auto* cppHeap = v8Isolate->GetCppHeap();
+  KJ_ASSERT(cppHeap != nullptr);
+
+  // Scoped rather than left on: the override only needs to cover the collection itself, and
+  // leaving it set would silently change the sweeping behaviour of every later GC in the isolate.
+  cppHeap->SetForceIncrementalSweepingForTesting(true);
+  KJ_DEFER(cppHeap->SetForceIncrementalSweepingForTesting(false));
+
+  v8Isolate->RequestGarbageCollectionForTesting(
+      v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
+}
+
+void Lock::finishDeferredSweepForTesting() const {
+  auto* cppHeap = v8Isolate->GetCppHeap();
+  KJ_ASSERT(cppHeap != nullptr);
+  cppHeap->FinishSweepingForTesting();
 }
 
 void Lock::v8Set(v8::Local<v8::Object> obj, kj::StringPtr name, v8::Local<v8::Value> value) {

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1668,7 +1668,7 @@ Ref<T> _jsgThis(T* obj) {
 //   use-after-free.
 //
 // - tryAddRef(js) answers "is the object still usable from JS?". It requires the isolate
-//   lock and returns kj::none for condemned objects (see Wrappable::wasTracedInLastGc()).
+//   lock and returns kj::none for condemned objects (see Wrappable::isCondemned()).
 //   Any JS-facing work through a WeakRef must go through tryAddRef().
 //
 // Use operator->() for convenient single-expression access that asserts liveness:
@@ -1772,7 +1772,7 @@ class WeakRef {
 
   // Try to promote to a strong Ref<T>. Returns kj::none if the target has been destroyed,
   // or if the target's V8 wrapper died in a major GC whose deferred cleanup has not yet
-  // released the target (detected via the GC epoch check in Wrappable::wasTracedInLastGc();
+  // released the target (detected via Wrappable::isCondemned();
   // see the implementation in setup.h). In the latter case the target is condemned and this
   // WeakRef is permanently invalidated.
   kj::Maybe<Ref<T>> tryAddRef(Lock&) const;
@@ -3118,6 +3118,19 @@ class Lock {
   // it will throw. If a need for a minor GC is needed look at the call in jsg.c++ and the
   // implementation in setup.c++. Use responsibly.
   void requestGcForTesting() const;
+
+  // Like requestGcForTesting(), but leaves cppgc's sweep pending rather than running it inside the
+  // collection. On return, wrappers unreachable at the start of the GC have been collected and
+  // their Wrappables condemned (see Wrappable::isCondemned()), but the ~CppgcShim that releases
+  // each Wrappable has not run yet. This is the state a natural major GC leaves behind, and the
+  // only state in which the condemned-wrapper hazard is observable.
+  //
+  // Pair with finishDeferredSweepForTesting() to close the window. Testing only.
+  void requestGcWithDeferredSweepForTesting() const;
+
+  // Completes a sweep left pending by requestGcWithDeferredSweepForTesting(), running the deferred
+  // ~CppgcShim finalizers. Testing only.
+  void finishDeferredSweepForTesting() const;
 
   // Runs the given function synchronously with a v8::HandleScope on the stack.
   // If the fn returns a v8::Local<T> or v8::MaybeLocal<T> type, then

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1462,9 +1462,13 @@ class Object: private Wrappable {
 // Declared in wrappable.h; see there for why this check exists.
 template <typename T>
 T& downcastObject(Object& object) {
+  const auto& actualType = typeid(object);
+  if (&actualType == &typeid(T) || actualType == typeid(T)) {
+    return static_cast<T&>(object);
+  }
   T* result = dynamic_cast<T*>(&object);
   if (result == nullptr) {
-    reportWrapperTypeMismatch(typeid(T), typeid(object));
+    reportWrapperTypeMismatch(typeid(T), actualType);
   }
   return *result;
 }

--- a/src/workerd/jsg/modules-new-test.c++
+++ b/src/workerd/jsg/modules-new-test.c++
@@ -1607,6 +1607,34 @@ KJ_TEST("Module source is decoded as UTF-8 across all encoding tiers") {
 
 // ======================================================================================
 
+KJ_TEST("Built-in source distinguishes UTF-8 from pre-encoded Latin-1") {
+  PREAMBLE([&](Lock& js) {
+    CompilationObserver compilationObserver;
+    ModuleBundle::BuiltinBuilder builtinBuilder;
+    static constexpr char utf8Source[] = "export default 'caf\xc3\xa9';";
+    static constexpr char latin1Source[] = "export default 'caf\xe9';";
+    builtinBuilder.addEsm("test:utf8"_url, kj::arrayPtr(utf8Source, sizeof(utf8Source) - 1));
+    builtinBuilder.addEsm("test:latin1"_url,
+        StaticExternalStringSource(kj::arrayPtr(latin1Source, sizeof(latin1Source) - 1)));
+
+    auto registry = ModuleRegistry::Builder(BASE).add(builtinBuilder.finish()).finish();
+    auto attached = registry->attachToIsolate(js, compilationObserver);
+
+    JSG_TRY(js) {
+      for (auto specifier: {"test:utf8"_kjc, "test:latin1"_kjc}) {
+        auto value =
+            ModuleRegistry::resolve(js, specifier, "default"_kjc, ResolveContext::Type::BUILTIN);
+        KJ_ASSERT(kj::str(value) == "caf\xc3\xa9", kj::str(value));
+      }
+    }
+    JSG_CATCH(exception) {
+      js.throwException(kj::mv(exception));
+    }
+  });
+}
+
+// ======================================================================================
+
 KJ_TEST("Owned ESM source outlives its release points across encoding tiers") {
   // The Arc<OwnedAscii> addEsmModule overload shares ownership of the UTF-8 source
   // buffer with the module. Non-ASCII sources are transcoded to an owned

--- a/src/workerd/jsg/modules-new.c++
+++ b/src/workerd/jsg/modules-new.c++
@@ -125,6 +125,7 @@ kj::Array<kj::String> normalizeNamedExports(kj::Array<kj::String> namedExports) 
 // compile cache consistent.
 struct EncodedSource {
   kj::OneOf<kj::ArrayPtr<const char>,  // borrowed process-lifetime ASCII
+      kj::ArrayPtr<const uint16_t>,    // borrowed process-lifetime UTF-16
       kj::Arc<OwnedAscii>,             // owned ASCII or Latin-1
       kj::Arc<OwnedUtf16>>             // owned UTF-16
       repr;
@@ -179,7 +180,8 @@ EncodedSource encodeSource(kj::Arc<OwnedAscii>&& source) {
   return transcodeSource(sourcePtr);
 }
 
-using UnencodedSource = kj::OneOf<kj::ArrayPtr<const char>, kj::Arc<OwnedAscii>>;
+using UnencodedSource =
+    kj::OneOf<kj::ArrayPtr<const char>, StaticExternalStringSource, kj::Arc<OwnedAscii>>;
 
 // The implementation of Module for ESM.
 class EsModule final: public Module {
@@ -189,6 +191,12 @@ class EsModule final: public Module {
   explicit EsModule(Url id, Type type, Flags flags, kj::ArrayPtr<const char> source)
       : Module(kj::mv(id), type, flags | Flags::ESM | Flags::EVAL),
         source(source),
+        cachedData(kj::none) {
+    KJ_DASSERT(isEsm());
+  }
+  explicit EsModule(Url id, Type type, Flags flags, StaticExternalStringSource source)
+      : Module(kj::mv(id), type, flags | Flags::ESM | Flags::EVAL),
+        source(kj::mv(source)),
         cachedData(kj::none) {
     KJ_DASSERT(isEsm());
   }
@@ -259,6 +267,16 @@ class EsModule final: public Module {
           KJ_CASE_ONEOF(borrowed, kj::ArrayPtr<const char>) {
             return space.construct(encodeSource(kj::mv(borrowed)));
           }
+          KJ_CASE_ONEOF(encoded, StaticExternalStringSource) {
+            KJ_SWITCH_ONEOF(encoded) {
+              KJ_CASE_ONEOF(oneByte, kj::ArrayPtr<const char>) {
+                return space.construct(EncodedSource{.repr = kj::mv(oneByte)});
+              }
+              KJ_CASE_ONEOF(twoByte, kj::ArrayPtr<const uint16_t>) {
+                return space.construct(EncodedSource{.repr = kj::mv(twoByte)});
+              }
+            }
+          }
           KJ_CASE_ONEOF(owned, kj::Arc<OwnedAscii>) {
             return space.construct(encodeSource(kj::mv(owned)));
           }
@@ -269,6 +287,9 @@ class EsModule final: public Module {
       KJ_SWITCH_ONEOF(encoded.repr) {
         KJ_CASE_ONEOF(ascii, kj::ArrayPtr<const char>) {
           contentStr = js.strExtern(ascii);
+        }
+        KJ_CASE_ONEOF(utf16, kj::ArrayPtr<const uint16_t>) {
+          contentStr = js.strExtern(utf16);
         }
         KJ_CASE_ONEOF(oneByte, kj::Arc<OwnedAscii>) {
           contentStr = js.strExtern(oneByte.addRef());
@@ -1823,6 +1844,49 @@ kj::HashSet<kj::StringPtr> toHashSet(kj::ArrayPtr<const kj::String> arr) {
 }  // namespace
 
 // ======================================================================================
+namespace {
+
+template <typename AddEsm>
+void addBuiltInBundleFromCapnp(ModuleBundle::BuiltinBuilder& builder,
+    Bundle::Reader bundle,
+    kj::Function<bool(workerd::jsg::Module::Reader)> filter,
+    AddEsm addEsm) {
+  auto typeFilter = ([&] {
+    switch (builder.type()) {
+      case Module::Type::BUILTIN:
+        return ModuleType::BUILTIN;
+      case Module::Type::BUILTIN_ONLY:
+        return ModuleType::INTERNAL;
+      case Module::Type::BUNDLE:
+      case Module::Type::FALLBACK:
+        break;
+    }
+    KJ_UNREACHABLE;
+  })();
+
+  for (auto module: bundle.getModules()) {
+    if (module.getType() != typeFilter || !filter(module)) continue;
+    auto id = KJ_ASSERT_NONNULL(Url::tryParse(module.getName()));
+    switch (module.which()) {
+      case workerd::jsg::Module::SRC:
+        addEsm(id, module);
+        continue;
+      case workerd::jsg::Module::WASM:
+        builder.addSynthetic(id, Module::newWasmModuleHandler(module.getWasm().asBytes()));
+        continue;
+      case workerd::jsg::Module::DATA:
+        builder.addSynthetic(id, Module::newDataModuleHandler(module.getData().asBytes()));
+        continue;
+      case workerd::jsg::Module::JSON:
+        builder.addSynthetic(id, Module::newJsonModuleHandler(module.getJson().asArray()));
+        continue;
+    }
+    KJ_UNREACHABLE;
+  }
+}
+
+}  // namespace
+
 kj::Own<ModuleBundle> ModuleBundle::newFallbackBundle(Builder::ResolveCallback callback) {
   return kj::heap<FallbackModuleBundle>(kj::mv(callback));
 }
@@ -1834,44 +1898,20 @@ void ModuleBundle::getBuiltInBundleFromCapnp(BuiltinBuilder& builder, Bundle::Re
 void ModuleBundle::getBuiltInBundleFromCapnp(BuiltinBuilder& builder,
     Bundle::Reader bundle,
     kj::Function<bool(workerd::jsg::Module::Reader)> filter) {
-  auto typeFilter = ([&] {
-    switch (builder.type()) {
-      case Module::Type::BUILTIN:
-        return ModuleType::BUILTIN;
-      case Module::Type::BUILTIN_ONLY:
-        return ModuleType::INTERNAL;
-      case Module::Type::BUNDLE:
-        break;
-      case Module::Type::FALLBACK:
-        break;
-    }
-    KJ_UNREACHABLE;
-  })();
+  addBuiltInBundleFromCapnp(
+      builder, bundle, kj::mv(filter), [&](const Url& id, workerd::jsg::Module::Reader module) {
+    builder.addEsm(id, module.getSrc().asChars());
+  });
+}
 
-  for (auto module: bundle.getModules()) {
-    if (module.getType() == typeFilter && filter(module)) {
-      auto id = KJ_ASSERT_NONNULL(Url::tryParse(module.getName()));
-      switch (module.which()) {
-        case workerd::jsg::Module::SRC: {
-          builder.addEsm(id, module.getSrc().asChars());
-          continue;
-        }
-        case workerd::jsg::Module::WASM: {
-          builder.addSynthetic(id, Module::newWasmModuleHandler(module.getWasm().asBytes()));
-          continue;
-        }
-        case workerd::jsg::Module::DATA: {
-          builder.addSynthetic(id, Module::newDataModuleHandler(module.getData().asBytes()));
-          continue;
-        }
-        case workerd::jsg::Module::JSON: {
-          builder.addSynthetic(id, Module::newJsonModuleHandler(module.getJson().asArray()));
-          continue;
-        }
-      }
-      KJ_UNREACHABLE;
-    }
-  }
+void ModuleBundle::getBuiltInBundleFromCapnp(BuiltinBuilder& builder,
+    Bundle::Reader bundle,
+    kj::Function<bool(workerd::jsg::Module::Reader)> filter,
+    kj::FunctionParam<StaticExternalStringSource(workerd::jsg::Module::Reader)> getSource) {
+  addBuiltInBundleFromCapnp(
+      builder, bundle, kj::mv(filter), [&](const Url& id, workerd::jsg::Module::Reader module) {
+    builder.addEsm(id, getSource(module));
+  });
 }
 
 ModuleBundle::ModuleBundle(Type type): type_(type) {}
@@ -2099,6 +2139,19 @@ ModuleBundle::BuiltinBuilder& ModuleBundle::BuiltinBuilder::addEsm(
   ensureIsNotBundleSpecifier(id);
   Builder::add(id,
       [url = id.clone(), source, type = type()](const ResolveContext& context) mutable
+      -> kj::Maybe<kj::OneOf<kj::String, kj::Own<Module>>> {
+    kj::Own<Module> mod = Module::newEsm(kj::mv(url), type, source);
+    return kj::Maybe<kj::OneOf<kj::String, kj::Own<Module>>>(kj::mv(mod));
+  });
+  return *this;
+}
+
+ModuleBundle::BuiltinBuilder& ModuleBundle::BuiltinBuilder::addEsm(
+    const Url& id, StaticExternalStringSource source) {
+  ensureIsNotBundleSpecifier(id);
+  Builder::add(id,
+      [url = id.clone(), source = kj::mv(source), type = type()](
+          const ResolveContext& context) mutable
       -> kj::Maybe<kj::OneOf<kj::String, kj::Own<Module>>> {
     kj::Own<Module> mod = Module::newEsm(kj::mv(url), type, source);
     return kj::Maybe<kj::OneOf<kj::String, kj::Own<Module>>>(kj::mv(mod));
@@ -2424,6 +2477,10 @@ kj::Own<Module> Module::newEsm(Url id, Type type, kj::Arc<OwnedAscii> code, Flag
 
 kj::Own<Module> Module::newEsm(Url id, Type type, kj::ArrayPtr<const char> code) {
   return kj::heap<EsModule>(kj::mv(id), type, Flags::ESM, code);
+}
+
+kj::Own<Module> Module::newEsm(Url id, Type type, StaticExternalStringSource code) {
+  return kj::heap<EsModule>(kj::mv(id), type, Flags::ESM, kj::mv(code));
 }
 
 Module::ModuleNamespace::ModuleNamespace(

--- a/src/workerd/jsg/modules-new.h
+++ b/src/workerd/jsg/modules-new.h
@@ -415,6 +415,8 @@ class Module {
   // This variation of newEsm does not take Flags as none of the existing
   // Flags are relevant other than the ESM flag which will be set automatically.
   static kj::Own<Module> newEsm(Url id, Type type, kj::ArrayPtr<const char> code);
+  // The source is already encoded as Latin-1 or UTF-16 for V8.
+  static kj::Own<Module> newEsm(Url id, Type type, StaticExternalStringSource code);
 
   // The following methods are used to create the evaluation callbacks for various
   // kinds of common simple synthetic module types. The module registry is not
@@ -604,6 +606,8 @@ class ModuleBundle {
 
     // The source must be backed by static process-lifetime storage.
     BuiltinBuilder& addEsm(const Url& id, kj::ArrayPtr<const char> source) KJ_LIFETIMEBOUND;
+    // The source is already encoded as Latin-1 or UTF-16 for V8.
+    BuiltinBuilder& addEsm(const Url& id, StaticExternalStringSource source) KJ_LIFETIMEBOUND;
 
     // Adds a module that is implemented in C++ as a jsg::Object
     template <typename T, typename TypeWrapper>
@@ -638,6 +642,11 @@ class ModuleBundle {
   static void getBuiltInBundleFromCapnp(BuiltinBuilder& builder,
       Bundle::Reader bundle,
       kj::Function<bool(::workerd::jsg::Module::Reader)> filter);
+
+  static void getBuiltInBundleFromCapnp(BuiltinBuilder& builder,
+      Bundle::Reader bundle,
+      kj::Function<bool(::workerd::jsg::Module::Reader)> filter,
+      kj::FunctionParam<StaticExternalStringSource(::workerd::jsg::Module::Reader)> getSource);
 
   KJ_DISALLOW_COPY_AND_MOVE(ModuleBundle);
 

--- a/src/workerd/jsg/modules.c++
+++ b/src/workerd/jsg/modules.c++
@@ -379,7 +379,7 @@ static CompilationObserver::Option convertOption(ModuleInfoCompileOption option)
 
 v8::Local<v8::Module> compileEsmModule(jsg::Lock& js,
     kj::StringPtr name,
-    kj::ArrayPtr<const char> content,
+    StaticExternalStringSource content,
     kj::ArrayPtr<const kj::byte> compileCache,
     ModuleInfoCompileOption option,
     const CompilationObserver& observer) {
@@ -400,12 +400,25 @@ v8::Local<v8::Module> compileEsmModule(jsg::Lock& js,
   v8::Local<v8::String> contentStr;
 
   if (option == ModuleInfoCompileOption::BUILTIN) {
-    // TODO(later): Use of newExternalOneByteString here limits our built-in source
-    // modules (for which this path is used) to only the latin1 character set. We
-    // may need to revisit that to import built-ins as UTF-16 (two-byte).
-    contentStr = jsg::newExternalOneByteString(js, content);
+    KJ_SWITCH_ONEOF(content) {
+      KJ_CASE_ONEOF(oneByte, kj::ArrayPtr<const char>) {
+        contentStr = jsg::newExternalOneByteString(js, oneByte);
+      }
+      KJ_CASE_ONEOF(twoByte, kj::ArrayPtr<const uint16_t>) {
+        contentStr = jsg::newExternalTwoByteString(js, twoByte);
+      }
+    }
   } else {
-    contentStr = jsg::v8Str(js.v8Isolate, content);
+    KJ_SWITCH_ONEOF(content) {
+      KJ_CASE_ONEOF(utf8, kj::ArrayPtr<const char>) {
+        contentStr = jsg::v8Str(js.v8Isolate, utf8);
+      }
+      KJ_CASE_ONEOF(utf16, kj::ArrayPtr<const uint16_t>) {
+        KJ_REQUIRE(utf16.size() <= v8::String::kMaxLength, "String is too long for a V8 string");
+        contentStr = jsg::check(v8::String::NewFromTwoByte(
+            js.v8Isolate, utf16.begin(), v8::NewStringType::kNormal, utf16.size()));
+      }
+    }
   }
 
   if (compileCache.size() > 0 && compileCache.begin() != nullptr) {
@@ -447,7 +460,15 @@ ModuleRegistry::ModuleInfo::ModuleInfo(jsg::Lock& js,
     kj::ArrayPtr<const kj::byte> compileCache,
     ModuleInfoCompileOption flags,
     const CompilationObserver& observer)
-    : ModuleInfo(js, compileEsmModule(js, name, content, compileCache, flags, observer)) {}
+    : ModuleInfo(js, name, StaticExternalStringSource(content), compileCache, flags, observer) {}
+
+ModuleRegistry::ModuleInfo::ModuleInfo(jsg::Lock& js,
+    kj::StringPtr name,
+    StaticExternalStringSource content,
+    kj::ArrayPtr<const kj::byte> compileCache,
+    ModuleInfoCompileOption flags,
+    const CompilationObserver& observer)
+    : ModuleInfo(js, compileEsmModule(js, name, kj::mv(content), compileCache, flags, observer)) {}
 
 ModuleRegistry::ModuleInfo::ModuleInfo(jsg::Lock& js,
     kj::StringPtr name,

--- a/src/workerd/jsg/modules.h
+++ b/src/workerd/jsg/modules.h
@@ -7,6 +7,7 @@
 #include <workerd/jsg/function.h>
 #include <workerd/jsg/modules.capnp.h>
 #include <workerd/jsg/observer.h>
+#include <workerd/jsg/util.h>
 #include <workerd/util/sentry.h>
 #include <workerd/util/thread-scopes.h>
 
@@ -174,6 +175,13 @@ class ModuleRegistry {
     ModuleInfo(jsg::Lock& js,
         kj::StringPtr name,
         kj::ArrayPtr<const char> content,
+        kj::ArrayPtr<const kj::byte> compileCache,
+        ModuleInfoCompileOption flags,
+        const CompilationObserver& observer);
+
+    ModuleInfo(jsg::Lock& js,
+        kj::StringPtr name,
+        StaticExternalStringSource content,
         kj::ArrayPtr<const kj::byte> compileCache,
         ModuleInfoCompileOption flags,
         const CompilationObserver& observer);
@@ -370,9 +378,15 @@ class ModuleRegistryImpl final: public ModuleRegistry {
 
   template <typename Func>
   void addBuiltinBundleFiltered(Bundle::Reader bundle, Func filter) {
+    addBuiltinBundleFiltered(
+        bundle, kj::mv(filter), [&](Module::Reader module) { addBuiltinModule(module); });
+  }
+
+  template <typename Filter, typename AddModule>
+  void addBuiltinBundleFiltered(Bundle::Reader bundle, Filter filter, AddModule addModule) {
     for (auto module: bundle.getModules()) {
       if (filter(module)) {
-        addBuiltinModule(module);
+        addModule(module);
       }
     }
   }
@@ -390,6 +404,15 @@ class ModuleRegistryImpl final: public ModuleRegistry {
     KJ_ASSERT(type != Type::BUNDLE);
     auto path = kj::Path::parse(specifier);
     entries.insert(kj::heap<Entry>(path, type, sourceCode, compileCache));
+  }
+
+  void addBuiltinModule(kj::StringPtr specifier,
+      StaticExternalStringSource sourceCode,
+      Type type = Type::BUILTIN,
+      kj::ArrayPtr<const kj::byte> compileCache = {}) {
+    KJ_ASSERT(type != Type::BUNDLE);
+    auto path = kj::Path::parse(specifier);
+    entries.insert(kj::heap<Entry>(path, type, kj::mv(sourceCode), compileCache));
   }
 
   void addBuiltinModule(
@@ -585,7 +608,7 @@ class ModuleRegistryImpl final: public ModuleRegistry {
   // we need to be able to search it by path (filename) as well as search for a specific module
   // object by identity. We use a kj::Table!
   struct Entry {
-    using Info = kj::OneOf<ModuleInfo, kj::ArrayPtr<const char>, ModuleCallback>;
+    using Info = kj::OneOf<ModuleInfo, StaticExternalStringSource, ModuleCallback>;
 
     struct Key {
       const kj::Path& specifier;
@@ -622,7 +645,16 @@ class ModuleRegistryImpl final: public ModuleRegistry {
         kj::ArrayPtr<const kj::byte> compileCache)
         : specifier(specifier.clone()),
           type(type),
-          info(src),
+          info(StaticExternalStringSource(src)),
+          compileCache(compileCache) {}
+
+    Entry(const kj::Path& specifier,
+        Type type,
+        StaticExternalStringSource src,
+        kj::ArrayPtr<const kj::byte> compileCache)
+        : specifier(specifier.clone()),
+          type(type),
+          info(kj::mv(src)),
           compileCache(compileCache) {}
 
     Entry(const kj::Path& specifier, Type type, ModuleCallback factory)
@@ -642,7 +674,7 @@ class ModuleRegistryImpl final: public ModuleRegistry {
         KJ_CASE_ONEOF(moduleInfo, ModuleInfo) {
           return kj::Maybe<ModuleInfo&>(moduleInfo);
         }
-        KJ_CASE_ONEOF(src, kj::ArrayPtr<const char>) {
+        KJ_CASE_ONEOF(src, StaticExternalStringSource) {
           info = ModuleInfo(js, specifier.toString(), src, compileCache,
               ModuleInfoCompileOption::BUILTIN, observer);
           return info.tryGet<ModuleInfo>();

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -2027,7 +2027,7 @@ class ResourceWrapper {
         // prototype-chain check, not here, and yields the kj::none below.)
         Wrappable* wrappable = Wrappable::unwrapFromShimInRangeOrAbort(
             js.v8Isolate, instance, TypeWrapper::template wrappableTagRange<T>());
-        return *reinterpret_cast<T*>(wrappable);
+        return downcastWrappable<T>(*wrappable);
       }
     }
 

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -366,25 +366,13 @@ void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
   // references in Wrappable::attachWrapper() for details.
   v8::HandleScope scope(isolate);
 
-  // V8 can only hand this polymorphic callback  an object that is in one of
-  // the sandbox-external tables, so it's genuinely one of our objects.  But
-  // sandbox-internal corruption can cause it to pick us the wrong object and
-  // since it is polymorphic we can't use a tag check.  Instead check that
-  // the wrappable points back at the object being dropped.
+  // V8 can only hand this polymorphic callback an object that is in one of the
+  // sandbox-external tables, so it's genuinely one of our objects. Sandbox-internal corruption
+  // can still substitute another shim, so resolve through the exact wrapper identity check.
   auto object = handle.As<v8::Object>().Get(isolate);
-  // unwrapFromShimAnyType() returning null is a sign of in-sandbox corruption.
-  Wrappable* wrappablePtr = Wrappable::unwrapFromShimAnyType(isolate, object);
-  if (wrappablePtr == nullptr) {
-    KJ_LOG(
-        FATAL, "wrapper type mismatch: dropped object's CppHeap handle resolves to no wrappable");
-    abort();
-  }
-  auto& wrappable = *wrappablePtr;
+  auto& wrappable =
+      *Wrappable::unwrapFromShimInRangeOrAbort(isolate, object, kJsgWrappableTagRange);
   auto& backReference = KJ_ASSERT_NONNULL(wrappable.wrapper);
-  if (backReference.Get(isolate) != object) {
-    KJ_LOG(FATAL, "wrapper type mismatch: dropped object's CppHeap handle names another wrappable");
-    abort();
-  }
 
   // V8 gets angry if we do not EXPLICITLY call `Reset()` on the wrapper. If we merely destroy it
   // (which is what `detachWrapper()` will do) it is not satisfied, and will come back and try to

--- a/src/workerd/jsg/setup.c++
+++ b/src/workerd/jsg/setup.c++
@@ -319,21 +319,7 @@ HeapTracer::HeapTracer(v8::Isolate* isolate)
       // after the fact will trigger a spurious ASAN failure.
       self.clearFreelistedShims();
     }
-    // Advance the GC epoch at the start of a major GC cycle, exactly once per cycle. An
-    // incremental cycle fires kGCTypeIncrementalMarking at marking start and then
-    // kGCTypeMarkSweepCompact again at the atomic pause; a non-incremental major GC fires
-    // only the latter. activeGcEpoch == completedGcEpoch identifies "no cycle in flight"
-    // (the mark-compact epilogue restores that equality), so the second prologue of the
-    // same cycle is a no-op. traceFromV8() stamps the active epoch into each wrapper it
-    // visits, and wasTracedInLastGc() compares against the last *completed* epoch — so
-    // objects not yet traced by an in-progress cycle are correctly treated as alive (they
-    // still carry the previous completed epoch).
-    if (self.activeGcEpoch == self.completedGcEpoch) {
-      ++self.activeGcEpoch;
-    }
-  }, this,
-      static_cast<v8::GCType>(
-          v8::GCType::kGCTypeMarkSweepCompact | v8::GCType::kGCTypeIncrementalMarking));
+  }, this, v8::GCType::kGCTypeMarkSweepCompact);
 
   isolate->AddGCEpilogueCallback(
       [](v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags, void* data) {
@@ -342,13 +328,6 @@ HeapTracer::HeapTracer(v8::Isolate* isolate)
       wrappable->detachWrapper(true);
     }
     self.detachLater.clear();
-    if (type == v8::GCType::kGCTypeMarkSweepCompact) {
-      // Promote the active epoch to completed. V8 has already zapped dead traced nodes
-      // (ResetDeadNodes runs during the atomic pause), so from this point — still before
-      // control returns to JavaScript — wasTracedInLastGc() reports false for any wrapper
-      // not traced during this cycle.
-      self.completedGcEpoch = self.activeGcEpoch;
-    }
   }, this, v8::GCType::kGCTypeAll);
 }
 
@@ -361,30 +340,7 @@ HeapTracer& HeapTracer::getTracer(v8::Isolate* isolate) {
   return IsolateBase::from(isolate).heapTracer;
 }
 
-void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
-  // V8 calls this to tell us when our wrapper can be dropped. See comment about droppable
-  // references in Wrappable::attachWrapper() for details.
-  v8::HandleScope scope(isolate);
-
-  // V8 can only hand this polymorphic callback an object that is in one of the
-  // sandbox-external tables, so it's genuinely one of our objects. Sandbox-internal corruption
-  // can still substitute another shim, so resolve through the exact wrapper identity check.
-  auto object = handle.As<v8::Object>().Get(isolate);
-  auto& wrappable =
-      *Wrappable::unwrapFromShimInRangeOrAbort(isolate, object, kJsgWrappableTagRange);
-  auto& backReference = KJ_ASSERT_NONNULL(wrappable.wrapper);
-
-  // V8 gets angry if we do not EXPLICITLY call `Reset()` on the wrapper. If we merely destroy it
-  // (which is what `detachWrapper()` will do) it is not satisfied, and will come back and try to
-  // visit the reference again, but it will DCHECK-fail on that second attempt because the
-  // reference is in an inconsistent state at that point.
-  backReference.Reset();
-
-  // We don't want to call `detachWrapper()` now because it may create new handles (specifically,
-  // if the wrappable has strong references, which means that its outgoing references need to be
-  // upgraded to strong).
-  detachLater.add(&wrappable);
-}
+// Note: ResetRoot() lives in wrappable.c++, where Wrappable::CppgcShim is a complete type.
 
 bool HeapTracer::TryResetRoot(const v8::TracedReference<v8::Value>& handle) {
   // This method is potentially called on a separate thread. Our ResetRoot() implementation,

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -1142,15 +1142,13 @@ template <typename T>
 kj::Maybe<Ref<T>> WeakRef<T>::tryAddRef(Lock&) const {
   KJ_IF_SOME(i, impl) {
     if (!i.anchor->isAlive()) return kj::none;
-    // After a major GC, V8's ResetDeadNodes zaps a dead droppable TracedReference without
-    // calling ResetRoot(). The CppgcShim destructor that would release the object (running
-    // ~Wrappable(), which invalidates the anchor) can be deferred past the end of the GC
-    // cycle, so the anchor still reports isAlive() while the TracedReference dangles.
-    // Promoting a Ref in that state would call addStrongRef(), which copies the dangling
-    // reference via TracedReference::Get() — a use-after-free. Detect it instead: a wrapper
-    // that exists but was not traced in the last completed major GC cycle is dead.
+    // A major GC may have collected the target's wrapper while the ~CppgcShim that would
+    // release the target Wrappable (running ~Wrappable(), which invalidates the anchor) is
+    // still deferred, so the anchor keeps reporting isAlive(). Promoting a Ref in that state
+    // would call addStrongRef() on a doomed Wrappable. cppgc tells us directly: it cleared the
+    // Wrappable's weak reference to its shim during the collecting GC's atomic pause.
     auto& target = static_cast<Wrappable&>(i.target);
-    if (!target.wasTracedInLastGc()) {
+    if (target.isCondemned()) {
       // The object is condemned: its wrapper died in a completed major GC, which also means
       // no strong refs exist (they would have rooted the wrapper) and no live wrappable
       // holds a traced ref to it (that would have marked it) — anything still referencing

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -14,6 +14,7 @@
 #include <kj/debug.h>
 
 #include <cstdlib>
+#include <new>
 #include <set>
 
 #if !_WIN32
@@ -801,14 +802,7 @@ void returnRejectedPromise(const v8::PropertyCallbackInfo<v8::Value>& info,
   returnRejectedPromiseImpl<const v8::PropertyCallbackInfo<v8::Value>&>(info, exception, tryCatch);
 }
 
-static ExternalStringAllocator& getAllocatorForIsolate(v8::Isolate* isolate) {
-  return IsolateBase::from(isolate).getExternalStringAllocator();
-}
-
 // Default allocator that uses standard new/delete.
-// We typically don't use the new/delete operators directly,
-// but in this case we have to because V8's ExternalStringResource may default to `delete this`
-// if not overridden, and we are allocating raw byte arrays for placement new.
 class DefaultExternalStringAllocator final: public ExternalStringAllocator {
  public:
   void* allocate(size_t size) override {
@@ -867,14 +861,6 @@ class ExternString: public Type {
     return length() * sizeof(Data);
   }
 
-  // Override Dispose() so that V8 properly deallocates through the configured
-  // ExternalStringAllocator rather than using `delete this` (the default).
-  void Dispose() override {
-    auto& allocator = getAllocatorForIsolate(isolate);
-    this->~ExternString();
-    allocator.deallocate(this);
-  }
-
   static v8::MaybeLocal<v8::String> createExtern(v8::Isolate* isolate, Backing backing) {
     if (getBuffer(backing).size() == 0) {
       return v8::String::Empty(isolate);
@@ -885,15 +871,12 @@ class ExternString: public Type {
     // heap allocated string than an external. We're not doing that here currently, but
     // we might?
 
-    auto& allocator = getAllocatorForIsolate(isolate);
-    auto mem = allocator.allocate(sizeof(ExternString<Type, Data>));
-    if (mem == nullptr) {
+    auto resource = new (std::nothrow) ExternString<Type, Data>(kj::mv(backing));
+    if (resource == nullptr) {
       isolate->ThrowException(v8::Exception::Error(
           v8::String::NewFromUtf8Literal(isolate, "String allocation failed")));
       return v8::MaybeLocal<v8::String>();
     }
-
-    auto resource = new (mem) ExternString<Type, Data>(isolate, kj::mv(backing));
 
     v8::MaybeLocal<v8::String> str;
     if constexpr (kj::isSameType<Type, v8::String::ExternalOneByteStringResource>()) {
@@ -904,8 +887,7 @@ class ExternString: public Type {
     }
     if (str.IsEmpty()) {
       // This should happen only if the string is too long
-      resource->~ExternString<Type, Data>();
-      allocator.deallocate(mem);
+      delete resource;
       isolate->ThrowException(v8::Exception::Error(
           v8::String::NewFromUtf8Literal(isolate, "String allocation failed")));
       return v8::MaybeLocal<v8::String>();
@@ -915,7 +897,6 @@ class ExternString: public Type {
   }
 
  private:
-  v8::Isolate* isolate;
   Backing backing;
 
   static kj::ArrayPtr<const Data> getBuffer(const Backing& backing) {
@@ -929,9 +910,7 @@ class ExternString: public Type {
     return getBuffer(backing);
   }
 
-  inline ExternString(v8::Isolate* isolate, Backing backing)
-      : isolate(isolate),
-        backing(kj::mv(backing)) {}
+  explicit ExternString(Backing backing): backing(kj::mv(backing)) {}
 };
 
 using ExternOneByteString = ExternString<v8::String::ExternalOneByteStringResource, char>;

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -15,6 +15,7 @@
 
 #include <kj/debug.h>
 #include <kj/exception.h>
+#include <kj/one-of.h>
 #include <kj/refcount.h>
 #include <kj/string.h>
 
@@ -533,7 +534,7 @@ concept StrictlyBool = kj::isSameType<T, bool>();
 
 class Lock;
 
-// Interface for allocating backing stores for v8 external string.
+// Interface for allocating V8 external string character buffers.
 class ExternalStringAllocator {
  public:
   virtual ~ExternalStringAllocator() = default;
@@ -547,6 +548,8 @@ kj::Own<ExternalStringAllocator> defaultExternalStringAllocator();
 
 using OwnedAscii = kj::Array<const char>;
 using OwnedUtf16 = kj::Array<const uint16_t>;
+using StaticExternalStringSource =
+    kj::OneOf<kj::ArrayPtr<const char>, kj::ArrayPtr<const uint16_t>>;
 
 // Creates v8 Strings from buffers not on the v8 heap. These do not copy and do not
 // take ownership of the buf. The buf *must* point to a static constant with infinite

--- a/src/workerd/jsg/wrappable-tag.h
+++ b/src/workerd/jsg/wrappable-tag.h
@@ -49,6 +49,11 @@ constexpr uint16_t kFirstResourceTag = kNonResourceWrappableTag + 1;
 // order of ~270 tags today.
 constexpr uint16_t kMaxWrappableTags = 310;
 
+// The full tag range owned by JSG. Only pointers with tags in this range are CppgcShims.
+constexpr v8::CppHeapPointerTagRange kJsgWrappableTagRange(
+    static_cast<v8::CppHeapPointerTag>(kNonResourceWrappableTag),
+    static_cast<v8::CppHeapPointerTag>(kNonResourceWrappableTag + kMaxWrappableTags - 1));
+
 // Index of a tag within the freelist bucket array: tags are dense starting at
 // kFirstObjectWrappableTag (the catch-all), so the offset is a compact array index.
 constexpr uint16_t wrappableTagBucketIndex(uint16_t tag) {

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -168,6 +168,19 @@ class Wrappable::CppgcShim final: public v8::Object::Wrappable {
     return false;
   }
 
+  JSGWrappable& resolve(v8::Local<v8::Object> object) {
+    KJ_IF_SOME(active, state.tryGet<Active>()) {
+      KJ_IF_SOME(wrapper, active.wrappable->wrapper) {
+        if (wrapper == object) {
+          return *active.wrappable;
+        }
+      } else {
+        KJ_FAIL_ASSERT("active CppgcShim has no wrapper");
+      }
+    }
+    reportWrapperIdentityMismatch();
+  }
+
   // The per-type CppHeapPointerTag this shim was Wrapped with. A shim is only ever reused for the
   // same tag (see HeapTracer::freelistedShimsByTag), so this value is fixed for the shim's whole
   // lifetime and identifies which freelist bucket it belongs to.
@@ -243,6 +256,37 @@ void HeapTracer::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
   // TODO(soon): Track the other fields here?
 }
 
+void HeapTracer::substituteCppgcShimForTest(
+    v8::Isolate* isolate, v8::Local<v8::Object> target, v8::Local<v8::Object> source) {
+  auto* shim = v8::Object::Unwrap<v8::Object::Wrappable>(isolate, source, kJsgWrappableTagRange);
+  KJ_REQUIRE(shim != nullptr);
+  v8::Object::Wrap(isolate, target, shim, static_cast<Wrappable::CppgcShim*>(shim)->tag);
+}
+
+void substituteCppgcShimForTest(
+    v8::Isolate* isolate, v8::Local<v8::Object> target, v8::Local<v8::Object> source) {
+  HeapTracer::substituteCppgcShimForTest(isolate, target, source);
+}
+
+void detachWrapperForTest(v8::Isolate* isolate, v8::Local<v8::Object> object) {
+  auto& wrappable = *Wrappable::unwrapFromShimAnyType(isolate, object);
+  auto drop = wrappable.detachWrapper(true);
+}
+
+void resetRootForTest(v8::Isolate* isolate, v8::Local<v8::Object> object) {
+  v8::TracedReference<v8::Value> handle(isolate, object);
+  HeapTracer::getTracer(isolate).ResetRoot(handle);
+}
+
+bool sharesCppgcShimForTest(
+    v8::Isolate* isolate, v8::Local<v8::Object> first, v8::Local<v8::Object> second) {
+  auto* firstShim =
+      v8::Object::Unwrap<v8::Object::Wrappable>(isolate, first, kJsgWrappableTagRange);
+  auto* secondShim =
+      v8::Object::Unwrap<v8::Object::Wrappable>(isolate, second, kJsgWrappableTagRange);
+  return firstShim != nullptr && secondShim != nullptr && firstShim == secondShim;
+}
+
 Wrappable* Wrappable::unwrapFromShim(
     v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTagRange tagRange) {
   // Read the CppgcShim out of V8's CppHeap pointer table, requiring the stored tag to fall within
@@ -254,36 +298,25 @@ Wrappable* Wrappable::unwrapFromShim(
     return nullptr;
   }
 
-  // Dispatch through the shim's owning reference, which is the lifetime-correct pointer: it is a
-  // kj::Own<Wrappable> that keeps the object alive for as long as the shim is Active. A minor-GC'd
-  // (Freelisted) or dead shim can never be reached here, because its table entry is only ever
-  // populated while Active (attachWrapper/allocateShim write it) and per-type freelisting keeps a
-  // recycled shim's tag constant, so a stale handle either misses the range or resolves to a live
-  // object of the same type.
-  KJ_IF_SOME(active, shim->state.tryGet<CppgcShim::Active>()) {
-    return active.wrappable.get();
-  }
-  return nullptr;
+  return &shim->resolve(object);
 }
 
 Wrappable* Wrappable::unwrapFromShimAnyType(v8::Isolate* isolate, v8::Local<v8::Object> object) {
-  return unwrapFromShim(isolate, object, v8::kObjectWrappableTagRange);
+  return unwrapFromShim(isolate, object, kJsgWrappableTagRange);
 }
 
 Wrappable* Wrappable::unwrapFromShimInRangeOrAbort(
     v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTagRange tagRange) {
-  // Unwrap with the wide wrappable range so Object::Unwrap never faults, then range-check the shim's
-  // own tag ourselves. See the header for why the check can't be delegated to Object::Unwrap, and
-  // why an out-of-range tag here is a memory-safety violation that must abort.
+  // Unwrap with the full JSG range so Object::Unwrap never faults, then range-check the shim's own
+  // tag ourselves. See the header for why the check can't be delegated to Object::Unwrap, and why
+  // an out-of-range tag here is a memory-safety violation that must abort.
   auto* shim = static_cast<CppgcShim*>(
-      v8::Object::Unwrap<v8::Object::Wrappable>(isolate, object, v8::kObjectWrappableTagRange));
+      v8::Object::Unwrap<v8::Object::Wrappable>(isolate, object, kJsgWrappableTagRange));
   if (shim != nullptr) {
     auto tag = static_cast<uint16_t>(shim->tag);
     if (tag >= static_cast<uint16_t>(tagRange.first) &&
         tag <= static_cast<uint16_t>(tagRange.last)) {
-      KJ_IF_SOME(active, shim->state.tryGet<CppgcShim::Active>()) {
-        return active.wrappable.get();
-      }
+      return &shim->resolve(object);
     }
   }
 
@@ -533,6 +566,11 @@ void reportWrapperTypeMismatch(const std::type_info& expected, const std::type_i
   // Abort: edgeworker's crash handler turns this into an abrupt shutdown of the isolate.
   KJ_LOG(FATAL, "JS wrapper's C++ object is not of the expected type", typeName(expected),
       typeName(actual));
+  abort();
+}
+
+void reportWrapperIdentityMismatch() {
+  KJ_LOG(FATAL, "JS wrapper's CppHeap shim does not own the dispatch receiver");
   abort();
 }
 

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -17,9 +17,6 @@
 #include <kj/debug.h>
 
 #include <cstdlib>
-#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
-#include <sanitizer/asan_interface.h>
-#endif
 
 namespace workerd::jsg {
 
@@ -52,7 +49,15 @@ void HeapTracer::clearWrappers() {
     // V8 operations. Without this, objects that outlive their isolate (like WebSockets
     // stored in a HibernationManager) would have a dangling isolate pointer and crash
     // when trying to check v8::Locker::IsLocked() or create V8 handles.
-    ownWrappable->isolate = nullptr;
+    if (ownWrappable.get() == nullptr) {
+      // cppgc has cleared the weak shim but has not run its deferred destructor yet. The shim
+      // will release the Wrappable later, after isolate teardown has unlinked it here.
+      KJ_DASSERT(wrappable.isCondemned());
+      wrappers.remove(wrappable);
+      wrappable.isolate = nullptr;
+    } else {
+      ownWrappable->isolate = nullptr;
+    }
   }
   clearFreelistedShims();
 }
@@ -90,8 +95,8 @@ class Wrappable::CppgcShim final: public v8::Object::Wrappable {
   CppgcShim(JSGWrappable& wrappable, v8::CppHeapPointerTag tag)
       : tag(tag),
         state(Active{kj::addRef(wrappable)}) {
-    KJ_DASSERT(wrappable.cppgcShim == kj::none);
-    wrappable.cppgcShim = *this;
+    KJ_DASSERT(!wrappable.hasWrapper());
+    wrappable.weakShim = this;
   }
 
   ~CppgcShim() {
@@ -104,9 +109,13 @@ class Wrappable::CppgcShim final: public v8::Object::Wrappable {
 
     KJ_SWITCH_ONEOF(state) {
       KJ_CASE_ONEOF(active, Active) {
-        KJ_DASSERT(&KJ_ASSERT_NONNULL(active.wrappable->cppgcShim) == this);
+        // A collected wrapper implies nothing was pinning it, i.e. strongRefcount == 0. This is
+        // what makes it safe for cppgc to clear `weakShim` without a GC visitation; see the
+        // comment on Wrappable::strongRefcount.
         KJ_DASSERT(active.wrappable->strongWrapper.IsEmpty());
-        active.wrappable->detachWrapper(false);
+        // Can't go through detachWrapper(): on the major-GC path cppgc already cleared the
+        // Wrappable's `weakShim`, so it can no longer find us. Hand it the shim directly.
+        active.wrappable->detachFromShim(*this, false);
       }
       KJ_CASE_ONEOF(freelisted, Freelisted) {
         KJ_DASSERT(&KJ_ASSERT_NONNULL(*freelisted.prev) == this);
@@ -123,6 +132,8 @@ class Wrappable::CppgcShim final: public v8::Object::Wrappable {
   void Trace(cppgc::Visitor* visitor) const override {
     KJ_SWITCH_ONEOF(state) {
       KJ_CASE_ONEOF(active, Active) {
+        // Trace the handle this shim owns, which is what cppgc expects of a GC-managed object.
+        visitor->Trace(KJ_ASSERT_NONNULL(wrapper));
         active.wrappable->traceFromV8(*visitor);
       }
       KJ_CASE_ONEOF(freelisted, Freelisted) {
@@ -170,12 +181,9 @@ class Wrappable::CppgcShim final: public v8::Object::Wrappable {
 
   JSGWrappable& resolve(v8::Local<v8::Object> object) {
     KJ_IF_SOME(active, state.tryGet<Active>()) {
-      KJ_IF_SOME(wrapper, active.wrappable->wrapper) {
-        if (wrapper == object) {
-          return *active.wrappable;
-        }
-      } else {
-        KJ_FAIL_ASSERT("active CppgcShim has no wrapper");
+      // An Active shim always holds its wrapper; see the invariant on `wrapper` below.
+      if (KJ_ASSERT_NONNULL(wrapper) == object) {
+        return *active.wrappable;
       }
     }
     reportWrapperIdentityMismatch();
@@ -185,6 +193,17 @@ class Wrappable::CppgcShim final: public v8::Object::Wrappable {
   // same tag (see HeapTracer::freelistedShimsByTag), so this value is fixed for the shim's whole
   // lifetime and identifies which freelist bucket it belongs to.
   v8::CppHeapPointerTag tag;
+
+  // Handle to the JS wrapper this shim was Wrapped into. Non-empty exactly while `state` is
+  // Active; addToFreelist() asserts it was cleared, and Trace() ignores it in the other states.
+  //
+  // This lives here rather than in the Wrappable so that the handle and the shim cppgc collects
+  // are one and the same: once the shim dies, nothing can observe the handle, which is the
+  // arrangement cppgc's contract assumes. It is cleared by dropping the kj::Maybe rather than by
+  // Reset(), because a full GC may already have freed the underlying traced node --
+  // ~TracedReference is trivial and writes nothing, whereas Reset() would touch freed memory. The
+  // minor-GC path is the exception and must Reset() explicitly; see HeapTracer::ResetRoot().
+  kj::Maybe<v8::TracedReference<v8::Object>> wrapper;
 
   mutable kj::OneOf<Active, Freelisted, Dead> state;
   // This is `mutable` because `Trace()` is const. We configure V8 to perform traces atomically in
@@ -200,6 +219,9 @@ kj::Maybe<JSGWrappable::CppgcShim&>& HeapTracer::freelistHeadFor(v8::CppHeapPoin
 }
 
 void HeapTracer::addToFreelist(JSGWrappable::CppgcShim& shim) {
+  // Trace() deliberately ignores the handle once a shim is no longer Active, so a freelisted shim
+  // holding one would silently drop a live edge. detachFromShim() clears it before we get here.
+  KJ_DASSERT(shim.wrapper == kj::none);
   auto& head = freelistHeadFor(shim.tag);
   auto& freelisted = shim.state.init<JSGWrappable::CppgcShim::Freelisted>();
   freelisted.next = head;
@@ -225,8 +247,8 @@ JSGWrappable::CppgcShim* HeapTracer::allocateShim(
       }
       KJ_DASSERT(shim.tag == tag);
       shim.state = JSGWrappable::CppgcShim::Active{kj::addRef(wrappable)};
-      KJ_DASSERT(wrappable.cppgcShim == kj::none);
-      wrappable.cppgcShim = shim;
+      KJ_DASSERT(!wrappable.hasWrapper());
+      wrappable.weakShim = &shim;
       return &shim;
     }
   }
@@ -247,6 +269,34 @@ void HeapTracer::clearFreelistedShims() {
       }
     }
   }
+}
+
+void HeapTracer::ResetRoot(const v8::TracedReference<v8::Value>& handle) {
+  // V8 calls this to tell us when our wrapper can be dropped. See comment about droppable
+  // references in Wrappable::attachWrapper() for details.
+  v8::HandleScope scope(isolate);
+
+  // V8 can only hand this polymorphic callback a wrapper that is in one of the sandbox-external
+  // tables, so it is genuinely one of ours. Sandbox-internal corruption can still substitute
+  // another shim, so resolve through the exact wrapper identity check.
+  auto object = handle.As<v8::Object>().Get(isolate);
+  auto& wrappable =
+      *JSGWrappable::unwrapFromShimInRangeOrAbort(isolate, object, kJsgWrappableTagRange);
+  auto& shim = KJ_ASSERT_NONNULL(wrappable.getShim());
+
+  // V8 gets angry if we do not EXPLICITLY call `Reset()` on the wrapper. If we merely destroy it
+  // (which is what `detachWrapper()` will do) it is not satisfied, and will come back and try to
+  // visit the reference again, but it will DCHECK-fail on that second attempt because the
+  // reference is in an inconsistent state at that point.
+  //
+  // Unlike the major-GC path, the node is definitely still live here: V8 is telling us it is
+  // dropping a droppable root it has decided to reclaim, not reporting one it already zapped.
+  KJ_ASSERT_NONNULL(shim.wrapper).Reset();
+
+  // We don't want to call `detachWrapper()` now because it may create new handles (specifically,
+  // if the wrappable has strong references, which means that its outgoing references need to be
+  // upgraded to strong).
+  detachLater.add(&wrappable);
 }
 
 void HeapTracer::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
@@ -324,58 +374,65 @@ Wrappable* Wrappable::unwrapFromShimInRangeOrAbort(
   abort();
 }
 
-kj::Own<JSGWrappable> JSGWrappable::detachWrapper(bool shouldFreelistShim) {
-  KJ_IF_SOME(shim, cppgcShim) {
-#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
-    // There's a possibility that the CppgcShim has already been found to be unreachable by a GC
-    // pass, but has not actually been destroyed yet. For some reason, cppgc likes to delay the
-    // calling of actual destructors. However, in ASAN builds, cppgc will poison the memory in the
-    // meantime, because it figures that we "shouldn't" be accessing unreachable memory. This
-    // assumption makes sense in the abstract, but not for our specific use case, where we are
-    // essentially maintaining a weak pointer to the CppgcShim. If the destructor had been called,
-    // then `cppgcShim` here would have been nulled out at that time. We're expecting that until
-    // the destructor is called, we can still safely access the object to detach the wrapper.
-    //
-    // So to work around cppgc's incorrect assumption, we manually unpoison the memory.
-    //
-    // Note: An alternative strategy could have been for CppgcShim itself to allocate a separate
-    // C++ heap object to store its own state in, so that that state could be modified even while
-    // the CppgcShim object itself is poisoned. In this case `Wrappable::cppgcShim` would change to
-    // point at this state object, not to the `CppgcShim` itself. However, this approach would
-    // require extra heap allocation for everyone, just to satisfy ASAN, which seems undesirable.
-    ASAN_UNPOISON_MEMORY_REGION(&shim, sizeof(shim));
-#endif
+kj::Maybe<JSGWrappable::CppgcShim&> JSGWrappable::getShim() const {
+  auto* shim = weakShim.Get();
+  if (shim == nullptr) return kj::none;
+  // Only CppgcShim instances are ever stored in `weakShim`.
+  return *static_cast<CppgcShim*>(shim);
+}
 
-    auto& tracer = HeapTracer::getTracer(isolate);
-    auto result =
-        kj::mv(KJ_ASSERT_NONNULL(shim.state.tryGet<JSGWrappable::CppgcShim::Active>()).wrappable);
-    if (shouldFreelistShim) {
-      tracer.addToFreelist(shim);
-    } else {
-      shim.state = JSGWrappable::CppgcShim::Dead{};
-    }
-    wrapper = kj::none;
-    cppgcShim = kj::none;
-    strongWrapper.Reset();
-    // Note: weak refs are deliberately NOT invalidated here. Detaching the wrapper does not
-    // imply the object is dying: this method also runs when V8 drops an unmodified droppable
-    // wrapper via ResetRoot() (the object stays alive through C++ refs and the wrapper is
-    // recreated on demand the next time it is passed to JS) and at isolate shutdown via
-    // clearWrappers() (objects like hibernatable WebSockets outlive the isolate). A
-    // jsg::WeakRef tracks the object's lifetime, not the wrapper's; invalidation happens in
-    // ~Wrappable(), or eagerly in WeakRef::tryAddRef() when a zapped wrapper proves the
-    // object is condemned.
-    tracer.removeWrapper({}, *this);
+kj::Maybe<v8::Local<v8::Object>> JSGWrappable::tryGetHandle(v8::Isolate* isolate) {
+  KJ_IF_SOME(shim, getShim()) {
+    return KJ_ASSERT_NONNULL(shim.wrapper).Get(isolate);
+  }
+  return kj::none;
+}
+
+kj::Own<JSGWrappable> JSGWrappable::detachWrapper(bool shouldFreelistShim) {
+  KJ_IF_SOME(shim, getShim()) {
+    return detachFromShim(shim, shouldFreelistShim);
+  } else {
+    return {};
+  }
+}
+
+kj::Own<JSGWrappable> JSGWrappable::detachFromShim(
+    JSGWrappable::CppgcShim& shim, bool shouldFreelistShim) {
+  auto result =
+      kj::mv(KJ_ASSERT_NONNULL(shim.state.tryGet<JSGWrappable::CppgcShim::Active>()).wrappable);
+  // Drop the handle without Reset()ing it: the traced node may already have been freed by a
+  // full GC. See the comment on CppgcShim::wrapper.
+  shim.wrapper = kj::none;
+  if (shouldFreelistShim) {
+    KJ_ASSERT(isolate != nullptr);
+    HeapTracer::getTracer(isolate).addToFreelist(shim);
+  } else {
+    shim.state = JSGWrappable::CppgcShim::Dead{};
+  }
+  // Already null when cppgc cleared it for us on the major-GC path; a no-op then.
+  weakShim.Clear();
+  strongWrapper.Reset();
+  // Note: weak refs are deliberately NOT invalidated here. Detaching the wrapper does not
+  // imply the Wrappable is dying: this method also runs when V8 drops an unmodified droppable
+  // wrapper via ResetRoot() (the Wrappable stays alive through C++ refs and the wrapper is
+  // recreated on demand the next time it is passed to JS) and at isolate shutdown via
+  // clearWrappers() (Wrappables like hibernatable WebSockets outlive the isolate). A
+  // jsg::WeakRef tracks the Wrappable's lifetime, not the wrapper's; invalidation happens in
+  // ~Wrappable(), or eagerly in WeakRef::tryAddRef() when isCondemned() proves the Wrappable
+  // is doomed.
+  if (isolate != nullptr) {
+    HeapTracer::getTracer(isolate).removeWrapper({}, *this);
     if (strongRefcount > 0) {
       // Need to visit child references in order to convert them to strong references, since we
       // no longer have an intervening wrapper.
       GcVisitor visitor(*this, kj::none);
       jsgVisitForGc(visitor);
     }
-    return result;
   } else {
-    return {};
+    KJ_DASSERT(!link.isLinked());
+    KJ_DASSERT(strongRefcount == 0);
   }
+  return result;
 }
 
 v8::Local<v8::Object> Wrappable::getHandle(v8::Isolate* isolate) {
@@ -389,10 +446,10 @@ void Wrappable::addStrongRef() {
       "referencing wrapper without isolate lock");
   if (strongRefcount++ == 0) {
     // This object previously had no strong references, but now it has one.
-    KJ_IF_SOME(w, wrapper) {
+    KJ_IF_SOME(shim, getShim()) {
       // Copy the traced reference into the strong reference.
       v8::HandleScope scope(isolate);
-      strongWrapper.Reset(isolate, w.Get(isolate));
+      strongWrapper.Reset(isolate, KJ_ASSERT_NONNULL(shim.wrapper).Get(isolate));
     } else {
       // Since we have no JS wrapper, we're forced to recursively mark all references reachable
       // through this wrapper as strong.
@@ -406,7 +463,7 @@ void Wrappable::removeStrongRef() {
       "destroying wrapper without isolate lock");
   if (--strongRefcount == 0) {
     // This was the last strong reference.
-    if (wrapper == kj::none) {
+    if (!hasWrapper()) {
       // We have no wrapper. We need to mark all references held by this object as weak.
       if (isolate != nullptr) {
         // But only if the current isolate isn't null. If strong ref count is zero,
@@ -440,8 +497,7 @@ void Wrappable::maybeDeferDestruction(bool strong, kj::Own<void> ownSelf, Wrappa
 }
 
 void Wrappable::traceFromV8(cppgc::Visitor& cppgcVisitor) {
-  tracedEpoch.store(HeapTracer::getTracer(isolate).getActiveGcEpoch(), std::memory_order_relaxed);
-  cppgcVisitor.Trace(KJ_ASSERT_NONNULL(wrapper));
+  // The wrapper handle is traced by our CppgcShim, which owns it.
   GcVisitor visitor(*this, cppgcVisitor);
   jsgVisitForGc(visitor);
 }
@@ -452,7 +508,7 @@ void Wrappable::attachWrapper(v8::Isolate* isolate,
     v8::CppHeapPointerTag tag) {
   auto& tracer = HeapTracer::getTracer(isolate);
 
-  KJ_REQUIRE(wrapper == kj::none);
+  KJ_REQUIRE(!hasWrapper());
   KJ_REQUIRE(strongWrapper.IsEmpty());
 
   // The C++ Wrappable object must hold a TracedReference to its own JavaScript wrapper, while
@@ -482,19 +538,7 @@ void Wrappable::attachWrapper(v8::Isolate* isolate,
   // our wrapper and recreated it, the property would be gone. Luckily, V8 already handles this
   // for us! V8 knows not to drop our wrapper if the application has done anything with it such
   // that a recreated wrapper would no longer be equivalent.
-  wrapper.emplace(isolate, object, v8::TracedReference<v8::Object>::IsDroppable());
   this->isolate = isolate;
-  // Stamp the last *completed* GC epoch so that wasTracedInLastGc() returns true for newly
-  // attached wrappers (otherwise a wrapper attached after any completed major GC would read as
-  // dead). Deliberately NOT the active epoch: creating a TracedReference is an initializing
-  // store, which V8 does not black-allocate, so a wrapper attached during an in-flight marking
-  // cycle whose JS object dies before the atomic pause is zapped by that same cycle. Stamping
-  // the completed epoch keeps such wrappers detectable as dead; if the wrapper instead survives
-  // the in-flight cycle, traceFromV8() re-stamps it with the active epoch during the pause.
-  tracedEpoch.store(tracer.getCompletedGcEpoch(), std::memory_order_relaxed);
-
-  // Add to list of objects to force-clean at isolate shutdown.
-  tracer.addWrapper({}, *this);
 
   // Set up internal fields for a newly-allocated object.
   KJ_REQUIRE(object->InternalFieldCount() == Wrappable::INTERNAL_FIELD_COUNT);
@@ -510,7 +554,13 @@ void Wrappable::attachWrapper(v8::Isolate* isolate,
   // never be driven by different pointers, closing the wrapper type-confusion / use-after-free
   // class of bugs. The shim carries the same tag so it lands in the matching freelist bucket.
   auto* shim = tracer.allocateShim(*this, tag);
+  shim->wrapper.emplace(isolate, object, v8::TracedReference<v8::Object>::IsDroppable());
   v8::Object::Wrap(isolate, object, shim, tag);
+
+  // Add to the list of Wrappables to force-clean at isolate shutdown. Done after the shim
+  // exists, so this Wrappable is never briefly linked-but-wrapperless, which is the state
+  // isCondemned() looks for.
+  tracer.addWrapper({}, *this);
 
   if (strongRefcount > 0) {
     strongWrapper.Reset(isolate, object);
@@ -525,7 +575,7 @@ void Wrappable::attachWrapper(v8::Isolate* isolate,
 }
 
 void Wrappable::jsgGetMemoryInfo(jsg::MemoryTracker& tracker) const {
-  tracker.trackField("cppgcshim", cppgcShim);
+  tracker.trackField("cppgcshim", getShim());
 }
 
 v8::Local<v8::Object> Wrappable::attachOpaqueWrapper(
@@ -590,7 +640,7 @@ void Wrappable::visitRef(GcVisitor& visitor, kj::Maybe<Wrappable&>& refParent, b
   }
 
   // Make ref strength match the parent.
-  if (visitor.parent.strongRefcount > 0 && visitor.parent.wrapper == kj::none) {
+  if (visitor.parent.strongRefcount > 0 && !visitor.parent.hasWrapper()) {
     // This reference should be strong, because the parent has strong refs and does not have its
     // own wrapper that will be traced.
 
@@ -618,8 +668,13 @@ void Wrappable::visitRef(GcVisitor& visitor, kj::Maybe<Wrappable&>& refParent, b
 
   KJ_IF_SOME(cgv, visitor.cppgcVisitor) {
     // We're visiting for the purpose of a GC trace.
-    KJ_IF_SOME(w, wrapper) {
-      cgv.Trace(w);
+    KJ_IF_SOME(shim, getShim()) {
+      // Reaching the handle through the weak persistent is safe inside a trace: cppgc clears
+      // weak persistents only in MarkerBase::ProcessWeakness(), at the end of the atomic pause
+      // and after every Trace() callback has run. So a live wrapper is always visible here, and
+      // a null shim means this Wrappable was condemned by an earlier GC -- handled below, since
+      // a condemned Wrappable must be traced through transitively just like an unwrapped one.
+      cgv.Trace(KJ_ASSERT_NONNULL(shim.wrapper));
     } else {
       // This object doesn't currently have a wrapper, so traces must transitively trace through
       // it. However, as an optimization, we can skip the trace if we've already been traced in
@@ -633,7 +688,7 @@ void Wrappable::visitRef(GcVisitor& visitor, kj::Maybe<Wrappable&>& refParent, b
 void GcVisitor::visit(Data& value) {
   if (!value.handle.IsEmpty()) {
     // Make ref strength match the parent.
-    if (parent.strongRefcount > 0 && parent.wrapper == kj::none) {
+    if (parent.strongRefcount > 0 && !parent.hasWrapper()) {
       // This is directly reachable by a strong ref, so mark the handle strong.
       if (value.tracedHandle != kj::none) {
         // Convert the handle back to strong and discard the traced reference.
@@ -674,7 +729,7 @@ void GcVisitor::visit(v8::Global<v8::Value>& strong, v8::TracedReference<v8::Dat
   // exists we must keep the handle in traced mode so cppgc can follow edges
   // from it.  Only when there is no wrapper yet (object not yet exported to JS)
   // does a positive strongRefcount alone justify keeping the handle strong.
-  if (parent.strongRefcount > 0 && parent.wrapper == kj::none) {
+  if (parent.strongRefcount > 0 && !parent.hasWrapper()) {
     // Parent has strong Rust refs and no JS wrapper — keep handle strong,
     // discard any traced ref.
     if (!traced.IsEmpty()) {

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -306,7 +306,7 @@ class Wrappable: public kj::Refcounted {
   static Wrappable* unwrapFromShim(
       v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTagRange tagRange);
 
-  // Like unwrapFromShim(), but accepts any wrappable tag. For call sites that have already
+  // Like unwrapFromShim(), but accepts any JSG wrappable tag. For call sites that have already
   // established the object's type by another means (a prototype-chain check, or an
   // isWorkerdApiObject() marker check plus a dynamic-type lookup) and only need the pointer.
   // Returns nullptr if the object was never wrapped.
@@ -323,9 +323,9 @@ class Wrappable: public kj::Refcounted {
   // memory-safety violation. We abort so it is surfaced rather than silently ignored; returning a
   // pointer would risk type confusion, and returning "not found" would hide the attack.
   //
-  // The range check is done in C++ (via a wide-range unwrap) rather than by passing `tagRange` to
-  // Object::Unwrap, because a checked V8 build turns a narrow-range miss into its own fatal DCHECK
-  // before returning, producing a different (and less informative) crash than the abort here.
+  // The range check is done in C++ (after unwrapping with the full JSG tag range) rather than by
+  // passing `tagRange` to Object::Unwrap, because a checked V8 build turns a narrow-range miss into
+  // its own fatal DCHECK before returning, producing a different crash than the abort here.
   static Wrappable* unwrapFromShimInRangeOrAbort(
       v8::Isolate* isolate, v8::Local<v8::Object> object, v8::CppHeapPointerTagRange tagRange);
 
@@ -432,6 +432,8 @@ class HeapTracer: public v8::EmbedderRootsHandler {
   void addToFreelist(Wrappable::CppgcShim& shim);
   Wrappable::CppgcShim* allocateShim(Wrappable& wrappable, v8::CppHeapPointerTag tag);
   void clearFreelistedShims();
+  static void substituteCppgcShimForTest(
+      v8::Isolate* isolate, v8::Local<v8::Object> target, v8::Local<v8::Object> source);
 
  private:
   // Returns the head slot of the intrusive freelist for `tag`. The slot has a stable address (it
@@ -557,6 +559,13 @@ inline bool Wrappable::wasTracedInLastGc() const {
       HeapTracer::getTracer(isolate).getCompletedGcEpoch();
 }
 
+void substituteCppgcShimForTest(
+    v8::Isolate* isolate, v8::Local<v8::Object> target, v8::Local<v8::Object> source);
+void detachWrapperForTest(v8::Isolate* isolate, v8::Local<v8::Object> object);
+void resetRootForTest(v8::Isolate* isolate, v8::Local<v8::Object> object);
+bool sharesCppgcShimForTest(
+    v8::Isolate* isolate, v8::Local<v8::Object> first, v8::Local<v8::Object> second);
+
 // Try to use this in any scope where JavaScript wrapped objects are destroyed, to confirm that
 // they don't hold disallowed references to KJ I/O objects. IoOwn's destructor will explicitly
 // create AllowAsyncDestructorsScope to permit holding such objects via IoOwn. This is meant to
@@ -571,6 +580,7 @@ inline bool Wrappable::wasTracedInLastGc() const {
 // templated, to keep the code that unwrappers inline as small as possible.
 [[noreturn]] void reportWrapperTypeMismatch(
     const std::type_info& expected, const std::type_info& actual);
+[[noreturn]] void reportWrapperIdentityMismatch();
 
 // Cast an `Object` that came from a wrapper to the type the callsite expects,
 // aborting if the object is not of that type.
@@ -604,9 +614,13 @@ T& downcastWrappable(Wrappable& wrappable) {
     // Wrappables that are not `Object`s -- `WrappableFunction` and
     // `OpaqueWrappable` -- inherit `Wrappable` publicly, so they can be cast
     // directly.
+    const auto& actualType = typeid(wrappable);
+    if (&actualType == &typeid(T) || actualType == typeid(T)) {
+      return static_cast<T&>(wrappable);
+    }
     T* result = dynamic_cast<T*>(&wrappable);
     if (result == nullptr) {
-      reportWrapperTypeMismatch(typeid(T), typeid(wrappable));
+      reportWrapperTypeMismatch(typeid(T), actualType);
     }
     return *result;
   }

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -10,6 +10,7 @@
 
 #include <workerd/jsg/wrappable-tag.h>
 
+#include <cppgc/persistent.h>
 #include <v8-context.h>
 #include <v8-object.h>
 #include <v8-version.h>
@@ -20,7 +21,6 @@
 #include <kj/refcount.h>
 #include <kj/vector.h>
 
-#include <atomic>
 #include <typeinfo>
 
 // Niche value optimization for v8::TracedReference<T>. This teaches kj::Maybe to use
@@ -180,22 +180,35 @@ class Wrappable: public kj::Refcounted {
         &WORKERD_WRAPPABLE_TAG;
   }
 
-  // Returns true if this object's V8 wrapper was traced by GC during the most recent
-  // *completed* major GC cycle, or if no wrapper (i.e. no v8::TracedReference) currently
-  // exists. A false return means the TracedReference was zapped by V8's ResetDeadNodes and
-  // is no longer safe to dereference, even though the C++ object (and its weak-ref anchor)
-  // may still be alive: V8 zaps dead droppable traced nodes during a full GC without calling
-  // ResetRoot(), and the CppgcShim destructor that would release the object can be deferred
-  // past the end of the cycle. Comparing against the completed epoch (not the in-flight
-  // epoch) ensures that objects not yet traced during an in-progress incremental marking
-  // cycle are not falsely reported as dead.
-  inline bool wasTracedInLastGc() const;
+  // Does a live JS wrapper currently exist for this Wrappable?
+  //
+  // False both before the first attachWrapper() and after detachWrapper(), and also during the
+  // window in which a major GC has collected the wrapper but the deferred ~CppgcShim has not run
+  // yet -- see isCondemned().
+  bool hasWrapper() const {
+    return weakShim.Get() != nullptr;
+  }
 
-  // Invalidate all outstanding jsg::WeakRef<T>s pointing at this object. Called lazily from
-  // WeakRef::tryAddRef() when a zapped wrapper is detected; ~Wrappable() performs the same
-  // invalidation for ordinary destruction. Deliberately NOT called from detachWrapper():
-  // that also runs when V8 drops an unmodified droppable wrapper via ResetRoot() and at
-  // isolate shutdown, while the object remains alive and usable — a WeakRef tracks object
+  // True when a completed major GC collected this Wrappable's wrapper and cleared `weakShim`,
+  // but the ~CppgcShim that will release this Wrappable has not run yet. The Wrappable is still
+  // alive and its weak-ref anchor still reports alive, yet it is doomed: the shim holds the last
+  // reference to it, and the shim's destructor is only deferred, not cancelled.
+  //
+  // A Wrappable is a member of HeapTracer::wrappers exactly between attachWrapper() and
+  // detachWrapper(), so being linked while having no wrapper isolates precisely the case where
+  // cppgc nulled `weakShim` behind our back. That link test is load-bearing, because a null
+  // `weakShim` has two producers: cppgc on major GC (this case), and detachWrapper() itself --
+  // including the minor-GC path, where V8 drops a droppable wrapper while the Wrappable lives
+  // on.
+  bool isCondemned() const {
+    return link.isLinked() && !hasWrapper();
+  }
+
+  // Invalidate all outstanding jsg::WeakRef<T>s pointing at this Wrappable. Called lazily from
+  // WeakRef::tryAddRef() when a condemned Wrappable is detected; ~Wrappable() performs the same
+  // invalidation for ordinary destruction. Deliberately NOT called from detachWrapper(): that
+  // also runs when V8 drops an unmodified droppable wrapper via ResetRoot() and at isolate
+  // shutdown, while the Wrappable remains alive and usable — a WeakRef tracks Wrappable
   // lifetime, not wrapper lifetime.
   void invalidateWeakRefs() {
     KJ_IF_SOME(a, weakRefAnchor) {
@@ -203,11 +216,9 @@ class Wrappable: public kj::Refcounted {
     }
   }
 
-  // Mark this object as condemned: its wrapper's TracedReference was zapped by a completed
-  // major GC, but the CppgcShim destructor that will release the object has not run yet.
-  // Invalidates outstanding weak refs and bumps the isolate's condemned counter (see
-  // HeapTracer::getCondemnedWrapperCount()). Called from WeakRef::tryAddRef() on the sole
-  // path that can observe the condition.
+  // Act on a condemned Wrappable (see isCondemned()): invalidate outstanding weak refs and bump
+  // the isolate's condemned counter (see HeapTracer::getCondemnedWrapperCount()). Called from
+  // WeakRef::tryAddRef(), which must refuse to promote such a Wrappable.
   inline void condemn();
 
   void addStrongRef();
@@ -223,9 +234,10 @@ class Wrappable: public kj::Refcounted {
 
   v8::Local<v8::Object> getHandle(v8::Isolate* isolate);
 
-  kj::Maybe<v8::Local<v8::Object>> tryGetHandle(v8::Isolate* isolate) {
-    return wrapper.map([&](v8::TracedReference<v8::Object>& ref) { return ref.Get(isolate); });
-  }
+  // This Wrappable's JS wrapper, or null if none currently exists. Reaches the handle through
+  // `weakShim`, so a wrapper the GC has already collected reads as absent rather than as a
+  // zapped handle.
+  kj::Maybe<v8::Local<v8::Object>> tryGetHandle(v8::Isolate* isolate);
 
   // Visits a Ref<T> pointing at this Wrappable. `refParent` and `refStrong` are the members of
   // `Ref<T>`, and this method is invoked on the object the ref points at. (This avoids the need
@@ -335,55 +347,68 @@ class Wrappable: public kj::Refcounted {
  private:
   class CppgcShim;
 
-  // If a JS wrapper is currently allocated, this point to the cppgc shim object.
-  kj::Maybe<CppgcShim&> cppgcShim;
+  // The shim owning this Wrappable's wrapper handle, or null when no live wrapper exists.
+  // Downcasts `weakShim`; see its comment for why that is stored as the cppgc base type.
+  kj::Maybe<CppgcShim&> getShim() const;
 
-  // Handle to the JS wrapper object. The wrapper is created lazily when the object is first
-  // exported to JavaScript; until then, the wrapper is empty.
+  // The body of detachWrapper(), taking the shim explicitly. ~CppgcShim must use this: on the
+  // major-GC path cppgc has already cleared `weakShim`, so getShim() would find nothing.
+  kj::Own<Wrappable> detachFromShim(CppgcShim& shim, bool shouldFreelistShim);
+
+  // The cppgc shim owning this Wrappable's JS wrapper, or null when no live wrapper exists.
   //
-  // If the wrapper object is "unmodified" from its original creation state, then V8 may choose to
-  // collect it even when it could still technically be reached via C++ objects. The idea here is
-  // that if the object is returned to JavaScript again later, the wrapper can be reconstructed at
-  // that time. However, if the wrapper is modified by the application (e.g. monkey-patched with
-  // a new property), then collecting and recreating it won't work. The logic to decide if an
-  // object has been "modified" is internal to V8 and baked into its use of EmbedderRootsHandler.
-  kj::Maybe<v8::TracedReference<v8::Object>> wrapper;
+  // The wrapper handle itself lives in the shim, not here. The wrapper is created lazily when the
+  // Wrappable is first exported to JavaScript; until then this is null.
+  //
+  // If the wrapper is "unmodified" from its original creation state, then V8 may choose to
+  // collect it even when the Wrappable could still technically be reached from C++. The idea here
+  // is that if the Wrappable is returned to JavaScript again later, the wrapper can be
+  // reconstructed at that time. However, if the wrapper is modified by the application (e.g.
+  // monkey-patched with a new property), then collecting and recreating it won't work. The logic
+  // to decide if a wrapper has been "modified" is internal to V8 and baked into its use of
+  // EmbedderRootsHandler.
+  //
+  // The reference is weak so that the GC, not us, decides when it goes away. When a major GC
+  // collects the wrapper, cppgc nulls this in MarkerBase::ProcessWeakness() -- during the same
+  // atomic pause that zaps the wrapper's traced node, and long before the deferred ~CppgcShim
+  // runs. Every reader therefore observes "no wrapper" as soon as the GC knows it, instead of
+  // reaching a zapped handle through a bare pointer.
+  //
+  // Declared as the cppgc base type because CppgcShim is defined in wrappable.c++ while
+  // cppgc::WeakPersistent needs a complete type. Only CppgcShim instances are ever stored here;
+  // getShim() does the downcast.
+  cppgc::WeakPersistent<v8::Object::Wrappable> weakShim;
 
-  // Whenever there are non-GC-traced references to the object (i.e. from other C++ objects, i.e.
-  // strongRefcount > 0), and `wrapper` is non-null, then `strongWrapper` contains a copy of
-  // `wrapper`, to force it to stay alive. Otherwise, `strongWrapper` is empty.
+  // Whenever there are non-GC-traced references to this Wrappable (i.e. from other C++ objects,
+  // i.e. strongRefcount > 0) and a wrapper exists, `strongWrapper` contains a copy of the wrapper
+  // handle, to force the wrapper to stay alive. Otherwise, `strongWrapper` is empty.
   v8::Global<v8::Object> strongWrapper;
 
-  // Will be non-null if `wrapper` has ever been non-null.
+  // Will be non-null if a wrapper has ever been attached.
   v8::Isolate* isolate = nullptr;
 
-  // How many strong Ref<T>s point at this object, forcing the wrapper to stay alive even if GC
-  // tracing doesn't find it?
+  // How many strong Ref<T>s point at this Wrappable, forcing its wrapper to stay alive even if
+  // GC tracing doesn't find it?
   //
-  // Whenever the value of the boolean expression (strongRefcount > 0 && wrapper.IsEmpty()) changes,
-  // a GC visitation is needed to update all outgoing refs.
+  // Whenever the value of the boolean expression (strongRefcount > 0 && !hasWrapper()) changes, a
+  // GC visitation is needed to update all outgoing refs. The four places that can change it --
+  // attachWrapper(), detachWrapper(), addStrongRef() and removeStrongRef() -- each run one.
+  //
+  // cppgc clearing `weakShim` behind our back does not count, and needs no visitation: clearing
+  // requires the wrapper to have been collected, which requires `strongWrapper` to be empty (see
+  // the assert in ~CppgcShim), which means strongRefcount is 0 -- so the expression is false both
+  // before and after. In other words, a wrapper can only be condemned while strongRefcount == 0.
   uint strongRefcount = 0;
 
-  // When `wrapperRef` is non-empty, the Wrappable is a member of the list `HeapTracer::wrappers`.
+  // While a wrapper is attached, the Wrappable is a member of the list `HeapTracer::wrappers`.
   kj::ListLink<Wrappable> link;
 
-  // Stamped with the active GC epoch in traceFromV8() each time V8 traces this wrapper, and
-  // with the completed epoch in attachWrapper(). wasTracedInLastGc() compares this against
-  // the last *completed* GC epoch to detect wrappers whose TracedReference was zapped by a
-  // full GC (see that method's comment).
-  //
-  // The CppHeap is configured with atomic marking (see newCppHeap() in setup.c++), so
-  // traceFromV8() only runs on the main thread during the atomic pause and no concurrent
-  // access occurs today; the atomic is defensive hardening in case that configuration ever
-  // changes. Relaxed ordering suffices: reads happen under the isolate lock on the same
-  // thread that runs the GC callbacks.
-  std::atomic<uint64_t> tracedEpoch{0};
-
-  // Lazy-allocated shared state for jsg::WeakRef<T>. Zero overhead for objects that never
+  // Lazy-allocated shared state for jsg::WeakRef<T>. Zero overhead for Wrappables that never
   // have weak references taken. Created on first call to getOrCreateWeakRefAnchor().
   kj::Maybe<kj::Rc<WeakRefAnchor>> weakRefAnchor;
 
-  // Returns (or creates) the shared WeakRefAnchor for this object. Used by Ref<T>::getWeakRef().
+  // Returns (or creates) the shared WeakRefAnchor for this Wrappable. Used by
+  // Ref<T>::getWeakRef().
   kj::Rc<WeakRefAnchor> getOrCreateWeakRefAnchor() {
     KJ_IF_SOME(a, weakRefAnchor) {
       return a.addRef();
@@ -441,25 +466,8 @@ class HeapTracer: public v8::EmbedderRootsHandler {
   kj::Maybe<Wrappable::CppgcShim&>& freelistHeadFor(v8::CppHeapPointerTag tag);
 
  public:
-  // The epoch of the currently active (possibly in-flight) major GC cycle. Advanced once
-  // per cycle in whichever prologue fires first (incremental-marking start or the
-  // mark-compact prologue). Wrappable::traceFromV8() stamps this value into
-  // Wrappable::tracedEpoch.
-  uint64_t getActiveGcEpoch() const {
-    return activeGcEpoch;
-  }
-
-  // The epoch of the last fully completed major GC cycle. Catches up to activeGcEpoch in
-  // the mark-compact epilogue, which runs after ResetDeadNodes() has zapped dead traced
-  // nodes but before control returns to JavaScript. Wrappable::wasTracedInLastGc() compares
-  // against this value, so objects not yet traced in an in-flight cycle are not falsely
-  // reported as dead.
-  uint64_t getCompletedGcEpoch() const {
-    return completedGcEpoch;
-  }
-
   // Number of times WeakRef::tryAddRef() has detected a condemned target in this isolate, i.e.
-  // the number of times the dangling-TracedReference hazard has actually been caught rather
+  // the number of times the dangling-wrapper hazard has actually been caught rather
   // than merely guarded against.
   //
   // This exists so that the regression test can assert it reached the hazard. The window is
@@ -518,14 +526,6 @@ class HeapTracer: public v8::EmbedderRootsHandler {
   // static_assert in TypeWrapper::wrappableTag<T>().
   kj::Maybe<Wrappable::CppgcShim&> freelistedShimsByTag[kMaxWrappableTags] = {};
 
-  // Major GC epoch counters; see getActiveGcEpoch()/getCompletedGcEpoch(). The two are equal
-  // exactly when no major cycle is in flight (the mark-compact epilogue restores equality),
-  // which is how the prologue advances the epoch exactly once per cycle: an incremental cycle
-  // fires prologues both at incremental-marking start and again at the atomic pause, and only
-  // the first of those observes equality.
-  uint64_t activeGcEpoch = 0;
-  uint64_t completedGcEpoch = 0;
-
   // See getCondemnedWrapperCount(). Plain (non-atomic) because it is only ever touched from
   // Wrappable::condemn(), which runs under the isolate lock.
   uint64_t condemnedWrapperCount = 0;
@@ -534,29 +534,11 @@ class HeapTracer: public v8::EmbedderRootsHandler {
 };
 
 inline void Wrappable::condemn() {
-  // Only reachable from wasTracedInLastGc() returning false, which implies a wrapper exists,
-  // which implies attachWrapper() set `isolate`.
+  // Only reachable from isCondemned() returning true, which implies this Wrappable is still
+  // linked into HeapTracer::wrappers, which implies attachWrapper() set `isolate`.
   KJ_DASSERT(isolate != nullptr);
   ++HeapTracer::getTracer(isolate).condemnedWrapperCount;
   invalidateWeakRefs();
-}
-
-inline bool Wrappable::wasTracedInLastGc() const {
-  // The hazard being detected is a dangling v8::TracedReference, so the check applies only
-  // when one exists. `wrapper` reads as none both when no wrapper was ever attached and after
-  // detachWrapper() (including when V8 drops an unmodified droppable wrapper via ResetRoot()
-  // while the object stays alive); in those states there is nothing to zap, and code paths
-  // that would touch the wrapper (e.g. addStrongRef()) already handle its absence. Note that
-  // `isolate` cannot be used to detect "never wrapped": GC visitation propagates it to
-  // wrapper-less children (see Wrappable::visitRef()).
-  //
-  // Reading the Maybe is safe even when the TracedReference dangles: its emptiness is a
-  // property of the local handle, not of the (possibly freed) node it points at.
-  if (wrapper == kj::none) return true;
-  // `wrapper` is only ever set in attachWrapper(), which also sets `isolate`.
-  KJ_DASSERT(isolate != nullptr);
-  return tracedEpoch.load(std::memory_order_relaxed) >=
-      HeapTracer::getTracer(isolate).getCompletedGcEpoch();
 }
 
 void substituteCppgcShimForTest(

--- a/src/workerd/server/channel-token-test.c++
+++ b/src/workerd/server/channel-token-test.c++
@@ -190,6 +190,20 @@ class MockActorChannel: public IoChannelFactory::ActorChannel {
   }
 };
 
+class MockWorkerStubChannel final: public WorkerStubChannel {
+ public:
+  kj::Own<IoChannelFactory::SubrequestChannel> getEntrypointResolved(
+      kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits) override {
+    return kj::refcounted<MockSubrequestChannel>(
+        ServiceTriplet("outer", kj::none, kj::mv(props)), Persistent::NO);
+  }
+
+  kj::Own<IoChannelFactory::ActorClassChannel> getActorClassResolved(
+      kj::Maybe<kj::String> name, Frankenvalue props, kj::Maybe<ResourceLimits> limits) override {
+    KJ_UNREACHABLE;
+  }
+};
+
 class MockResolver: public ChannelTokenHandler::Resolver {
  public:
   kj::Own<IoChannelFactory::SubrequestChannel> resolveEntrypoint(kj::StringPtr serviceName,
@@ -518,6 +532,31 @@ KJ_TEST("channel token with nested channel that generates token asynchronously")
   KJ_EXPECT(nestedActor.triplet ==
       ServiceTriplet("async-actor", "AsyncEntry"_kj,
           Frankenvalue::fromJson(kj::str("{\"inner\": \"async\"}"))));
+}
+
+KJ_TEST("resolving channel props keeps promised caps alive") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  auto paf = kj::newPromiseAndFulfiller<kj::Own<IoChannelFactory::SubrequestChannel>>();
+  kj::Vector<kj::Own<Frankenvalue::CapTableEntry>> caps;
+  caps.add(newPromisedChannel<IoChannelFactory::SubrequestChannel>(kj::mv(paf.promise)));
+
+  auto worker = kj::refcounted<MockWorkerStubChannel>();
+  auto channel = worker->getEntrypoint(kj::none, propsWithCaps(kj::mv(caps)), kj::none);
+  auto resolutionResult = channel->getResolved();
+  auto resolution =
+      KJ_ASSERT_NONNULL(kj::mv(resolutionResult)
+                            .tryGet<kj::Promise<kj::Own<IoChannelFactory::TokenizableChannel>>>());
+
+  paf.fulfiller->fulfill(kj::refcounted<MockSubrequestChannel>(
+      ServiceTriplet("nested", kj::none, Frankenvalue()), Persistent::NO));
+
+  auto resolved = resolution.wait(waitScope).downcast<MockSubrequestChannel>();
+  auto capTable = resolved->triplet.props.getCapTable();
+  KJ_ASSERT(capTable.size() == 1);
+  auto& nested = KJ_ASSERT_NONNULL(kj::tryDowncast<MockSubrequestChannel>(*capTable[0]));
+  KJ_EXPECT(nested.triplet.serviceName == "nested");
 }
 
 }  // namespace


### PR DESCRIPTION
Let the embedder store node sources in its own registry

Move wrapper handle to shim

Fix promised channel use-after-free

Reject substituted JSG wrapper identities
