### PR TITLE
Python tests: Use compat date matching the enable date of the Python version

### DIFF
--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -13,6 +13,7 @@ def wd_test(
         generate_gc_stress_variant = True,
         predictable = True,
         compat_date = "",
+        no_default_compat_date = False,
         **kwargs):
     """Rule to define tests that run `workerd test` with a particular config.
 
@@ -30,6 +31,8 @@ def wd_test(
      predictable: If True (default), pass `--predictable` to workerd.
      compat_date: If specified, use this compat date for the default variant instead of 2000-01-01.
         Does not affect the @all-compat-flags variant which always uses 2999-12-31.
+     no_default_compat_date: If True, do not override compatibility dates in the default,
+        @all-autogates, or compat-date-sensitive @gc-stress variants.
 
     The following test variants are generated based on the flags:
      - name@ (if generate_default_variant): oldest compat date (2000-01-01)
@@ -75,11 +78,16 @@ def wd_test(
 
     # Define the compat-date args for each variant
     # Note: dates must be in range [2000-01-01, 2999-12-31] due to parsing constraints
-    default_compat_args = ["--compat-date=2000-01-01"]
     newest_compat_args = ["--compat-date=2999-12-31"]
 
+    if compat_date and no_default_compat_date:
+        fail("compat_date and no_default_compat_date cannot both be set")
     if compat_date:
         default_compat_args = ["--compat-date={}".format(compat_date)]
+    elif no_default_compat_date:
+        default_compat_args = []
+    else:
+        default_compat_args = ["--compat-date=2000-01-01"]
 
     # Generate variants based on the flags
     # Default variant: oldest compat date

--- a/src/cloudflare/internal/test/ai/python-ai-api-test.wd-test
+++ b/src/cloudflare/internal/test/ai/python-ai-api-test.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "ai-api-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "ai-api-test.py")
         ],
@@ -24,6 +26,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "ai-mock",
       worker = (
+        %COMPAT_DATE,
         compatibilityFlags = ["experimental", "nodejs_compat"],
         modules = [
           (name = "worker", esModule = embed "ai-mock.js")

--- a/src/cloudflare/internal/test/aig/python-aig-api-test.wd-test
+++ b/src/cloudflare/internal/test/aig/python-aig-api-test.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "aig-api-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "aig-api-test.py")
         ],
@@ -24,6 +26,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "aig-mock",
       worker = (
+        %COMPAT_DATE,
         compatibilityFlags = ["experimental", "nodejs_compat"],
         modules = [
           (name = "worker", esModule = embed "aig-mock.js")

--- a/src/cloudflare/internal/test/autorag/python-autorag-api-test.wd-test
+++ b/src/cloudflare/internal/test/autorag/python-autorag-api-test.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "autorag-api-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "autorag-api-test.py")
         ],
@@ -24,6 +26,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "autorag-mock",
       worker = (
+        %COMPAT_DATE,
         compatibilityFlags = ["experimental", "nodejs_compat"],
         modules = [
           (name = "worker", esModule = embed "autorag-mock.js")

--- a/src/cloudflare/internal/test/br/python-br-api-test.wd-test
+++ b/src/cloudflare/internal/test/br/python-br-api-test.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "br-api-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "br-api-test.py")
         ],
@@ -24,6 +26,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "br-mock",
       worker = (
+        %COMPAT_DATE,
         compatibilityFlags = ["experimental", "nodejs_compat"],
         modules = [
           (name = "worker", esModule = embed "br-mock.js")

--- a/src/cloudflare/internal/test/d1/python-d1-api-test.wd-test
+++ b/src/cloudflare/internal/test/d1/python-d1-api-test.wd-test
@@ -1,10 +1,12 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "TEST_TMPDIR", disk = (writable = true) ),
     ( name = "d1-api-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "d1-api-test.py")
         ],
@@ -25,6 +27,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "d1-mock",
       worker = (
+        %COMPAT_DATE,
         compatibilityFlags = ["experimental", "nodejs_compat"],
         modules = [
           (name = "worker", esModule = embed "d1-mock.js")

--- a/src/cloudflare/internal/test/to-markdown/python-to-markdown-api-test.wd-test
+++ b/src/cloudflare/internal/test/to-markdown/python-to-markdown-api-test.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "to-markdown-api-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "to-markdown-api-test.py")
         ],
@@ -24,6 +26,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "to-markdown-mock",
       worker = (
+        %COMPAT_DATE,
         compatibilityFlags = ["experimental", "nodejs_compat"],
         modules = [
           (name = "worker", esModule = embed "to-markdown-mock.js")

--- a/src/cloudflare/internal/test/vectorize/python-vectorize-api-test.wd-test
+++ b/src/cloudflare/internal/test/vectorize/python-vectorize-api-test.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "vectorize-api-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           ( name = "worker.py", pythonModule = embed "vectorize-api-test.py" )
         ],
@@ -23,6 +25,7 @@ const unitTests :Workerd.Config = (
     ),
     ( name = "vector-search-mock",
       worker = (
+        %COMPAT_DATE,
         modules = [
           ( name = "worker", esModule = embed "vectorize-mock.js" )
         ],

--- a/src/workerd/server/tests/python/BUILD.bazel
+++ b/src/workerd/server/tests/python/BUILD.bazel
@@ -1,9 +1,29 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//:build/wd_cc_binary.bzl", "wd_cc_binary")
 load("//src/workerd/server/tests/python:py_wd_test.bzl", "py_wd_test", "python_test_setup")
 load("//src/workerd/server/tests/python/vendor_pkg_tests:vendor_test.bzl", "vendored_py_wd_test")
 
 python_test_setup()
+
+wd_cc_binary(
+    name = "generate-python-compatibility-dates",
+    srcs = ["generate-python-compatibility-dates.c++"],
+    deps = [
+        "//src/workerd/io:compatibility-date",
+        "@capnp-cpp//src/capnp",
+        "@capnp-cpp//src/kj",
+    ],
+)
+
+genrule(
+    name = "python-compatibility-dates",
+    srcs = ["//src/workerd/io:trimmed-release-version-gen"],
+    outs = ["generated/python-compatibility-dates.capnp"],
+    cmd = "$(execpath :generate-python-compatibility-dates_cross) $(location //src/workerd/io:trimmed-release-version-gen) $@",
+    tools = [":generate-python-compatibility-dates_cross"],
+    visibility = ["//visibility:public"],
+)
 
 # NOTE: Each test takes a while to start up, so if possible add additional tests to pytest or to
 # top-level-tests or sdk or some other existing test.
@@ -34,7 +54,7 @@ py_wd_test("subdirectory")
 
 py_wd_test(
     "sdk",
-    compat_date = "2026-01-01",
+    feature_flags = ["http_headers_getsetcookie"],
 )
 
 py_wd_test("undefined-handler")

--- a/src/workerd/server/tests/python/asgi-sse/asgi-sse.wd-test
+++ b/src/workerd/server/tests/python/asgi-sse/asgi-sse.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-asgi-sse",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
         ],

--- a/src/workerd/server/tests/python/asgi/asgi.wd-test
+++ b/src/workerd/server/tests/python/asgi/asgi.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-asgi",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
         ],

--- a/src/workerd/server/tests/python/default-class-with-legacy-global-handlers/default-class-with-legacy-global-handlers.wd-test
+++ b/src/workerd/server/tests/python/default-class-with-legacy-global-handlers/default-class-with-legacy-global-handlers.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "default-class-with-legacy-global-handlers",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py")
         ],

--- a/src/workerd/server/tests/python/durable-object-websocket/durable-object-websocket.wd-test
+++ b/src/workerd/server/tests/python/durable-object-websocket/durable-object-websocket.wd-test
@@ -1,4 +1,5 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const config :Workerd.Config = (
   services = [
@@ -9,6 +10,7 @@ const config :Workerd.Config = (
 );
 
 const mainWorker :Workerd.Worker = (
+  %COMPAT_DATE,
 
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_no_global_handlers"],
 
@@ -31,6 +33,7 @@ const mainWorker :Workerd.Worker = (
 
 
 const testerWorker :Workerd.Worker = (
+  %COMPAT_DATE,
 
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_no_global_handlers"],
 

--- a/src/workerd/server/tests/python/durable-object/durable-object.wd-test
+++ b/src/workerd/server/tests/python/durable-object/durable-object.wd-test
@@ -1,4 +1,5 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const config :Workerd.Config = (
   services = [
@@ -8,6 +9,7 @@ const config :Workerd.Config = (
 );
 
 const mainWorker :Workerd.Worker = (
+  %COMPAT_DATE,
 
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "rpc", "python_no_global_handlers"],
 

--- a/src/workerd/server/tests/python/env-param/env.wd-test
+++ b/src/workerd/server/tests/python/env-param/env.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-hello",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py")
         ],

--- a/src/workerd/server/tests/python/generate-python-compatibility-dates.c++
+++ b/src/workerd/server/tests/python/generate-python-compatibility-dates.c++
@@ -1,0 +1,55 @@
+#include <workerd/io/compatibility-date.h>
+
+#include <capnp/dynamic.h>
+#include <capnp/schema.h>
+#include <kj/debug.h>
+#include <kj/filesystem.h>
+#include <kj/string.h>
+#include <kj/vector.h>
+
+int main(int argc, char* argv[]) {
+  KJ_REQUIRE(argc == 3, "expected release date and output paths");
+
+  auto filesystem = kj::newDiskFilesystem();
+  auto releaseDatePath = filesystem->getCurrentPath().evalNative(argv[1]);
+  auto releaseDate = filesystem->getRoot().openFile(releaseDatePath)->readAllText();
+
+  kj::Vector<kj::String> output;
+  output.add(kj::str("@0xd9e8b7e1607f5c54;\n\n"));
+
+  auto schema = capnp::Schema::from<workerd::CompatibilityFlags>();
+  for (auto field: schema.getFields()) {
+    bool isPythonSnapshotRelease = false;
+    kj::Maybe<kj::StringPtr> impliedDate;
+
+    for (auto annotation: field.getProto().getAnnotations()) {
+      if (annotation.getId() == workerd::PYTHON_SNAPSHOT_RELEASE_ANNOTATION_ID) {
+        isPythonSnapshotRelease = true;
+      } else if (annotation.getId() == workerd::IMPLIED_BY_AFTER_DATE_ANNOTATION_ID) {
+        impliedDate = annotation.getValue().getStruct().as<workerd::ImpliedByAfterDate>().getDate();
+      }
+    }
+
+    if (!isPythonSnapshotRelease) {
+      continue;
+    }
+
+    kj::StringPtr date = "2024-03-01"_kj;
+    KJ_IF_SOME(value, impliedDate) {
+      date = value;
+    }
+    if (releaseDate < date) {
+      date = releaseDate;
+    }
+
+    output.add(kj::str("const ", field.getProto().getName(), " :Text = \"", date, "\";\n"));
+  }
+
+  auto outputPath = filesystem->getCurrentPath().evalNative(argv[2]);
+  auto outputFile =
+      filesystem->getRoot().replaceFile(outputPath, kj::WriteMode::CREATE | kj::WriteMode::MODIFY);
+  auto content = kj::strArray(output, "");
+  outputFile->get().writeAll(content.asBytes());
+  outputFile->commit();
+  return 0;
+}

--- a/src/workerd/server/tests/python/hello/hello.wd-test
+++ b/src/workerd/server/tests/python/hello/hello.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-hello",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py")
         ],

--- a/src/workerd/server/tests/python/hello/worker.py
+++ b/src/workerd/server/tests/python/hello/worker.py
@@ -10,14 +10,21 @@ else:
     # js should be patched at top level in order to allow snapshotting.
     assert js != globalThis
 
-# Calling fetch at top level should give a good error message despite patching.
+
+# Calling fetch at top level should give a good error message despite patching. Depending on the
+# compatibility date, fetch either throws synchronously or returns a rejected promise.
+def check_fetch_error(error):
+    print(error)
+    assert "Disallowed operation called within global scope" in str(error)
+
+
 try:
-    js.fetch("example.com")
+    fetch_result = js.fetch("example.com")
 except JsException as e:
-    print(e)
-    assert "Disallowed operation called within global scope" in str(e)
+    check_fetch_error(e)
 else:
-    assert False  # noqa: B011
+    fetch_result.catch(check_fetch_error)
+    del fetch_result
 
 
 def test():

--- a/src/workerd/server/tests/python/jspi/jspi.wd-test
+++ b/src/workerd/server/tests/python/jspi/jspi.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "jspi",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py")
         ],

--- a/src/workerd/server/tests/python/metadata-read-overflow/metadata-read-overflow.wd-test
+++ b/src/workerd/server/tests/python/metadata-read-overflow/metadata-read-overflow.wd-test
@@ -8,7 +8,7 @@ const unitTests :Workerd.Config = (
           (name = "worker.py", pythonModule = embed "worker.py"),
           (name = "payload.dat", data = "payload.dat")
         ],
-        compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "disable_python_no_global_handlers"],
       )
     ),
   ],

--- a/src/workerd/server/tests/python/metadata-read-overflow/metadata-read-overflow.wd-test
+++ b/src/workerd/server/tests/python/metadata-read-overflow/metadata-read-overflow.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "metadata-read-overflow",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
           (name = "payload.dat", data = "payload.dat")

--- a/src/workerd/server/tests/python/nodejs-compat/nodejs-compat.wd-test
+++ b/src/workerd/server/tests/python/nodejs-compat/nodejs-compat.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-nodejs-compat",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
         ],

--- a/src/workerd/server/tests/python/nodejs-compat/nodejs-compat.wd-test
+++ b/src/workerd/server/tests/python/nodejs-compat/nodejs-compat.wd-test
@@ -12,6 +12,7 @@ const unitTests :Workerd.Config = (
           "nodejs_compat",
           "nodejs_compat_v2",
           "enable_nodejs_process_v2",
+          "disable_python_no_global_handlers",
         ],
       )
     ),

--- a/src/workerd/server/tests/python/pth-file/pth-file.wd-test
+++ b/src/workerd/server/tests/python/pth-file/pth-file.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "pth-file",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
           # The .pth file must live in python_modules/ so that addsitedir() picks

--- a/src/workerd/server/tests/python/py_wd_test.bzl
+++ b/src/workerd/server/tests/python/py_wd_test.bzl
@@ -15,6 +15,16 @@ def _get_enable_flags(python_flag):
             flags.append("no_" + value["enable_flag_name"])
     return flags
 
+def _get_compatibility_date_flag(python_flag):
+    version_info = BUNDLE_VERSION_INFO[python_flag]
+    if python_flag != "development":
+        return version_info["flag"]
+
+    for name, info in BUNDLE_VERSION_INFO.items():
+        if name != "development" and info["pyodide_version"] == version_info["real_pyodide_version"]:
+            return info["flag"]
+    fail("No released Python bundle matches the development bundle")
+
 def _py_wd_test_helper(
         name,
         src,
@@ -29,6 +39,16 @@ def _py_wd_test_helper(
     name_flag = name + "_" + python_flag
     templated_src = name_flag.replace("/", "-") + "@template"
     templated_src = "/".join(src.split("/")[:-1] + [templated_src])
+    compatibility_dates_src = name_flag.replace("/", "-") + "@compatibility-dates.capnp"
+    compatibility_dates_src = "/".join(src.split("/")[:-1] + [compatibility_dates_src])
+
+    compatibility_dates_rule = name_flag + "@compatibility-dates"
+    copy_file(
+        name = compatibility_dates_rule,
+        src = "//src/workerd/server/tests/python:python-compatibility-dates",
+        out = compatibility_dates_src,
+    )
+    data = data + [":" + compatibility_dates_rule]
 
     pyodide_version = BUNDLE_VERSION_INFO[python_flag]["real_pyodide_version"]
 
@@ -49,6 +69,9 @@ def _py_wd_test_helper(
     if make_snapshot and pyodide_version != "0.26.0a2":
         feature_flags = feature_flags + ["python_dedicated_snapshot"]
 
+    if "enable_python_external_sdk" not in feature_flags and "disable_python_external_sdk" not in feature_flags:
+        feature_flags = feature_flags + ["disable_python_external_sdk"]
+
     if load_snapshot and not make_snapshot:
         args += ["--python-load-snapshot", "load_snapshot.bin"]
 
@@ -57,12 +80,17 @@ def _py_wd_test_helper(
     # deduplicate flag list because passing the same flag multiple times fails with "Compatibility flag specified multiple times"
     flags = list({flag: 1 for flag in flags})
     feature_flags_txt = ",".join(['"{}"'.format(flag) for flag in flags])
+    compatibility_date_flag = _get_compatibility_date_flag(python_flag)
 
     expand_template(
         name = name_flag + "@rule",
         out = templated_src,
         template = src,
-        substitutions = {"%PYTHON_FEATURE_FLAGS": feature_flags_txt},
+        substitutions = {
+            "%PYTHON_COMPAT_DATES_IMPORT": 'using PythonCompatibilityDates = import "%s"' % compatibility_dates_src.rsplit("/", 1)[-1],
+            "%COMPAT_DATE": "compatibilityDate = PythonCompatibilityDates.%s" % compatibility_date_flag,
+            "%PYTHON_FEATURE_FLAGS": feature_flags_txt,
+        },
     )
 
     # Since we bumped the development flag to point to 0.28.2, it doesn't work on windows CI.
@@ -80,6 +108,7 @@ def _py_wd_test_helper(
         python_snapshot_test = make_snapshot,
         data = data,
         load_snapshot = load_snapshot,
+        no_default_compat_date = True,
         # TODO(soon): at the time of disabling these they all passed but because of how slow python
         #             tests are we disabled them for now. We should re-enable them when we have
         #             a better way to run them.

--- a/src/workerd/server/tests/python/pytest/pytest.wd-test
+++ b/src/workerd/server/tests/python/pytest/pytest.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "pytest-vendor-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "main.py", pythonModule = embed "pytest/main.py"),
           (name = "tests/test_env.py", pythonModule = embed "pytest/tests/test_env.py"),

--- a/src/workerd/server/tests/python/pytest/tests/test_import_from_javascript.py
+++ b/src/workerd/server/tests/python/pytest/tests/test_import_from_javascript.py
@@ -46,4 +46,4 @@ def test_import_failures():
 
     # Assert that non existent modules throw ImportError
     with pytest.raises(ImportError):
-        import_from_javascript("crypto")
+        import_from_javascript("nonexistent-module")

--- a/src/workerd/server/tests/python/python-compat-flag/python-compat-flag.wd-test
+++ b/src/workerd/server/tests/python/python-compat-flag/python-compat-flag.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
         ],
-        compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows"],
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "disable_python_no_global_handlers"],
       )
     ),
   ],

--- a/src/workerd/server/tests/python/python-compat-flag/python-compat-flag.wd-test
+++ b/src/workerd/server/tests/python/python-compat-flag/python-compat-flag.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-compat-flag",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
         ],

--- a/src/workerd/server/tests/python/python-rpc/python-rpc.wd-test
+++ b/src/workerd/server/tests/python/python-rpc/python-rpc.wd-test
@@ -1,4 +1,5 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const config :Workerd.Config = (
   services = [
@@ -8,6 +9,7 @@ const config :Workerd.Config = (
 );
 
 const pyWorker :Workerd.Worker = (
+  %COMPAT_DATE,
 
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "rpc", "disable_python_no_global_handlers", "set_tostring_tag"],
 
@@ -23,6 +25,7 @@ const pyWorker :Workerd.Worker = (
 );
 
 const jsWorker :Workerd.Worker = (
+  %COMPAT_DATE,
 
   compatibilityFlags = ["nodejs_compat", "rpc"],
 

--- a/src/workerd/server/tests/python/random/random.wd-test
+++ b/src/workerd/server/tests/python/random/random.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-hello",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py")
         ],

--- a/src/workerd/server/tests/python/sdk/sdk.wd-test
+++ b/src/workerd/server/tests/python/sdk/sdk.wd-test
@@ -1,6 +1,8 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const python :Workerd.Worker = (
+  %COMPAT_DATE,
   modules = [
     (name = "worker.py", pythonModule = embed "worker.py")
   ],
@@ -12,6 +14,7 @@ const python :Workerd.Worker = (
 );
 
 const server :Workerd.Worker = (
+  %COMPAT_DATE,
   modules = [
     (name = "server.py", pythonModule = embed "server.py")
   ],

--- a/src/workerd/server/tests/python/sockets/sockets.wd-test
+++ b/src/workerd/server/tests/python/sockets/sockets.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-sockets",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py")
         ],

--- a/src/workerd/server/tests/python/stack-switching-state/stack-switching-state.wd-test
+++ b/src/workerd/server/tests/python/stack-switching-state/stack-switching-state.wd-test
@@ -1,4 +1,5 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const config :Workerd.Config = (
   services = [
@@ -7,6 +8,7 @@ const config :Workerd.Config = (
 );
 
 const pyWorker :Workerd.Worker = (
+  %COMPAT_DATE,
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS],
   modules = [
     (name = "worker.py", pythonModule = embed "worker.py"),

--- a/src/workerd/server/tests/python/subdirectory/subdirectory.wd-test
+++ b/src/workerd/server/tests/python/subdirectory/subdirectory.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "main",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "a.py", pythonModule = embed "./a.py"),
           (name = "subdir/__init__.py", pythonModule = embed "./subdir/__init__.py"),

--- a/src/workerd/server/tests/python/top-level-tests/env.wd-test
+++ b/src/workerd/server/tests/python/top-level-tests/env.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "python-hello",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py")
         ],

--- a/src/workerd/server/tests/python/undefined-handler/server.mjs
+++ b/src/workerd/server/tests/python/undefined-handler/server.mjs
@@ -5,10 +5,9 @@ import { rejects } from 'node:assert';
 
 export default {
   async test(ctrl, env) {
-    await rejects(env.pythonWorker.fetch(new Request('http://example.com')), {
-      name: 'Error',
-      message:
-        'Python entrypoint "undefined_handler.py" does not export a handler named "on_fetch"',
-    });
+    await rejects(
+      env.pythonWorker.fetch(new Request('http://example.com')),
+      /Python entrypoint "undefined_handler.py" does not export a handler named "on_fetch"/
+    );
   },
 };

--- a/src/workerd/server/tests/python/undefined-handler/undefined-handler.wd-test
+++ b/src/workerd/server/tests/python/undefined-handler/undefined-handler.wd-test
@@ -1,6 +1,8 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const undefinedHandler :Workerd.Worker = (
+  %COMPAT_DATE,
   modules = [
     (name = "undefined_handler.py", pythonModule = embed "undefined_handler.py")
   ],
@@ -8,6 +10,7 @@ const undefinedHandler :Workerd.Worker = (
 );
 
 const server :Workerd.Worker = (
+  %COMPAT_DATE,
   modules = [
     (name = "server.js", esModule = embed "server.mjs")
   ],

--- a/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
+++ b/src/workerd/server/tests/python/vendor_dir/vendor_dir.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "vendor_dir",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
           (name = "duplicate.py", pythonModule = embed "vendor/a.py"),

--- a/src/workerd/server/tests/python/vendor_dir_compat_flag/vendor_dir_compat_flag.wd-test
+++ b/src/workerd/server/tests/python/vendor_dir_compat_flag/vendor_dir_compat_flag.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "vendor_dir_compat_flag",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "worker.py", pythonModule = embed "worker.py"),
           (name = "vendor/a.py", pythonModule = embed "vendor/a.py"),

--- a/src/workerd/server/tests/python/vendor_pkg_tests/beautifulsoup4_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/beautifulsoup4_vendor.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "beautifulsoup4-vendor-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "main.py", pythonModule = embed "beautifulsoup4.py"),
           %PYTHON_VENDORED_MODULES%

--- a/src/workerd/server/tests/python/vendor_pkg_tests/existing_dedicated_fastapi_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/existing_dedicated_fastapi_vendor.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "existing-dedicated-fastapi-vendor-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           # The snapshot's main module is also named worker.py. This needs to match.
           (name = "worker.py", pythonModule = embed "existing_dedicated_fastapi.py"),

--- a/src/workerd/server/tests/python/vendor_pkg_tests/fastapi_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/fastapi_vendor.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "fastapi-vendor-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "main.py", pythonModule = embed "fastapi.py"),
           %PYTHON_VENDORED_MODULES%

--- a/src/workerd/server/tests/python/vendor_pkg_tests/numpy_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/numpy_vendor.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "numpy-vendor-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "main.py", pythonModule = embed "numpy.py"),
           %PYTHON_VENDORED_MODULES%

--- a/src/workerd/server/tests/python/vendor_pkg_tests/python-workers-runtime-sdk_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/python-workers-runtime-sdk_vendor.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "workers-sdk-vendor-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "main.py", pythonModule = embed "python-workers-runtime-sdk.py"),
           %PYTHON_VENDORED_MODULES%

--- a/src/workerd/server/tests/python/vendor_pkg_tests/scipy_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/scipy_vendor.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "scipy-vendor-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "main.py", pythonModule = embed "scipy.py"),
           %PYTHON_VENDORED_MODULES%

--- a/src/workerd/server/tests/python/vendor_pkg_tests/shapely_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/shapely_vendor.wd-test
@@ -1,9 +1,11 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const unitTests :Workerd.Config = (
   services = [
     ( name = "shapely-vendor-test",
       worker = (
+        %COMPAT_DATE,
         modules = [
           (name = "main.py", pythonModule = embed "shapely.py"),
           %PYTHON_VENDORED_MODULES%

--- a/src/workerd/server/tests/python/worker-entrypoint/worker-entrypoint.wd-test
+++ b/src/workerd/server/tests/python/worker-entrypoint/worker-entrypoint.wd-test
@@ -1,4 +1,5 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const config :Workerd.Config = (
   services = [
@@ -8,6 +9,7 @@ const config :Workerd.Config = (
 );
 
 const mainWorker :Workerd.Worker = (
+  %COMPAT_DATE,
 
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "rpc", "disable_python_no_global_handlers"],
 

--- a/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
+++ b/src/workerd/server/tests/python/workflow-entrypoint/workflow-entrypoint.wd-test
@@ -1,4 +1,5 @@
 using Workerd = import "/workerd/workerd.capnp";
+%PYTHON_COMPAT_DATES_IMPORT;
 
 const config :Workerd.Config = (
   services = [
@@ -9,6 +10,7 @@ const config :Workerd.Config = (
 );
 
 const pyWorker :Workerd.Worker = (
+  %COMPAT_DATE,
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "python_workflows_implicit_dependencies"],
 
   modules = [
@@ -21,6 +23,7 @@ const pyWorker :Workerd.Worker = (
 );
 
 const pyWorkerOld :Workerd.Worker = (
+  %COMPAT_DATE,
   compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "python_workflows", "no_python_workflows_implicit_dependencies"],
 
   modules = [
@@ -33,6 +36,7 @@ const pyWorkerOld :Workerd.Worker = (
 );
 
 const jsWorker :Workerd.Worker = (
+  %COMPAT_DATE,
   compatibilityFlags = ["nodejs_compat", "rpc"],
 
   modules = [

--- a/src/workerd/server/workerd.c++
+++ b/src/workerd/server/workerd.c++
@@ -1493,7 +1493,6 @@ class CliMain final: public SchemaFileImpl::ErrorReporter {
     KJ_IF_SOME(compatDate, testCompatDate) {
       server->setTestCompatibilityDateOverride(kj::str(compatDate));
     }
-
     // Enable loopback sockets in tests only.
     network.enableLoopback();
 


### PR DESCRIPTION
The goal here is to increase the real-world relevance of the tests. Before this
change, we test the oldest compat date and the newest compat date if we run
these variants but we don't test compat dates from the range that are most
likely to be used with each Python variant. This makes it so that each Python
test passes the enable date of the Python version it uses as the compat date.

I added a `no_default_compat_date` option to wd_test to remove the
`--compat-date=...` argument because we get the compat dates directly from
compatibility-date.capnp which can't flow into starlark so we can't pass it as
the `compat_date` argument to `wd_test`. Instead, I template the dates into the
wd-test file.

I took the minimum of the date in `maximum-compatibility-date.txt` and the
enable date to deal with flags with future enable dates. I also added an extra
`--allow-future-compatibility-date` flag to workerd since it seems that
`maximum-compatibility-date.txt` can contain future dates which workerd normally
rejects.

Only quite minor changes were needed to the actual tests. I separated the
template changes into a different commit because they are noisy.

cc @fhanau 