### PR TITLE
Preserve predecessor rejection delivery state

### DIFF
--- a/src/workerd/api/actor-fetch-retry-test.c++
+++ b/src/workerd/api/actor-fetch-retry-test.c++
@@ -109,6 +109,7 @@ enum class ReplayFailure {
   NOT_DELIVERED,
   DELIVERED,
   CLAIM_REJECTED,
+  PREDECESSOR_REJECTED,
   SLOW_RESPONSE,
   RETRY_DELAY_EXCEEDS_BUDGET,
 };
@@ -228,15 +229,19 @@ class ReplayFetchTarget final: public WorkerInterface {
         auto exception = failure == ReplayFailure::CLAIM_REJECTED
             ? KJ_EXCEPTION(FAILED, "actor retry claim rejected")
             : KJ_EXCEPTION(DISCONNECTED, "actor fetch disconnected");
-        if (failure == ReplayFailure::NOT_DELIVERED) {
-          exception.setDetail(
-              jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID, kj::heapArray<kj::byte>(0));
+        if (failure == ReplayFailure::NOT_DELIVERED ||
+            failure == ReplayFailure::PREDECESSOR_REJECTED) {
+          jsg::markActorRequestNotDelivered(exception);
         } else if (failure == ReplayFailure::DELIVERED) {
           exception.setDetail(
               jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID, kj::heapArray<kj::byte>(0));
-        } else if (failure == ReplayFailure::CLAIM_REJECTED) {
+        }
+        if (failure == ReplayFailure::CLAIM_REJECTED) {
           exception.setDetail(
               jsg::ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID, kj::heapArray<kj::byte>(0));
+        } else if (failure == ReplayFailure::PREDECESSOR_REJECTED) {
+          exception.setDetail(
+              jsg::ACTOR_PREDECESSOR_REJECTED_DETAIL_ID, kj::heapArray<kj::byte>(0));
         }
         kj::throwRecoverableException(kj::mv(exception));
       }
@@ -586,6 +591,25 @@ KJ_TEST("actor fetch updates retry metadata and rewinds the body") {
   for (auto& body: state.requestBodies) {
     KJ_EXPECT(body == "request body"_kj.asBytes());
   }
+}
+
+KJ_TEST("actor fetch retries a predecessor rejection as a fresh attempt") {
+  ReplayState state{.failures = kj::arr(ReplayFailure::PREDECESSOR_REJECTED)};
+  KJ_EXPECT(runActorFetch(state, ActorRetryGateEnabled::YES, "request body"_kj,
+                ActorFetchKind::HTTP) == kj::none);
+
+  KJ_EXPECT(state.requestCount == 2);
+  KJ_EXPECT(state.retryCount == 1);
+  KJ_ASSERT(state.metadata.size() == 2);
+  KJ_EXPECT(state.metadata[0].nonce != state.metadata[1].nonce);
+  KJ_EXPECT(state.metadata[0].isRetry == IsActorRetry::NO);
+  KJ_EXPECT(state.metadata[1].isRetry == IsActorRetry::NO);
+  KJ_ASSERT(state.countSubrequests.size() == 2);
+  KJ_EXPECT(state.countSubrequests[0] == CountSubrequest::YES);
+  KJ_EXPECT(state.countSubrequests[1] == CountSubrequest::NO);
+  KJ_ASSERT(state.requestBodies.size() == 2);
+  KJ_EXPECT(state.requestBodies[0] == "request body"_kj.asBytes());
+  KJ_EXPECT(state.requestBodies[1] == "request body"_kj.asBytes());
 }
 
 KJ_TEST("actor fetch does not retry when the enforce gate is disabled") {

--- a/src/workerd/io/worker-entrypoint-test.c++
+++ b/src/workerd/io/worker-entrypoint-test.c++
@@ -4,6 +4,7 @@
 
 #include "worker-entrypoint.h"
 
+#include <workerd/jsg/util.h>
 #include <workerd/tests/test-fixture.h>
 
 #include <kj/test.h>
@@ -194,6 +195,74 @@ class RecordingObserver final: public RequestObserver, public WorkerInterface {
  private:
   kj::Maybe<WorkerInterface&> inner;
 };
+
+class PredecessorRejectedObserver final: public RequestObserver {
+ public:
+  void claimRetryTokenBeforeUserCode() override {
+    auto exception = KJ_EXCEPTION(DISCONNECTED, "request rejected before user code");
+    jsg::markActorRequestNotDelivered(exception);
+    exception.setDetail(jsg::ACTOR_PREDECESSOR_REJECTED_DETAIL_ID, kj::heapArray<kj::byte>(0));
+    kj::throwFatalException(kj::mv(exception));
+  }
+};
+
+KJ_TEST("actor fetch preserves a predecessor rejection before user code") {
+  TestFixture fixture(TestFixture::SetupParams{
+    .actorId = Worker::Actor::Id(kj::str("not-delivered-test")),
+    .requestObserverFactory = kj::Function<kj::Own<RequestObserver>()>(
+        []() -> kj::Own<RequestObserver> { return kj::refcounted<PredecessorRejectedObserver>(); }),
+  });
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+  kj::HttpHeaderTable headerTable;
+  kj::HttpHeaders headers(headerTable);
+  kj::NullStream requestBody;
+  TestResponse response;
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    entrypoint->request(kj::HttpMethod::GET, "https://example.com", headers, requestBody, response)
+        .wait(fixture.getWaitScope());
+  });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getType() == kj::Exception::Type::DISCONNECTED, e);
+  KJ_EXPECT(e.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none, e);
+  KJ_EXPECT(e.getDetail(jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID) == kj::none, e);
+  KJ_EXPECT(e.getDetail(jsg::ACTOR_PREDECESSOR_REJECTED_DETAIL_ID) != kj::none, e);
+}
+
+class UnqualifiedNotDeliveredObserver final: public RequestObserver {
+ public:
+  void claimRetryTokenBeforeUserCode() override {
+    auto exception = KJ_EXCEPTION(DISCONNECTED, "request rejected before user code");
+    jsg::markActorRequestNotDelivered(exception);
+    kj::throwFatalException(kj::mv(exception));
+  }
+};
+
+KJ_TEST("actor fetch does not preserve an unqualified not-delivered marker") {
+  TestFixture fixture(TestFixture::SetupParams{
+    .actorId = Worker::Actor::Id(kj::str("not-delivered-test")),
+    .requestObserverFactory =
+        kj::Function<kj::Own<RequestObserver>()>([]() -> kj::Own<RequestObserver> {
+    return kj::refcounted<UnqualifiedNotDeliveredObserver>();
+  }),
+  });
+  auto entrypoint = fixture.makeWorkerEntrypoint();
+  kj::HttpHeaderTable headerTable;
+  kj::HttpHeaders headers(headerTable);
+  kj::NullStream requestBody;
+  TestResponse response;
+
+  auto exception = kj::runCatchingExceptions([&]() {
+    entrypoint->request(kj::HttpMethod::GET, "https://example.com", headers, requestBody, response)
+        .wait(fixture.getWaitScope());
+  });
+
+  auto& e = KJ_ASSERT_NONNULL(exception);
+  KJ_EXPECT(e.getType() == kj::Exception::Type::DISCONNECTED, e);
+  KJ_EXPECT(e.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) == kj::none, e);
+  KJ_EXPECT(e.getDetail(jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none, e);
+}
 
 KJ_TEST("connect pass-through tags failures after delivery") {
   capnp::MallocMessageBuilder flagsMessage;

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -613,10 +613,19 @@ kj::Promise<void> WorkerEntrypoint::requestImpl(kj::HttpMethod method,
       // `delivered()` in Stage 1), so user code may have run. Annotate DISCONNECTED failures so the
       // caller-side actor-call classifier knows this failure must not be retried as a fresh
       // delivery. Only DISCONNECTED failures participate in the delivery-position metric, so other
-      // exception types need no annotation. Set before exceptionToPropagate() so it survives the
-      // internal-exception description rewrite; the detail serializes back across the RPC boundary.
+      // exception types need no annotation. Preserve not-delivered only for a predecessor rejection,
+      // which occurs before user code despite crossing this entrypoint. Set before
+      // exceptionToPropagate() so the detail survives the internal-exception description rewrite
+      // and serializes back across the RPC boundary.
       if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
-        exception.setDetail(jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID, kj::heapArray<kj::byte>(0));
+        bool predecessorRejected =
+            exception.getDetail(jsg::ACTOR_PREDECESSOR_REJECTED_DETAIL_ID) != kj::none &&
+            exception.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none;
+        if (!predecessorRejected) {
+          exception.releaseDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID);
+          exception.setDetail(
+              jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID, kj::heapArray<kj::byte>(0));
+        }
       }
       // TODO(cleanup): We'd really like to tunnel exceptions any time a worker is calling another
       // worker, not just for actors (and W2W below), but getting that right will require cleaning

--- a/src/workerd/jsg/util.h
+++ b/src/workerd/jsg/util.h
@@ -97,12 +97,19 @@ constexpr kj::Exception::DetailTypeId TUNNELED_EXCEPTION_DETAIL_ID = 0xe80272921
 // Detail type for JavaScript exception metadata (error type and stack trace)
 constexpr kj::Exception::DetailTypeId JS_EXCEPTION_METADATA_DETAIL_ID = 0xa9ae63464030fcefull;
 
-// Set on a DISCONNECTED actor-call failure that is known to have occurred BEFORE the call reached
-// the actor (i.e. user code definitely never ran). Such failures are safe to retry as a fresh
-// attempt. Set by edgeworker's pre-delivery routing/getActor failure paths; read by the caller-side
-// actor-call classifier. The payload is a zero-length array (marker only).
+// Set on a DISCONNECTED actor-call failure for an attempt that definitely did not enter user code.
+// Such failures are safe to retry; the caller decides whether to reuse the logical call's token
+// based on earlier attempts. Set by edgeworker's pre-delivery routing and getActor failure paths,
+// and by sandbox-side rejections before user code; read by the caller-side actor-call classifier.
+// The payload is a zero-length array (marker only).
 constexpr kj::Exception::DetailTypeId REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID =
     0x1a07d0b6559baea6ull;
+
+inline void markActorRequestNotDelivered(kj::Exception& exception) {
+  if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
+    exception.setDetail(REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID, kj::heapArray<kj::byte>(0));
+  }
+}
 
 // Set on a failure that is known to have occurred AFTER the call reached the actor (user code may
 // have run). Must not be retried as a delivery failure. Set at the receiving entrypoint's actor
@@ -111,9 +118,13 @@ constexpr kj::Exception::DetailTypeId REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID =
 constexpr kj::Exception::DetailTypeId REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID = 0x7f6e0bece261e8eeull;
 
 // Set when an actor invocation is rejected before user code because its retry token could not be
-// claimed. This distinguishes a claim rejection from other delivery failures so a caller can avoid
-// retrying it. The payload is a zero-length array (marker only).
+// claimed. This distinguishes a terminal claim rejection from other delivery failures. The payload
+// is a zero-length array (marker only).
 constexpr kj::Exception::DetailTypeId ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID = 0x6fb3a97323600af2ull;
+
+// Set when a draining predecessor rejects an actor invocation before user code. The caller can
+// retry the request against the replacement actor. The payload is a zero-length array (marker only).
+constexpr kj::Exception::DetailTypeId ACTOR_PREDECESSOR_REJECTED_DETAIL_ID = 0xaef1c0c972f21fe7ull;
 
 // Detail type for Durable Object metadata on exceptions propagated out of actor execution.
 constexpr kj::Exception::DetailTypeId DURABLE_OBJECT_EXCEPTION_METADATA_DETAIL_ID =


### PR DESCRIPTION
Keep draining-predecessor rejections distinct from terminal retry claim failures. Preserve their not-delivered state through the actor entrypoint so callers can retry safely.