### PR TITLE
Enable perfetto in workerd v8 build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -87,6 +87,13 @@ build:macos --per_file_copt=v8/src/heap/heap.cc@-O3
 # causing compile errors. Undefine DEBUG to match Linux behavior.
 build:macos --copt=-UDEBUG
 
+# Keep workerd and V8's Perfetto build configurations in sync.
+build:perfetto --//src/workerd/util:use_perfetto=True
+build:perfetto --@v8//:v8_use_perfetto=True
+build:no-perfetto --//src/workerd/util:use_perfetto=False
+build:no-perfetto --@v8//:v8_use_perfetto=False
+build:unix --config=perfetto
+
 # Increasing the optimization level of V8 significantly speeds up tests using V8 a lot, especially
 # python tests. This is useful for both CI and local development and enabled by default, but still
 # kept in a separate configuration to make it easy to disable.

--- a/build/deps/v8.MODULE.bazel
+++ b/build/deps/v8.MODULE.bazel
@@ -62,6 +62,7 @@ PATCHES = [
     "0037-Fix-CFunction-MemorySpan-declarations-on-Windows.patch",
     "0038-Properly-depend-on-llvm-libc.patch",
     "0039-Fix-TSan-build-without-the-V8-sandbox.patch",
+    "0040-Enable-Perfetto-support-in-the-V8-Bazel-build.patch",
 ]
 
 http_archive(
@@ -96,9 +97,6 @@ bazel_dep(name = "workerd-v8")
 # This is overridden in the internal non-OSS repo.
 #
 # TODO(cleanup): There must be a better way to do this?
-# TODO(soon): Figure out how to build v8 with perfetto enabled. It does not appear
-#             as if the v8 bazel build currently includes support for building with
-#             perfetto enabled as an option.
 local_path_override(
     module_name = "workerd-v8",
     path = "build/workerd-v8",

--- a/patches/v8/0040-Enable-Perfetto-support-in-the-V8-Bazel-build.patch
+++ b/patches/v8/0040-Enable-Perfetto-support-in-the-V8-Bazel-build.patch
@@ -1,0 +1,116 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: James M Snell <jsnell@cloudflare.com>
+Date: Wed, 2 Sep 2026 12:00:00 +0000
+Subject: Enable Perfetto support in the V8 Bazel build
+
+Mirror the non-SDK v8_use_perfetto configuration from BUILD.gn. V8's
+Bazel build does not currently expose this configuration, despite the
+implementation being present in the source tree.
+
+Use V8's standard v8_flag mechanism so the define, sources, and
+Perfetto dependency are controlled together.
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 3a4f48806cd0018a70cfa9cda0c192c2e55ffaa1..1111111111111111111111111111111111111111 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -190,8 +190,10 @@ v8_flag(
+ v8_flag(
+     name = "v8_use_host_cpu_arm_features",
+     default = True,
+ )
+-
++
++v8_flag(name = "v8_use_perfetto")
++
+ # Default setting for v8_enable_maglev
+ selects.config_setting_group(
+     name = "maglev_by_default",
+@@ -543,10 +545,11 @@ v8_config(
+         "v8_enable_seeded_array_index_hash": "V8_ENABLE_SEEDED_ARRAY_INDEX_HASH",
+         "v8_jitless": "V8_JITLESS",
+         "v8_enable_vtunejit": "ENABLE_VTUNE_JIT_INTERFACE",
+         "v8_enable_undefined_double": "V8_ENABLE_UNDEFINED_DOUBLE",
+         "v8_use_host_cpu_arm_features": "V8_USE_HOST_CPU_ARM_FEATURES",
++        "v8_use_perfetto": "V8_USE_PERFETTO",
+         "v8_use_zlib": "V8_USE_ZLIB",
+     },
+     defines = [
+         "GOOGLE3",
+         "V8_ADVANCED_BIGINT_ALGORITHMS",
+@@ -1070,17 +1073,23 @@ filegroup(
+         "src/libplatform/delayed-task-queue.h",
+         "src/libplatform/task-queue.cc",
+         "src/libplatform/task-queue.h",
+         "src/libplatform/tracing/recorder.h",
+-        "src/libplatform/tracing/trace-buffer.cc",
+-        "src/libplatform/tracing/trace-buffer.h",
+         "src/libplatform/tracing/trace-config.cc",
+-        "src/libplatform/tracing/trace-object.cc",
+-        "src/libplatform/tracing/trace-writer.cc",
+-        "src/libplatform/tracing/trace-writer.h",
+         "src/libplatform/tracing/tracing-controller.cc",
+         "src/libplatform/worker-thread.cc",
+         "src/libplatform/worker-thread.h",
+-    ],
++    ] + select({
++        ":is_v8_use_perfetto": [
++            "src/libplatform/tracing/trace-event-listener.h",
++        ],
++        "//conditions:default": [
++            "src/libplatform/tracing/trace-buffer.cc",
++            "src/libplatform/tracing/trace-buffer.h",
++            "src/libplatform/tracing/trace-object.cc",
++            "src/libplatform/tracing/trace-writer.cc",
++            "src/libplatform/tracing/trace-writer.h",
++        ],
++    }),
+ )
+ 
+ filegroup(
+@@ -2722,7 +2731,6 @@ filegroup(
+         "src/tracing/perfetto-sdk.h",
+         "src/tracing/trace-event.cc",
+         "src/tracing/trace-event.h",
+-        "src/tracing/trace-event-no-perfetto.h",
+         "src/tracing/trace-id.h",
+         "src/tracing/traced-value.cc",
+         "src/tracing/traced-value.h",
+@@ -2785,6 +2793,22 @@ filegroup(
+         ":generated_bytecode_builtins_list",
+         ":v8_bigint",
+         ":v8_heap_base_files",
++    ] + select({
++        ":is_v8_use_perfetto": [
++            "include/v8-trace-categories.h",
++            "src/tracing/code-data-source.cc",
++            "src/tracing/code-data-source.h",
++            "src/tracing/code-trace-context.h",
++            "src/tracing/perfetto-logger.cc",
++            "src/tracing/perfetto-logger.h",
++            "src/tracing/perfetto-utils.cc",
++            "src/tracing/perfetto-utils.h",
++            "src/tracing/trace-categories.cc",
++            "src/tracing/trace-categories.h",
++        ],
++        "//conditions:default": [
++            "src/tracing/trace-event-no-perfetto.h",
++        ],
+-    ] + select({
++    }) + select({
+         "@v8//bazel/config:v8_target_ia32": [
+             "src/baseline/ia32/baseline-assembler-ia32-inl.h",
+@@ -4726,7 +4748,10 @@ v8_library(
+         "@simdutf",
+         "@zlib",
+         "@zlib//:compression_utils_portable",
+-    ],
++    ] + select({
++        ":is_v8_use_perfetto": ["@perfetto//:libperfetto_client_experimental"],
++        "//conditions:default": [],
++    }),
+ )
+ 
+ v8_library(
+-- 
+2.39.5

--- a/src/workerd/io/per-isolate-bootstrap.c++
+++ b/src/workerd/io/per-isolate-bootstrap.c++
@@ -12,6 +12,7 @@
 #include <workerd/jsg/jsvalue.h>
 #include <workerd/jsg/util.h>
 #include <workerd/util/autogate.h>
+#include <workerd/util/use-perfetto-categories.h>
 
 #include <per_isolate/per_isolate.capnp.h>
 
@@ -489,13 +490,19 @@ void runPerIsolateBootstrap(jsg::Lock& js, CompatibilityFlags::Reader flags) {
   // The result is cached in state and injected as a pseudo-global into every
   // subsequent script via the context extension object.
   JSG_TRY(js) {
-    auto result =
-        state->requireFn.getHandle(js).call(js, js.undefined(), js.strIntern("primordials"_kj));
-    state->primordials = result.addRef(js);
+    {
+      TRACE_EVENT("workerd", "PerIsolateBootrap::primordials");
+      auto result =
+          state->requireFn.getHandle(js).call(js, js.undefined(), js.strIntern("primordials"_kj));
+      state->primordials = result.addRef(js);
+    }
 
-    // Run the entry point. This synchronously executes main.js, which may
-    // require() other scripts. All execution is synchronous.
-    state->requireFn.getHandle(js).call(js, js.undefined(), js.strIntern("main"_kj));
+    {
+      TRACE_EVENT("workerd", "PerIsolateBootstrap::main");
+      // Run the entry point. This synchronously executes main.js, which may
+      // require() other scripts. All execution is synchronous.
+      state->requireFn.getHandle(js).call(js, js.undefined(), js.strIntern("main"_kj));
+    }
 
     if (!flags.getJsWeakRef()) {
       jsg::deleteWeakRefGlobals(js.v8Isolate, context);

--- a/src/workerd/io/worker.c++
+++ b/src/workerd/io/worker.c++
@@ -34,6 +34,7 @@
 #include <workerd/util/mimetype.h>
 #include <workerd/util/stream-utils.h>
 #include <workerd/util/thread-scopes.h>
+#include <workerd/util/use-perfetto-categories.h>
 #include <workerd/util/uuid.h>
 #include <workerd/util/xthreadnotifier.h>
 
@@ -153,6 +154,7 @@ void maybePerIsolateBootstrap(CompatibilityFlags::Reader& featureFlags,
     v8::Local<v8::Context> context,
     kj::Maybe<ValidationErrorReporter&> errorReporter) {
   if (util::Autogate::isEnabled(util::AutogateKey::PER_ISOLATE_JAVASCRIPT_BOOTSTRAP)) {
+    TRACE_EVENT("workerd", "Worker::perIsolateBootstrap");
     JSG_WITHIN_CONTEXT_SCOPE(
         lock, context, [&](jsg::Lock& js) { runPerIsolateBootstrap(js, featureFlags); });
   } else if (featureFlags.getTypeScriptImplementedStreams()) {

--- a/src/workerd/util/BUILD.bazel
+++ b/src/workerd/util/BUILD.bazel
@@ -19,6 +19,7 @@ selects.config_setting_group(
         ":set_use_perfetto",
         "//:is_unix",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # The routing layer owning the unprefixed zlib symbol names; @zlib//:zlib depends on this, so


### PR DESCRIPTION
Patches v8's bazel build to allow building v8 with perfetto enabled.

Also, add perfetto traces for per-isolate boostrap.