### PR TITLE
[build] Disable unsupported tests under RBE, improve hermeticity

### DIFF
--- a/build/wd_test.bzl
+++ b/build/wd_test.bzl
@@ -241,6 +241,12 @@ def _wd_test_impl(ctx):
     )
 
     runfiles = ctx.runfiles(files = ctx.files.data)
+
+    # Add runfiles for the workerd binary, such as shared libraries (if any)
+    workerd_runfiles = ctx.attr.workerd[DefaultInfo].default_runfiles
+    if workerd_runfiles:
+        runfiles = runfiles.merge(workerd_runfiles)
+
     if ctx.file.sidecar:
         runfiles = runfiles.merge(ctx.runfiles(files = [ctx.file.sidecar]))
 

--- a/build/wpt_test.bzl
+++ b/build/wpt_test.bzl
@@ -22,7 +22,7 @@ PORT_BINDINGS = [
 ### (Invokes wpt_js_test_gen, wpt_wd_test_gen and wd_test to assemble a complete test suite.)
 ### -----------------------------------------------------------------------------------------
 
-def wpt_test(name, wpt_directory, config, compat_date = "", compat_flags = [], autogates = [], start_server = False, **kwargs):
+def wpt_test(name, wpt_directory, config, compat_date = "", compat_flags = [], autogates = [], start_server = False, tags = [], **kwargs):
     """
     Main entry point.
 
@@ -98,6 +98,8 @@ def wpt_test(name, wpt_directory, config, compat_date = "", compat_flags = [], a
         # blobs emitted by the WPT harness and break tools/cross/wpt_logs.py parsing.
         predictable = False,
         data = data,
+        # WPT tests are not supported in RBE so far
+        tags = tags + ["no-remote-exec"],
         **kwargs
     )
 

--- a/src/workerd/api/node/tests/BUILD.bazel
+++ b/src/workerd/api/node/tests/BUILD.bazel
@@ -409,7 +409,11 @@ wd_test(
     src = "dns-nodejs-test.wd-test",
     args = ["--experimental"],
     data = ["dns-nodejs-test.js"],
-    tags = ["requires-network"],
+    # Requires network access and certificates not available in RBE
+    tags = [
+        "no-remote-exec",
+        "requires-network",
+    ],
 )
 
 js_binary(

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -1212,7 +1212,11 @@ wd_test(
     src = "worker-loader-test.wd-test",
     args = ["--experimental"],
     data = ["worker-loader-test.js"],
-    tags = ["requires-network"],
+    # Needs to fetch pyodide which is not supported under RBE
+    tags = [
+        "no-remote-exec",
+        "requires-network",
+    ],
 )
 
 wd_test(

--- a/src/workerd/server/tests/compile-tests/BUILD.bazel
+++ b/src/workerd/server/tests/compile-tests/BUILD.bazel
@@ -15,5 +15,9 @@ sh_test(
         "//samples:helloworld/worker.js",
         "//src/workerd/server:workerd",
     ],
-    tags = ["no-qemu"],
+    # Requires curl, which may not be available under remote execution
+    tags = [
+        "no-qemu",
+        "no-remote-exec",
+    ],
 )


### PR DESCRIPTION
Expands RBE support to running workerd tests, with few exclusions. See downstream PR (to follow) for more context.