### PR TITLE
Update capnp-cpp to pick up Executor::isCurrent()

### DIFF
--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -27,10 +27,10 @@ bazel_dep(name = "brotli", version = "1.2.0.bcr.3")
 # capnp-cpp
 http.archive(
     name = "capnp-cpp",
-    sha256 = "d968608e08b40b3a8df43ff44d641ca6db3f9b9547b6decff2ddff4d19e9dae3",
-    strip_prefix = "capnproto-capnproto-f984ac8/c++",
+    sha256 = "73a3f249ec2a835abaeb8f3caa5bddde044312f2c65b6353a788028b5b7e59f2",
+    strip_prefix = "capnproto-capnproto-7077d44/c++",
     type = "tgz",
-    url = "https://github.com/capnproto/capnproto/tarball/f984ac8096a488fb0053b717e646ee2542b66480",
+    url = "https://github.com/capnproto/capnproto/tarball/7077d443af81e94ea923e41b9990f697058e3b56",
 )
 use_repo(http, "capnp-cpp")
 


### PR DESCRIPTION
Bumps the capnp-cpp pin to the current v2 head (`7077d44`), a small delta over the previous pin (`f984ac8`) that picks up [capnproto/capnproto#2811](https://github.com/capnproto/capnproto/pull/2811): `kj::Executor::isCurrent()` and `kj::tryGetCurrentThreadExecutor()`.

The kj-rs async-bridge rework in #7010 depends on these to replace its exception-catching "is there a current executor" probe, so this bump needs to land before that stack.

Validated locally: `bazel test //src/rust/...` and a full `workerd` build against the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)