### PR TITLE
STOR-5489: Observe Durable Object fetch retry activity

### DIFF
--- a/src/workerd/api/actor-fetch-retry-test.c++
+++ b/src/workerd/api/actor-fetch-retry-test.c++
@@ -163,8 +163,40 @@ struct ReplayState {
   uint requestCount = 0;
   uint webSocketRequestCount = 0;
   uint retryCount = 0;
+  uint observedRetryCount = 0;
+  uint observedOutcomeCounts[static_cast<size_t>(ActorRetryOutcome::COUNT)] = {};
   kj::Maybe<DeterministicTimerChannel&> timerChannel;
 };
+
+class RetryRecordingObserver final: public RequestObserver {
+ public:
+  explicit RetryRecordingObserver(ReplayState& state): state(state) {}
+
+  void recordActorRetry(ActorRetryCallType callType) override {
+    KJ_EXPECT(callType == ActorRetryCallType::FETCH);
+    ++state.observedRetryCount;
+  }
+
+  void recordActorRetryOutcome(ActorRetryCallType callType, ActorRetryOutcome outcome) override {
+    KJ_EXPECT(callType == ActorRetryCallType::FETCH);
+    ++state.observedOutcomeCounts[static_cast<size_t>(outcome)];
+  }
+
+ private:
+  ReplayState& state;
+};
+
+uint outcomeCount(const ReplayState& state, ActorRetryOutcome outcome) {
+  return state.observedOutcomeCounts[static_cast<size_t>(outcome)];
+}
+
+uint totalOutcomeCount(const ReplayState& state) {
+  uint result = 0;
+  for (auto count: state.observedOutcomeCounts) {
+    result += count;
+  }
+  return result;
+}
 
 class ReplayFetchTarget final: public WorkerInterface {
  public:
@@ -289,6 +321,10 @@ kj::Maybe<kj::Exception> runActorFetch(ReplayState& state,
     .ioChannelFactory = kj::Function<kj::Rc<IoChannelFactory>(TimerChannel&)>(
         [&](TimerChannel&) -> kj::Rc<IoChannelFactory> {
     return kj::rc<TestFixture::DummyIoChannelFactory>(timerChannel);
+  }),
+    .requestObserverFactory =
+        kj::Function<kj::Own<RequestObserver>()>([&]() -> kj::Own<RequestObserver> {
+    return kj::refcounted<RetryRecordingObserver>(state);
   }),
   });
   if (retryGateEnabled.toBool()) {
@@ -528,6 +564,9 @@ KJ_TEST("actor fetch updates retry metadata and rewinds the body") {
   KJ_ASSERT(state.metadata.size() == 4);
   KJ_EXPECT(state.requestCount == 4);
   KJ_EXPECT(state.retryCount == 3);
+  KJ_EXPECT(state.observedRetryCount == 3);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::RECOVERED) == 1);
+  KJ_EXPECT(totalOutcomeCount(state) == 1);
   KJ_EXPECT(state.metadata[0].nonce != state.metadata[1].nonce);
   KJ_EXPECT(state.metadata[1].nonce == state.metadata[2].nonce);
   KJ_EXPECT(state.metadata[1].nonce == state.metadata[3].nonce);
@@ -558,6 +597,8 @@ KJ_TEST("actor fetch does not retry when the enforce gate is disabled") {
   KJ_EXPECT(state.retryCount == 0);
   KJ_ASSERT(state.metadata.size() == 1);
   KJ_EXPECT(state.metadata[0].retryGateEnabled == ActorRetryGateEnabled::NO);
+  KJ_EXPECT(state.observedRetryCount == 0);
+  KJ_EXPECT(totalOutcomeCount(state) == 0);
 }
 
 KJ_TEST("actor fetch does not retry a delivered disconnect") {
@@ -567,6 +608,7 @@ KJ_TEST("actor fetch does not retry a delivered disconnect") {
       runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) != kj::none);
   KJ_EXPECT(state.requestCount == 1);
   KJ_EXPECT(state.retryCount == 0);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::UNABLE_TO_RETRY) == 1);
 }
 
 KJ_TEST("actor fetch stops after a retry claim rejection") {
@@ -580,6 +622,9 @@ KJ_TEST("actor fetch stops after a retry claim rejection") {
   KJ_EXPECT(!failure.getDescription().contains("claim rejected"), failure);
   KJ_EXPECT(state.requestCount == 2);
   KJ_EXPECT(state.retryCount == 1);
+  KJ_EXPECT(state.observedRetryCount == 1);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::UNABLE_TO_RETRY) == 1);
+  KJ_EXPECT(totalOutcomeCount(state) == 1);
 }
 
 KJ_TEST("actor fetch normalizes an initial retry claim rejection") {
@@ -591,6 +636,7 @@ KJ_TEST("actor fetch normalizes an initial retry claim rejection") {
   KJ_EXPECT(!failure.getDescription().contains("claim rejected"), failure);
   KJ_EXPECT(state.requestCount == 1);
   KJ_EXPECT(state.retryCount == 0);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::UNABLE_TO_RETRY) == 1);
 }
 
 KJ_TEST("actor WebSocket fetch retries a disconnected handshake") {
@@ -604,6 +650,8 @@ KJ_TEST("actor WebSocket fetch retries a disconnected handshake") {
   KJ_EXPECT(state.requestCount == 2);
   KJ_EXPECT(state.webSocketRequestCount == 2);
   KJ_EXPECT(state.retryCount == 1);
+  KJ_EXPECT(state.observedRetryCount == 1);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::RECOVERED) == 1);
   KJ_EXPECT(state.acceptedWebSocket != kj::none);
 }
 
@@ -614,6 +662,10 @@ KJ_TEST("actor fetch honors an abort before retrying") {
     .autogates = kj::arr<kj::StringPtr>(
         "durable-object-retries-fetch"_kj, "durable-object-retries-fetch-retry-requests"_kj),
     .useRealTimers = true,
+    .requestObserverFactory =
+        kj::Function<kj::Own<RequestObserver>()>([&]() -> kj::Own<RequestObserver> {
+    return kj::refcounted<RetryRecordingObserver>(state);
+  }),
   });
 
   fixture.runInIoContext([&](const TestFixture::Environment& env) {
@@ -636,6 +688,9 @@ KJ_TEST("actor fetch honors an abort before retrying") {
   KJ_EXPECT(exception.getDescription().contains("The operation was aborted"), exception);
   KJ_EXPECT(state.requestCount == 1);
   KJ_EXPECT(state.retryCount == 0);
+  KJ_EXPECT(state.observedRetryCount == 0);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::OTHER) == 1);
+  KJ_EXPECT(totalOutcomeCount(state) == 1);
 }
 
 KJ_TEST("actor fetch stops after five attempts") {
@@ -648,6 +703,9 @@ KJ_TEST("actor fetch stops after five attempts") {
       runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) != kj::none);
   KJ_EXPECT(state.requestCount == 5);
   KJ_EXPECT(state.retryCount == 4);
+  KJ_EXPECT(state.observedRetryCount == 4);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::RETRIES_EXHAUSTED) == 1);
+  KJ_EXPECT(totalOutcomeCount(state) == 1);
 }
 
 KJ_TEST("actor fetch allows an in-flight retry to finish after the start budget") {
@@ -659,6 +717,8 @@ KJ_TEST("actor fetch allows an in-flight retry to finish after the start budget"
       runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) == kj::none);
   KJ_EXPECT(state.requestCount == 2);
   KJ_EXPECT(state.retryCount == 1);
+  KJ_EXPECT(state.observedRetryCount == 1);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::RECOVERED) == 1);
 }
 
 KJ_TEST("actor fetch does not start a retry after the start budget") {
@@ -670,6 +730,9 @@ KJ_TEST("actor fetch does not start a retry after the start budget") {
       runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) != kj::none);
   KJ_EXPECT(state.requestCount == 1);
   KJ_EXPECT(state.retryCount == 1);
+  KJ_EXPECT(state.observedRetryCount == 0);
+  KJ_EXPECT(outcomeCount(state, ActorRetryOutcome::RETRIES_EXHAUSTED) == 1);
+  KJ_EXPECT(totalOutcomeCount(state) == 1);
 }
 
 KJ_TEST("replica actor fetch retries a request-level disconnect on its primary channel") {

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1471,9 +1471,46 @@ namespace {
 // Fetch spec requires (suggests?) 20: https://fetch.spec.whatwg.org/#http-redirect-fetch
 constexpr auto MAX_REDIRECT_COUNT = 20;
 
+class ActorRetryMetrics final: public kj::Refcounted {
+ public:
+  explicit ActorRetryMetrics(RequestObserver& observer): observer(kj::addRef(observer)) {}
+
+  ~ActorRetryMetrics() noexcept(false) {
+    if (sawRetryRelevantFailure && !recordedOutcome) {
+      recordOutcome(ActorRetryOutcome::OTHER);
+    }
+  }
+
+  void noteRetryRelevantFailure() {
+    sawRetryRelevantFailure = true;
+  }
+
+  void observeAttemptFailure(const kj::Exception& exception) {
+    if (exception.getType() == kj::Exception::Type::DISCONNECTED ||
+        exception.getDetail(jsg::ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID) != kj::none) {
+      noteRetryRelevantFailure();
+    }
+  }
+
+  void recordRetry() {
+    observer->recordActorRetry(ActorRetryCallType::FETCH);
+  }
+
+  void recordOutcome(ActorRetryOutcome outcome) {
+    if (recordedOutcome) return;
+    recordedOutcome = true;
+    observer->recordActorRetryOutcome(ActorRetryCallType::FETCH, outcome);
+  }
+
+ private:
+  kj::Own<RequestObserver> observer;
+  bool sawRetryRelevantFailure = false;
+  bool recordedOutcome = false;
+};
+
 class ActorFetchRetryState {
  public:
-  static ActorFetchRetryState create(TimerChannel& timer);
+  static ActorFetchRetryState create(TimerChannel& timer, RequestObserver& observer);
 
   IoChannelFactory::ActorRetryRequestMetadata getMetadata() const {
     return metadata;
@@ -1489,6 +1526,16 @@ class ActorFetchRetryState {
 
   kj::Maybe<kj::Exception> checkDeadline();
   kj::OneOf<kj::Duration, kj::Exception> prepareRetry(kj::Exception exception);
+  void recordRetry() {
+    if (attemptCount > 1) {
+      metrics->recordRetry();
+    }
+  }
+  kj::Rc<ActorRetryMetrics> addMetricsRef() {
+    return metrics.addRef();
+  }
+  void recordRecovered();
+  void recordAbort(const kj::Exception& exception);
 
  private:
   static constexpr uint MAX_ATTEMPTS = 5;
@@ -1497,16 +1544,19 @@ class ActorFetchRetryState {
 
   ActorFetchRetryState(IoChannelFactory::ActorRetryRequestMetadata metadata,
       kj::Maybe<kj::TimePoint> deadline,
-      TimerChannel& timer)
+      TimerChannel& timer,
+      kj::Rc<ActorRetryMetrics> metrics)
       : metadata(kj::mv(metadata)),
         deadline(kj::mv(deadline)),
-        timer(timer) {}
+        timer(timer),
+        metrics(kj::mv(metrics)) {}
 
   kj::Duration retryDelay();
 
   IoChannelFactory::ActorRetryRequestMetadata metadata;
   kj::Maybe<kj::TimePoint> deadline;
   TimerChannel& timer;
+  kj::Rc<ActorRetryMetrics> metrics;
   kj::Maybe<kj::Exception> originalDisconnect;
   uint attemptCount = 1;
 };
@@ -1518,7 +1568,7 @@ struct ActorFetchFailure {
 template <typename T>
 using ActorFetchAttemptResult = kj::OneOf<T, ActorFetchFailure>;
 
-ActorFetchRetryState ActorFetchRetryState::create(TimerChannel& timer) {
+ActorFetchRetryState ActorFetchRetryState::create(TimerChannel& timer, RequestObserver& observer) {
   bool retryGateEnabled = util::Autogate::isEnabled(
       util::AutogateKey::DURABLE_OBJECT_RETRIES_FETCH_RETRY_REQUESTS);
   auto metadata = generateActorRetryRequestMetadata(kj::systemCoarseCalendarClock().now(),
@@ -1528,12 +1578,14 @@ ActorFetchRetryState ActorFetchRetryState::create(TimerChannel& timer) {
       retryGateEnabled) {
     deadline = timer.nowForLimitTimeout() + RETRY_BUDGET;
   }
-  return ActorFetchRetryState(kj::mv(metadata), kj::mv(deadline), timer);
+  return ActorFetchRetryState(kj::mv(metadata), kj::mv(deadline), timer,
+      kj::rc<ActorRetryMetrics>(observer));
 }
 
 kj::Maybe<kj::Exception> ActorFetchRetryState::checkDeadline() {
   KJ_IF_SOME(deadlineValue, deadline) {
     if (attemptCount > 1 && timer.nowForLimitTimeout() >= deadlineValue) {
+      metrics->recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
       return KJ_ASSERT_NONNULL(originalDisconnect).clone();
     }
   }
@@ -1557,6 +1609,8 @@ kj::OneOf<kj::Duration, kj::Exception> ActorFetchRetryState::prepareRetry(
     return kj::mv(exception);
   }
   if (exception.getDetail(jsg::ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID) != kj::none) {
+    metrics->noteRetryRelevantFailure();
+    metrics->recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
     KJ_IF_SOME(original, originalDisconnect) {
       return kj::mv(original);
     }
@@ -1567,11 +1621,19 @@ kj::OneOf<kj::Duration, kj::Exception> ActorFetchRetryState::prepareRetry(
     return normalized;
   }
 
-  if (exception.getType() != kj::Exception::Type::DISCONNECTED ||
-      exception.getDetail(jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none) {
+  if (exception.getType() != kj::Exception::Type::DISCONNECTED) {
+    if (originalDisconnect != kj::none) {
+      metrics->recordOutcome(ActorRetryOutcome::OTHER);
+    }
+    return kj::mv(exception);
+  }
+  metrics->noteRetryRelevantFailure();
+  if (exception.getDetail(jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none) {
+    metrics->recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
     return kj::mv(exception);
   }
   if (attemptCount >= MAX_ATTEMPTS) {
+    metrics->recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
     return KJ_ASSERT_NONNULL(originalDisconnect).clone();
   }
 
@@ -1588,17 +1650,35 @@ kj::OneOf<kj::Duration, kj::Exception> ActorFetchRetryState::prepareRetry(
   auto delay = retryDelay();
   auto deadline = KJ_ASSERT_NONNULL(this->deadline);
   if (timer.nowForLimitTimeout() + delay >= deadline) {
+    metrics->recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
     return KJ_ASSERT_NONNULL(originalDisconnect).clone();
   }
   ++attemptCount;
   return delay;
 }
 
+void ActorFetchRetryState::recordRecovered() {
+  if (originalDisconnect != kj::none) {
+    metrics->recordOutcome(ActorRetryOutcome::RECOVERED);
+  }
+}
+
+void ActorFetchRetryState::recordAbort(const kj::Exception& exception) {
+  if (originalDisconnect != kj::none || exception.getType() == kj::Exception::Type::DISCONNECTED ||
+      exception.getDetail(jsg::ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID) != kj::none) {
+    metrics->noteRetryRelevantFailure();
+    metrics->recordOutcome(ActorRetryOutcome::OTHER);
+  }
+}
+
 template <typename T>
-kj::Promise<ActorFetchAttemptResult<T>> captureActorFetchAttempt(kj::Promise<T> promise) {
+kj::Promise<ActorFetchAttemptResult<T>> captureActorFetchAttempt(
+    kj::Promise<T> promise, kj::Rc<ActorRetryMetrics> metrics) {
   return kj::mv(promise)
       .then([](T&& result) -> ActorFetchAttemptResult<T> { return kj::mv(result); })
-      .catch_([](kj::Exception&& exception) -> ActorFetchAttemptResult<T> {
+      .catch_([metrics = kj::mv(metrics)](
+                  kj::Exception&& exception) mutable -> ActorFetchAttemptResult<T> {
+    metrics->observeAttemptFailure(exception);
     return ActorFetchFailure{kj::mv(exception)};
   });
 }
@@ -1696,6 +1776,7 @@ jsg::Promise<jsg::Ref<Response>> retryActorFetch(jsg::Lock& js,
     ActorFetchRetryState state,
     kj::Exception exception) {
   KJ_IF_SOME(reason, getAbortReason(js, *jsRequest)) {
+    state.recordAbort(exception);
     return js.rejectedPromise<jsg::Ref<Response>>(kj::mv(reason));
   }
   auto delayOrException = state.prepareRetry(kj::mv(exception));
@@ -1723,7 +1804,9 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
     kj::Vector<kj::Url> urlList) {
   kj::Maybe<ActorFetchRetryState> retryState;
   if (jsRequest->canRewindBody() && fetcher->supportsActorFetchRetries()) {
-    retryState = ActorFetchRetryState::create(IoContext::current().getIoChannelFactory().getTimer());
+    auto& context = IoContext::current();
+    retryState = ActorFetchRetryState::create(
+        context.getIoChannelFactory().getTimer(), context.getMetrics());
   }
 
   return fetchImplNoOutputLockAttempt(
@@ -1747,6 +1830,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
     KJ_IF_SOME(exception, state.checkDeadline()) {
       return rejectFetch(js, kj::mv(exception));
     }
+    state.recordRetry();
   }
 
   // Stash whether this request's body can be rewound (and so the request re-sent), before we lose
@@ -1840,7 +1924,9 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
         AbortSignal::maybeCancelWrap(js, signal, client->openWebSocket(url, headers));
     KJ_IF_SOME(state, retryState) {
       if (state.isRetryEnabled()) {
-        return ioContext.awaitIo(js, captureActorFetchAttempt(kj::mv(webSocketResponse)),
+        auto resultPromise =
+            captureActorFetchAttempt(kj::mv(webSocketResponse), state.addMetricsRef());
+        return ioContext.awaitIo(js, kj::mv(resultPromise),
             [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest),
                 urlList = kj::mv(urlList), client = kj::mv(client), signal = kj::mv(signal),
                 retryState = kj::mv(retryState)](jsg::Lock& js,
@@ -1848,6 +1934,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
             -> jsg::Promise<jsg::Ref<Response>> {
           KJ_SWITCH_ONEOF(result) {
             KJ_CASE_ONEOF(response, kj::HttpClient::WebSocketResponse) {
+              KJ_ASSERT_NONNULL(retryState).recordRecovered();
               return handleWebSocketFetchResponse(js, kj::mv(fetcher), kj::mv(jsRequest),
                   kj::mv(urlList), kj::mv(client), kj::mv(signal), kj::mv(response));
             }
@@ -1936,7 +2023,8 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
     });
     KJ_IF_SOME(state, retryState) {
       if (state.isRetryEnabled()) {
-        auto resultPromise = captureActorFetchAttempt(kj::mv(responsePromise));
+        auto resultPromise =
+            captureActorFetchAttempt(kj::mv(responsePromise), state.addMetricsRef());
         return ioContext.awaitIo(js, kj::mv(resultPromise),
             [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest),
                 urlList = kj::mv(urlList), client = kj::mv(client),
@@ -1945,6 +2033,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
             -> jsg::Promise<jsg::Ref<Response>> {
           KJ_SWITCH_ONEOF(result) {
             KJ_CASE_ONEOF(response, kj::HttpClient::Response) {
+              KJ_ASSERT_NONNULL(retryState).recordRecovered();
               return handleHttpFetchResponse(js, kj::mv(fetcher), kj::mv(jsRequest),
                   kj::mv(urlList), kj::mv(client), traceContext, kj::mv(response));
             }

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -25,6 +25,22 @@ class IoContext;
 WD_STRONG_BOOL(SubrequestBodyRewindable);
 // Whether an outgoing request contributes to the logical subrequest count.
 WD_STRONG_BOOL(CountSubrequest);
+
+enum class ActorRetryCallType : uint8_t {
+  FETCH,
+  JSRPC,
+  OTHER,
+  COUNT,
+};
+
+enum class ActorRetryOutcome : uint8_t {
+  RECOVERED,
+  RETRIES_EXHAUSTED,
+  UNABLE_TO_RETRY,
+  OTHER,
+  COUNT,
+};
+
 class WorkerInterface;
 class LimitEnforcer;
 class TimerChannel;
@@ -142,6 +158,12 @@ class RequestObserver: public kj::Refcounted {
   // so it applies equally to actor and (potentially, in the future) non-actor subrequests. No-op in
   // the base observer; edgeworker overrides it to feed retry classification.
   virtual void setNextSubrequestBodyRewindable(SubrequestBodyRewindable bodyRewindable) {}
+
+  // Records an additional outgoing actor call started by a runtime retry loop.
+  virtual void recordActorRetry(ActorRetryCallType callType) {}
+
+  // Records the terminal outcome of an outgoing actor call after a retry-relevant failure.
+  virtual void recordActorRetryOutcome(ActorRetryCallType callType, ActorRetryOutcome outcome) {}
 
   // Fired immediately before an actor fetch dispatches into user code, so an observer can claim the
   // request's retry-token nonce against the actor's claim store. No-op in the base observer;


### PR DESCRIPTION
Reports Durable Object fetch retry attempts and final outcomes through `RequestObserver`. Edgeworker can count retries without tying workerd to Prometheus.

Observation stays within the existing enabled, rewindable fetch retry path. Requests with retries disabled continue through the ordinary response path and emit no retry metrics.

The tests cover successful recovery, exhausted retries, aborts, and failures that cannot be retried.