### PR TITLE
Add public workflows event subscription type definitions

### DIFF
--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -106,6 +106,7 @@ type InstanceStatus = {
     | 'complete'
     | 'waiting' // instance is hibernating and waiting for sleep or event to finish
     | 'waitingForPause' // instance is finishing the current work to pause
+    | 'rollingBack'
     | 'unknown';
   error?: {
     name: string;
@@ -149,61 +150,89 @@ interface WorkflowInstanceRestartOptions {
   };
 }
 
-type WorkflowInstanceEventCommon = {
+type WorkflowInstanceEvent = {
   instanceId: string;
   eventId: number;
   timestamp: number;
-};
-
-type WorkflowInstanceEvent = WorkflowInstanceEventCommon &
-  (
-    | { type: 'workflow_queued' }
-    | { type: 'workflow_started'; params?: unknown }
-    | { type: 'workflow_completed'; output?: unknown }
-    | { type: 'workflow_failed'; error: { name: string; message: string } }
-    | { type: 'workflow_terminated' }
-    | { type: 'step_started'; stepName: string }
-    | { type: 'step_completed'; stepName: string; output?: unknown }
-    | { type: 'step_failed'; stepName: string }
-    | { type: 'attempt_started'; stepName: string; attempt: number }
-    | { type: 'attempt_completed'; stepName: string; attempt: number }
-    | {
-        type: 'attempt_failed';
-        stepName: string;
-        attempt: number;
-        retryDelayMs?: number;
-        error: { name: string; message: string };
-      }
-    | { type: 'sleep_started'; stepName: string; durationMs: number }
-    | { type: 'sleep_completed'; stepName: string }
-    | { type: 'wait_started'; stepName: string; eventType: string }
-    | { type: 'wait_completed'; stepName: string }
-    | { type: 'wait_timed_out'; stepName: string }
-    | { type: 'rollback_started' }
-    | { type: 'rollback_step_started'; stepName: string }
-    | { type: 'rollback_step_completed'; stepName: string }
-    | {
-        type: 'rollback_step_failed';
-        stepName: string;
-        error: { name: string; message: string };
-      }
-    | { type: 'rollback_attempt_started'; stepName: string; attempt: number }
-    | { type: 'rollback_attempt_completed'; stepName: string; attempt: number }
-    | {
-        type: 'rollback_attempt_failed';
-        stepName: string;
-        attempt: number;
-        retryDelayMs?: number;
-        error: { name: string; message: string };
-      }
-    | { type: 'rollback_completed' }
-    | { type: 'rollback_failed' }
-  );
+} & (
+  | { type: 'workflow_queued' }
+  | { type: 'workflow_started'; params?: unknown }
+  | { type: 'workflow_running' }
+  | { type: 'workflow_paused' }
+  | { type: 'workflow_waiting_for_pause' }
+  | { type: 'workflow_waiting' }
+  | { type: 'workflow_completed'; output?: unknown }
+  | { type: 'workflow_errored'; error: { name: string; message: string } }
+  | { type: 'workflow_terminated' }
+  | {
+      type: 'step_started';
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | '[dynamic]';
+          backoff?: 'constant' | 'linear' | 'exponential';
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: 'output';
+      };
+    }
+  | { type: 'step_completed'; stepName: string; output?: unknown }
+  | { type: 'step_errored'; stepName: string }
+  | { type: 'attempt_started'; stepName: string; attempt: number }
+  | { type: 'attempt_completed'; stepName: string; attempt: number }
+  | {
+      type: 'attempt_errored';
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: { name: string; message: string };
+    }
+  | { type: 'sleep_started'; stepName: string; durationMs: number }
+  | { type: 'sleep_completed'; stepName: string }
+  | { type: 'wait_started'; stepName: string; eventType: string }
+  | { type: 'wait_completed'; stepName: string }
+  | { type: 'wait_timed_out'; stepName: string }
+  | { type: 'rollback_started' }
+  | {
+      type: 'rollback_step_started';
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | '[dynamic]';
+          backoff?: 'constant' | 'linear' | 'exponential';
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: 'output';
+      };
+    }
+  | { type: 'rollback_step_completed'; stepName: string }
+  | {
+      type: 'rollback_step_errored';
+      stepName: string;
+      error: { name: string; message: string };
+    }
+  | { type: 'rollback_attempt_started'; stepName: string; attempt: number }
+  | { type: 'rollback_attempt_completed'; stepName: string; attempt: number }
+  | {
+      type: 'rollback_attempt_errored';
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: { name: string; message: string };
+    }
+  | { type: 'rollback_completed' }
+  | { type: 'rollback_errored' }
+);
 
 type WorkflowInstanceEventType = WorkflowInstanceEvent['type'];
 
+/** Options available for a Workflow instance subscription. */
 type WorkflowInstanceSubscribeOptions = {
+  /** The value from which to start the subscription. */
   cursor?: number;
+  /** The event types to include in the subscription. */
   filter?: WorkflowInstanceEventType[];
 };
 

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -116,6 +116,7 @@ type InstanceStatus = {
     | 'complete'
     | 'waiting' // instance is hibernating and waiting for sleep or event to finish
     | 'waitingForPause' // instance is finishing the current work to pause
+    | 'rollingBack'
     | 'unknown';
   error?: {
     name: string;
@@ -157,6 +158,99 @@ interface WorkflowInstanceRestartOptions {
      */
     type?: 'do' | 'sleep' | 'waitForEvent';
   };
+}
+
+/** An event emitted by a Workflow instance. */
+type WorkflowInstanceEvent = {
+  instanceId: string;
+  eventId: number;
+  timestamp: number;
+} &
+  (
+    | { type: 'workflow_queued' }
+    | { type: 'workflow_started'; params?: unknown }
+    | { type: 'workflow_running' }
+    | { type: 'workflow_paused' }
+    | { type: 'workflow_waiting_for_pause' }
+    | { type: 'workflow_waiting' }
+    | { type: 'workflow_completed'; output?: unknown }
+    | { type: 'workflow_errored'; error: { name: string; message: string } }
+    | { type: 'workflow_terminated' }
+    | {
+        type: 'step_started';
+        stepName: string;
+        config?: {
+          retries: {
+            limit: number;
+            delay: WorkflowSleepDuration | '[dynamic]';
+            backoff?: 'constant' | 'linear' | 'exponential';
+          };
+          timeout: WorkflowSleepDuration;
+          sensitive?: 'output';
+        };
+      }
+    | { type: 'step_completed'; stepName: string; output?: unknown }
+    | { type: 'step_errored'; stepName: string }
+    | { type: 'attempt_started'; stepName: string; attempt: number }
+    | { type: 'attempt_completed'; stepName: string; attempt: number }
+    | {
+        type: 'attempt_errored';
+        stepName: string;
+        attempt: number;
+        retryDelayMs?: number;
+        error: { name: string; message: string };
+      }
+    | { type: 'sleep_started'; stepName: string; durationMs: number }
+    | { type: 'sleep_completed'; stepName: string }
+    | { type: 'wait_started'; stepName: string; eventType: string }
+    | { type: 'wait_completed'; stepName: string }
+    | { type: 'wait_timed_out'; stepName: string }
+    | { type: 'rollback_started' }
+    | {
+        type: 'rollback_step_started';
+        stepName: string;
+        config?: {
+          retries: {
+            limit: number;
+            delay: WorkflowSleepDuration | '[dynamic]';
+            backoff?: 'constant' | 'linear' | 'exponential';
+          };
+          timeout: WorkflowSleepDuration;
+          sensitive?: 'output';
+        };
+      }
+    | { type: 'rollback_step_completed'; stepName: string }
+    | {
+        type: 'rollback_step_errored';
+        stepName: string;
+        error: { name: string; message: string };
+      }
+    | { type: 'rollback_attempt_started'; stepName: string; attempt: number }
+    | { type: 'rollback_attempt_completed'; stepName: string; attempt: number }
+    | {
+        type: 'rollback_attempt_errored';
+        stepName: string;
+        attempt: number;
+        retryDelayMs?: number;
+        error: { name: string; message: string };
+      }
+    | { type: 'rollback_completed' }
+    | { type: 'rollback_errored' }
+  );
+
+type WorkflowInstanceEventType = WorkflowInstanceEvent['type'];
+
+/** Options available for a Workflow instance subscription. */
+type WorkflowInstanceSubscribeOptions = {
+  /** The value from which to start the subscription. */
+  cursor?: number;
+  /** The event types to include in the subscription. */
+  filter?: WorkflowInstanceEventType[];
+};
+
+/** A disposable subscription to a Workflow instance's events. */
+interface WorkflowInstanceSubscription extends Disposable {
+  next(): Promise<IteratorResult<WorkflowInstanceEvent, void>>;
 }
 
 declare abstract class WorkflowInstance {
@@ -205,4 +299,11 @@ declare abstract class WorkflowInstance {
     type: string;
     payload: unknown;
   }): Promise<void>;
+
+  /**
+   * Subscribe to events emitted by this instance.
+   */
+  public subscribe(
+    options?: WorkflowInstanceSubscribeOptions
+  ): Promise<WorkflowInstanceSubscription>;
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -17744,6 +17744,7 @@ type InstanceStatus = {
     | "complete"
     | "waiting" // instance is hibernating and waiting for sleep or event to finish
     | "waitingForPause" // instance is finishing the current work to pause
+    | "rollingBack"
     | "unknown";
   error?: {
     name: string;
@@ -17782,6 +17783,176 @@ interface WorkflowInstanceRestartOptions {
      */
     type?: "do" | "sleep" | "waitForEvent";
   };
+}
+/** An event emitted by a Workflow instance. */
+type WorkflowInstanceEvent = {
+  instanceId: string;
+  eventId: number;
+  timestamp: number;
+} & (
+  | {
+      type: "workflow_queued";
+    }
+  | {
+      type: "workflow_started";
+      params?: unknown;
+    }
+  | {
+      type: "workflow_running";
+    }
+  | {
+      type: "workflow_paused";
+    }
+  | {
+      type: "workflow_waiting_for_pause";
+    }
+  | {
+      type: "workflow_waiting";
+    }
+  | {
+      type: "workflow_completed";
+      output?: unknown;
+    }
+  | {
+      type: "workflow_errored";
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "workflow_terminated";
+    }
+  | {
+      type: "step_started";
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | "[dynamic]";
+          backoff?: "constant" | "linear" | "exponential";
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: "output";
+      };
+    }
+  | {
+      type: "step_completed";
+      stepName: string;
+      output?: unknown;
+    }
+  | {
+      type: "step_errored";
+      stepName: string;
+    }
+  | {
+      type: "attempt_started";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "attempt_completed";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "attempt_errored";
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "sleep_started";
+      stepName: string;
+      durationMs: number;
+    }
+  | {
+      type: "sleep_completed";
+      stepName: string;
+    }
+  | {
+      type: "wait_started";
+      stepName: string;
+      eventType: string;
+    }
+  | {
+      type: "wait_completed";
+      stepName: string;
+    }
+  | {
+      type: "wait_timed_out";
+      stepName: string;
+    }
+  | {
+      type: "rollback_started";
+    }
+  | {
+      type: "rollback_step_started";
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | "[dynamic]";
+          backoff?: "constant" | "linear" | "exponential";
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: "output";
+      };
+    }
+  | {
+      type: "rollback_step_completed";
+      stepName: string;
+    }
+  | {
+      type: "rollback_step_errored";
+      stepName: string;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "rollback_attempt_started";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "rollback_attempt_completed";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "rollback_attempt_errored";
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "rollback_completed";
+    }
+  | {
+      type: "rollback_errored";
+    }
+);
+type WorkflowInstanceEventType = WorkflowInstanceEvent["type"];
+/** Options available for a Workflow instance subscription. */
+type WorkflowInstanceSubscribeOptions = {
+  /** The value from which to start the subscription. */
+  cursor?: number;
+  /** The event types to include in the subscription. */
+  filter?: WorkflowInstanceEventType[];
+};
+/** A disposable subscription to a Workflow instance's events. */
+interface WorkflowInstanceSubscription extends Disposable {
+  next(): Promise<IteratorResult<WorkflowInstanceEvent, void>>;
 }
 declare abstract class WorkflowInstance {
   public id: string;
@@ -17822,4 +17993,10 @@ declare abstract class WorkflowInstance {
     type: string;
     payload: unknown;
   }): Promise<void>;
+  /**
+   * Subscribe to events emitted by this instance.
+   */
+  public subscribe(
+    options?: WorkflowInstanceSubscribeOptions,
+  ): Promise<WorkflowInstanceSubscription>;
 }

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -17693,6 +17693,7 @@ export type InstanceStatus = {
     | "complete"
     | "waiting" // instance is hibernating and waiting for sleep or event to finish
     | "waitingForPause" // instance is finishing the current work to pause
+    | "rollingBack"
     | "unknown";
   error?: {
     name: string;
@@ -17731,6 +17732,176 @@ export interface WorkflowInstanceRestartOptions {
      */
     type?: "do" | "sleep" | "waitForEvent";
   };
+}
+/** An event emitted by a Workflow instance. */
+export type WorkflowInstanceEvent = {
+  instanceId: string;
+  eventId: number;
+  timestamp: number;
+} & (
+  | {
+      type: "workflow_queued";
+    }
+  | {
+      type: "workflow_started";
+      params?: unknown;
+    }
+  | {
+      type: "workflow_running";
+    }
+  | {
+      type: "workflow_paused";
+    }
+  | {
+      type: "workflow_waiting_for_pause";
+    }
+  | {
+      type: "workflow_waiting";
+    }
+  | {
+      type: "workflow_completed";
+      output?: unknown;
+    }
+  | {
+      type: "workflow_errored";
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "workflow_terminated";
+    }
+  | {
+      type: "step_started";
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | "[dynamic]";
+          backoff?: "constant" | "linear" | "exponential";
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: "output";
+      };
+    }
+  | {
+      type: "step_completed";
+      stepName: string;
+      output?: unknown;
+    }
+  | {
+      type: "step_errored";
+      stepName: string;
+    }
+  | {
+      type: "attempt_started";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "attempt_completed";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "attempt_errored";
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "sleep_started";
+      stepName: string;
+      durationMs: number;
+    }
+  | {
+      type: "sleep_completed";
+      stepName: string;
+    }
+  | {
+      type: "wait_started";
+      stepName: string;
+      eventType: string;
+    }
+  | {
+      type: "wait_completed";
+      stepName: string;
+    }
+  | {
+      type: "wait_timed_out";
+      stepName: string;
+    }
+  | {
+      type: "rollback_started";
+    }
+  | {
+      type: "rollback_step_started";
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | "[dynamic]";
+          backoff?: "constant" | "linear" | "exponential";
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: "output";
+      };
+    }
+  | {
+      type: "rollback_step_completed";
+      stepName: string;
+    }
+  | {
+      type: "rollback_step_errored";
+      stepName: string;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "rollback_attempt_started";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "rollback_attempt_completed";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "rollback_attempt_errored";
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "rollback_completed";
+    }
+  | {
+      type: "rollback_errored";
+    }
+);
+export type WorkflowInstanceEventType = WorkflowInstanceEvent["type"];
+/** Options available for a Workflow instance subscription. */
+export type WorkflowInstanceSubscribeOptions = {
+  /** The value from which to start the subscription. */
+  cursor?: number;
+  /** The event types to include in the subscription. */
+  filter?: WorkflowInstanceEventType[];
+};
+/** A disposable subscription to a Workflow instance's events. */
+export interface WorkflowInstanceSubscription extends Disposable {
+  next(): Promise<IteratorResult<WorkflowInstanceEvent, void>>;
 }
 export declare abstract class WorkflowInstance {
   public id: string;
@@ -17771,4 +17942,10 @@ export declare abstract class WorkflowInstance {
     type: string;
     payload: unknown;
   }): Promise<void>;
+  /**
+   * Subscribe to events emitted by this instance.
+   */
+  public subscribe(
+    options?: WorkflowInstanceSubscribeOptions,
+  ): Promise<WorkflowInstanceSubscription>;
 }

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -17467,6 +17467,7 @@ type InstanceStatus = {
     | "complete"
     | "waiting" // instance is hibernating and waiting for sleep or event to finish
     | "waitingForPause" // instance is finishing the current work to pause
+    | "rollingBack"
     | "unknown";
   error?: {
     name: string;
@@ -17505,6 +17506,176 @@ interface WorkflowInstanceRestartOptions {
      */
     type?: "do" | "sleep" | "waitForEvent";
   };
+}
+/** An event emitted by a Workflow instance. */
+type WorkflowInstanceEvent = {
+  instanceId: string;
+  eventId: number;
+  timestamp: number;
+} & (
+  | {
+      type: "workflow_queued";
+    }
+  | {
+      type: "workflow_started";
+      params?: unknown;
+    }
+  | {
+      type: "workflow_running";
+    }
+  | {
+      type: "workflow_paused";
+    }
+  | {
+      type: "workflow_waiting_for_pause";
+    }
+  | {
+      type: "workflow_waiting";
+    }
+  | {
+      type: "workflow_completed";
+      output?: unknown;
+    }
+  | {
+      type: "workflow_errored";
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "workflow_terminated";
+    }
+  | {
+      type: "step_started";
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | "[dynamic]";
+          backoff?: "constant" | "linear" | "exponential";
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: "output";
+      };
+    }
+  | {
+      type: "step_completed";
+      stepName: string;
+      output?: unknown;
+    }
+  | {
+      type: "step_errored";
+      stepName: string;
+    }
+  | {
+      type: "attempt_started";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "attempt_completed";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "attempt_errored";
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "sleep_started";
+      stepName: string;
+      durationMs: number;
+    }
+  | {
+      type: "sleep_completed";
+      stepName: string;
+    }
+  | {
+      type: "wait_started";
+      stepName: string;
+      eventType: string;
+    }
+  | {
+      type: "wait_completed";
+      stepName: string;
+    }
+  | {
+      type: "wait_timed_out";
+      stepName: string;
+    }
+  | {
+      type: "rollback_started";
+    }
+  | {
+      type: "rollback_step_started";
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | "[dynamic]";
+          backoff?: "constant" | "linear" | "exponential";
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: "output";
+      };
+    }
+  | {
+      type: "rollback_step_completed";
+      stepName: string;
+    }
+  | {
+      type: "rollback_step_errored";
+      stepName: string;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "rollback_attempt_started";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "rollback_attempt_completed";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "rollback_attempt_errored";
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "rollback_completed";
+    }
+  | {
+      type: "rollback_errored";
+    }
+);
+type WorkflowInstanceEventType = WorkflowInstanceEvent["type"];
+/** Options available for a Workflow instance subscription. */
+type WorkflowInstanceSubscribeOptions = {
+  /** The value from which to start the subscription. */
+  cursor?: number;
+  /** The event types to include in the subscription. */
+  filter?: WorkflowInstanceEventType[];
+};
+/** A disposable subscription to a Workflow instance's events. */
+interface WorkflowInstanceSubscription extends Disposable {
+  next(): Promise<IteratorResult<WorkflowInstanceEvent, void>>;
 }
 declare abstract class WorkflowInstance {
   public id: string;
@@ -17545,4 +17716,10 @@ declare abstract class WorkflowInstance {
     type: string;
     payload: unknown;
   }): Promise<void>;
+  /**
+   * Subscribe to events emitted by this instance.
+   */
+  public subscribe(
+    options?: WorkflowInstanceSubscribeOptions,
+  ): Promise<WorkflowInstanceSubscription>;
 }

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -17416,6 +17416,7 @@ export type InstanceStatus = {
     | "complete"
     | "waiting" // instance is hibernating and waiting for sleep or event to finish
     | "waitingForPause" // instance is finishing the current work to pause
+    | "rollingBack"
     | "unknown";
   error?: {
     name: string;
@@ -17454,6 +17455,176 @@ export interface WorkflowInstanceRestartOptions {
      */
     type?: "do" | "sleep" | "waitForEvent";
   };
+}
+/** An event emitted by a Workflow instance. */
+export type WorkflowInstanceEvent = {
+  instanceId: string;
+  eventId: number;
+  timestamp: number;
+} & (
+  | {
+      type: "workflow_queued";
+    }
+  | {
+      type: "workflow_started";
+      params?: unknown;
+    }
+  | {
+      type: "workflow_running";
+    }
+  | {
+      type: "workflow_paused";
+    }
+  | {
+      type: "workflow_waiting_for_pause";
+    }
+  | {
+      type: "workflow_waiting";
+    }
+  | {
+      type: "workflow_completed";
+      output?: unknown;
+    }
+  | {
+      type: "workflow_errored";
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "workflow_terminated";
+    }
+  | {
+      type: "step_started";
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | "[dynamic]";
+          backoff?: "constant" | "linear" | "exponential";
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: "output";
+      };
+    }
+  | {
+      type: "step_completed";
+      stepName: string;
+      output?: unknown;
+    }
+  | {
+      type: "step_errored";
+      stepName: string;
+    }
+  | {
+      type: "attempt_started";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "attempt_completed";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "attempt_errored";
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "sleep_started";
+      stepName: string;
+      durationMs: number;
+    }
+  | {
+      type: "sleep_completed";
+      stepName: string;
+    }
+  | {
+      type: "wait_started";
+      stepName: string;
+      eventType: string;
+    }
+  | {
+      type: "wait_completed";
+      stepName: string;
+    }
+  | {
+      type: "wait_timed_out";
+      stepName: string;
+    }
+  | {
+      type: "rollback_started";
+    }
+  | {
+      type: "rollback_step_started";
+      stepName: string;
+      config?: {
+        retries: {
+          limit: number;
+          delay: WorkflowSleepDuration | "[dynamic]";
+          backoff?: "constant" | "linear" | "exponential";
+        };
+        timeout: WorkflowSleepDuration;
+        sensitive?: "output";
+      };
+    }
+  | {
+      type: "rollback_step_completed";
+      stepName: string;
+    }
+  | {
+      type: "rollback_step_errored";
+      stepName: string;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "rollback_attempt_started";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "rollback_attempt_completed";
+      stepName: string;
+      attempt: number;
+    }
+  | {
+      type: "rollback_attempt_errored";
+      stepName: string;
+      attempt: number;
+      retryDelayMs?: number;
+      error: {
+        name: string;
+        message: string;
+      };
+    }
+  | {
+      type: "rollback_completed";
+    }
+  | {
+      type: "rollback_errored";
+    }
+);
+export type WorkflowInstanceEventType = WorkflowInstanceEvent["type"];
+/** Options available for a Workflow instance subscription. */
+export type WorkflowInstanceSubscribeOptions = {
+  /** The value from which to start the subscription. */
+  cursor?: number;
+  /** The event types to include in the subscription. */
+  filter?: WorkflowInstanceEventType[];
+};
+/** A disposable subscription to a Workflow instance's events. */
+export interface WorkflowInstanceSubscription extends Disposable {
+  next(): Promise<IteratorResult<WorkflowInstanceEvent, void>>;
 }
 export declare abstract class WorkflowInstance {
   public id: string;
@@ -17494,4 +17665,10 @@ export declare abstract class WorkflowInstance {
     type: string;
     payload: unknown;
   }): Promise<void>;
+  /**
+   * Subscribe to events emitted by this instance.
+   */
+  public subscribe(
+    options?: WorkflowInstanceSubscribeOptions,
+  ): Promise<WorkflowInstanceSubscription>;
 }

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -1329,3 +1329,45 @@ expectTypeOf<WorkflowBatchDeleteResult['errors'][number]>().toEqualTypeOf<{
   code: number;
   message: string;
 }>();
+
+expectTypeOf(workflowInstance.subscribe()).toEqualTypeOf<
+  Promise<WorkflowInstanceSubscription>
+>();
+
+declare const workflowInstanceSubscription: WorkflowInstanceSubscription;
+expectTypeOf(workflowInstanceSubscription.next()).toEqualTypeOf<
+  Promise<IteratorResult<WorkflowInstanceEvent, void>>
+>();
+
+declare const workflowInstanceEventType: WorkflowInstanceEventType;
+expectTypeOf(workflowInstanceEventType).toEqualTypeOf<
+  | 'workflow_queued'
+  | 'workflow_started'
+  | 'workflow_running'
+  | 'workflow_paused'
+  | 'workflow_waiting_for_pause'
+  | 'workflow_waiting'
+  | 'workflow_completed'
+  | 'workflow_errored'
+  | 'workflow_terminated'
+  | 'step_started'
+  | 'step_completed'
+  | 'step_errored'
+  | 'attempt_started'
+  | 'attempt_completed'
+  | 'attempt_errored'
+  | 'sleep_started'
+  | 'sleep_completed'
+  | 'wait_started'
+  | 'wait_completed'
+  | 'wait_timed_out'
+  | 'rollback_started'
+  | 'rollback_step_started'
+  | 'rollback_step_completed'
+  | 'rollback_step_errored'
+  | 'rollback_attempt_started'
+  | 'rollback_attempt_completed'
+  | 'rollback_attempt_errored'
+  | 'rollback_completed'
+  | 'rollback_errored'
+>();


### PR DESCRIPTION
This PR mainly does two things:
- update existing internal type definitions with the changes made during final API checking/changes
- add public type definitions to instance subscribe, events and subscription options