### PR TITLE
Refactor Durable Object Retries to be fetch-agnostic

### DIFF
--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -9,6 +9,7 @@ filegroup(
     # Only add files here when needed: Where possible, new src/header files should be defined in
     # their own targets, modularizing bazel targets makes incremental rebuilds faster.
     srcs = [
+        "actor-call-retry.c++",
         "actor.c++",
         "actor-state.c++",
         "basics.c++",
@@ -63,6 +64,7 @@ filegroup(
 filegroup(
     name = "hdrs",
     srcs = [
+        "actor-call-retry.h",
         "actor.h",
         "actor-state.h",
         "basics.h",
@@ -792,6 +794,13 @@ kj_test(
 kj_test(
     src = "cf-property-test.c++",
     deps = ["//src/workerd/tests:test-fixture"],
+)
+
+kj_test(
+    src = "actor-call-retry-test.c++",
+    deps = [
+        "//src/workerd/io",
+    ],
 )
 
 kj_test(

--- a/src/workerd/api/BUILD.bazel
+++ b/src/workerd/api/BUILD.bazel
@@ -9,8 +9,8 @@ filegroup(
     # Only add files here when needed: Where possible, new src/header files should be defined in
     # their own targets, modularizing bazel targets makes incremental rebuilds faster.
     srcs = [
-        "actor-call-retry.c++",
         "actor.c++",
+        "actor-call-retry.c++",
         "actor-state.c++",
         "basics.c++",
         "blob.c++",
@@ -64,8 +64,8 @@ filegroup(
 filegroup(
     name = "hdrs",
     srcs = [
-        "actor-call-retry.h",
         "actor.h",
+        "actor-call-retry.h",
         "actor-state.h",
         "basics.h",
         "blob.h",

--- a/src/workerd/api/actor-call-retry-test.c++
+++ b/src/workerd/api/actor-call-retry-test.c++
@@ -241,8 +241,7 @@ KJ_TEST("actor calls do not retry when retry requests are disabled") {
 
   auto first = startAttempt(*state);
   KJ_EXPECT(KJ_ASSERT_NONNULL(first.getMetadata()).retryGateEnabled == ActorRetryGateEnabled::NO);
-  auto result = handleFailure(*state, makeDisconnect("disconnected"_kj));
-  KJ_EXPECT(result.is<kj::Exception>());
+  KJ_EXPECT(!state->isRetryEnabled());
   KJ_EXPECT(observer->outcomes.size() == 0);
 }
 

--- a/src/workerd/api/actor-call-retry-test.c++
+++ b/src/workerd/api/actor-call-retry-test.c++
@@ -1,0 +1,250 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "actor-call-retry.h"
+
+#include <workerd/jsg/util.h>
+
+#include <kj/test.h>
+
+namespace workerd::api {
+namespace {
+
+class TestTimerChannel final: public TimerChannel {
+ public:
+  void syncTime() override {}
+
+  kj::Date now(kj::Maybe<kj::Date>) override {
+    return kj::UNIX_EPOCH;
+  }
+
+  kj::Promise<void> atTime(kj::Date) override {
+    return kj::NEVER_DONE;
+  }
+
+  kj::Promise<void> afterLimitTimeout(kj::Duration) override {
+    return kj::NEVER_DONE;
+  }
+
+  kj::TimePoint nowForLimitTimeout() override {
+    return currentTime;
+  }
+
+  void advance(kj::Duration duration) {
+    currentTime += duration;
+  }
+
+ private:
+  kj::TimePoint currentTime = kj::origin<kj::TimePoint>();
+};
+
+class RecordingObserver final: public RequestObserver {
+ public:
+  void recordActorRetry(ActorRetryCallType callType) override {
+    retryCallTypes.add(callType);
+  }
+
+  void recordActorRetryOutcome(
+      ActorRetryCallType callType, ActorRetryOutcome outcome, kj::Duration) override {
+    outcomeCallTypes.add(callType);
+    outcomes.add(outcome);
+  }
+
+  kj::Vector<ActorRetryCallType> retryCallTypes;
+  kj::Vector<ActorRetryCallType> outcomeCallTypes;
+  kj::Vector<ActorRetryOutcome> outcomes;
+};
+
+kj::Rc<ActorCallRetryState> newRetryState(TestTimerChannel& timer, RecordingObserver& observer) {
+  return kj::rc<ActorCallRetryState>(timer, observer,
+      ActorCallRetryState::Config{
+        .callType = ActorRetryCallType::JSRPC,
+        .observationEnabled = ActorRetryGateEnabled::YES,
+        .enforcementEnabled = ActorRetryGateEnabled::YES,
+        .payloadReplayable = ActorCallPayloadReplayable::YES,
+      });
+}
+
+ActorCallRetryState::Attempt startAttempt(ActorCallRetryState& state) {
+  auto result = state.startAttempt();
+  return kj::mv(KJ_REQUIRE_NONNULL(result.tryGet<ActorCallRetryState::Attempt>()));
+}
+
+kj::Exception makeDisconnect(kj::StringPtr description) {
+  return KJ_EXCEPTION(DISCONNECTED, description);
+}
+
+kj::OneOf<kj::Duration, kj::Exception> handleFailure(
+    ActorCallRetryState& state, kj::Exception exception) {
+  return state.handleAttemptFailure(kj::mv(exception));
+}
+
+KJ_TEST("not-delivered actor calls retry with a new token") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = newRetryState(timer, *observer);
+
+  auto first = startAttempt(*state);
+  auto firstNonce = KJ_ASSERT_NONNULL(first.getMetadata()).nonce;
+  KJ_EXPECT(KJ_ASSERT_NONNULL(first.getMetadata()).isRetry == IsActorRetry::NO);
+
+  auto notDelivered = makeDisconnect("not delivered"_kj);
+  jsg::markActorRequestNotDelivered(notDelivered);
+  KJ_EXPECT(handleFailure(*state, kj::mv(notDelivered)).is<kj::Duration>());
+
+  auto second = startAttempt(*state);
+  auto secondNonce = KJ_ASSERT_NONNULL(second.getMetadata()).nonce;
+  KJ_EXPECT(secondNonce != firstNonce);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(second.getMetadata()).isRetry == IsActorRetry::NO);
+
+  state->recordRecovered();
+}
+
+KJ_TEST("ambiguous actor calls retry with the same token") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = newRetryState(timer, *observer);
+
+  auto first = startAttempt(*state);
+  auto firstNonce = KJ_ASSERT_NONNULL(first.getMetadata()).nonce;
+
+  KJ_EXPECT(handleFailure(*state, makeDisconnect("ambiguous"_kj)).is<kj::Duration>());
+
+  auto second = startAttempt(*state);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(second.getMetadata()).nonce == firstNonce);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(second.getMetadata()).isRetry == IsActorRetry::YES);
+
+  state->recordRecovered();
+}
+
+KJ_TEST("actor retries count only the first attempt as a subrequest") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = newRetryState(timer, *observer);
+
+  auto first = startAttempt(*state);
+  KJ_EXPECT(first.getCountSubrequest() == CountSubrequest::YES);
+
+  KJ_EXPECT(handleFailure(*state, makeDisconnect("ambiguous"_kj)).is<kj::Duration>());
+
+  auto second = startAttempt(*state);
+  KJ_EXPECT(second.getCountSubrequest() == CountSubrequest::NO);
+
+  state->recordRecovered();
+}
+
+KJ_TEST("successful actor retries report recovered") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = newRetryState(timer, *observer);
+
+  startAttempt(*state);
+  KJ_EXPECT(handleFailure(*state, makeDisconnect("ambiguous"_kj)).is<kj::Duration>());
+  startAttempt(*state);
+
+  KJ_ASSERT(observer->retryCallTypes.size() == 1);
+  KJ_EXPECT(observer->retryCallTypes[0] == ActorRetryCallType::JSRPC);
+
+  state->recordRecovered();
+  KJ_ASSERT(observer->outcomes.size() == 1);
+  KJ_EXPECT(observer->outcomeCallTypes[0] == ActorRetryCallType::JSRPC);
+  KJ_EXPECT(observer->outcomes[0] == ActorRetryOutcome::RECOVERED);
+}
+
+KJ_TEST("actor retries return the original disconnect after claim rejection") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = newRetryState(timer, *observer);
+
+  startAttempt(*state);
+  auto original = makeDisconnect("original disconnect"_kj);
+  KJ_EXPECT(handleFailure(*state, kj::mv(original)).is<kj::Duration>());
+  startAttempt(*state);
+
+  auto rejected = KJ_EXCEPTION(FAILED, "claim rejected");
+  rejected.setDetail(jsg::ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID, kj::heapArray<kj::byte>(0));
+  auto result = handleFailure(*state, kj::mv(rejected));
+  auto& failure = KJ_ASSERT_NONNULL(result.tryGet<kj::Exception>());
+  KJ_EXPECT(failure.getType() == kj::Exception::Type::DISCONNECTED);
+  KJ_EXPECT(failure.getDescription().contains("original disconnect"));
+  KJ_ASSERT(observer->outcomes.size() == 1);
+  KJ_EXPECT(observer->outcomes[0] == ActorRetryOutcome::CLAIM_REJECTED);
+}
+
+KJ_TEST("actor retries stop after five total attempts") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = newRetryState(timer, *observer);
+
+  for (uint attempt = 0; attempt < 5; ++attempt) {
+    startAttempt(*state);
+    auto exception = makeDisconnect("disconnected"_kj);
+    auto result = handleFailure(*state, kj::mv(exception));
+    if (attempt < 4) {
+      KJ_EXPECT(result.is<kj::Duration>());
+    } else {
+      KJ_EXPECT(result.is<kj::Exception>());
+    }
+  }
+
+  KJ_ASSERT(observer->retryCallTypes.size() == 4);
+  KJ_ASSERT(observer->outcomes.size() == 1);
+  KJ_EXPECT(observer->outcomes[0] == ActorRetryOutcome::RETRIES_EXHAUSTED);
+}
+
+KJ_TEST("actor retries return the original disconnect when the deadline expires before retry") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = newRetryState(timer, *observer);
+
+  startAttempt(*state);
+  auto original = makeDisconnect("original disconnect"_kj);
+  KJ_EXPECT(handleFailure(*state, kj::mv(original)).is<kj::Duration>());
+  timer.advance(11 * kj::SECONDS);
+
+  auto result = state->startAttempt();
+  auto& failure = KJ_ASSERT_NONNULL(result.tryGet<kj::Exception>());
+  KJ_EXPECT(failure.getDescription().contains("original disconnect"));
+  KJ_EXPECT(observer->retryCallTypes.size() == 0);
+  KJ_EXPECT(observer->outcomes.size() == 0);
+}
+
+KJ_TEST("actor calls do not retry a failure after the deadline") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = newRetryState(timer, *observer);
+
+  startAttempt(*state);
+  timer.advance(11 * kj::SECONDS);
+  auto failure = makeDisconnect("first attempt exceeded deadline"_kj);
+  jsg::markActorRequestNotDelivered(failure);
+
+  auto result = handleFailure(*state, kj::mv(failure));
+  auto& finalFailure = KJ_ASSERT_NONNULL(result.tryGet<kj::Exception>());
+  KJ_EXPECT(finalFailure.getDescription().contains("first attempt exceeded deadline"));
+  KJ_EXPECT(finalFailure.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none);
+  KJ_EXPECT(observer->retryCallTypes.size() == 0);
+  KJ_EXPECT(observer->outcomes.size() == 0);
+}
+
+KJ_TEST("actor calls do not retry when retry requests are disabled") {
+  TestTimerChannel timer;
+  auto observer = kj::refcounted<RecordingObserver>();
+  auto state = kj::rc<ActorCallRetryState>(timer, *observer,
+      ActorCallRetryState::Config{
+        .callType = ActorRetryCallType::JSRPC,
+        .observationEnabled = ActorRetryGateEnabled::YES,
+        .enforcementEnabled = ActorRetryGateEnabled::NO,
+        .payloadReplayable = ActorCallPayloadReplayable::YES,
+      });
+
+  auto first = startAttempt(*state);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(first.getMetadata()).retryGateEnabled == ActorRetryGateEnabled::NO);
+  auto result = handleFailure(*state, makeDisconnect("disconnected"_kj));
+  KJ_EXPECT(result.is<kj::Exception>());
+  KJ_EXPECT(observer->outcomes.size() == 0);
+}
+
+}  // namespace
+}  // namespace workerd::api

--- a/src/workerd/api/actor-call-retry.c++
+++ b/src/workerd/api/actor-call-retry.c++
@@ -1,0 +1,166 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "actor-call-retry.h"
+
+#include <workerd/jsg/util.h>
+#include <workerd/util/entropy.h>
+
+#include <random>
+
+namespace workerd::api {
+
+ActorCallRetryState::ActorCallRetryState(
+    TimerChannel& timer, RequestObserver& observer, Config config)
+    : timer(timer),
+      observer(kj::addRef(observer)),
+      config(config) {
+  retriesEnabled = config.observationEnabled.toBool() && config.enforcementEnabled.toBool();
+  if (config.payloadReplayable.toBool()) {
+    metadata = generateActorRetryRequestMetadata(
+        kj::systemCoarseCalendarClock().now(), config.enforcementEnabled);
+    if (retriesEnabled) {
+      deadline = timer.nowForLimitTimeout() + RETRY_BUDGET;
+    }
+  }
+}
+
+ActorCallRetryState::~ActorCallRetryState() noexcept(false) {
+  if (retryStartTime != kj::none && !recordedOutcome) {
+    recordOutcome(ActorRetryOutcome::OTHER);
+  }
+}
+
+kj::OneOf<ActorCallRetryState::Attempt, kj::Exception> ActorCallRetryState::startAttempt() {
+  auto isFirstAttempt = IsFirstActorCallAttempt(attemptCount == 1);
+  if (!isFirstAttempt.toBool()) {
+    KJ_IF_SOME(deadlineValue, deadline) {
+      if (timer.nowForLimitTimeout() >= deadlineValue) {
+        recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
+        return KJ_ASSERT_NONNULL(originalDisconnect).clone();
+      }
+    }
+    ++retryAttemptsStarted;
+    observer->recordActorRetry(config.callType);
+  }
+  return Attempt(metadata, isFirstAttempt);
+}
+
+kj::OneOf<kj::Duration, kj::Exception> ActorCallRetryState::handleAttemptFailure(
+    kj::Exception exception) {
+  if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
+    startRetryLatencyTimer();
+  }
+  KJ_IF_SOME(claimRejection, handleClaimRejection(exception)) {
+    return kj::mv(claimRejection);
+  }
+
+  auto decision = checkCanRetry(kj::mv(exception));
+  KJ_SWITCH_ONEOF(decision) {
+    KJ_CASE_ONEOF(plan, RetryPlan) {
+      return prepareRetry(kj::mv(plan));
+    }
+    KJ_CASE_ONEOF(finalFailure, kj::Exception) {
+      return kj::mv(finalFailure);
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+kj::Maybe<kj::Exception> ActorCallRetryState::handleClaimRejection(const kj::Exception& exception) {
+  if (exception.getDetail(jsg::ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID) == kj::none) {
+    return kj::none;
+  }
+
+  recordOutcome(ActorRetryOutcome::CLAIM_REJECTED);
+  return KJ_ASSERT_NONNULL(originalDisconnect).clone();
+}
+
+kj::OneOf<ActorCallRetryState::RetryPlan, kj::Exception> ActorCallRetryState::checkCanRetry(
+    kj::Exception exception) {
+  if (exception.getType() != kj::Exception::Type::DISCONNECTED) {
+    recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
+    return kj::mv(exception);
+  }
+  if (exception.getDetail(jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none) {
+    recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
+    return kj::mv(exception);
+  }
+  if (!config.payloadReplayable.toBool()) {
+    recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
+    return kj::mv(exception);
+  }
+  if (!retriesEnabled) {
+    recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
+    return kj::mv(exception);
+  }
+  if (attemptCount >= MAX_ATTEMPTS) {
+    recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
+    return KJ_ASSERT_NONNULL(originalDisconnect).clone();
+  }
+
+  auto delay = retryDelay();
+  auto deadline = KJ_ASSERT_NONNULL(this->deadline);
+  if (timer.nowForLimitTimeout() + delay >= deadline) {
+    recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
+    KJ_IF_SOME(original, originalDisconnect) {
+      return original.clone();
+    }
+    return kj::mv(exception);
+  }
+  return RetryPlan{kj::mv(exception), delay};
+}
+
+kj::Duration ActorCallRetryState::prepareRetry(RetryPlan plan) {
+  if (attemptCount == 1) {
+    originalDisconnect = plan.failure.clone();
+  }
+  if (plan.failure.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) == kj::none) {
+    KJ_ASSERT_NONNULL(metadata).isRetry = IsActorRetry::YES;
+  } else if (KJ_ASSERT_NONNULL(metadata).isRetry == IsActorRetry::NO) {
+    metadata = generateActorRetryRequestMetadata(
+        kj::systemCoarseCalendarClock().now(), config.enforcementEnabled);
+  }
+
+  ++attemptCount;
+  return plan.delay;
+}
+
+void ActorCallRetryState::recordRecovered() {
+  if (originalDisconnect != kj::none) {
+    recordOutcome(ActorRetryOutcome::RECOVERED);
+  }
+}
+
+void ActorCallRetryState::recordCanceled() {
+  recordOutcome(ActorRetryOutcome::CANCELED);
+}
+
+kj::Duration ActorCallRetryState::retryDelay() {
+  static thread_local auto generator = [] {
+    uint64_t seed;
+    getEntropy(kj::asBytes(seed));
+    return std::mt19937_64(seed);
+  }();
+  auto maximum = INITIAL_BACKOFF * (1u << (attemptCount - 1));
+  std::uniform_int_distribution<uint64_t> distribution(0, maximum / kj::NANOSECONDS);
+  return distribution(generator) * kj::NANOSECONDS;
+}
+
+void ActorCallRetryState::startRetryLatencyTimer() {
+  if (retryStartTime == kj::none) {
+    retryStartTime = kj::systemPreciseMonotonicClock().now();
+  }
+}
+
+void ActorCallRetryState::recordOutcome(ActorRetryOutcome outcome) {
+  if (recordedOutcome) return;
+  recordedOutcome = true;
+  if (retryAttemptsStarted == 0) return;
+  auto startTime = KJ_ASSERT_NONNULL(retryStartTime);
+  observer->recordActorRetryOutcome(
+      config.callType, outcome, kj::systemPreciseMonotonicClock().now() - startTime);
+}
+
+}  // namespace workerd::api

--- a/src/workerd/api/actor-call-retry.c++
+++ b/src/workerd/api/actor-call-retry.c++
@@ -16,13 +16,15 @@ ActorCallRetryState::ActorCallRetryState(
     : timer(timer),
       observer(kj::addRef(observer)),
       config(config) {
-  retriesEnabled = config.observationEnabled.toBool() && config.enforcementEnabled.toBool();
-  if (config.payloadReplayable.toBool()) {
+  auto payloadReplayable = config.payloadReplayable.toBool();
+  retriesEnabled =
+      payloadReplayable && config.observationEnabled.toBool() && config.enforcementEnabled.toBool();
+  if (payloadReplayable) {
     metadata = generateActorRetryRequestMetadata(
         kj::systemCoarseCalendarClock().now(), config.enforcementEnabled);
-    if (retriesEnabled) {
-      deadline = timer.nowForLimitTimeout() + RETRY_BUDGET;
-    }
+  }
+  if (retriesEnabled) {
+    deadline = timer.nowForLimitTimeout() + RETRY_BUDGET;
   }
 }
 
@@ -49,23 +51,18 @@ kj::OneOf<ActorCallRetryState::Attempt, kj::Exception> ActorCallRetryState::star
 
 kj::OneOf<kj::Duration, kj::Exception> ActorCallRetryState::handleAttemptFailure(
     kj::Exception exception) {
-  if (exception.getType() == kj::Exception::Type::DISCONNECTED) {
-    startRetryLatencyTimer();
-  }
+  maybeStartRetryLatencyTimer(exception);
   KJ_IF_SOME(claimRejection, handleClaimRejection(exception)) {
     return kj::mv(claimRejection);
   }
 
-  auto decision = checkCanRetry(kj::mv(exception));
-  KJ_SWITCH_ONEOF(decision) {
-    KJ_CASE_ONEOF(plan, RetryPlan) {
-      return prepareRetry(kj::mv(plan));
-    }
-    KJ_CASE_ONEOF(finalFailure, kj::Exception) {
-      return kj::mv(finalFailure);
-    }
+  return checkCanRetry(kj::mv(exception));
+}
+
+void ActorCallRetryState::maybeStartRetryLatencyTimer(const kj::Exception& exception) {
+  if (exception.getType() == kj::Exception::Type::DISCONNECTED && retryStartTime == kj::none) {
+    retryStartTime = kj::systemPreciseMonotonicClock().now();
   }
-  KJ_UNREACHABLE;
 }
 
 kj::Maybe<kj::Exception> ActorCallRetryState::handleClaimRejection(const kj::Exception& exception) {
@@ -74,24 +71,17 @@ kj::Maybe<kj::Exception> ActorCallRetryState::handleClaimRejection(const kj::Exc
   }
 
   recordOutcome(ActorRetryOutcome::CLAIM_REJECTED);
-  return KJ_ASSERT_NONNULL(originalDisconnect).clone();
+  return KJ_ASSERT_NONNULL(
+      originalDisconnect, "actor retry claim rejected before a retry was attempted")
+      .clone();
 }
 
-kj::OneOf<ActorCallRetryState::RetryPlan, kj::Exception> ActorCallRetryState::checkCanRetry(
-    kj::Exception exception) {
+kj::OneOf<kj::Duration, kj::Exception> ActorCallRetryState::checkCanRetry(kj::Exception exception) {
   if (exception.getType() != kj::Exception::Type::DISCONNECTED) {
     recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
     return kj::mv(exception);
   }
   if (exception.getDetail(jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none) {
-    recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
-    return kj::mv(exception);
-  }
-  if (!config.payloadReplayable.toBool()) {
-    recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
-    return kj::mv(exception);
-  }
-  if (!retriesEnabled) {
     recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
     return kj::mv(exception);
   }
@@ -109,14 +99,10 @@ kj::OneOf<ActorCallRetryState::RetryPlan, kj::Exception> ActorCallRetryState::ch
     }
     return kj::mv(exception);
   }
-  return RetryPlan{kj::mv(exception), delay};
-}
-
-kj::Duration ActorCallRetryState::prepareRetry(RetryPlan plan) {
   if (attemptCount == 1) {
-    originalDisconnect = plan.failure.clone();
+    originalDisconnect = exception.clone();
   }
-  if (plan.failure.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) == kj::none) {
+  if (exception.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) == kj::none) {
     KJ_ASSERT_NONNULL(metadata).isRetry = IsActorRetry::YES;
   } else if (KJ_ASSERT_NONNULL(metadata).isRetry == IsActorRetry::NO) {
     metadata = generateActorRetryRequestMetadata(
@@ -124,7 +110,7 @@ kj::Duration ActorCallRetryState::prepareRetry(RetryPlan plan) {
   }
 
   ++attemptCount;
-  return plan.delay;
+  return delay;
 }
 
 void ActorCallRetryState::recordRecovered() {
@@ -146,12 +132,6 @@ kj::Duration ActorCallRetryState::retryDelay() {
   auto maximum = INITIAL_BACKOFF * (1u << (attemptCount - 1));
   std::uniform_int_distribution<uint64_t> distribution(0, maximum / kj::NANOSECONDS);
   return distribution(generator) * kj::NANOSECONDS;
-}
-
-void ActorCallRetryState::startRetryLatencyTimer() {
-  if (retryStartTime == kj::none) {
-    retryStartTime = kj::systemPreciseMonotonicClock().now();
-  }
 }
 
 void ActorCallRetryState::recordOutcome(ActorRetryOutcome outcome) {

--- a/src/workerd/api/actor-call-retry.h
+++ b/src/workerd/api/actor-call-retry.h
@@ -64,24 +64,21 @@ class ActorCallRetryState final: public kj::Refcounted {
   kj::OneOf<Attempt, kj::Exception> startAttempt();
   kj::OneOf<kj::Duration, kj::Exception> handleAttemptFailure(kj::Exception exception);
 
+  bool isRetryEnabled() const {
+    return retriesEnabled;
+  }
+  void maybeStartRetryLatencyTimer(const kj::Exception& exception);
   void recordRecovered();
   void recordCanceled();
 
  private:
-  struct RetryPlan {
-    kj::Exception failure;
-    kj::Duration delay;
-  };
-
   static constexpr uint MAX_ATTEMPTS = 5;
   static constexpr auto RETRY_BUDGET = 10 * kj::SECONDS;
   static constexpr auto INITIAL_BACKOFF = 50 * kj::MILLISECONDS;
 
   kj::Maybe<kj::Exception> handleClaimRejection(const kj::Exception& exception);
-  kj::OneOf<RetryPlan, kj::Exception> checkCanRetry(kj::Exception exception);
-  kj::Duration prepareRetry(RetryPlan plan);
+  kj::OneOf<kj::Duration, kj::Exception> checkCanRetry(kj::Exception exception);
   kj::Duration retryDelay();
-  void startRetryLatencyTimer();
   void recordOutcome(ActorRetryOutcome outcome);
 
   TimerChannel& timer;

--- a/src/workerd/api/actor-call-retry.h
+++ b/src/workerd/api/actor-call-retry.h
@@ -1,0 +1,100 @@
+// Copyright (c) 2017-2022 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include <workerd/io/io-channels.h>
+#include <workerd/io/observer.h>
+#include <workerd/util/strong-bool.h>
+
+#include <kj/exception.h>
+#include <kj/one-of.h>
+#include <kj/refcount.h>
+#include <kj/time.h>
+
+namespace workerd::api {
+
+WD_STRONG_BOOL(ActorCallPayloadReplayable);
+WD_STRONG_BOOL(IsFirstActorCallAttempt);
+
+class ActorCallRetryState final: public kj::Refcounted {
+ public:
+  struct Config {
+    ActorRetryCallType callType;
+    ActorRetryGateEnabled observationEnabled;
+    ActorRetryGateEnabled enforcementEnabled;
+    ActorCallPayloadReplayable payloadReplayable;
+  };
+
+  class Attempt {
+   public:
+    Attempt(kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> metadata,
+        IsFirstActorCallAttempt isFirstAttempt)
+        : metadata(kj::mv(metadata)),
+          isFirstAttempt(isFirstAttempt) {
+      KJ_REQUIRE(isFirstAttempt.toBool() || this->metadata != kj::none,
+          "actor call retry attempt requires retry metadata");
+    }
+
+    bool hasMetadata() const {
+      return metadata != kj::none;
+    }
+    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> getMetadata() const {
+      return metadata;
+    }
+    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> takeMetadata() {
+      return kj::mv(metadata);
+    }
+    CountSubrequest getCountSubrequest() const {
+      return CountSubrequest(isFirstAttempt.toBool());
+    }
+    IsFirstActorCallAttempt getIsFirstAttempt() const {
+      return isFirstAttempt;
+    }
+
+   private:
+    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> metadata;
+    IsFirstActorCallAttempt isFirstAttempt;
+  };
+
+  ActorCallRetryState(TimerChannel& timer, RequestObserver& observer, Config config);
+  ~ActorCallRetryState() noexcept(false);
+
+  kj::OneOf<Attempt, kj::Exception> startAttempt();
+  kj::OneOf<kj::Duration, kj::Exception> handleAttemptFailure(kj::Exception exception);
+
+  void recordRecovered();
+  void recordCanceled();
+
+ private:
+  struct RetryPlan {
+    kj::Exception failure;
+    kj::Duration delay;
+  };
+
+  static constexpr uint MAX_ATTEMPTS = 5;
+  static constexpr auto RETRY_BUDGET = 10 * kj::SECONDS;
+  static constexpr auto INITIAL_BACKOFF = 50 * kj::MILLISECONDS;
+
+  kj::Maybe<kj::Exception> handleClaimRejection(const kj::Exception& exception);
+  kj::OneOf<RetryPlan, kj::Exception> checkCanRetry(kj::Exception exception);
+  kj::Duration prepareRetry(RetryPlan plan);
+  kj::Duration retryDelay();
+  void startRetryLatencyTimer();
+  void recordOutcome(ActorRetryOutcome outcome);
+
+  TimerChannel& timer;
+  kj::Own<RequestObserver> observer;
+  Config config;
+  bool retriesEnabled;
+  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> metadata;
+  kj::Maybe<kj::TimePoint> deadline;
+  kj::Maybe<kj::Exception> originalDisconnect;
+  kj::Maybe<kj::TimePoint> retryStartTime;
+  uint attemptCount = 1;
+  uint retryAttemptsStarted = 0;
+  bool recordedOutcome = false;
+};
+
+}  // namespace workerd::api

--- a/src/workerd/api/actor-fetch-retry-test.c++
+++ b/src/workerd/api/actor-fetch-retry-test.c++
@@ -87,15 +87,15 @@ class RetryMetadataOutgoingFactory final: public Fetcher::OutgoingFactory {
     return {.client = kj::heap<MockFetchTarget>(), .spanParents = kj::none};
   }
 
-  bool supportsActorFetchRetries() const override {
+  bool supportsActorCallRetries() const override {
     return true;
   }
 
-  Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String>,
-      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-      CountSubrequest,
-      MakeUserSpanParent) override {
-    capturedMetadata = kj::mv(actorRetryRequestMetadata);
+  void onActorCallRetry() override {}
+
+  Result newActorCallAttempt(
+      kj::Maybe<kj::String>, ActorCallRetryState::Attempt attempt, MakeUserSpanParent) override {
+    capturedMetadata = attempt.takeMetadata();
     return {.client = kj::heap<MockFetchTarget>(), .spanParents = kj::none};
   }
 
@@ -212,6 +212,7 @@ struct ReplayState {
   uint requestCount = 0;
   uint webSocketRequestCount = 0;
   uint retryCount = 0;
+  uint acceptedRetryCount = 0;
   uint observedRetryCount = 0;
   kj::Vector<ActorRetryOutcome> outcomes;
   kj::Maybe<DeterministicTimerChannel&> timerChannel;
@@ -326,20 +327,21 @@ class ReplayOutgoingFactory final: public Fetcher::OutgoingFactory {
     return {.client = kj::heap<ReplayFetchTarget>(state), .spanParents = kj::none};
   }
 
-  bool supportsActorFetchRetries() const override {
+  bool supportsActorCallRetries() const override {
     return true;
   }
 
-  void onActorFetchRetry() override {
-    ++state.retryCount;
+  void onActorCallRetry() override {
+    ++state.acceptedRetryCount;
   }
 
-  Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String>,
-      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-      CountSubrequest countSubrequest,
-      MakeUserSpanParent) override {
-    state.metadata.add(KJ_REQUIRE_NONNULL(actorRetryRequestMetadata));
-    state.countSubrequests.add(countSubrequest);
+  Result newActorCallAttempt(
+      kj::Maybe<kj::String>, ActorCallRetryState::Attempt attempt, MakeUserSpanParent) override {
+    if (!attempt.getIsFirstAttempt().toBool()) {
+      ++state.retryCount;
+    }
+    state.metadata.add(KJ_REQUIRE_NONNULL(attempt.takeMetadata()));
+    state.countSubrequests.add(attempt.getCountSubrequest());
     if (state.requestCount < state.actions.size()) {
       auto action = state.actions[state.requestCount];
       if (action == ReplayAction::CLIENT_CREATION_FAILURE) {
@@ -822,18 +824,6 @@ KJ_TEST("actor fetch stops after a retry claim rejection") {
   KJ_EXPECT(state.outcomes[0] == ActorRetryOutcome::CLAIM_REJECTED);
 }
 
-KJ_TEST("actor fetch normalizes an initial retry claim rejection") {
-  ReplayState state{.actions = kj::arr(ReplayAction::CLAIM_REJECTED)};
-  auto failure = KJ_REQUIRE_NONNULL(
-      runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP));
-
-  KJ_EXPECT(failure.getType() == kj::Exception::Type::DISCONNECTED, failure);
-  KJ_EXPECT(!failure.getDescription().contains("claim rejected"), failure);
-  KJ_EXPECT(state.requestCount == 1);
-  KJ_EXPECT(state.retryCount == 0);
-  KJ_EXPECT(state.outcomes.size() == 0);
-}
-
 KJ_TEST("actor WebSocket fetch retries a disconnected handshake") {
   ReplayState state{
     .actions = kj::arr(ReplayAction::AMBIGUOUS),
@@ -884,6 +874,7 @@ KJ_TEST("actor fetch abort before an actor failure does not report retry telemet
   KJ_EXPECT(exception.getDescription().contains("The operation was aborted"), exception);
   KJ_EXPECT(state.requestCount == 1);
   KJ_EXPECT(state.retryCount == 0);
+  KJ_EXPECT(state.acceptedRetryCount == 0);
   KJ_EXPECT(state.observedRetryCount == 0);
   KJ_EXPECT(state.outcomes.size() == 0);
 }
@@ -930,6 +921,8 @@ KJ_TEST("actor fetch abort before the first retry does not report an outcome") {
   });
 
   KJ_EXPECT(state.requestCount == 1);
+  KJ_EXPECT(state.acceptedRetryCount == 1);
+  KJ_EXPECT(state.retryCount == 0);
   KJ_EXPECT(state.observedRetryCount == 0);
   KJ_EXPECT(state.outcomes.size() == 0);
 }
@@ -1039,7 +1032,7 @@ KJ_TEST("actor fetch does not start a retry after the start budget") {
   KJ_EXPECT(
       runActorFetch(state, ActorRetryGateEnabled::YES, kj::none, ActorFetchKind::HTTP) != kj::none);
   KJ_EXPECT(state.requestCount == 1);
-  KJ_EXPECT(state.retryCount == 1);
+  KJ_EXPECT(state.retryCount == 0);
   KJ_EXPECT(state.observedRetryCount == 0);
   KJ_EXPECT(state.outcomes.size() == 0);
 }
@@ -1109,16 +1102,18 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
         env.js.alloc<DurableObjectId>(kj::heap<MockActorId>()), kj::str("location"),
         ActorGetMode::GET_OR_CREATE, false, ActorRoutingMode::DEFAULT,
         ActorVersion{.cohort = kj::str("cohort")}, Persistent::NO);
-    KJ_EXPECT(factory.supportsActorFetchRetries());
+    KJ_EXPECT(factory.supportsActorCallRetries());
 
-    auto client = factory.newSingleUseClientWithActorRetryMetadata(kj::none,
-        IoChannelFactory::ActorRetryRequestMetadata{
-          .nonce = 0x123456789abcdef0,
-          .createdAt = kj::UNIX_EPOCH + 123 * kj::MILLISECONDS,
-          .isRetry = IsActorRetry::YES,
-          .retryGateEnabled = ActorRetryGateEnabled::NO,
-        },
-        CountSubrequest::YES, [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
+    auto client = factory.newActorCallAttempt(kj::none,
+        ActorCallRetryState::Attempt(
+            IoChannelFactory::ActorRetryRequestMetadata{
+              .nonce = 0x123456789abcdef0,
+              .createdAt = kj::UNIX_EPOCH + 123 * kj::MILLISECONDS,
+              .isRetry = IsActorRetry::YES,
+              .retryGateEnabled = ActorRetryGateEnabled::NO,
+            },
+            IsFirstActorCallAttempt::YES),
+        [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
 
     KJ_IF_SOME(metadata, capturedMetadata) {
       KJ_EXPECT(metadata.nonce == 0x123456789abcdef0);
@@ -1128,15 +1123,17 @@ KJ_TEST("GlobalActorOutgoingFactory forwards metadata and recreates channels for
       KJ_FAIL_EXPECT("actor retry metadata was not forwarded to the actor channel");
     }
 
-    factory.onActorFetchRetry();
-    auto retryClient = factory.newSingleUseClientWithActorRetryMetadata(kj::none,
-        IoChannelFactory::ActorRetryRequestMetadata{
-          .nonce = 0xfedcba9876543210,
-          .createdAt = kj::UNIX_EPOCH + 456 * kj::MILLISECONDS,
-          .isRetry = IsActorRetry::YES,
-          .retryGateEnabled = ActorRetryGateEnabled::NO,
-        },
-        CountSubrequest::NO, [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
+    factory.onActorCallRetry();
+    auto retryClient = factory.newActorCallAttempt(kj::none,
+        ActorCallRetryState::Attempt(
+            IoChannelFactory::ActorRetryRequestMetadata{
+              .nonce = 0xfedcba9876543210,
+              .createdAt = kj::UNIX_EPOCH + 456 * kj::MILLISECONDS,
+              .isRetry = IsActorRetry::YES,
+              .retryGateEnabled = ActorRetryGateEnabled::NO,
+            },
+            IsFirstActorCallAttempt::NO),
+        [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
     KJ_EXPECT(checkedSubrequestCount == 1);
     KJ_EXPECT(channelCount == 2);
     KJ_ASSERT(locationHints.size() == 2);

--- a/src/workerd/api/actor.c++
+++ b/src/workerd/api/actor.c++
@@ -110,24 +110,24 @@ IoChannelFactory::ActorChannel& GlobalActorOutgoingFactory::getOrCreateActorChan
   return *KJ_REQUIRE_NONNULL(actorChannel);
 }
 
-void GlobalActorOutgoingFactory::onActorFetchRetry() {
+Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::newSingleUseClient(
+    kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) {
+  return newActorCallAttempt(kj::mv(cfStr),
+      ActorCallRetryState::Attempt(kj::none, IsFirstActorCallAttempt::YES),
+      kj::mv(makeUserSpanParent));
+}
+
+void GlobalActorOutgoingFactory::onActorCallRetry() {
   // The cached channel may contain the disconnected routing pipeline. Clear it so the retry
   // resolves a fresh route instead of reusing that pipeline.
   actorChannel = kj::none;
   channelMemoryAdjustment = kj::none;
 }
 
-Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::newSingleUseClient(
-    kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) {
-  return newSingleUseClientWithActorRetryMetadata(
-      kj::mv(cfStr), kj::none, CountSubrequest::YES, kj::mv(makeUserSpanParent));
-}
-
-Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::
-    newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
-        kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-        CountSubrequest countSubrequest,
-        MakeUserSpanParent makeUserSpanParent) {
+Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::newActorCallAttempt(
+    kj::Maybe<kj::String> cfStr,
+    ActorCallRetryState::Attempt attempt,
+    MakeUserSpanParent makeUserSpanParent) {
   auto& context = IoContext::current();
 
   kj::Maybe<TraceContextParent> spanParents;
@@ -143,9 +143,9 @@ Fetcher::OutgoingFactory::Result GlobalActorOutgoingFactory::
         .startRequest({.cfBlobJson = kj::mv(cfStr),
           .parentSpan = tracing.getInternalSpanParent(),
           .userSpanParent = kj::mv(userSpanParent),
-          .actorRetryRequestMetadata = kj::mv(actorRetryRequestMetadata)});
+          .actorRetryRequestMetadata = attempt.takeMetadata()});
   };
-  auto client = startActorSubrequest(context, makeClient, countSubrequest);
+  auto client = startActorSubrequest(context, makeClient, attempt.getCountSubrequest());
   return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
 }
 
@@ -156,15 +156,15 @@ kj::Own<IoChannelFactory::SubrequestChannel> GlobalActorOutgoingFactory::getSubr
 
 Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::newSingleUseClient(
     kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) {
-  return newSingleUseClientWithActorRetryMetadata(
-      kj::mv(cfStr), kj::none, CountSubrequest::YES, kj::mv(makeUserSpanParent));
+  return newActorCallAttempt(kj::mv(cfStr),
+      ActorCallRetryState::Attempt(kj::none, IsFirstActorCallAttempt::YES),
+      kj::mv(makeUserSpanParent));
 }
 
-Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::
-    newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
-        kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-        CountSubrequest countSubrequest,
-        MakeUserSpanParent makeUserSpanParent) {
+Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::newActorCallAttempt(
+    kj::Maybe<kj::String> cfStr,
+    ActorCallRetryState::Attempt attempt,
+    MakeUserSpanParent makeUserSpanParent) {
   auto& context = IoContext::current();
 
   kj::Maybe<TraceContextParent> spanParents;
@@ -181,9 +181,9 @@ Fetcher::OutgoingFactory::Result ReplicaActorOutgoingFactory::
     return actorChannel->startRequest({.cfBlobJson = kj::mv(cfStr),
       .parentSpan = tracing.getInternalSpanParent(),
       .userSpanParent = kj::mv(userSpanParent),
-      .actorRetryRequestMetadata = kj::mv(actorRetryRequestMetadata)});
+      .actorRetryRequestMetadata = attempt.takeMetadata()});
   };
-  auto client = startActorSubrequest(context, startRequest, countSubrequest);
+  auto client = startActorSubrequest(context, startRequest, attempt.getCountSubrequest());
   return {.client = kj::mv(client), .spanParents = kj::mv(spanParents)};
 }
 

--- a/src/workerd/api/actor.h
+++ b/src/workerd/api/actor.h
@@ -348,13 +348,12 @@ class GlobalActorOutgoingFactory final: public Fetcher::OutgoingFactory {
 
   Result newSingleUseClient(
       kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) override;
-  bool supportsActorFetchRetries() const override {
+  bool supportsActorCallRetries() const override {
     return true;
   }
-  void onActorFetchRetry() override;
-  Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
-      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-      CountSubrequest countSubrequest,
+  void onActorCallRetry() override;
+  Result newActorCallAttempt(kj::Maybe<kj::String> cfStr,
+      ActorCallRetryState::Attempt attempt,
       MakeUserSpanParent makeUserSpanParent) override;
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() override;
 
@@ -417,16 +416,15 @@ class ReplicaActorOutgoingFactory final: public Fetcher::OutgoingFactory {
 
   Result newSingleUseClient(
       kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) override;
-  bool supportsActorFetchRetries() const override {
+  bool supportsActorCallRetries() const override {
     return true;
   }
-  void onActorFetchRetry() override {
-    // Keep the pre-resolved primary channel. Reconnecting a broken channel requires routing state
-    // that this factory does not own, but request-level disconnects can still succeed on retry.
+  void onActorCallRetry() override {
+    // Keep the pre-resolved primary channel on retries. Reconnecting a broken channel requires
+    // routing state that this factory does not own, but request-level disconnects can still succeed.
   }
-  Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
-      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-      CountSubrequest countSubrequest,
+  Result newActorCallAttempt(kj::Maybe<kj::String> cfStr,
+      ActorCallRetryState::Attempt attempt,
       MakeUserSpanParent makeUserSpanParent) override;
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel() override;
 

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1471,109 +1471,6 @@ namespace {
 // Fetch spec requires (suggests?) 20: https://fetch.spec.whatwg.org/#http-redirect-fetch
 constexpr auto MAX_REDIRECT_COUNT = 20;
 
-class ActorRetryMetrics final: public kj::Refcounted {
- public:
-  explicit ActorRetryMetrics(RequestObserver& observer): observer(kj::addRef(observer)) {}
-
-  ~ActorRetryMetrics() noexcept(false) {
-    if (retryStartTime != kj::none && !recordedOutcome) {
-      recordOutcome(ActorRetryOutcome::OTHER);
-    }
-  }
-
-  void startRetryLatencyTimer() {
-    if (retryStartTime == kj::none) {
-      retryStartTime = kj::systemPreciseMonotonicClock().now();
-    }
-  }
-
-  void observeAttemptFailure(const kj::Exception& exception) {
-    if (exception.getType() == kj::Exception::Type::DISCONNECTED ||
-        exception.getDetail(jsg::ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID) != kj::none) {
-      startRetryLatencyTimer();
-    }
-  }
-
-  void recordRetry() {
-    retryStarted = true;
-    observer->recordActorRetry(ActorRetryCallType::FETCH);
-  }
-
-  void recordCanceled() {
-    recordOutcome(ActorRetryOutcome::CANCELED);
-  }
-
-  void recordOutcome(ActorRetryOutcome outcome) {
-    if (recordedOutcome) return;
-    recordedOutcome = true;
-    if (!retryStarted) return;
-    auto startTime = KJ_ASSERT_NONNULL(retryStartTime);
-    observer->recordActorRetryOutcome(ActorRetryCallType::FETCH, outcome,
-        kj::systemPreciseMonotonicClock().now() - startTime);
-  }
-
- private:
-  kj::Own<RequestObserver> observer;
-  kj::Maybe<kj::TimePoint> retryStartTime;
-  bool retryStarted = false;
-  bool recordedOutcome = false;
-};
-
-class ActorFetchRetryState {
- public:
-  static ActorFetchRetryState create(TimerChannel& timer, RequestObserver& observer);
-
-  IoChannelFactory::ActorRetryRequestMetadata getMetadata() const {
-    return metadata;
-  }
-
-  bool isRetryEnabled() const {
-    return deadline != kj::none;
-  }
-
-  CountSubrequest countSubrequest() const {
-    return CountSubrequest(attemptCount == 1);
-  }
-
-  kj::Maybe<kj::Exception> checkDeadline();
-  kj::OneOf<kj::Duration, kj::Exception> prepareRetry(kj::Exception exception);
-  void recordRetry() {
-    if (attemptCount > 1) {
-      metrics->recordRetry();
-    }
-  }
-  kj::Rc<ActorRetryMetrics> addMetricsRef() {
-    return metrics.addRef();
-  }
-  void recordRecovered();
-  void recordCanceled() {
-    metrics->recordCanceled();
-  }
-
- private:
-  static constexpr uint MAX_ATTEMPTS = 5;
-  static constexpr auto RETRY_BUDGET = 10 * kj::SECONDS;
-  static constexpr auto INITIAL_BACKOFF = 50 * kj::MILLISECONDS;
-
-  ActorFetchRetryState(IoChannelFactory::ActorRetryRequestMetadata metadata,
-      kj::Maybe<kj::TimePoint> deadline,
-      TimerChannel& timer,
-      kj::Rc<ActorRetryMetrics> metrics)
-      : metadata(kj::mv(metadata)),
-        deadline(kj::mv(deadline)),
-        timer(timer),
-        metrics(kj::mv(metrics)) {}
-
-  kj::Duration retryDelay();
-
-  IoChannelFactory::ActorRetryRequestMetadata metadata;
-  kj::Maybe<kj::TimePoint> deadline;
-  TimerChannel& timer;
-  kj::Rc<ActorRetryMetrics> metrics;
-  kj::Maybe<kj::Exception> originalDisconnect;
-  uint attemptCount = 1;
-};
-
 struct ActorFetchFailure {
   kj::Exception exception;
 };
@@ -1581,119 +1478,22 @@ struct ActorFetchFailure {
 template <typename T>
 using ActorFetchAttemptResult = kj::OneOf<T, ActorFetchFailure>;
 
-ActorFetchRetryState ActorFetchRetryState::create(TimerChannel& timer, RequestObserver& observer) {
-  bool retryGateEnabled = util::Autogate::isEnabled(
-      util::AutogateKey::DURABLE_OBJECT_RETRIES_FETCH_RETRY_REQUESTS);
-  auto metadata = generateActorRetryRequestMetadata(kj::systemCoarseCalendarClock().now(),
-      ActorRetryGateEnabled(retryGateEnabled));
-  kj::Maybe<kj::TimePoint> deadline;
-  if (util::Autogate::isEnabled(util::AutogateKey::DURABLE_OBJECT_RETRIES_FETCH) &&
-      retryGateEnabled) {
-    deadline = timer.nowForLimitTimeout() + RETRY_BUDGET;
-  }
-  return ActorFetchRetryState(
-      kj::mv(metadata), kj::mv(deadline), timer, kj::rc<ActorRetryMetrics>(observer));
-}
-
-kj::Maybe<kj::Exception> ActorFetchRetryState::checkDeadline() {
-  KJ_IF_SOME(deadlineValue, deadline) {
-    if (attemptCount > 1 && timer.nowForLimitTimeout() >= deadlineValue) {
-      metrics->recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
-      return KJ_ASSERT_NONNULL(originalDisconnect).clone();
-    }
-  }
-  return kj::none;
-}
-
-kj::Duration ActorFetchRetryState::retryDelay() {
-  static thread_local auto generator = [] {
-    uint64_t seed;
-    getEntropy(kj::asBytes(seed));
-    return std::mt19937_64(seed);
-  }();
-  auto maximum = INITIAL_BACKOFF * (1u << (attemptCount - 1));
-  std::uniform_int_distribution<uint64_t> distribution(0, maximum / kj::NANOSECONDS);
-  return distribution(generator) * kj::NANOSECONDS;
-}
-
-kj::OneOf<kj::Duration, kj::Exception> ActorFetchRetryState::prepareRetry(
-    kj::Exception exception) {
-  if (!isRetryEnabled()) {
-    return kj::mv(exception);
-  }
-  if (exception.getDetail(jsg::ACTOR_RETRY_CLAIM_REJECTED_DETAIL_ID) != kj::none) {
-    metrics->startRetryLatencyTimer();
-    metrics->recordOutcome(ActorRetryOutcome::CLAIM_REJECTED);
-    KJ_IF_SOME(original, originalDisconnect) {
-      return kj::mv(original);
-    }
-    auto normalized = KJ_EXCEPTION(DISCONNECTED, "Durable Object fetch failed");
-    for (auto& detail: exception.getDetails()) {
-      normalized.setDetail(detail.id, kj::heapArray(detail.value.asPtr()));
-    }
-    return normalized;
-  }
-
-  if (exception.getType() != kj::Exception::Type::DISCONNECTED) {
-    if (originalDisconnect != kj::none) {
-      metrics->recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
-    }
-    return kj::mv(exception);
-  }
-  metrics->startRetryLatencyTimer();
-  if (exception.getDetail(jsg::REQUEST_DELIVERED_TO_ACTOR_DETAIL_ID) != kj::none) {
-    metrics->recordOutcome(ActorRetryOutcome::UNABLE_TO_RETRY);
-    return kj::mv(exception);
-  }
-  if (attemptCount >= MAX_ATTEMPTS) {
-    metrics->recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
-    return KJ_ASSERT_NONNULL(originalDisconnect).clone();
-  }
-
-  if (attemptCount == 1) {
-    originalDisconnect = exception.clone();
-  }
-  if (exception.getDetail(jsg::REQUEST_NOT_DELIVERED_TO_ACTOR_DETAIL_ID) == kj::none) {
-    metadata.isRetry = IsActorRetry::YES;
-  } else if (metadata.isRetry == IsActorRetry::NO) {
-    auto requestGateEnabled = metadata.retryGateEnabled;
-    metadata = generateActorRetryRequestMetadata(
-        kj::systemCoarseCalendarClock().now(), requestGateEnabled);
-  }
-
-  auto delay = retryDelay();
-  auto deadline = KJ_ASSERT_NONNULL(this->deadline);
-  if (timer.nowForLimitTimeout() + delay >= deadline) {
-    metrics->recordOutcome(ActorRetryOutcome::RETRIES_EXHAUSTED);
-    return KJ_ASSERT_NONNULL(originalDisconnect).clone();
-  }
-  ++attemptCount;
-  return delay;
-}
-
-void ActorFetchRetryState::recordRecovered() {
-  if (originalDisconnect != kj::none) {
-    metrics->recordOutcome(ActorRetryOutcome::RECOVERED);
-  }
-}
-
 template <typename T>
 kj::Promise<ActorFetchAttemptResult<T>> captureActorFetchAttempt(jsg::Lock& js,
     kj::Maybe<jsg::Ref<AbortSignal>>& signal,
     kj::Promise<T> promise,
-    kj::Rc<ActorRetryMetrics> metrics) {
-  auto cancellationMetrics = metrics.addRef();
+    kj::Rc<ActorCallRetryState> retryState) {
   auto result = kj::mv(promise)
       .then([](T&& result) -> ActorFetchAttemptResult<T> { return kj::mv(result); })
-      .catch_([metrics = kj::mv(metrics)](
+      .catch_([retryState = retryState.addRef()](
                   kj::Exception&& exception) mutable -> ActorFetchAttemptResult<T> {
-    metrics->observeAttemptFailure(exception);
+    retryState->maybeStartRetryLatencyTimer(exception);
     return ActorFetchFailure{kj::mv(exception)};
   });
   return AbortSignal::maybeCancelWrap(js, signal, kj::mv(result))
-      .catch_([metrics = kj::mv(cancellationMetrics)](
+      .catch_([retryState = kj::mv(retryState)](
                   kj::Exception&& exception) mutable -> kj::Promise<ActorFetchAttemptResult<T>> {
-    metrics->recordCanceled();
+    retryState->recordCanceled();
     return kj::mv(exception);
   });
 }
@@ -1702,7 +1502,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
     jsg::Ref<Fetcher> fetcher,
     jsg::Ref<Request> jsRequest,
     kj::Vector<kj::Url> urlList,
-    kj::Maybe<ActorFetchRetryState> retryState);
+    kj::Maybe<kj::Rc<ActorCallRetryState>> retryState);
 
 jsg::Promise<jsg::Ref<Response>> handleHttpResponse(jsg::Lock& js,
     jsg::Ref<Fetcher> fetcher,
@@ -1788,31 +1588,31 @@ jsg::Promise<jsg::Ref<Response>> retryActorFetch(jsg::Lock& js,
     jsg::Ref<Fetcher> fetcher,
     jsg::Ref<Request> jsRequest,
     kj::Vector<kj::Url> urlList,
-    ActorFetchRetryState state,
+    kj::Rc<ActorCallRetryState> retryState,
     kj::Exception exception) {
   KJ_IF_SOME(reason, getAbortReason(js, *jsRequest)) {
-    state.recordCanceled();
+    retryState->recordCanceled();
     return js.rejectedPromise<jsg::Ref<Response>>(kj::mv(reason));
   }
-  auto delayOrException = state.prepareRetry(kj::mv(exception));
+  auto delayOrException = retryState->handleAttemptFailure(kj::mv(exception));
   KJ_IF_SOME(exception, delayOrException.tryGet<kj::Exception>()) {
     return rejectFetch(js, kj::mv(exception));
   }
   auto delay = KJ_ASSERT_NONNULL(delayOrException.tryGet<kj::Duration>());
+  fetcher->onActorCallRetry();
   auto& ioContext = IoContext::current();
   jsRequest->rewindBody(js);
-  fetcher->onActorFetchRetry();
 
   auto signal = jsRequest->getSignal();
   auto delayPromise = AbortSignal::maybeCancelWrap(js, signal, ioContext.afterLimitTimeout(delay))
-                          .catch_([metrics = state.addMetricsRef()](
+                          .catch_([retryState = retryState.addRef()](
                                       kj::Exception&& exception) mutable -> kj::Promise<void> {
-    metrics->recordCanceled();
+    retryState->recordCanceled();
     return kj::mv(exception);
   });
   return ioContext.awaitIo(js, kj::mv(delayPromise),
       [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest), urlList = kj::mv(urlList),
-          retryState = kj::Maybe(kj::mv(state))](jsg::Lock& js) mutable {
+          retryState = kj::Maybe(kj::mv(retryState))](jsg::Lock& js) mutable {
     return fetchImplNoOutputLockAttempt(
         js, kj::mv(fetcher), kj::mv(jsRequest), kj::mv(urlList), kj::mv(retryState));
   });
@@ -1821,12 +1621,22 @@ jsg::Promise<jsg::Ref<Response>> retryActorFetch(jsg::Lock& js,
 jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLock(jsg::Lock& js,
     jsg::Ref<Fetcher> fetcher,
     jsg::Ref<Request> jsRequest,
-    kj::Vector<kj::Url> urlList) {
-  kj::Maybe<ActorFetchRetryState> retryState;
-  if (jsRequest->canRewindBody() && fetcher->supportsActorFetchRetries()) {
+  kj::Vector<kj::Url> urlList) {
+  kj::Maybe<kj::Rc<ActorCallRetryState>> retryState;
+  if (fetcher->supportsActorCallRetries()) {
     auto& context = IoContext::current();
-    retryState = ActorFetchRetryState::create(
-        context.getIoChannelFactory().getTimer(), context.getMetrics());
+    auto observationEnabled = ActorRetryGateEnabled(
+        util::Autogate::isEnabled(util::AutogateKey::DURABLE_OBJECT_RETRIES_FETCH));
+    auto enforcementEnabled = ActorRetryGateEnabled(util::Autogate::isEnabled(
+        util::AutogateKey::DURABLE_OBJECT_RETRIES_FETCH_RETRY_REQUESTS));
+    retryState = kj::rc<ActorCallRetryState>(context.getIoChannelFactory().getTimer(),
+        context.getMetrics(),
+        ActorCallRetryState::Config{
+          .callType = ActorRetryCallType::FETCH,
+          .observationEnabled = observationEnabled,
+          .enforcementEnabled = enforcementEnabled,
+          .payloadReplayable = ActorCallPayloadReplayable(jsRequest->canRewindBody()),
+        });
   }
 
   return fetchImplNoOutputLockAttempt(
@@ -1837,7 +1647,7 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
     jsg::Ref<Fetcher> fetcher,
     jsg::Ref<Request> jsRequest,
     kj::Vector<kj::Url> urlList,
-    kj::Maybe<ActorFetchRetryState> retryState) {
+    kj::Maybe<kj::Rc<ActorCallRetryState>> retryState) {
   KJ_ASSERT(!urlList.empty());
 
   auto& ioContext = IoContext::current();
@@ -1845,15 +1655,18 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
   auto signal = jsRequest->getSignal();
   KJ_IF_SOME(reason, getAbortReason(js, *jsRequest)) {
     KJ_IF_SOME(state, retryState) {
-      state.recordCanceled();
+      state->recordCanceled();
     }
     return js.rejectedPromise<jsg::Ref<Response>>(kj::mv(reason));
   }
+  kj::Maybe<ActorCallRetryState::Attempt> actorCallAttempt;
   KJ_IF_SOME(state, retryState) {
-    KJ_IF_SOME(exception, state.checkDeadline()) {
+    auto attemptOrException = state->startAttempt();
+    KJ_IF_SOME(exception, attemptOrException.tryGet<kj::Exception>()) {
       return rejectFetch(js, kj::mv(exception));
     }
-    state.recordRetry();
+    actorCallAttempt =
+        kj::mv(KJ_ASSERT_NONNULL(attemptOrException.tryGet<ActorCallRetryState::Attempt>()));
   }
 
   // Stash whether this request's body can be rewound (and so the request re-sent), before we lose
@@ -1864,17 +1677,17 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
   bool bodyRewindable = jsRequest->canRewindBody();
   ioContext.getMetrics().setNextSubrequestBodyRewindable(SubrequestBodyRewindable(bodyRewindable));
 
-  kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata;
-  auto countSubrequest = CountSubrequest::YES;
-  KJ_IF_SOME(state, retryState) {
-    actorRetryRequestMetadata = state.getMetadata();
-    countSubrequest = state.countSubrequest();
-  }
-
   // Get client and trace context (if needed) in one clean call.
-  auto clientWithTracing = fetcher->getClientWithTracing(ioContext,
-      jsRequest->serializeCfBlobJson(js), "fetch"_kjc,
-      kj::mv(actorRetryRequestMetadata), countSubrequest);
+  auto cfBlobJson = jsRequest->serializeCfBlobJson(js);
+  kj::Maybe<Fetcher::ClientWithTracing> maybeClientWithTracing;
+  KJ_IF_SOME(attempt, actorCallAttempt) {
+    maybeClientWithTracing = fetcher->getClientForActorCallAttempt(
+        ioContext, kj::mv(cfBlobJson), "fetch"_kjc, kj::mv(attempt));
+  } else {
+    maybeClientWithTracing =
+        fetcher->getClientWithTracing(ioContext, kj::mv(cfBlobJson), "fetch"_kjc);
+  }
+  auto clientWithTracing = kj::mv(KJ_ASSERT_NONNULL(maybeClientWithTracing));
   auto traceContext = kj::mv(clientWithTracing.traceContext);
 
   // TODO(cleanup): Don't convert to HttpClient. Use the HttpService interface instead. This
@@ -1945,18 +1758,18 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
     }
     auto webSocketResponse = client->openWebSocket(url, headers);
     KJ_IF_SOME(state, retryState) {
-      if (state.isRetryEnabled()) {
+      if (state->isRetryEnabled()) {
         auto resultPromise = captureActorFetchAttempt(
-            js, signal, kj::mv(webSocketResponse), state.addMetricsRef());
+            js, signal, kj::mv(webSocketResponse), state.addRef());
         return ioContext.awaitIo(js, kj::mv(resultPromise),
-            [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest),
-                urlList = kj::mv(urlList), client = kj::mv(client), signal = kj::mv(signal),
-                retryState = kj::mv(retryState)](jsg::Lock& js,
-                ActorFetchAttemptResult<kj::HttpClient::WebSocketResponse>&& result) mutable
-            -> jsg::Promise<jsg::Ref<Response>> {
-          KJ_SWITCH_ONEOF(result) {
-            KJ_CASE_ONEOF(response, kj::HttpClient::WebSocketResponse) {
-              KJ_ASSERT_NONNULL(retryState).recordRecovered();
+              [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest),
+                  urlList = kj::mv(urlList), client = kj::mv(client), signal = kj::mv(signal),
+                  retryState = kj::mv(retryState)](jsg::Lock& js,
+                  ActorFetchAttemptResult<kj::HttpClient::WebSocketResponse>&& result) mutable
+              -> jsg::Promise<jsg::Ref<Response>> {
+            KJ_SWITCH_ONEOF(result) {
+              KJ_CASE_ONEOF(response, kj::HttpClient::WebSocketResponse) {
+              KJ_ASSERT_NONNULL(retryState)->recordRecovered();
               return handleWebSocketFetchResponse(js, kj::mv(fetcher), kj::mv(jsRequest),
                   kj::mv(urlList), kj::mv(client), kj::mv(signal), kj::mv(response));
             }
@@ -1964,9 +1777,9 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
               return retryActorFetch(js, kj::mv(fetcher), kj::mv(jsRequest), kj::mv(urlList),
                   kj::mv(KJ_ASSERT_NONNULL(retryState)), kj::mv(failure.exception));
             }
-          }
-          KJ_UNREACHABLE;
-        });
+            }
+            KJ_UNREACHABLE;
+          });
       }
     }
     webSocketResponse = AbortSignal::maybeCancelWrap(js, signal, kj::mv(webSocketResponse));
@@ -2045,18 +1858,18 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
       return kj::mv(exception);
     });
     KJ_IF_SOME(state, retryState) {
-      if (state.isRetryEnabled()) {
+      if (state->isRetryEnabled()) {
         auto resultPromise =
-            captureActorFetchAttempt(js, signal, kj::mv(responsePromise), state.addMetricsRef());
+            captureActorFetchAttempt(js, signal, kj::mv(responsePromise), state.addRef());
         return ioContext.awaitIo(js, kj::mv(resultPromise),
-            [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest),
-                urlList = kj::mv(urlList), client = kj::mv(client),
-                traceContext = kj::mv(traceContext), retryState = kj::mv(retryState)](
-                jsg::Lock& js, ActorFetchAttemptResult<kj::HttpClient::Response>&& result) mutable
-            -> jsg::Promise<jsg::Ref<Response>> {
-          KJ_SWITCH_ONEOF(result) {
-            KJ_CASE_ONEOF(response, kj::HttpClient::Response) {
-              KJ_ASSERT_NONNULL(retryState).recordRecovered();
+              [fetcher = kj::mv(fetcher), jsRequest = kj::mv(jsRequest),
+                  urlList = kj::mv(urlList), client = kj::mv(client),
+                  traceContext = kj::mv(traceContext), retryState = kj::mv(retryState)](
+                  jsg::Lock& js, ActorFetchAttemptResult<kj::HttpClient::Response>&& result) mutable
+              -> jsg::Promise<jsg::Ref<Response>> {
+            KJ_SWITCH_ONEOF(result) {
+              KJ_CASE_ONEOF(response, kj::HttpClient::Response) {
+              KJ_ASSERT_NONNULL(retryState)->recordRecovered();
               return handleHttpFetchResponse(js, kj::mv(fetcher), kj::mv(jsRequest),
                   kj::mv(urlList), kj::mv(client), traceContext, kj::mv(response));
             }
@@ -2064,9 +1877,9 @@ jsg::Promise<jsg::Ref<Response>> fetchImplNoOutputLockAttempt(jsg::Lock& js,
               return retryActorFetch(js, kj::mv(fetcher), kj::mv(jsRequest), kj::mv(urlList),
                   kj::mv(KJ_ASSERT_NONNULL(retryState)), kj::mv(failure.exception));
             }
-          }
-          KJ_UNREACHABLE;
-        });
+            }
+            KJ_UNREACHABLE;
+          });
       }
     }
     responsePromise = AbortSignal::maybeCancelWrap(js, signal, kj::mv(responsePromise));
@@ -2890,40 +2703,43 @@ jsg::Promise<Fetcher::ScheduledResult> Fetcher::scheduled(
 
 kj::Own<WorkerInterface> Fetcher::getClient(
     IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName) {
-  auto clientWithTracing = getClientWithTracing(
-      ioContext, kj::mv(cfStr), kj::mv(operationName), kj::none, CountSubrequest::YES);
+  auto clientWithTracing =
+      getClientWithTracing(ioContext, kj::mv(cfStr), kj::mv(operationName));
   return clientWithTracing.client.attach(kj::mv(clientWithTracing.traceContext));
 }
 
 Fetcher::ClientWithTracing Fetcher::getClientWithTracing(IoContext& ioContext,
     kj::Maybe<kj::String> cfStr,
+    kj::ConstString operationName) {
+  return buildClient(ioContext, kj::mv(cfStr), kj::mv(operationName));
+}
+
+Fetcher::ClientWithTracing Fetcher::getClientForActorCallAttempt(IoContext& ioContext,
+    kj::Maybe<kj::String> cfStr,
     kj::ConstString operationName,
-    kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-    CountSubrequest countSubrequest) {
-  KJ_IF_SOME(metadata, actorRetryRequestMetadata) {
-    auto& outgoingFactory = KJ_REQUIRE_NONNULL(
-        channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>(),
-        "actor retry metadata supplied to an unsupported Fetcher");
-    KJ_REQUIRE(outgoingFactory->supportsActorFetchRetries(),
-        "actor retry metadata supplied to an unsupported Fetcher");
-    if (!util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING)) {
-      auto result = outgoingFactory->newSingleUseClientWithActorRetryMetadata(kj::mv(cfStr),
-          kj::mv(metadata), countSubrequest,
-          [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
-      return ClientWithTracing{kj::mv(result.client), kj::none};
-    }
-    kj::Maybe<TraceContext> traceContext;
-    auto result = outgoingFactory->newSingleUseClientWithActorRetryMetadata(kj::mv(cfStr),
-        kj::mv(metadata), countSubrequest,
-        [&](TraceContext& outerTraceContext) -> kj::Maybe<SpanParent> {
-      if (!outerTraceContext.isObserved()) return kj::none;
-      traceContext = outerTraceContext.getSpanParents().newChild(operationName.clone());
-      return KJ_ASSERT_NONNULL(traceContext).getUserSpanParent();
-    });
-    return ClientWithTracing{kj::mv(result.client), kj::mv(traceContext)};
+    ActorCallRetryState::Attempt attempt) {
+  if (!attempt.hasMetadata()) {
+    return buildClient(ioContext, kj::mv(cfStr), kj::mv(operationName));
   }
 
-  return buildClient(ioContext, kj::mv(cfStr), kj::mv(operationName));
+  auto& outgoingFactory = KJ_REQUIRE_NONNULL(
+      channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>(),
+      "actor call attempt supplied to an unsupported Fetcher");
+  KJ_REQUIRE(outgoingFactory->supportsActorCallRetries(),
+      "actor call attempt supplied to an unsupported Fetcher");
+  if (!util::Autogate::isEnabled(util::AutogateKey::JSRPC_TRACING)) {
+    auto result = outgoingFactory->newActorCallAttempt(kj::mv(cfStr), kj::mv(attempt),
+        [](TraceContext&) -> kj::Maybe<SpanParent> { return kj::none; });
+    return ClientWithTracing{kj::mv(result.client), kj::none};
+  }
+  kj::Maybe<TraceContext> traceContext;
+  auto result = outgoingFactory->newActorCallAttempt(kj::mv(cfStr), kj::mv(attempt),
+      [&](TraceContext& outerTraceContext) -> kj::Maybe<SpanParent> {
+    if (!outerTraceContext.isObserved()) return kj::none;
+    traceContext = outerTraceContext.getSpanParents().newChild(operationName.clone());
+    return KJ_ASSERT_NONNULL(traceContext).getUserSpanParent();
+  });
+  return ClientWithTracing{kj::mv(result.client), kj::mv(traceContext)};
 }
 
 Fetcher::ClientWithTracing Fetcher::wrapWithInnerSpan(
@@ -2982,11 +2798,20 @@ Fetcher::ClientWithTracing Fetcher::buildClient(IoContext& ioContext,
   KJ_UNREACHABLE;
 }
 
-bool Fetcher::supportsActorFetchRetries() {
+bool Fetcher::supportsActorCallRetries() {
   KJ_IF_SOME(outgoingFactory, channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>()) {
-    return outgoingFactory->supportsActorFetchRetries();
+    return outgoingFactory->supportsActorCallRetries();
   }
   return false;
+}
+
+void Fetcher::onActorCallRetry() {
+  auto& outgoingFactory = KJ_REQUIRE_NONNULL(
+      channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>(),
+      "actor call retry requested from an unsupported Fetcher");
+  KJ_REQUIRE(outgoingFactory->supportsActorCallRetries(),
+      "actor call retry requested from an unsupported Fetcher");
+  outgoingFactory->onActorCallRetry();
 }
 
 Fetcher::ClientWithTracing Fetcher::buildClient(IoContext& ioContext,
@@ -3046,15 +2871,6 @@ Fetcher::ClientWithTracing Fetcher::buildClient(IoContext& ioContext,
     }
   }
   KJ_UNREACHABLE;
-}
-
-void Fetcher::onActorFetchRetry() {
-  auto& outgoingFactory = KJ_REQUIRE_NONNULL(
-      channelOrClientFactory.tryGet<IoOwn<OutgoingFactory>>(),
-      "actor fetch retry requested from an unsupported Fetcher");
-  KJ_REQUIRE(outgoingFactory->supportsActorFetchRetries(),
-      "actor fetch retry requested from an unsupported Fetcher");
-  outgoingFactory->onActorFetchRetry();
 }
 
 kj::Own<IoChannelFactory::SubrequestChannel> Fetcher::getSubrequestChannel(IoContext& ioContext) {

--- a/src/workerd/api/http.h
+++ b/src/workerd/api/http.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "actor-call-retry.h"
 #include "basics.h"
 #include "blob.h"
 #include "form-data.h"
@@ -253,21 +254,20 @@ class Fetcher: public JsRpcClientProvider {
     virtual Result newSingleUseClient(
         kj::Maybe<kj::String> cfStr, MakeUserSpanParent makeUserSpanParent) = 0;
 
-    virtual bool supportsActorFetchRetries() const {
+    virtual bool supportsActorCallRetries() const {
       return false;
     }
 
-    virtual void onActorFetchRetry() {
-      KJ_FAIL_REQUIRE("actor fetch retry requested from an unsupported Fetcher");
+    virtual void onActorCallRetry() {
+      KJ_FAIL_REQUIRE("actor call retry requested from an unsupported Fetcher");
     }
 
-    // Factories that can carry actor retry metadata override this method. The default rejects the
-    // metadata rather than silently starting a new logical call.
-    virtual Result newSingleUseClientWithActorRetryMetadata(kj::Maybe<kj::String> cfStr,
-        kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-        CountSubrequest countSubrequest,
+    // Factories that support actor call retries override this method. The default rejects the
+    // attempt rather than silently starting a new logical call.
+    virtual Result newActorCallAttempt(kj::Maybe<kj::String> cfStr,
+        ActorCallRetryState::Attempt attempt,
         MakeUserSpanParent makeUserSpanParent) {
-      KJ_FAIL_REQUIRE("actor retry metadata supplied to an unsupported Fetcher");
+      KJ_FAIL_REQUIRE("actor call attempt supplied to an unsupported Fetcher");
     }
 
     // Get a `SubrequestChannel` representing this Fetcher. This is used especially when the
@@ -328,14 +328,16 @@ class Fetcher: public JsRpcClientProvider {
 
   // Get client and optionally create trace context, all in one call.
   //
-  [[nodiscard]] ClientWithTracing getClientWithTracing(IoContext& ioContext,
+  [[nodiscard]] ClientWithTracing getClientWithTracing(
+      IoContext& ioContext, kj::Maybe<kj::String> cfStr, kj::ConstString operationName);
+
+  [[nodiscard]] ClientWithTracing getClientForActorCallAttempt(IoContext& ioContext,
       kj::Maybe<kj::String> cfStr,
       kj::ConstString operationName,
-      kj::Maybe<IoChannelFactory::ActorRetryRequestMetadata> actorRetryRequestMetadata,
-      CountSubrequest countSubrequest);
+      ActorCallRetryState::Attempt attempt);
 
-  bool supportsActorFetchRetries();
-  void onActorFetchRetry();
+  bool supportsActorCallRetries();
+  void onActorCallRetry();
 
   // Get a SubrequestChannel representing this Fetcher.
   kj::Own<IoChannelFactory::SubrequestChannel> getSubrequestChannel(IoContext& ioContext);

--- a/src/workerd/io/BUILD.bazel
+++ b/src/workerd/io/BUILD.bazel
@@ -536,7 +536,6 @@ kj_test(
     src = "observer-test.c++",
     deps = [
         ":observer",
-        "//src/workerd/io:worker-interface",
         "//src/workerd/util:strings",
         "@capnp-cpp//src/capnp:capnpc",
     ],

--- a/src/workerd/io/observer-test.c++
+++ b/src/workerd/io/observer-test.c++
@@ -1,5 +1,4 @@
 #include "observer.h"
-#include "worker-interface.h"
 
 #include <kj/test.h>
 

--- a/src/workerd/io/observer.c++
+++ b/src/workerd/io/observer.c++
@@ -11,6 +11,16 @@
 
 namespace workerd {
 
+kj::Own<WorkerInterface> RequestObserver::wrapSubrequestClient(
+    kj::Own<WorkerInterface> client, CountSubrequest) {
+  return kj::mv(client);
+}
+
+kj::Own<WorkerInterface> RequestObserver::wrapActorSubrequestClient(
+    kj::Own<WorkerInterface> client) {
+  return kj::mv(client);
+}
+
 namespace {
 kj::Maybe<kj::Own<FeatureObserver>> featureObserver;
 

--- a/src/workerd/io/observer.h
+++ b/src/workerd/io/observer.h
@@ -142,14 +142,10 @@ class RequestObserver: public kj::Refcounted {
   // Wrap an HttpClient to observe its request and response activity. `countSubrequest` controls
   // whether its usage contributes to the request's logical subrequest count.
   virtual kj::Own<WorkerInterface> wrapSubrequestClient(
-      kj::Own<WorkerInterface> client, CountSubrequest countSubrequest) {
-    return kj::mv(client);
-  }
+      kj::Own<WorkerInterface> client, CountSubrequest countSubrequest);
 
   // Wrap an HttpClient so that its usage is counted in the request's actor subrequest count.
-  virtual kj::Own<WorkerInterface> wrapActorSubrequestClient(kj::Own<WorkerInterface> client) {
-    return kj::mv(client);
-  }
+  virtual kj::Own<WorkerInterface> wrapActorSubrequestClient(kj::Own<WorkerInterface> client);
 
   // Record whether the next outgoing subrequest's request body can be rewound (e.g. a buffered or
   // null fetch body). Consumed when the subrequest client for that call is constructed. The


### PR DESCRIPTION
This PR lays the groundwork for retrying RPC alongside fetch. It extracts core concerns into a more generic "call" concept, and leaves fetch-specific concerns in their respective classes/tests.

Both the fetch and RPC path will then make use of the new `ActorCallRetryState`, which is effectively responsible for tracking + creating state relating to retries.