### PR TITLE
Decode stacked Content-Encoding values

### DIFF
--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1299,8 +1299,10 @@ kj::Promise<DeferredProxy<void>> Response::send(jsg::Lock& js,
     return wsPromise;
   } else KJ_IF_SOME(jsBody, getBody(js)) {
     auto encodings = getContentEncoding(context, outHeaders, bodyEncoding, FeatureFlags::get(js));
-    auto maybeLength = jsBody.tryGetLength(
-        js, encodings.size() == 1 ? encodings[0] : StreamEncoding::IDENTITY);
+    // The length is known whenever the body will reach the wire in exactly the coding chain the
+    // headers advertise -- including a proxied body whose chain passes through untouched. A body
+    // that genuinely has to be re-encoded reports no length and is sent chunked.
+    auto maybeLength = jsBody.tryGetLength(js, encodings.asPtr());
     auto stream = newSystemStream(
         outer.send(statusCode, getStatusText(), outHeaders, maybeLength), kj::mv(encodings));
     // We need to enter the AsyncContextFrame that was captured when the

--- a/src/workerd/api/http.c++
+++ b/src/workerd/api/http.c++
@@ -1298,10 +1298,11 @@ kj::Promise<DeferredProxy<void>> Response::send(jsg::Lock& js,
     }
     return wsPromise;
   } else KJ_IF_SOME(jsBody, getBody(js)) {
-    auto encoding = getContentEncoding(context, outHeaders, bodyEncoding, FeatureFlags::get(js));
-    auto maybeLength = jsBody.tryGetLength(js, encoding);
-    auto stream =
-        newSystemStream(outer.send(statusCode, getStatusText(), outHeaders, maybeLength), encoding);
+    auto encodings = getContentEncoding(context, outHeaders, bodyEncoding, FeatureFlags::get(js));
+    auto maybeLength = jsBody.tryGetLength(
+        js, encodings.size() == 1 ? encodings[0] : StreamEncoding::IDENTITY);
+    auto stream = newSystemStream(
+        outer.send(statusCode, getStatusText(), outHeaders, maybeLength), kj::mv(encodings));
     // We need to enter the AsyncContextFrame that was captured when the
     // Response was created before starting the loop.
     jsg::AsyncContextFrame::Scope scope(js, asyncContext);

--- a/src/workerd/api/js-readable-stream.c++
+++ b/src/workerd/api/js-readable-stream.c++
@@ -840,6 +840,39 @@ kj::Maybe<uint64_t> JsReadableStream::tryGetLength(jsg::Lock& js, StreamEncoding
   return kj::none;
 }
 
+kj::Maybe<uint64_t> JsReadableStream::tryGetLength(
+    jsg::Lock& js, kj::ArrayPtr<const StreamEncoding> encodings) {
+  if (encodings.size() == 0) {
+    return tryGetLength(js, StreamEncoding::IDENTITY);
+  } else if (encodings.size() == 1) {
+    return tryGetLength(js, encodings[0]);
+  }
+  KJ_IF_SOME(i, impl) {
+    KJ_SWITCH_ONEOF(i.stream) {
+      KJ_CASE_ONEOF(stream, jsg::Ref<ReadableStream>) {
+        return stream->tryGetLength(encodings);
+      }
+      KJ_CASE_ONEOF(obj, jsg::JsRef<jsg::JsObject>) {
+        // A chain of more than one coding can only be answered by a native underlying source
+        // (see the single-encoding overload above for why queued streams answer kj::none for
+        // any encoded query).
+        auto handle = obj.getHandle(js);
+        auto sourceValue = webstreams::dispatchCall(js, "getReadableStreamNativeSource", handle);
+        if (sourceValue.isUndefined()) {
+          return kj::none;
+        }
+        auto& handler =
+            KJ_ASSERT_NONNULL(js.tryGetTypeHandler<jsg::Ref<ReadableStreamNativeSource>>());
+        auto source = KJ_REQUIRE_NONNULL(handler.tryUnwrap(js, sourceValue),
+            "getReadableStreamNativeSource did not return a ReadableStreamNativeSource");
+        return source->tryGetLength(encodings);
+      }
+    }
+    KJ_UNREACHABLE;
+  }
+  return kj::none;
+}
+
 StreamEncoding JsReadableStream::getPreferredEncoding(jsg::Lock& js) {
   KJ_IF_SOME(i, impl) {
     KJ_SWITCH_ONEOF(i.stream) {
@@ -1659,6 +1692,25 @@ kj::Maybe<uint64_t> ReadableStreamNativeSource::tryGetLength(StreamEncoding enco
   // EOF'd, canceled, or consumed: nothing more will be produced, but distinguishing
   // "closed, hence zero" from "unknown" is the stream layer's business, not the
   // source's; report unknown.
+  return kj::none;
+}
+
+kj::Maybe<uint64_t> ReadableStreamNativeSource::tryGetLength(
+    kj::ArrayPtr<const StreamEncoding> encodings) {
+  if (encodings.size() == 0) {
+    return tryGetLength(StreamEncoding::IDENTITY);
+  } else if (encodings.size() == 1) {
+    return tryGetLength(encodings[0]);
+  }
+  KJ_IF_SOME(active, state) {
+    // Stashed bytes are identity bytes already drawn from the source: once any exist, an
+    // encoded length no longer describes what this source will deliver.
+    if (!stash.empty()) {
+      return kj::none;
+    }
+    return active.source->tryGetLength(encodings);
+  }
+  // EOF'd, canceled, or consumed: report unknown, as in the single-encoding overload.
   return kj::none;
 }
 

--- a/src/workerd/api/js-readable-stream.h
+++ b/src/workerd/api/js-readable-stream.h
@@ -154,6 +154,12 @@ class JsReadableStream final {
   kj::Maybe<uint64_t> tryGetLength(
       jsg::Lock& js, StreamEncoding encoding = StreamEncoding::IDENTITY);
 
+  // Chain-aware variant: `encodings` is the coding chain a sink will apply, in applied order,
+  // with an empty chain meaning identity. Chains of at most one coding answer through the
+  // single-encoding overload; longer chains can only be answered by a native underlying source
+  // whose own chain matches (a passthrough), and are kj::none for everything else.
+  kj::Maybe<uint64_t> tryGetLength(jsg::Lock& js, kj::ArrayPtr<const StreamEncoding> encodings);
+
   // The encoding the stream's remaining content would prefer to be transferred in: forwarded
   // from the underlying native source when there is one (in a state where its preference
   // still describes the remainder), IDENTITY otherwise (JS-sourced streams produce identity
@@ -385,6 +391,11 @@ class ReadableStreamNativeSource final: public jsg::Object {
   // tryGetLength arm of JsReadableStream, reached through the TypeScript side's
   // non-detaching source accessor.
   kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding);
+
+  // Chain-aware variant of the above: forwards a chain of more than one coding to the
+  // underlying source (which can only answer while no identity bytes are stashed); chains of
+  // at most one coding answer through the single-encoding overload.
+  kj::Maybe<uint64_t> tryGetLength(kj::ArrayPtr<const StreamEncoding> encodings);
 
   // The encoding the underlying source would prefer to deliver its remaining content in
   // (e.g. GZIP for a passthrough-compressed response body). IDENTITY once the source is

--- a/src/workerd/api/streams/common.h
+++ b/src/workerd/api/streams/common.h
@@ -321,6 +321,13 @@ class ReadableStreamSource: public kj::PtrTarget {
 
   virtual kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding);
 
+  // Chain-aware variant of tryGetLength(): `encodings` is the coding chain a sink will apply,
+  // in applied order, with an empty chain meaning identity. The default implementation answers
+  // via the single-encoding overload for chains of at most one coding and kj::none otherwise;
+  // only sources that can recognize a whole chain as their own (the encoded system streams)
+  // override it.
+  virtual kj::Maybe<uint64_t> tryGetLength(kj::ArrayPtr<const StreamEncoding> encodings);
+
   kj::Promise<kj::Array<byte>> readAllBytes(uint64_t limit);
   kj::Promise<kj::String> readAllText(
       uint64_t limit, ReadAllTextOption option = ReadAllTextOption::NULL_TERMINATE);
@@ -653,6 +660,19 @@ class ReadableStreamController {
   virtual jsg::Promise<kj::String> readAllText(jsg::Lock& js, uint64_t limit) = 0;
 
   virtual kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) = 0;
+
+  // Chain-aware variant of tryGetLength(), mirroring ReadableStreamSource. The default maps
+  // chains of at most one coding onto the single-encoding overload and answers kj::none for
+  // longer chains; the internal controller overrides it to forward the chain to its source.
+  virtual kj::Maybe<uint64_t> tryGetLength(kj::ArrayPtr<const StreamEncoding> encodings) {
+    if (encodings.size() == 0) {
+      return tryGetLength(StreamEncoding::IDENTITY);
+    } else if (encodings.size() == 1) {
+      return tryGetLength(encodings[0]);
+    } else {
+      return kj::none;
+    }
+  }
 
   virtual void setup(jsg::Lock& js,
       jsg::Optional<UnderlyingSource> maybeUnderlyingSource,

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -462,6 +462,19 @@ kj::Maybe<uint64_t> ReadableStreamSource::tryGetLength(StreamEncoding encoding) 
   return kj::none;
 }
 
+kj::Maybe<uint64_t> ReadableStreamSource::tryGetLength(
+    kj::ArrayPtr<const StreamEncoding> encodings) {
+  // A source that doesn't understand chains can still answer for the trivial cases through the
+  // single-encoding overload.
+  if (encodings.size() == 0) {
+    return tryGetLength(StreamEncoding::IDENTITY);
+  } else if (encodings.size() == 1) {
+    return tryGetLength(encodings[0]);
+  } else {
+    return kj::none;
+  }
+}
+
 kj::Promise<kj::Array<byte>> ReadableStreamSource::readAllBytes(uint64_t limit) {
   AllReader allReader(addPtrToThis(), limit);
   co_return co_await allReader.readAllBytes();
@@ -2931,6 +2944,22 @@ kj::Maybe<uint64_t> ReadableStreamInternalController::tryGetLength(StreamEncodin
     }
     KJ_CASE_ONEOF(readable, Readable) {
       return readable->tryGetLength(encoding);
+    }
+  }
+  KJ_UNREACHABLE;
+}
+
+kj::Maybe<uint64_t> ReadableStreamInternalController::tryGetLength(
+    kj::ArrayPtr<const StreamEncoding> encodings) {
+  KJ_SWITCH_ONEOF(state) {
+    KJ_CASE_ONEOF(closed, StreamStates::Closed) {
+      return static_cast<uint64_t>(0);
+    }
+    KJ_CASE_ONEOF(errored, StreamStates::Errored) {
+      return kj::none;
+    }
+    KJ_CASE_ONEOF(readable, Readable) {
+      return readable->tryGetLength(encodings);
     }
   }
   KJ_UNREACHABLE;

--- a/src/workerd/api/streams/internal.h
+++ b/src/workerd/api/streams/internal.h
@@ -108,6 +108,7 @@ class ReadableStreamInternalController: public ReadableStreamController, public 
   jsg::Promise<kj::String> readAllText(jsg::Lock& js, uint64_t limit) override;
 
   kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding) override;
+  kj::Maybe<uint64_t> tryGetLength(kj::ArrayPtr<const StreamEncoding> encodings) override;
 
   kj::Promise<DeferredProxy<void>> pumpTo(
       jsg::Lock& js, kj::Own<WritableStreamSink> sink, bool end) override;

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -590,6 +590,10 @@ kj::Maybe<uint64_t> ReadableStream::tryGetLength(StreamEncoding encoding) {
   return getController().tryGetLength(encoding);
 }
 
+kj::Maybe<uint64_t> ReadableStream::tryGetLength(kj::ArrayPtr<const StreamEncoding> encodings) {
+  return getController().tryGetLength(encodings);
+}
+
 kj::Promise<DeferredProxy<void>> ReadableStream::pumpTo(
     jsg::Lock& js, kj::Own<WritableStreamSink> sink, bool end) {
   JSG_REQUIRE(

--- a/src/workerd/api/streams/readable.h
+++ b/src/workerd/api/streams/readable.h
@@ -453,6 +453,7 @@ public:
   jsg::Ref<ReadableStream> detach(jsg::Lock& js, bool ignoreDisturbed=false);
 
   kj::Maybe<uint64_t> tryGetLength(StreamEncoding encoding);
+  kj::Maybe<uint64_t> tryGetLength(kj::ArrayPtr<const StreamEncoding> encodings);
 
   // A potentially optimized version of pipe that sends this stream's data to the given
   // sink. The entire stream is consumed. The ReadableStream will be left locked and

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -63,6 +63,8 @@ class EncodedAsyncInputStream final: public ReadableStreamSource {
   kj::Maybe<size_t> tryReadSync(kj::ArrayPtr<kj::byte> buffer, size_t minBytes) override;
 
   StreamEncoding getPreferredEncoding() override {
+    // A chain of multiple encodings cannot be expressed as a single preferred encoding, so
+    // advertise IDENTITY in that case; reads always produce fully-decoded bytes anyway.
     return encodings.size() == 1 ? encodings[0] : StreamEncoding::IDENTITY;
   }
 
@@ -72,6 +74,10 @@ class EncodedAsyncInputStream final: public ReadableStreamSource {
   // It is likely an error to call this function without immediately following it with a pumpTo()
   // to a EncodedAsyncOutputStream of that exact encoding.
   kj::Maybe<uint64_t> tryGetLength(StreamEncoding outEncoding) override;
+
+  // Chain-aware variant: the length is known whenever the sink applies exactly this stream's
+  // coding chain, because tryPumpFrom() then passes the bytes through unchanged.
+  kj::Maybe<uint64_t> tryGetLength(kj::ArrayPtr<const StreamEncoding> outEncodings) override;
 
   // Consume this stream and return two streams with the same encoding that read the exact same
   // data.
@@ -142,9 +148,23 @@ kj::Maybe<size_t> EncodedAsyncInputStream::tryReadSync(
 }
 
 kj::Maybe<uint64_t> EncodedAsyncInputStream::tryGetLength(StreamEncoding outEncoding) {
+  // A chain of multiple encodings can never match a single output encoding, so a length is only
+  // known for identity or single-coding streams.
   bool matches = encodings.size() == 0 ? outEncoding == StreamEncoding::IDENTITY
                                        : encodings.size() == 1 && outEncoding == encodings[0];
   if (matches) {
+    return inner->tryGetLength();
+  } else {
+    // We have no idea what the length will be once encoded/decoded.
+    return kj::none;
+  }
+}
+
+kj::Maybe<uint64_t> EncodedAsyncInputStream::tryGetLength(
+    kj::ArrayPtr<const StreamEncoding> outEncodings) {
+  if (encodings.asPtr() == outEncodings) {
+    // The sink applies exactly the chain this stream already carries, so tryPumpFrom() will move
+    // the bytes through without decoding or re-encoding and the inner length is the wire length.
     return inner->tryGetLength();
   } else {
     // We have no idea what the length will be once encoded/decoded.
@@ -178,11 +198,10 @@ void EncodedAsyncInputStream::cancel(kj::Exception reason) {
 
 void EncodedAsyncInputStream::ensureIdentityEncoding() {
   // Decompression gets added to the stream here if needed based on the content encoding chain.
-  // The chain never holds more than one coding yet (getContentEncoding() produces at most one
-  // element), so this reduces to wrapping the inner stream at most once.
-  KJ_ASSERT(encodings.size() <= 1);
-  if (encodings.size() == 1) {
-    StreamEncoding encoding = encodings[0];
+  // Codings are listed in the order they were applied, so the chain is walked backwards: the
+  // last-applied coding is decoded first, directly off the wire.
+  for (size_t i = encodings.size(); i > 0; i--) {
+    StreamEncoding encoding = encodings[i - 1];
     if (encoding == StreamEncoding::GZIP) {
       inner = kj::heap<kj::GzipAsyncInputStream>(*inner).attach(kj::mv(inner));
     } else if (encoding == StreamEncoding::BROTLI) {
@@ -233,12 +252,25 @@ class EncodedAsyncOutputStream final: public WritableStreamSink {
  private:
   void ensureIdentityEncoding();
 
+  // Chain `promise` with end() calls for every compressor layer buried under `inner`, outermost
+  // first, so that each layer's trailer is flushed through the layers beneath it. The caller is
+  // responsible for keeping the layers alive until the returned promise settles.
+  kj::Promise<void> endInnerLayers(kj::Promise<void> promise);
+
   // Unwrap `inner` as a `kj::AsyncOutputStream`.
   kj::AsyncOutputStream& getInner();
   // TODO(cleanup): Obviously this is polymorphism. We should be able to do better.
 
   // A sentinel indicating that the EncodedOutputStream has ended and is no longer usable.
   struct Ended {};
+
+  // Compressor layers sitting between `inner` and the original stream, innermost first. Only
+  // non-empty once a chain of more than one encoding has been applied: `inner` then holds the
+  // outermost compressor, which writes into `innerLayers.back()`, and so on down to
+  // `innerLayers.front()`, which writes into the original stream (attached to it). Declared
+  // before `inner` so that `inner` is destroyed first.
+  kj::Vector<kj::OneOf<kj::Own<kj::GzipAsyncOutputStream>, kj::Own<kj::BrotliAsyncOutputStream>>>
+      innerLayers;
 
   // I use a OneOf here rather than probing with downcasts because end() must be called for
   // correctness rather than for optimization. I "know" this code will never be compiled w/o RTTI,
@@ -381,10 +413,10 @@ kj::Maybe<kj::Promise<DeferredProxy<void>>> EncodedAsyncOutputStream::tryPumpFro
           }
         }
         KJ_CASE_ONEOF(gz, kj::Own<kj::GzipAsyncOutputStream>) {
-          promise = promise.then([&gz = gz]() { return gz->end(); });
+          promise = endInnerLayers(promise.then([&gz = gz]() { return gz->end(); }));
         }
         KJ_CASE_ONEOF(br, kj::Own<kj::BrotliAsyncOutputStream>) {
-          promise = promise.then([&br = br]() { return br->end(); });
+          promise = endInnerLayers(promise.then([&br = br]() { return br->end(); }));
         }
         KJ_CASE_ONEOF(e, Ended) {}
       }
@@ -399,6 +431,11 @@ kj::Maybe<kj::Promise<DeferredProxy<void>>> EncodedAsyncOutputStream::tryPumpFro
 }
 
 StreamEncoding EncodedAsyncOutputStream::disownEncodingResponsibility() {
+  if (encodings.size() > 1) {
+    // A chain of multiple encodings cannot be handed to the caller as a single StreamEncoding,
+    // so we keep responsibility for applying it. Identity writes remain correct either way.
+    return StreamEncoding::IDENTITY;
+  }
   StreamEncoding result = encodings.size() == 1 ? encodings[0] : StreamEncoding::IDENTITY;
   encodings = nullptr;
   return result;
@@ -421,10 +458,10 @@ kj::Promise<void> EncodedAsyncOutputStream::end() {
       }
     }
     KJ_CASE_ONEOF(gz, kj::Own<kj::GzipAsyncOutputStream>) {
-      promise = gz->end().attach(kj::mv(gz));
+      promise = endInnerLayers(gz->end()).attach(kj::mv(gz), kj::mv(innerLayers));
     }
     KJ_CASE_ONEOF(br, kj::Own<kj::BrotliAsyncOutputStream>) {
-      promise = br->end().attach(kj::mv(br));
+      promise = endInnerLayers(br->end()).attach(kj::mv(br), kj::mv(innerLayers));
     }
     KJ_CASE_ONEOF(e, Ended) {}
   }
@@ -448,28 +485,77 @@ void EncodedAsyncOutputStream::abort(kj::Exception reason) {
     KJ_CASE_ONEOF(e, Ended) {}
   }
   inner.init<Ended>();
+  // Layers are destroyed back-to-front, i.e. outermost first.
+  innerLayers.clear();
 }
 
 void EncodedAsyncOutputStream::ensureIdentityEncoding() {
   // Compression gets added to the stream here if needed based on the content encoding chain.
-  // The chain never holds more than one coding yet (getContentEncoding() produces at most one
-  // element), so this reduces to wrapping the inner stream at most once.
   KJ_DASSERT(!inner.is<Ended>(), "the EncodedAsyncOutputStream has been ended or aborted");
-  KJ_ASSERT(encodings.size() <= 1);
-  if (encodings.size() == 1) {
-    StreamEncoding encoding = encodings[0];
-    // This is safe because only a kj::AsyncOutputStream can have non-identity encoding.
-    auto& stream = inner.get<kj::Own<kj::AsyncOutputStream>>();
+  if (encodings.size() == 0) {
+    return;
+  }
+
+  // This is safe because only a kj::AsyncOutputStream can have non-identity encoding.
+  auto base = kj::mv(inner.get<kj::Own<kj::AsyncOutputStream>>());
+
+  // Codings are listed in the order they were applied: writes must pass through the compressors
+  // in list order, so the compressor for the last-applied coding is created first, closest to
+  // the wire, and takes ownership of the original stream. Any further layers stack on top of it;
+  // the compressor for the first-listed coding becomes the outermost stream in `inner`. With a
+  // single coding this reduces to wrapping the original stream directly, exactly as before.
+  kj::AsyncOutputStream* target = base.get();
+  for (size_t i = encodings.size(); i > 1; i--) {
+    StreamEncoding encoding = encodings[i - 1];
+    bool innermost = i == encodings.size();
     if (encoding == StreamEncoding::GZIP) {
-      inner = kj::heap<kj::GzipAsyncOutputStream>(*stream).attach(kj::mv(stream));
+      auto layer = innermost ? kj::heap<kj::GzipAsyncOutputStream>(*target).attach(kj::mv(base))
+                             : kj::heap<kj::GzipAsyncOutputStream>(*target);
+      target = layer.get();
+      innerLayers.add(kj::mv(layer));
     } else if (encoding == StreamEncoding::BROTLI) {
-      inner = kj::heap<kj::BrotliAsyncOutputStream>(*stream).attach(kj::mv(stream));
+      auto layer = innermost ? kj::heap<kj::BrotliAsyncOutputStream>(*target).attach(kj::mv(base))
+                             : kj::heap<kj::BrotliAsyncOutputStream>(*target);
+      target = layer.get();
+      innerLayers.add(kj::mv(layer));
     } else {
       // We currently support gzip and brotli as non-identity content encodings.
       KJ_FAIL_ASSERT("unsupported content encoding in chain");
     }
   }
+
+  StreamEncoding outermost = encodings[0];
+  if (outermost == StreamEncoding::GZIP) {
+    if (encodings.size() == 1) {
+      inner = kj::heap<kj::GzipAsyncOutputStream>(*target).attach(kj::mv(base));
+    } else {
+      inner = kj::heap<kj::GzipAsyncOutputStream>(*target);
+    }
+  } else if (outermost == StreamEncoding::BROTLI) {
+    if (encodings.size() == 1) {
+      inner = kj::heap<kj::BrotliAsyncOutputStream>(*target).attach(kj::mv(base));
+    } else {
+      inner = kj::heap<kj::BrotliAsyncOutputStream>(*target);
+    }
+  } else {
+    // We currently support gzip and brotli as non-identity content encodings.
+    KJ_FAIL_ASSERT("unsupported content encoding in chain");
+  }
   encodings = nullptr;
+}
+
+kj::Promise<void> EncodedAsyncOutputStream::endInnerLayers(kj::Promise<void> promise) {
+  for (size_t i = innerLayers.size(); i > 0; i--) {
+    KJ_SWITCH_ONEOF(innerLayers[i - 1]) {
+      KJ_CASE_ONEOF(gz, kj::Own<kj::GzipAsyncOutputStream>) {
+        promise = promise.then([&gz = *gz]() { return gz.end(); });
+      }
+      KJ_CASE_ONEOF(br, kj::Own<kj::BrotliAsyncOutputStream>) {
+        promise = promise.then([&br = *br]() { return br.end(); });
+      }
+    }
+  }
+  return promise;
 }
 
 kj::AsyncOutputStream& EncodedAsyncOutputStream::getInner() {
@@ -519,6 +605,52 @@ SystemMultiStream newSystemMultiStream(kj::Rc<kj::AsyncIoStream> stream, IoConte
 ContentEncodingOptions::ContentEncodingOptions(CompatibilityFlags::Reader flags)
     : brotliEnabled(flags.getBrotliContentEncoding()) {}
 
+namespace {
+
+// Upper bound on the number of codings we are willing to decode from one Content-Encoding
+// header, counted after skipping "identity" tokens and empty list elements (neither names a
+// transformation to undo). Longer lists are passed through unchanged. The value matches
+// undici's maxContentEncodings, though undici counts raw list elements and fails the fetch
+// instead of passing the body through.
+constexpr size_t MAX_CONTENT_ENCODINGS = 5;
+
+// Parse a Content-Encoding header value as the comma-separated list of codings RFC 9110 defines,
+// listed in the order they were applied. Empty list elements are ignored, as RFC 9110 5.6.1.2
+// says recipients should, and "identity" tokens denote no transformation, so neither contributes
+// to the chain. If any coding is unsupported (or the chain is too long), returns the empty chain
+// so the body is passed through unchanged, consistent with the longstanding behavior for a
+// single unsupported value.
+kj::Array<StreamEncoding> parseContentEncodings(
+    kj::StringPtr value, ContentEncodingOptions options) {
+  kj::Vector<StreamEncoding> encodings;
+  for (kj::ArrayPtr<const char> token: value.asArray().split(',')) {
+    // Trim optional whitespace (SP / HTAB) around the coding.
+    while (token.size() > 0 && (token.front() == ' ' || token.front() == '\t')) {
+      token = token.slice(1, token.size());
+    }
+    while (token.size() > 0 && (token.back() == ' ' || token.back() == '\t')) {
+      token = token.first(token.size() - 1);
+    }
+    if (token.size() == 0 || token == "identity"_kj.asArray()) {
+      // No transformation to undo; does not count toward the cap.
+      continue;
+    }
+    if (encodings.size() == MAX_CONTENT_ENCODINGS) {
+      return nullptr;
+    }
+    if (token == "gzip"_kj.asArray()) {
+      encodings.add(StreamEncoding::GZIP);
+    } else if (options.brotliEnabled && token == "br"_kj.asArray()) {
+      encodings.add(StreamEncoding::BROTLI);
+    } else {
+      return nullptr;
+    }
+  }
+  return encodings.releaseAsArray();
+}
+
+}  // namespace
+
 kj::Array<StreamEncoding> getContentEncoding(IoContext& context,
     const kj::HttpHeaders& headers,
     Response::BodyEncoding bodyEncoding,
@@ -527,11 +659,9 @@ kj::Array<StreamEncoding> getContentEncoding(IoContext& context,
     return nullptr;
   }
   KJ_IF_SOME(encodingStr, headers.get(context.getHeaderIds().contentEncoding)) {
-    if (encodingStr == "gzip") {
-      return kj::arr(StreamEncoding::GZIP);
-    } else if (options.brotliEnabled && encodingStr == "br") {
-      return kj::arr(StreamEncoding::BROTLI);
-    }
+    // Note: if chain handling ever needs to sit behind a compatibility flag, this is the seam;
+    // the fallback is matching encodingStr against "gzip"/"br" as a whole.
+    return parseContentEncodings(encodingStr, options);
   }
   return nullptr;
 }

--- a/src/workerd/api/system-streams.c++
+++ b/src/workerd/api/system-streams.c++
@@ -41,12 +41,20 @@ kj::Exception translateEncodedStreamException(kj::Exception&& exception) {
   return kj::mv(exception);
 }
 
+// Represent a single StreamEncoding as an encoding chain: IDENTITY is the empty chain.
+kj::Array<StreamEncoding> toEncodingChain(StreamEncoding encoding) {
+  if (encoding == StreamEncoding::IDENTITY) {
+    return nullptr;
+  }
+  return kj::arr(encoding);
+}
+
 // A wrapper around a native `kj::AsyncInputStream` which knows the underlying encoding of the
 // stream and whether or not it requires pending event registration.
 class EncodedAsyncInputStream final: public ReadableStreamSource {
  public:
   explicit EncodedAsyncInputStream(
-      kj::Own<kj::AsyncInputStream> inner, StreamEncoding encoding, IoContext& context);
+      kj::Own<kj::AsyncInputStream> inner, kj::Array<StreamEncoding> encodings, IoContext& context);
 
   // Read bytes in identity encoding. If the stream is not already in identity encoding, it will be
   // converted to identity encoding via an appropriate stream wrapper.
@@ -55,7 +63,7 @@ class EncodedAsyncInputStream final: public ReadableStreamSource {
   kj::Maybe<size_t> tryReadSync(kj::ArrayPtr<kj::byte> buffer, size_t minBytes) override;
 
   StreamEncoding getPreferredEncoding() override {
-    return encoding;
+    return encodings.size() == 1 ? encodings[0] : StreamEncoding::IDENTITY;
   }
 
   // Return the number of bytes, if known, which this input stream will produce if the sink is known
@@ -81,16 +89,18 @@ class EncodedAsyncInputStream final: public ReadableStreamSource {
   void ensureIdentityEncoding();
 
   kj::Own<kj::AsyncInputStream> inner;
-  StreamEncoding encoding;
+  // The stream's content encoding chain, in the order the codings were applied. Empty means
+  // identity.
+  kj::Array<StreamEncoding> encodings;
   kj::Canceler canceler;
 
   IoContext& ioContext;
 };
 
 EncodedAsyncInputStream::EncodedAsyncInputStream(
-    kj::Own<kj::AsyncInputStream> inner, StreamEncoding encoding, IoContext& context)
+    kj::Own<kj::AsyncInputStream> inner, kj::Array<StreamEncoding> encodings, IoContext& context)
     : inner(kj::mv(inner)),
-      encoding(encoding),
+      encodings(kj::mv(encodings)),
       ioContext(context) {}
 
 kj::Promise<size_t> EncodedAsyncInputStream::tryRead(
@@ -132,7 +142,9 @@ kj::Maybe<size_t> EncodedAsyncInputStream::tryReadSync(
 }
 
 kj::Maybe<uint64_t> EncodedAsyncInputStream::tryGetLength(StreamEncoding outEncoding) {
-  if (outEncoding == encoding) {
+  bool matches = encodings.size() == 0 ? outEncoding == StreamEncoding::IDENTITY
+                                       : encodings.size() == 1 && outEncoding == encodings[0];
+  if (matches) {
     return inner->tryGetLength();
   } else {
     // We have no idea what the length will be once encoded/decoded.
@@ -150,8 +162,10 @@ kj::Maybe<ReadableStreamSource::Tee> EncodedAsyncInputStream::tryTee(uint64_t li
   auto tee = kj::newTee(kj::mv(inner), limit);
 
   Tee result;
-  result.branches[0] = newSystemStream(newTeeErrorAdapter(kj::mv(tee.branches[0])), encoding);
-  result.branches[1] = newSystemStream(newTeeErrorAdapter(kj::mv(tee.branches[1])), encoding);
+  result.branches[0] = newSystemStream(
+      newTeeErrorAdapter(kj::mv(tee.branches[0])), kj::heapArray(encodings.asPtr()));
+  result.branches[1] = newSystemStream(
+      newTeeErrorAdapter(kj::mv(tee.branches[1])), kj::heapArray(encodings.asPtr()));
   return kj::mv(result);
 }
 
@@ -163,17 +177,22 @@ void EncodedAsyncInputStream::cancel(kj::Exception reason) {
 }
 
 void EncodedAsyncInputStream::ensureIdentityEncoding() {
-  // Decompression gets added to the stream here if needed based on the content encoding.
-  if (encoding == StreamEncoding::GZIP) {
-    inner = kj::heap<kj::GzipAsyncInputStream>(*inner).attach(kj::mv(inner));
-    encoding = StreamEncoding::IDENTITY;
-  } else if (encoding == StreamEncoding::BROTLI) {
-    inner = kj::heap<kj::BrotliAsyncInputStream>(*inner).attach(kj::mv(inner));
-    encoding = StreamEncoding::IDENTITY;
-  } else {
-    // We currently support gzip and brotli as non-identity content encodings.
-    KJ_ASSERT(encoding == StreamEncoding::IDENTITY);
+  // Decompression gets added to the stream here if needed based on the content encoding chain.
+  // The chain never holds more than one coding yet (getContentEncoding() produces at most one
+  // element), so this reduces to wrapping the inner stream at most once.
+  KJ_ASSERT(encodings.size() <= 1);
+  if (encodings.size() == 1) {
+    StreamEncoding encoding = encodings[0];
+    if (encoding == StreamEncoding::GZIP) {
+      inner = kj::heap<kj::GzipAsyncInputStream>(*inner).attach(kj::mv(inner));
+    } else if (encoding == StreamEncoding::BROTLI) {
+      inner = kj::heap<kj::BrotliAsyncInputStream>(*inner).attach(kj::mv(inner));
+    } else {
+      // We currently support gzip and brotli as non-identity content encodings.
+      KJ_FAIL_ASSERT("unsupported content encoding in chain");
+    }
   }
+  encodings = nullptr;
 }
 
 // =======================================================================================
@@ -192,8 +211,9 @@ void EncodedAsyncInputStream::ensureIdentityEncoding() {
 // does, it is important for us to release it as soon as end() or abort() are called.
 class EncodedAsyncOutputStream final: public WritableStreamSink {
  public:
-  explicit EncodedAsyncOutputStream(
-      kj::Own<kj::AsyncOutputStream> inner, StreamEncoding encoding, IoContext& context);
+  explicit EncodedAsyncOutputStream(kj::Own<kj::AsyncOutputStream> inner,
+      kj::Array<StreamEncoding> encodings,
+      IoContext& context);
 
   kj::Promise<void> write(kj::ArrayPtr<const byte> buffer) override;
   kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override;
@@ -229,15 +249,17 @@ class EncodedAsyncOutputStream final: public WritableStreamSink {
       Ended>
       inner;
 
-  StreamEncoding encoding;
+  // The sink's content encoding chain, in the order the codings are to be applied. Empty means
+  // identity.
+  kj::Array<StreamEncoding> encodings;
 
   IoContext& ioContext;
 };
 
 EncodedAsyncOutputStream::EncodedAsyncOutputStream(
-    kj::Own<kj::AsyncOutputStream> inner, StreamEncoding encoding, IoContext& context)
+    kj::Own<kj::AsyncOutputStream> inner, kj::Array<StreamEncoding> encodings, IoContext& context)
     : inner(kj::mv(inner)),
-      encoding(encoding),
+      encodings(kj::mv(encodings)),
       ioContext(context) {}
 
 kj::Promise<void> EncodedAsyncOutputStream::write(kj::ArrayPtr<const byte> buffer) {
@@ -322,7 +344,7 @@ kj::Maybe<kj::Promise<DeferredProxy<void>>> EncodedAsyncOutputStream::tryPumpFro
     // We can still optimize the pump a little by registering only a single pending event rather
     // than falling back to the heavier weight algorithm in ReadableStreamSource, which depends on
     // tryRead() and write() registering their own individual events on every call.
-    if (nativeInput.encoding != encoding) {
+    if (nativeInput.encodings.asPtr() != encodings.asPtr()) {
       ensureIdentityEncoding();
       nativeInput.ensureIdentityEncoding();
     }
@@ -377,8 +399,8 @@ kj::Maybe<kj::Promise<DeferredProxy<void>>> EncodedAsyncOutputStream::tryPumpFro
 }
 
 StreamEncoding EncodedAsyncOutputStream::disownEncodingResponsibility() {
-  StreamEncoding result = encoding;
-  encoding = StreamEncoding::IDENTITY;
+  StreamEncoding result = encodings.size() == 1 ? encodings[0] : StreamEncoding::IDENTITY;
+  encodings = nullptr;
   return result;
 }
 
@@ -429,23 +451,25 @@ void EncodedAsyncOutputStream::abort(kj::Exception reason) {
 }
 
 void EncodedAsyncOutputStream::ensureIdentityEncoding() {
-  // Compression gets added to the stream here if needed based on the content encoding.
+  // Compression gets added to the stream here if needed based on the content encoding chain.
+  // The chain never holds more than one coding yet (getContentEncoding() produces at most one
+  // element), so this reduces to wrapping the inner stream at most once.
   KJ_DASSERT(!inner.is<Ended>(), "the EncodedAsyncOutputStream has been ended or aborted");
-  if (encoding == StreamEncoding::GZIP) {
+  KJ_ASSERT(encodings.size() <= 1);
+  if (encodings.size() == 1) {
+    StreamEncoding encoding = encodings[0];
     // This is safe because only a kj::AsyncOutputStream can have non-identity encoding.
     auto& stream = inner.get<kj::Own<kj::AsyncOutputStream>>();
-
-    inner = kj::heap<kj::GzipAsyncOutputStream>(*stream).attach(kj::mv(stream));
-    encoding = StreamEncoding::IDENTITY;
-  } else if (encoding == StreamEncoding::BROTLI) {
-    auto& stream = inner.get<kj::Own<kj::AsyncOutputStream>>();
-
-    inner = kj::heap<kj::BrotliAsyncOutputStream>(*stream).attach(kj::mv(stream));
-    encoding = StreamEncoding::IDENTITY;
-  } else {
-    // We currently support gzip and brotli as non-identity content encodings.
-    KJ_ASSERT(encoding == StreamEncoding::IDENTITY);
+    if (encoding == StreamEncoding::GZIP) {
+      inner = kj::heap<kj::GzipAsyncOutputStream>(*stream).attach(kj::mv(stream));
+    } else if (encoding == StreamEncoding::BROTLI) {
+      inner = kj::heap<kj::BrotliAsyncOutputStream>(*stream).attach(kj::mv(stream));
+    } else {
+      // We currently support gzip and brotli as non-identity content encodings.
+      KJ_FAIL_ASSERT("unsupported content encoding in chain");
+    }
   }
+  encodings = nullptr;
 }
 
 kj::AsyncOutputStream& EncodedAsyncOutputStream::getInner() {
@@ -471,39 +495,45 @@ kj::AsyncOutputStream& EncodedAsyncOutputStream::getInner() {
 
 kj::Own<ReadableStreamSource> newSystemStream(
     kj::Own<kj::AsyncInputStream> inner, StreamEncoding encoding, IoContext& context) {
-  return kj::heap<EncodedAsyncInputStream>(kj::mv(inner), encoding, context);
+  return kj::heap<EncodedAsyncInputStream>(kj::mv(inner), toEncodingChain(encoding), context);
+}
+kj::Own<ReadableStreamSource> newSystemStream(
+    kj::Own<kj::AsyncInputStream> inner, kj::Array<StreamEncoding> encodings, IoContext& context) {
+  return kj::heap<EncodedAsyncInputStream>(kj::mv(inner), kj::mv(encodings), context);
 }
 kj::Own<WritableStreamSink> newSystemStream(
     kj::Own<kj::AsyncOutputStream> inner, StreamEncoding encoding, IoContext& context) {
-  return kj::heap<EncodedAsyncOutputStream>(kj::mv(inner), encoding, context);
+  return kj::heap<EncodedAsyncOutputStream>(kj::mv(inner), toEncodingChain(encoding), context);
+}
+kj::Own<WritableStreamSink> newSystemStream(
+    kj::Own<kj::AsyncOutputStream> inner, kj::Array<StreamEncoding> encodings, IoContext& context) {
+  return kj::heap<EncodedAsyncOutputStream>(kj::mv(inner), kj::mv(encodings), context);
 }
 
 SystemMultiStream newSystemMultiStream(kj::Rc<kj::AsyncIoStream> stream, IoContext& context) {
 
-  return {.readable = kj::heap<EncodedAsyncInputStream>(
-              stream.addRef().toOwn(), StreamEncoding::IDENTITY, context),
-    .writable = kj::heap<EncodedAsyncOutputStream>(
-        kj::mv(stream).toOwn(), StreamEncoding::IDENTITY, context)};
+  return {.readable = kj::heap<EncodedAsyncInputStream>(stream.addRef().toOwn(), nullptr, context),
+    .writable = kj::heap<EncodedAsyncOutputStream>(kj::mv(stream).toOwn(), nullptr, context)};
 }
 
 ContentEncodingOptions::ContentEncodingOptions(CompatibilityFlags::Reader flags)
     : brotliEnabled(flags.getBrotliContentEncoding()) {}
 
-StreamEncoding getContentEncoding(IoContext& context,
+kj::Array<StreamEncoding> getContentEncoding(IoContext& context,
     const kj::HttpHeaders& headers,
     Response::BodyEncoding bodyEncoding,
     ContentEncodingOptions options) {
   if (bodyEncoding == Response::BodyEncoding::MANUAL) {
-    return StreamEncoding::IDENTITY;
+    return nullptr;
   }
   KJ_IF_SOME(encodingStr, headers.get(context.getHeaderIds().contentEncoding)) {
     if (encodingStr == "gzip") {
-      return StreamEncoding::GZIP;
+      return kj::arr(StreamEncoding::GZIP);
     } else if (options.brotliEnabled && encodingStr == "br") {
-      return StreamEncoding::BROTLI;
+      return kj::arr(StreamEncoding::BROTLI);
     }
   }
-  return StreamEncoding::IDENTITY;
+  return nullptr;
 }
 
 }  // namespace workerd::api

--- a/src/workerd/api/system-streams.h
+++ b/src/workerd/api/system-streams.h
@@ -25,12 +25,28 @@ namespace workerd::api {
 kj::Own<ReadableStreamSource> newSystemStream(kj::Own<kj::AsyncInputStream> inner,
     StreamEncoding encoding,
     IoContext& context = IoContext::current());
+// Chain-taking overload: `encodings` is the stream's content coding chain in the order the
+// codings were applied, and an empty array means identity. StreamEncoding::IDENTITY must never
+// appear in the array -- it is not a transformation, so it has no place in a chain, and a
+// violation trips a KJ_FAIL_ASSERT on the read path. getContentEncoding() maintains this
+// invariant for chains parsed from headers.
+kj::Own<ReadableStreamSource> newSystemStream(kj::Own<kj::AsyncInputStream> inner,
+    kj::Array<StreamEncoding> encodings,
+    IoContext& context = IoContext::current());
 
 // A WritableStreamSink which automatically encodes its underlying stream.
 //
 // NOTE: As with the other overload of newSystemStream(), `inner` must be wholly owned.
 kj::Own<WritableStreamSink> newSystemStream(kj::Own<kj::AsyncOutputStream> inner,
     StreamEncoding encoding,
+    IoContext& context = IoContext::current());
+// Chain-taking overload: `encodings` is the coding chain to apply to written bytes, in applied
+// order, and an empty array means identity. StreamEncoding::IDENTITY must never appear in the
+// array -- it is not a transformation, so it has no place in a chain, and a violation trips a
+// KJ_FAIL_ASSERT on the write path. getContentEncoding() maintains this invariant for chains
+// parsed from headers.
+kj::Own<WritableStreamSink> newSystemStream(kj::Own<kj::AsyncOutputStream> inner,
+    kj::Array<StreamEncoding> encodings,
     IoContext& context = IoContext::current());
 
 struct SystemMultiStream {
@@ -48,9 +64,12 @@ struct ContentEncodingOptions {
   ContentEncodingOptions(CompatibilityFlags::Reader flags);
 };
 
-// Get the Content-Encoding header from an HttpHeaders object as a StreamEncoding enum. Unsupported
-// encodings return IDENTITY.
-StreamEncoding getContentEncoding(IoContext& context,
+// Get the Content-Encoding header from an HttpHeaders object as a chain of StreamEncoding values,
+// listed in the order they were applied. An empty array means identity. The chain currently never
+// holds more than one element: the whole header value is matched against the supported codings,
+// and any other value (including a comma-separated list) yields the empty chain, so the body is
+// passed through unchanged, exactly as before.
+kj::Array<StreamEncoding> getContentEncoding(IoContext& context,
     const kj::HttpHeaders& headers,
     Response::BodyEncoding bodyEncoding = Response::BodyEncoding::AUTO,
     ContentEncodingOptions options = {});

--- a/src/workerd/api/system-streams.h
+++ b/src/workerd/api/system-streams.h
@@ -65,10 +65,11 @@ struct ContentEncodingOptions {
 };
 
 // Get the Content-Encoding header from an HttpHeaders object as a chain of StreamEncoding values,
-// listed in the order they were applied. An empty array means identity. The chain currently never
-// holds more than one element: the whole header value is matched against the supported codings,
-// and any other value (including a comma-separated list) yields the empty chain, so the body is
-// passed through unchanged, exactly as before.
+// listed in the order they were applied. An empty array means identity. "identity" tokens and
+// empty list elements are skipped rather than added to the chain. If any coding in the list is
+// unsupported, or more than five codings remain after the skips, an empty array is returned and
+// the body is passed through unchanged, matching the longstanding behavior for a single
+// unsupported value.
 kj::Array<StreamEncoding> getContentEncoding(IoContext& context,
     const kj::HttpHeaders& headers,
     Response::BodyEncoding bodyEncoding = Response::BodyEncoding::AUTO,

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -720,6 +720,14 @@ wd_test(
 )
 
 wd_test(
+    src = "content-encoding-chain-test.wd-test",
+    data = [
+        "content-encoding-chain-helper.js",
+        "content-encoding-chain-test.js",
+    ],
+)
+
+wd_test(
     src = "streams-consumer-reentry-gc-test.wd-test",
     args = ["--experimental"],
     data = ["streams-consumer-reentry-gc-test.js"],

--- a/src/workerd/api/tests/content-encoding-chain-helper.js
+++ b/src/workerd/api/tests/content-encoding-chain-helper.js
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Helper worker for content-encoding-chain-test. Serves pre-compressed payloads with
+// encodeBody: 'manual' so the wire bytes are exactly the embedded payloads. All payloads
+// compress DATA below; they were generated with Node's zlib (gzipSync / brotliCompressSync).
+//
+// The same module runs as two services: "ce-chain-helper" (brotli enabled, has a SELF
+// binding to itself) and "ce-chain-nobr" (brotli disabled, has a PEER binding to the
+// helper). The /nobr* routes only run in the latter, where fetches through PEER decode
+// according to *this* worker's flags.
+
+const DATA = 'The quick brown fox jumps over the lazy dog. '.repeat(32);
+
+// gzip(DATA)
+const GZ =
+  'H4sIAAAAAAAAEwvJSFUoLM1MzlZIKsovz1NIy69QyCrNLShWyC9LLVIoyUhVyEmsqlRIyU/XUwgZVTyqeFTxqOJRxfRSDABOoPepoAUAAA==';
+// gzip(gzip(DATA))
+const GZGZ =
+  'H4sIAAAAAAAAE5Pv5mAAA2Hukx6hGjpnfc6FeWid0j8f7HF6fcAJrbO6GmEn9L11gzROeoSe8FyzKsTjpP/1YA7JUJtVFSEfVzwKPPoliIfBb8H3lQtYGRgAFoN6Ek8AAAA=';
+// brotli(DATA)
+const BR =
+  'G58FiCwOeNPQlV2XELsXK6nK0JLMjK1BXObyNsgZnp4Ke4MNOHBIIG8kv0GnFc4cHieqKTjCaWmfBgM=';
+// brotli(gzip(DATA)), i.e. Content-Encoding: gzip, br
+const BRGZ =
+  'CyeAH4sIAAAAAAAAEwvJSFUoLM1MzlZIKsovz1NIy69QyCrNLShWyC9LLVIoyUhVyEmsqlRIyU/XUwgZVTyqeFTxqOJRxfRSDABOoPepoAUAAAM=';
+// gzip applied five times to DATA, i.e. exactly the decode cap
+const GZ5 =
+  'H4sIAAAAAAAAEwGKAHX/H4sIAAAAAAAAE5Pv5mAAA+HJ758lMDA/PPl+vqqBgfq+2TrbA05p7f0Wk5167I73t0/5XKuz+AvW3d3jrRX49/S9S2nC+1dNq5RPMsuWrdzz5P91ln2TGTc7u4o+PZy7I6duZdkW+TP2P2q1yluWsDRHFE+dYH8hhcEv+/+UJKBlAGro4pV1AAAATTwn7ooAAAA=';
+
+function decode(b64) {
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+const PAYLOADS = {
+  'single-gzip': { body: GZ, ce: 'gzip' },
+  'single-br': { body: BR, ce: 'br' },
+  'double-gzip': { body: GZGZ, ce: 'gzip, gzip' },
+  'gzip-br': { body: BRGZ, ce: 'gzip, br' },
+  'identity-chain': { body: GZ, ce: 'identity, gzip, identity' },
+  'ows-chain': { body: BRGZ, ce: 'gzip\t,  br' },
+  'unknown-chain': { body: GZ, ce: 'gzip, deflate' },
+  'unknown-single': { body: GZ, ce: 'deflate' },
+  'unknown-mid': { body: GZ, ce: 'gzip, deflate, gzip' },
+  'empty-segment': { body: BRGZ, ce: 'gzip,,br' },
+  'case-single': { body: GZ, ce: 'GZIP' },
+  'case-chain': { body: GZGZ, ce: 'gzip, GZIP' },
+  'cap-boundary': { body: GZ5, ce: 'gzip, gzip, gzip, gzip, gzip' },
+  'too-long': { body: GZGZ, ce: 'gzip, gzip, gzip, gzip, gzip, gzip' },
+  'cap-identity': {
+    body: GZ,
+    ce: 'identity, identity, identity, identity, identity, gzip',
+  },
+};
+
+async function bodyOf(response) {
+  return new Response(await response.arrayBuffer());
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const [, route, name] = url.pathname.split('/');
+
+    if (route === 'raw') {
+      const p = PAYLOADS[name];
+      if (p === undefined) return new Response('not found', { status: 404 });
+      return new Response(decode(p.body), { encodeBody: 'manual' });
+    }
+
+    if (route === 'p') {
+      if (name === 'dup-headers') {
+        // Two separate Content-Encoding headers rather than one comma-separated value.
+        const headers = new Headers();
+        headers.append('Content-Encoding', 'gzip');
+        headers.append('Content-Encoding', 'gzip');
+        return new Response(decode(GZGZ), { encodeBody: 'manual', headers });
+      }
+      const p = PAYLOADS[name];
+      if (p === undefined) return new Response('not found', { status: 404 });
+      return new Response(decode(p.body), {
+        encodeBody: 'manual',
+        headers: { 'Content-Encoding': p.ce },
+      });
+    }
+
+    if (route === 'proxy') {
+      // Return the fetched Response as-is; the body must survive unmodified.
+      return env.SELF.fetch(`http://helper/p/${name}`);
+    }
+
+    if (route === 'out') {
+      if (name === 'auto-chain') {
+        return new Response(DATA, {
+          headers: { 'Content-Encoding': 'gzip, gzip' },
+        });
+      }
+      if (name === 'auto-br-chain') {
+        return new Response(DATA, {
+          headers: { 'Content-Encoding': 'gzip, br' },
+        });
+      }
+      if (name === 'manual-chain') {
+        return new Response(decode(GZGZ), {
+          encodeBody: 'manual',
+          headers: { 'Content-Encoding': 'gzip, gzip' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    }
+
+    // The /nobr* routes run in the ce-chain-nobr service (no brotli): the fetch through
+    // PEER decodes with brotli disabled, and the body is returned as plain bytes with no
+    // Content-Encoding, so the test worker sees exactly what this worker's decoder
+    // produced.
+    if (route === 'nobr') {
+      return bodyOf(await env.PEER.fetch(`http://helper/p/${name}`));
+    }
+    if (route === 'nobr-raw') {
+      return bodyOf(await env.PEER.fetch(`http://helper/raw/${name}`));
+    }
+    if (route === 'nobr-out') {
+      return bodyOf(await env.PEER.fetch(`http://helper/out/${name}`));
+    }
+
+    return new Response('not found', { status: 404 });
+  },
+};

--- a/src/workerd/api/tests/content-encoding-chain-test.js
+++ b/src/workerd/api/tests/content-encoding-chain-test.js
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import { strictEqual, deepStrictEqual } from 'node:assert';
+import { gunzipSync, brotliDecompressSync } from 'node:zlib';
+
+// Tests for stacked Content-Encoding values (https://github.com/cloudflare/workerd/issues/7051).
+// The helper service serves pre-compressed payloads with encodeBody: 'manual', so the bytes on
+// the wire are exactly the embedded payloads. Decoding happens on this side of the fetch.
+
+const DATA = 'The quick brown fox jumps over the lazy dog. '.repeat(32);
+
+async function text(env, path) {
+  const resp = await env.HELPER.fetch(`http://helper${path}`);
+  return await resp.text();
+}
+
+async function bytes(fetcher, path) {
+  const resp = await fetcher.fetch(`http://helper${path}`);
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+// Expects the body to arrive decoded all the way down to the original text.
+async function expectDecoded(env, name) {
+  strictEqual(await text(env, `/p/${name}`), DATA);
+}
+
+// Expects the two paths to produce byte-identical bodies through the given fetcher.
+async function expectSameBytes(fetcher, pathA, pathB) {
+  deepStrictEqual(await bytes(fetcher, pathA), await bytes(fetcher, pathB));
+}
+
+// Expects the body to arrive byte-identical to the stored payload (no decoding at all).
+async function expectPassthrough(env, name) {
+  await expectSameBytes(env.HELPER, `/p/${name}`, `/raw/${name}`);
+}
+
+export const singleTokenBehaviorUnchanged = {
+  async test(ctrl, env) {
+    // Pre-existing single-token behavior must not change.
+    await expectDecoded(env, 'single-gzip');
+    await expectDecoded(env, 'single-br');
+    await expectPassthrough(env, 'unknown-single');
+    // Token matching is case-sensitive, as it always has been for single values.
+    await expectPassthrough(env, 'case-single');
+  },
+};
+
+export const doubleGzipChain = {
+  async test(ctrl, env) {
+    await expectDecoded(env, 'double-gzip');
+  },
+};
+
+export const gzipBrotliChain = {
+  async test(ctrl, env) {
+    await expectDecoded(env, 'gzip-br');
+  },
+};
+
+export const identityTokensSkipped = {
+  async test(ctrl, env) {
+    // "identity, gzip, identity" only requires undoing the gzip layer.
+    await expectDecoded(env, 'identity-chain');
+  },
+};
+
+export const emptySegmentsIgnored = {
+  async test(ctrl, env) {
+    // Empty list elements are ignored per RFC 9110 5.6.1.2: "gzip,,br" decodes the same as
+    // "gzip, br".
+    await expectDecoded(env, 'empty-segment');
+  },
+};
+
+export const optionalWhitespaceTrimmed = {
+  async test(ctrl, env) {
+    // OWS around the commas must be ignored per RFC 9110.
+    await expectDecoded(env, 'ows-chain');
+  },
+};
+
+export const unknownTokenDisablesDecoding = {
+  async test(ctrl, env) {
+    // An unsupported coding anywhere in the list means the body is passed through untouched,
+    // consistent with the single unknown-value behavior.
+    await expectPassthrough(env, 'unknown-chain');
+    await expectPassthrough(env, 'case-chain');
+  },
+};
+
+export const probeDeflateMid = {
+  async test(ctrl, env) {
+    // An unsupported coding in the *middle* of the list (not just the last position) also
+    // disables decoding for the whole body.
+    await expectPassthrough(env, 'unknown-mid');
+  },
+};
+
+export const probeCapBoundary = {
+  async test(ctrl, env) {
+    // Exactly five codings sit on the cap and decode; a sixth pushes the list over and the
+    // body passes through.
+    await expectDecoded(env, 'cap-boundary');
+    await expectPassthrough(env, 'too-long');
+  },
+};
+
+export const capCountsEffectiveCodings = {
+  async test(ctrl, env) {
+    // The cap counts codings that actually transform the body: five "identity" tokens plus a
+    // gzip is one effective coding, well under the cap, so it decodes.
+    await expectDecoded(env, 'cap-identity');
+  },
+};
+
+export const duplicateHeadersJoined = {
+  async test(ctrl, env) {
+    // Two separate Content-Encoding headers are equivalent to one comma-separated list.
+    await expectDecoded(env, 'dup-headers');
+  },
+};
+
+export const proxiedChainStillDecodes = {
+  async test(ctrl, env) {
+    // A worker that returns a fetched Response unmodified must not corrupt the body.
+    strictEqual(await text(env, '/proxy/gzip-br'), DATA);
+    await expectSameBytes(env.HELPER, '/proxy/unknown-chain', '/raw/unknown-chain');
+  },
+};
+
+export const proxiedChainKeepsContentLength = {
+  async test(ctrl, env) {
+    // HELPER_WIRE reaches the helper over a real (loopback) HTTP socket, so Content-Length
+    // vs. chunked is actual wire behavior rather than an in-process shortcut. A proxied
+    // multi-coding body passes through with its chain intact, so its encoded length is known
+    // and must survive as Content-Length.
+    const raw = await bytes(env.HELPER, '/raw/gzip-br');
+    const resp = await env.HELPER_WIRE.fetch('http://helper/proxy/gzip-br');
+    strictEqual(resp.headers.get('content-length'), String(raw.byteLength));
+    strictEqual(resp.headers.get('transfer-encoding'), null);
+    strictEqual(await resp.text(), DATA);
+  },
+};
+
+export const constructedChainHasNoContentLength = {
+  async test(ctrl, env) {
+    // A worker-constructed Response with a stacked Content-Encoding header is genuinely
+    // re-encoded on send: no length can be advertised, so the body goes out chunked.
+    const resp = await env.HELPER_WIRE.fetch('http://helper/out/auto-chain');
+    strictEqual(resp.headers.get('content-length'), null);
+    strictEqual(await resp.text(), DATA);
+  },
+};
+
+export const outputChainEncoded = {
+  async test(ctrl, env) {
+    // A Response constructed with a stacked Content-Encoding header and an identity body gets
+    // encoded on send, mirroring the existing single-value behavior.
+    strictEqual(await text(env, '/out/auto-chain'), DATA);
+    strictEqual(await text(env, '/out/auto-br-chain'), DATA);
+  },
+};
+
+export const probeEncoderByteLayout = {
+  async test(ctrl, env) {
+    // Byte-level check of the *encode* path, independent of workerd's decoder (a symmetric
+    // layering bug would round-trip cleanly through /out tests alone). The brotli-disabled
+    // service fetches /out/auto-br-chain from the helper and passes the body through raw
+    // (its "gzip, br" is an unknown chain there), and this side decodes with node:zlib:
+    // the bytes must be br(gzip(DATA)), i.e. the codings applied in list order.
+    const encoded = await bytes(env.NOBR, '/nobr-out/auto-br-chain');
+    const decoded = gunzipSync(brotliDecompressSync(encoded));
+    strictEqual(decoded.toString('utf8'), DATA);
+  },
+};
+
+export const manualBodyNotReencoded = {
+  async test(ctrl, env) {
+    // encodeBody: 'manual' keeps meaning "the app already encoded the body": the pre-compressed
+    // payload goes out untouched and decodes to the original text exactly once on this side.
+    strictEqual(await text(env, '/out/manual-chain'), DATA);
+  },
+};
+
+export const brotliDisabledMakesChainUnknown = {
+  async test(ctrl, env) {
+    // In a worker without brotli_content_encoding, "br" in a chain is an unknown token, so the
+    // whole body passes through; a single "br" behaves the same as before.
+    await expectSameBytes(env.NOBR, '/nobr/gzip-br', '/nobr-raw/gzip-br');
+    await expectSameBytes(env.NOBR, '/nobr/single-br', '/nobr-raw/single-br');
+  },
+};

--- a/src/workerd/api/tests/content-encoding-chain-test.wd-test
+++ b/src/workerd/api/tests/content-encoding-chain-test.wd-test
@@ -1,0 +1,57 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "content-encoding-chain-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "content-encoding-chain-test.js")
+        ],
+        compatibilityFlags = ["nodejs_compat", "nodejs_zlib", "brotli_content_encoding"],
+        bindings = [
+          ( name = "HELPER", service = "ce-chain-helper" ),
+          ( name = "NOBR", service = "ce-chain-nobr" ),
+          # Reaches the helper over a real (loopback) HTTP socket rather than an in-process
+          # service binding, so tests can observe genuine wire framing (Content-Length vs.
+          # chunked).
+          ( name = "HELPER_WIRE", service = "ce-chain-wire" ),
+        ],
+      )
+    ),
+    ( name = "ce-chain-helper",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "content-encoding-chain-helper.js")
+        ],
+        compatibilityFlags = ["brotli_content_encoding"],
+        bindings = [
+          ( name = "SELF", service = "ce-chain-helper" ),
+        ],
+      )
+    ),
+    ( name = "ce-chain-nobr",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "content-encoding-chain-helper.js")
+        ],
+        compatibilityFlags = ["no_brotli_content_encoding"],
+        bindings = [
+          ( name = "PEER", service = "ce-chain-helper" ),
+        ],
+      )
+    ),
+    ( name = "ce-chain-wire",
+      external = (
+        address = "loopback:ce-chain-wire",
+        http = ()
+      )
+    ),
+  ],
+  sockets = [
+    ( name = "ce-chain-wire",
+      address = "loopback:ce-chain-wire",
+      service = "ce-chain-helper",
+      http = ()
+    ),
+  ],
+);


### PR DESCRIPTION
Fixes #7051.

getContentEncoding matched the whole header value against "gzip"/"br", so "gzip, br" (or two separate headers, which kj joins at parse time) matched nothing and bodies arrived still compressed. This parses the value as the RFC 9110 list and makes the encoded system streams carry the whole chain, decoding in reverse-applied order. Two commits: the first is pure plumbing (single enum to a 0-or-1 element chain, no behavior change), the second is the fix.

Design notes, mostly following what I sketched on the issue.

Any unsupported coding anywhere in the list (including br with brotli_content_encoding off, or unmatched case) means whole-body passthrough, same stance as today's single unknown value. Token matching stays case-sensitive so single-value behavior is byte-identical to before. undici lowercases the value first, but widening that would change existing behavior too, so it is left for a compat flag if wanted.

identity tokens and empty list elements are skipped per RFC 9110 5.6.1.2. The cap is five codings, counted after those skips. undici caps at five raw elements and fails the fetch, here longer chains pass through untouched, matching the existing unknown-value stance. Five nested layers from a hostile origin is the amplification ceiling this admits, which is why the cap is tight rather than generous.

Proxied chain responses keep the passthrough fast path and their Content-Length (a chain-aware tryGetLength overload). A worker-constructed Response carrying a stacked header genuinely gets re-encoded, so it advertises no length and goes out chunked, and a HEAD response for one now says chunked where it previously claimed the identity length under an encoded header. Passthrough keeps the Content-Encoding header as is, in line with #5112.

The compat-flag question from the issue is still open from my side. #6836 gates a new coding behind zstd_content_encoding the way br sits behind brotli_content_encoding. This adds no coding, it only walks the list the existing ones already arrive in, so it is flagless, the parse site has a marked seam if you would rather gate it. #6836's zstd arm becomes a one-line case in parseContentEncodings, happy to rebase whichever lands first. The inspector preview path in worker.c++ carries its own copy of the old whole-string match, left alone since #6836 already touches that file.

Tests: a new wd-test covering both chain directions, the cap boundary at exactly five effective codings, identity/empty-element skipping, duplicate headers, proxy passthrough, and Content-Length assertions in both directions over a real socket. One case decodes workerd's encoded wire bytes with node zlib through a brotli-disabled service, proving the br(gzip(data)) layering independently of our own decoder. It stays a standalone wd_test under api/tests because it exercises fetch and Response decoding through system-streams, not the CompressionStream API that moved into the streams suites. bazel test --nocache_test_results //src/workerd/api/... //src/workerd/io/... on the rebased branch: 1221 of 1224 pass, the 3 skipped are the opennextjs tests, which are linux-only.
