### PR TITLE
Workflows create batch overload

### DIFF
--- a/src/cloudflare/internal/test/workflows/workflows-api-test.js
+++ b/src/cloudflare/internal/test/workflows/workflows-api-test.js
@@ -59,6 +59,34 @@ export const workflowsApi = {
     }
 
     {
+      const result = await env.workflow.createBatch({
+        count: 2,
+        params: { bar: 'baz' },
+      });
+      assert.deepStrictEqual(
+        result.created.map(({ id }) => id),
+        ['generated-0', 'generated-1']
+      );
+      assert.deepStrictEqual(result.errors, []);
+    }
+
+    {
+      const result = await env.workflow.createBatch({
+        instances: [{ id: 'batch-ok' }, { id: 'batch-error' }],
+      });
+      assert.deepStrictEqual(result.created[0].id, 'batch-ok');
+      assert.strictEqual(typeof result.created[0].status, 'function');
+      assert.deepStrictEqual(result.errors, [
+        {
+          index: 1,
+          id: 'batch-error',
+          code: 10405,
+          message: 'Provided instance ID already exists',
+        },
+      ]);
+    }
+
+    {
       const result = await env.workflow.deleteBatch([
         'delete-1',
         'missing-delete',

--- a/src/cloudflare/internal/test/workflows/workflows-mock.js
+++ b/src/cloudflare/internal/test/workflows/workflows-mock.js
@@ -8,6 +8,7 @@ const restartBodies = new Map();
 const subscribeOptions = new Map();
 
 const THROW_ID = 'throw';
+const BATCH_ERROR_ID = 'batch-error';
 const MISSING_DELETE_ID = 'missing-delete';
 
 class SubscriptionMock extends RpcTarget {
@@ -41,7 +42,32 @@ export default class WorkflowsMock extends WorkerEntrypoint {
   }
 
   async createBatch(options) {
-    return options.map((val) => ({ id: val.id }));
+    if (Array.isArray(options)) {
+      return options.map((val) => ({ id: val.id }));
+    }
+
+    const instances =
+      options.instances ??
+      Array.from({ length: options.count }, (_, index) => ({
+        id: `generated-${index}`,
+      }));
+    const created = [];
+    const errors = [];
+
+    for (const [index, instance] of instances.entries()) {
+      if (instance.id === BATCH_ERROR_ID) {
+        errors.push({
+          index,
+          id: instance.id,
+          code: 10405,
+          message: 'Provided instance ID already exists',
+        });
+      } else {
+        created.push({ id: instance.id });
+      }
+    }
+
+    return { created, errors };
   }
 
   async deleteBatch(options) {

--- a/src/cloudflare/internal/workflows-api.ts
+++ b/src/cloudflare/internal/workflows-api.ts
@@ -23,6 +23,10 @@ interface Fetcher {
   createBatch(
     options: WorkflowInstanceCreateOptions[]
   ): Promise<{ id: string }[]>;
+  createBatch(options: WorkflowBatchCreateOptions): Promise<{
+    created: { id: string }[];
+    errors: WorkflowBatchCreateResult['errors'];
+  }>;
   deleteBatch(options: {
     instances: string[];
   }): Promise<WorkflowBatchDeleteResult>;
@@ -123,10 +127,29 @@ class WorkflowImpl extends wrappedBinding.WrappedBinding {
 
   async createBatch(
     options: WorkflowInstanceCreateOptions[]
-  ): Promise<WorkflowInstance[]> {
-    const results = await this.#fetcher.createBatch(options);
+  ): Promise<WorkflowInstance[]>;
+  async createBatch(
+    options: WorkflowBatchCreateOptions
+  ): Promise<WorkflowBatchCreateResult>;
+  async createBatch(
+    options: WorkflowInstanceCreateOptions[] | WorkflowBatchCreateOptions
+  ): Promise<WorkflowInstance[] | WorkflowBatchCreateResult> {
+    if (Array.isArray(options)) {
+      const results = await this.#fetcher.createBatch(options);
 
-    return results.map((result) => new InstanceImpl(result.id, this.#fetcher));
+      return results.map(
+        (result) => new InstanceImpl(result.id, this.#fetcher)
+      );
+    }
+
+    const result = await this.#fetcher.createBatch(options);
+
+    return {
+      created: result.created.map(
+        ({ id }) => new InstanceImpl(id, this.#fetcher)
+      ),
+      errors: result.errors,
+    };
   }
 
   async deleteBatch(instanceIds: string[]): Promise<WorkflowBatchDeleteResult> {

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -51,7 +51,7 @@ declare abstract class Workflow<PARAMS = unknown> {
 
   /**
    * Create a batch of instances and return handles for all of them.
-   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
+   * @deprecated Use the object form of `createBatch` instead of the array form.
    */
   createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[]

--- a/src/cloudflare/internal/workflows.d.ts
+++ b/src/cloudflare/internal/workflows.d.ts
@@ -40,15 +40,52 @@ declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowInstance>;
 
   /**
-   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * Create a batch of instances and return handles for the created instances and any per-instance errors.
    * `createBatch` is limited at 100 instances at a time or when the RPC limit (1MiB) is reached.
-   * @param batch List of Options when creating an instance including name and params
-   * @returns A promise that resolves with a list of handles for the created instances.
+   * @param options Options for creating instances by count or from a list of instance options
+   * @returns A promise that resolves with the created instance handles and any per-instance errors.
+   */
+  createBatch(
+    options: WorkflowBatchCreateOptions<PARAMS>
+  ): Promise<WorkflowBatchCreateResult>;
+
+  /**
+   * Create a batch of instances and return handles for all of them.
+   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
    */
   createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[]
   ): Promise<WorkflowInstance[]>;
 }
+
+type WorkflowBatchCreateOptions<PARAMS = unknown> =
+  | {
+      count: number;
+      params?: PARAMS;
+      retention?: {
+        successRetention?: WorkflowRetentionDuration;
+        errorRetention?: WorkflowRetentionDuration;
+      };
+      locationHint?: WorkflowInstanceLocationHint;
+      instances?: never;
+    }
+  | {
+      instances: WorkflowInstanceCreateOptions<PARAMS>[];
+      count?: never;
+      params?: never;
+      retention?: never;
+      locationHint?: never;
+    };
+
+type WorkflowBatchCreateResult = {
+  created: WorkflowInstance[];
+  errors: {
+    index: number;
+    id?: string;
+    code: number;
+    message: string;
+  }[];
+};
 
 type WorkflowDurationLabel =
   'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -26,10 +26,18 @@ declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowInstance>;
 
   /**
-   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * Create a batch of instances and return handles for the created instances and any per-instance errors.
    * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
-   * @param batch List of Options when creating an instance including name and params
-   * @returns A promise that resolves with a list of handles for the created instances.
+   * @param options Options for creating instances by count or from a list of instance options
+   * @returns A promise that resolves with the created instance handles and any per-instance errors.
+   */
+  public createBatch(
+    options: WorkflowBatchCreateOptions<PARAMS>
+  ): Promise<WorkflowBatchCreateResult>;
+
+  /**
+   * Create a batch of instances and return handles for all of them.
+   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[]
@@ -44,6 +52,35 @@ declare abstract class Workflow<PARAMS = unknown> {
    */
   public deleteBatch(instanceIds: string[]): Promise<WorkflowBatchDeleteResult>;
 }
+
+type WorkflowBatchCreateOptions<PARAMS = unknown> =
+  | {
+      count: number;
+      params?: PARAMS;
+      retention?: {
+        successRetention?: WorkflowRetentionDuration;
+        errorRetention?: WorkflowRetentionDuration;
+      };
+      locationHint?: WorkflowInstanceLocationHint;
+      instances?: never;
+    }
+  | {
+      instances: WorkflowInstanceCreateOptions<PARAMS>[];
+      count?: never;
+      params?: never;
+      retention?: never;
+      locationHint?: never;
+    };
+
+type WorkflowBatchCreateResult = {
+  created: WorkflowInstance[];
+  errors: {
+    index: number;
+    id?: string;
+    code: number;
+    message: string;
+  }[];
+};
 
 type WorkflowBatchDeleteResult = {
   deleted: { id: string }[];

--- a/types/defines/workflows.d.ts
+++ b/types/defines/workflows.d.ts
@@ -37,7 +37,7 @@ declare abstract class Workflow<PARAMS = unknown> {
 
   /**
    * Create a batch of instances and return handles for all of them.
-   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
+   * @deprecated Use the object form of `createBatch` instead of the array form.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[]

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -17667,10 +17667,17 @@ declare abstract class Workflow<PARAMS = unknown> {
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
   /**
-   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * Create a batch of instances and return handles for the created instances and any per-instance errors.
    * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
-   * @param batch List of Options when creating an instance including name and params
-   * @returns A promise that resolves with a list of handles for the created instances.
+   * @param options Options for creating instances by count or from a list of instance options
+   * @returns A promise that resolves with the created instance handles and any per-instance errors.
+   */
+  public createBatch(
+    options: WorkflowBatchCreateOptions<PARAMS>,
+  ): Promise<WorkflowBatchCreateResult>;
+  /**
+   * Create a batch of instances and return handles for all of them.
+   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[],
@@ -17684,6 +17691,33 @@ declare abstract class Workflow<PARAMS = unknown> {
    */
   public deleteBatch(instanceIds: string[]): Promise<WorkflowBatchDeleteResult>;
 }
+type WorkflowBatchCreateOptions<PARAMS = unknown> =
+  | {
+      count: number;
+      params?: PARAMS;
+      retention?: {
+        successRetention?: WorkflowRetentionDuration;
+        errorRetention?: WorkflowRetentionDuration;
+      };
+      locationHint?: WorkflowInstanceLocationHint;
+      instances?: never;
+    }
+  | {
+      instances: WorkflowInstanceCreateOptions<PARAMS>[];
+      count?: never;
+      params?: never;
+      retention?: never;
+      locationHint?: never;
+    };
+type WorkflowBatchCreateResult = {
+  created: WorkflowInstance[];
+  errors: {
+    index: number;
+    id?: string;
+    code: number;
+    message: string;
+  }[];
+};
 type WorkflowBatchDeleteResult = {
   deleted: {
     id: string;

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -17677,7 +17677,7 @@ declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowBatchCreateResult>;
   /**
    * Create a batch of instances and return handles for all of them.
-   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
+   * @deprecated Use the object form of `createBatch` instead of the array form.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[],

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -17626,7 +17626,7 @@ export declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowBatchCreateResult>;
   /**
    * Create a batch of instances and return handles for all of them.
-   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
+   * @deprecated Use the object form of `createBatch` instead of the array form.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[],

--- a/types/generated-snapshot/experimental/index.ts
+++ b/types/generated-snapshot/experimental/index.ts
@@ -17616,10 +17616,17 @@ export declare abstract class Workflow<PARAMS = unknown> {
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
   /**
-   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * Create a batch of instances and return handles for the created instances and any per-instance errors.
    * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
-   * @param batch List of Options when creating an instance including name and params
-   * @returns A promise that resolves with a list of handles for the created instances.
+   * @param options Options for creating instances by count or from a list of instance options
+   * @returns A promise that resolves with the created instance handles and any per-instance errors.
+   */
+  public createBatch(
+    options: WorkflowBatchCreateOptions<PARAMS>,
+  ): Promise<WorkflowBatchCreateResult>;
+  /**
+   * Create a batch of instances and return handles for all of them.
+   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[],
@@ -17633,6 +17640,33 @@ export declare abstract class Workflow<PARAMS = unknown> {
    */
   public deleteBatch(instanceIds: string[]): Promise<WorkflowBatchDeleteResult>;
 }
+export type WorkflowBatchCreateOptions<PARAMS = unknown> =
+  | {
+      count: number;
+      params?: PARAMS;
+      retention?: {
+        successRetention?: WorkflowRetentionDuration;
+        errorRetention?: WorkflowRetentionDuration;
+      };
+      locationHint?: WorkflowInstanceLocationHint;
+      instances?: never;
+    }
+  | {
+      instances: WorkflowInstanceCreateOptions<PARAMS>[];
+      count?: never;
+      params?: never;
+      retention?: never;
+      locationHint?: never;
+    };
+export type WorkflowBatchCreateResult = {
+  created: WorkflowInstance[];
+  errors: {
+    index: number;
+    id?: string;
+    code: number;
+    message: string;
+  }[];
+};
 export type WorkflowBatchDeleteResult = {
   deleted: {
     id: string;

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -17400,7 +17400,7 @@ declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowBatchCreateResult>;
   /**
    * Create a batch of instances and return handles for all of them.
-   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
+   * @deprecated Use the object form of `createBatch` instead of the array form.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[],

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -17390,10 +17390,17 @@ declare abstract class Workflow<PARAMS = unknown> {
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
   /**
-   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * Create a batch of instances and return handles for the created instances and any per-instance errors.
    * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
-   * @param batch List of Options when creating an instance including name and params
-   * @returns A promise that resolves with a list of handles for the created instances.
+   * @param options Options for creating instances by count or from a list of instance options
+   * @returns A promise that resolves with the created instance handles and any per-instance errors.
+   */
+  public createBatch(
+    options: WorkflowBatchCreateOptions<PARAMS>,
+  ): Promise<WorkflowBatchCreateResult>;
+  /**
+   * Create a batch of instances and return handles for all of them.
+   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[],
@@ -17407,6 +17414,33 @@ declare abstract class Workflow<PARAMS = unknown> {
    */
   public deleteBatch(instanceIds: string[]): Promise<WorkflowBatchDeleteResult>;
 }
+type WorkflowBatchCreateOptions<PARAMS = unknown> =
+  | {
+      count: number;
+      params?: PARAMS;
+      retention?: {
+        successRetention?: WorkflowRetentionDuration;
+        errorRetention?: WorkflowRetentionDuration;
+      };
+      locationHint?: WorkflowInstanceLocationHint;
+      instances?: never;
+    }
+  | {
+      instances: WorkflowInstanceCreateOptions<PARAMS>[];
+      count?: never;
+      params?: never;
+      retention?: never;
+      locationHint?: never;
+    };
+type WorkflowBatchCreateResult = {
+  created: WorkflowInstance[];
+  errors: {
+    index: number;
+    id?: string;
+    code: number;
+    message: string;
+  }[];
+};
 type WorkflowBatchDeleteResult = {
   deleted: {
     id: string;

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -17349,7 +17349,7 @@ export declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowBatchCreateResult>;
   /**
    * Create a batch of instances and return handles for all of them.
-   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
+   * @deprecated Use the object form of `createBatch` instead of the array form.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[],

--- a/types/generated-snapshot/index.ts
+++ b/types/generated-snapshot/index.ts
@@ -17339,10 +17339,17 @@ export declare abstract class Workflow<PARAMS = unknown> {
     options?: WorkflowInstanceCreateOptions<PARAMS>,
   ): Promise<WorkflowInstance>;
   /**
-   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * Create a batch of instances and return handles for the created instances and any per-instance errors.
    * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
-   * @param batch List of Options when creating an instance including name and params
-   * @returns A promise that resolves with a list of handles for the created instances.
+   * @param options Options for creating instances by count or from a list of instance options
+   * @returns A promise that resolves with the created instance handles and any per-instance errors.
+   */
+  public createBatch(
+    options: WorkflowBatchCreateOptions<PARAMS>,
+  ): Promise<WorkflowBatchCreateResult>;
+  /**
+   * Create a batch of instances and return handles for all of them.
+   * @deprecated Use the object form `createBatch({ instances: batch })` instead.
    */
   public createBatch(
     batch: WorkflowInstanceCreateOptions<PARAMS>[],
@@ -17356,6 +17363,33 @@ export declare abstract class Workflow<PARAMS = unknown> {
    */
   public deleteBatch(instanceIds: string[]): Promise<WorkflowBatchDeleteResult>;
 }
+export type WorkflowBatchCreateOptions<PARAMS = unknown> =
+  | {
+      count: number;
+      params?: PARAMS;
+      retention?: {
+        successRetention?: WorkflowRetentionDuration;
+        errorRetention?: WorkflowRetentionDuration;
+      };
+      locationHint?: WorkflowInstanceLocationHint;
+      instances?: never;
+    }
+  | {
+      instances: WorkflowInstanceCreateOptions<PARAMS>[];
+      count?: never;
+      params?: never;
+      retention?: never;
+      locationHint?: never;
+    };
+export type WorkflowBatchCreateResult = {
+  created: WorkflowInstance[];
+  errors: {
+    index: number;
+    id?: string;
+    code: number;
+    message: string;
+  }[];
+};
 export type WorkflowBatchDeleteResult = {
   deleted: {
     id: string;

--- a/types/test/types/rpc.ts
+++ b/types/test/types/rpc.ts
@@ -1318,9 +1318,39 @@ expectTypeOf(withoutSchedule.schedule).toEqualTypeOf<
   WorkflowCronSchedule | undefined
 >();
 
-declare const workflow: Workflow;
+declare const workflow: Workflow<WorkflowPayload>;
 declare const workflowInstance: WorkflowInstance;
 expectTypeOf(workflowInstance.delete()).toEqualTypeOf<Promise<void>>();
+expectTypeOf(
+  workflow.createBatch({
+    count: 2,
+    params: {foo: 'bar'},
+    retention: {successRetention: '1 day'},
+    locationHint: 'weur',
+  })
+).toEqualTypeOf<Promise<WorkflowBatchCreateResult>>();
+expectTypeOf(
+  workflow.createBatch({instances: [{id: 'one', params: {foo: 'bar'}}]})
+).toEqualTypeOf<Promise<WorkflowBatchCreateResult>>();
+expectTypeOf(
+  workflow.createBatch([{id: 'one', params: {foo: 'bar'}}])
+).toEqualTypeOf<Promise<WorkflowInstance[]>>();
+expectTypeOf<WorkflowBatchCreateResult['created'][number]>().toEqualTypeOf<
+  WorkflowInstance
+>();
+expectTypeOf<WorkflowBatchCreateResult['errors'][number]>().toEqualTypeOf<{
+  index: number;
+  id?: string;
+  code: number;
+  message: string;
+}>();
+
+// @ts-expect-error count and instances are mutually exclusive
+workflow.createBatch({count: 1, instances: []});
+
+// @ts-expect-error batch params must match the Workflow generic
+workflow.createBatch({count: 1, params: {foo: 1}});
+
 expectTypeOf(workflow.deleteBatch(['one', 'two'])).toEqualTypeOf<
   Promise<WorkflowBatchDeleteResult>
 >();


### PR DESCRIPTION
Adds an overload to the `createBatch` method in the Workflows binding, reflecting the new V2 API we are releasing for this method.