### PR TITLE
Increase HTMLRewriter fiber stack size under ASan

### DIFF
--- a/src/workerd/api/html-rewriter.c++
+++ b/src/workerd/api/html-rewriter.c++
@@ -429,9 +429,15 @@ Rewriter::Rewriter(jsg::Lock& js,
 
 namespace {
 
+#if KJ_HAS_COMPILER_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+// encoding_rs decoder frames can consume over 60 KiB in ASan debug builds. Leave room for
+// the rest of the rewriter's call stack as well.
+const size_t FIBER_STACK_SIZE = 1024 * 256;
+#else
 // The stack size floor enforced by kj. We could go lower,
 // but it'd always be increased to this anyway.
 const size_t FIBER_STACK_SIZE = 1024 * 64;
+#endif
 
 const kj::FiberPool& getFiberPool() {
   const static kj::FiberPool FIBER_POOL(FIBER_STACK_SIZE);


### PR DESCRIPTION
encoding_rs 0.8.40 uses roughly 61 KiB for a decoder stack frame in ASan debug builds. Including callers exceeds the 64 KiB fiber stack, causing HTMLRewriter and related async-context tests to crash. Use a 256 KiB fiber stack under ASan, retaining 64 KiB otherwise.