### PR TITLE
Check signature of non-resource JSG objects, simplify tag checks

### DIFF
--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -81,12 +81,12 @@ WrappableFunction<Signature>& unwrapWrappableFunction(
     v8::Isolate* isolate, v8::Local<v8::Object> object) {
   // WrappableFunction<Sig> for every Sig shares kNonResourceWrappableTag, so the tag range check
   // only proves "some non-resource wrappable". The concrete signature -- which determines how
-  // operator() is called -- must be verified separately, and must not depend on the belt-and-braces
-  // dynamic_cast in downcastWrappable (which we may remove once tags are trusted).
+  // operator() is called -- must be verified separately.
   Wrappable* wrappable =
       Wrappable::unwrapFromShimInRangeOrAbort(isolate, object, kNonResourceWrappableTagRange);
   auto* function = dynamic_cast<WrappableFunction<Signature>*>(wrappable);
   if (function == nullptr) {
+    // TODO: Should still report the expected and actual types here?
     KJ_LOG(FATAL, "wrapper type mismatch: object is not the expected native function signature");
     abort();
   }

--- a/src/workerd/jsg/function.h
+++ b/src/workerd/jsg/function.h
@@ -74,6 +74,25 @@ class WrappableFunctionImpl<Ret(Args...), Impl>: public WrappableFunction<Ret(Ar
   Impl func;
 };
 
+// Given the wrapper object that a native jsg::Function stashed as its callback data, recover the
+// WrappableFunction it wraps, aborting if it is not one of the expected signature.
+template <typename Signature>
+WrappableFunction<Signature>& unwrapWrappableFunction(
+    v8::Isolate* isolate, v8::Local<v8::Object> object) {
+  // WrappableFunction<Sig> for every Sig shares kNonResourceWrappableTag, so the tag range check
+  // only proves "some non-resource wrappable". The concrete signature -- which determines how
+  // operator() is called -- must be verified separately, and must not depend on the belt-and-braces
+  // dynamic_cast in downcastWrappable (which we may remove once tags are trusted).
+  Wrappable* wrappable =
+      Wrappable::unwrapFromShimInRangeOrAbort(isolate, object, kNonResourceWrappableTagRange);
+  auto* function = dynamic_cast<WrappableFunction<Signature>*>(wrappable);
+  if (function == nullptr) {
+    KJ_LOG(FATAL, "wrapper type mismatch: object is not the expected native function signature");
+    abort();
+  }
+  return *function;
+}
+
 template <typename TypeWrapper, typename Signature, typename = ArgumentIndexes<Signature>>
 struct FunctorCallback;
 
@@ -85,8 +104,7 @@ struct FunctorCallback<TypeWrapper, Ret(Args...), kj::_::Indexes<indexes...>> {
       auto context = isolate->GetCurrentContext();
       auto& js = Lock::from(isolate);
       auto& wrapper = TypeWrapper::from(isolate);
-      auto& func = extractInternalPointer<WrappableFunction<Ret(Args...)>, false>(
-          isolate, context, args.Data().As<v8::Object>(), kNonResourceWrappableTagRange);
+      auto& func = unwrapWrappableFunction<Ret(Args...)>(isolate, args.Data().As<v8::Object>());
 
       auto unwrapped = _::unwrapArgs<Args...>(wrapper, js, context, args,
           []<size_t i>() { return TypeErrorContext::callbackArgument(i); });
@@ -113,9 +131,9 @@ struct FunctorCallback<TypeWrapper,
       auto context = isolate->GetCurrentContext();
       auto& wrapper = TypeWrapper::from(isolate);
       auto& js = Lock::from(isolate);
-      auto& func = extractInternalPointer<
-          WrappableFunction<Ret(const v8::FunctionCallbackInfo<v8::Value>&, Args...)>, false>(
-          isolate, context, args.Data().As<v8::Object>(), kNonResourceWrappableTagRange);
+      auto& func =
+          unwrapWrappableFunction<Ret(const v8::FunctionCallbackInfo<v8::Value>&, Args...)>(
+              isolate, args.Data().As<v8::Object>());
 
       auto unwrapped = _::unwrapArgs<Args...>(wrapper, js, context, args,
           []<size_t i>() { return TypeErrorContext::callbackArgument(i); });

--- a/src/workerd/jsg/jsg.h
+++ b/src/workerd/jsg/jsg.h
@@ -1459,20 +1459,6 @@ class Object: private Wrappable {
   friend class WeakRef;
 };
 
-// Declared in wrappable.h; see there for why this check exists.
-template <typename T>
-T& downcastObject(Object& object) {
-  const auto& actualType = typeid(object);
-  if (&actualType == &typeid(T) || actualType == typeid(T)) {
-    return static_cast<T&>(object);
-  }
-  T* result = dynamic_cast<T*>(&object);
-  if (result == nullptr) {
-    reportWrapperTypeMismatch(typeid(T), actualType);
-  }
-  return *result;
-}
-
 // Ref<T> is a reference to a resource type (a type with a JSG_RESOURCE_TYPE block) living on
 // the V8 heap.
 //

--- a/src/workerd/jsg/jsvalue.h
+++ b/src/workerd/jsg/jsvalue.h
@@ -755,21 +755,13 @@ class JsObject final: public JsBase<v8::Object, JsObject> {
  public:
   template <typename T>
   bool isInstanceOf(Lock& js) {
-    KJ_IF_SOME(instance, js.getInstance(inner, typeid(T))) {
-      // getInstance() checks the prototype chain, but the wrapper may be
-      // pointing at the wrong object after a V8 sandbox corruption, so defense
-      // in depth means we need to confirm the type before answering yes.
-      downcastObject<T>(instance);
-      return true;
-    } else {
-      return false;
-    }
+    return js.getInstance(inner, typeid(T)) != kj::none;
   }
 
   template <typename T>
   kj::Maybe<jsg::Ref<T>> tryUnwrapAs(Lock& js) {
-    KJ_IF_SOME(instance, js.getInstance(inner, typeid(T))) {
-      return _jsgThis(&downcastObject<T>(instance));
+    KJ_IF_SOME(ins, js.getInstance(inner, typeid(T))) {
+      return _jsgThis(static_cast<T*>(&ins));
     } else {
       return kj::none;
     }

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -97,7 +97,7 @@ T unwrapOpaque(v8::Isolate* isolate, v8::Local<v8::Value> handle) {
   Wrappable& wrappable = KJ_ASSERT_NONNULL(Wrappable::tryUnwrapOpaque(isolate, handle));
   OpaqueWrappable<T>* holder = dynamic_cast<OpaqueWrappable<T>*>(&wrappable);
   if (holder == nullptr) {
-    KJ_LOG(FATAL, "wrapper type mismatch: object is not the expected native function signature");
+    KJ_LOG(FATAL, "wrapper type mismatch: object is not the expected opaque type");
     abort();
   }
   KJ_ASSERT(!holder->movedAway);
@@ -116,7 +116,7 @@ T& unwrapOpaqueRef(v8::Isolate* isolate, v8::Local<v8::Value> handle) {
   Wrappable& wrappable = KJ_ASSERT_NONNULL(Wrappable::tryUnwrapOpaque(isolate, handle));
   OpaqueWrappable<T>* holder = dynamic_cast<OpaqueWrappable<T>*>(&wrappable);
   if (holder == nullptr) {
-    KJ_LOG(FATAL, "wrapper type mismatch: object is not the expected native function signature");
+    KJ_LOG(FATAL, "wrapper type mismatch: object is not the expected opaque type");
     abort();
   }
   KJ_ASSERT(!holder->movedAway);

--- a/src/workerd/jsg/promise.h
+++ b/src/workerd/jsg/promise.h
@@ -96,7 +96,10 @@ T unwrapOpaque(v8::Isolate* isolate, v8::Local<v8::Value> handle) {
 
   Wrappable& wrappable = KJ_ASSERT_NONNULL(Wrappable::tryUnwrapOpaque(isolate, handle));
   OpaqueWrappable<T>* holder = dynamic_cast<OpaqueWrappable<T>*>(&wrappable);
-  KJ_ASSERT(holder != nullptr);
+  if (holder == nullptr) {
+    KJ_LOG(FATAL, "wrapper type mismatch: object is not the expected native function signature");
+    abort();
+  }
   KJ_ASSERT(!holder->movedAway);
   holder->movedAway = true;
   return kj::mv(holder->value);
@@ -112,7 +115,10 @@ T& unwrapOpaqueRef(v8::Isolate* isolate, v8::Local<v8::Value> handle) {
 
   Wrappable& wrappable = KJ_ASSERT_NONNULL(Wrappable::tryUnwrapOpaque(isolate, handle));
   OpaqueWrappable<T>* holder = dynamic_cast<OpaqueWrappable<T>*>(&wrappable);
-  KJ_ASSERT(holder != nullptr);
+  if (holder == nullptr) {
+    KJ_LOG(FATAL, "wrapper type mismatch: object is not the expected native function signature");
+    abort();
+  }
   KJ_ASSERT(!holder->movedAway);
   return holder->value;
 }

--- a/src/workerd/jsg/resource.h
+++ b/src/workerd/jsg/resource.h
@@ -2027,7 +2027,10 @@ class ResourceWrapper {
         // prototype-chain check, not here, and yields the kj::none below.)
         Wrappable* wrappable = Wrappable::unwrapFromShimInRangeOrAbort(
             js.v8Isolate, instance, TypeWrapper::template wrappableTagRange<T>());
-        return downcastWrappable<T>(*wrappable);
+        // TODO: Would need something more substantial here, do we need to maintain
+        // downcastWrappable after the rebase?
+        // return downcastWrappable<T>(*wrappable);
+        return *reinterpret_cast<T*>(wrappable);
       }
     }
 

--- a/src/workerd/jsg/setup.h
+++ b/src/workerd/jsg/setup.h
@@ -1054,14 +1054,7 @@ class Isolate: public IsolateBase {
         // its prototype chain was left intact -- an in-sandbox memory-safety violation, which aborts.
         Wrappable* wrappable =
             Wrappable::unwrapFromShimInRangeOrAbort(v8Isolate, instance, info.tagRange);
-        // Even after checking the tags we use the vtable check to confirm the type
-        // matches our expectations. This should never fail unless we have an attacker
-        // that has somehow got around the tag check.
-        Object* object = wrappable->jsgTryGetObject();
-        if (object == nullptr) {
-          reportWrapperTypeMismatch(type, typeid(*wrappable));
-        }
-        return *object;
+        return KJ_ASSERT_NONNULL(wrappable->jsgTryGetObject());
       }
     }
 

--- a/src/workerd/jsg/wrappable.c++
+++ b/src/workerd/jsg/wrappable.c++
@@ -610,15 +610,6 @@ kj::Maybe<Wrappable&> Wrappable::tryUnwrapOpaque(
   return kj::none;
 }
 
-void reportWrapperTypeMismatch(const std::type_info& expected, const std::type_info& actual) {
-  // Only reachable if the wrapper's internal field has been made to point at an object of the
-  // wrong type, which means memory outside this process's control has already been corrupted.
-  // Abort: edgeworker's crash handler turns this into an abrupt shutdown of the isolate.
-  KJ_LOG(FATAL, "JS wrapper's C++ object is not of the expected type", typeName(expected),
-      typeName(actual));
-  abort();
-}
-
 void reportWrapperIdentityMismatch() {
   KJ_LOG(FATAL, "JS wrapper's CppHeap shim does not own the dispatch receiver");
   abort();

--- a/src/workerd/jsg/wrappable.h
+++ b/src/workerd/jsg/wrappable.h
@@ -21,8 +21,6 @@
 #include <kj/refcount.h>
 #include <kj/vector.h>
 
-#include <typeinfo>
-
 // Niche value optimization for v8::TracedReference<T>. This teaches kj::Maybe to use
 // TracedReference's built-in empty state (IsEmpty()) as the "none" representation, eliminating
 // the extra bool + alignment padding that kj::Maybe normally adds. This saves 8 bytes per
@@ -558,55 +556,7 @@ bool sharesCppgcShimForTest(
 // TODO(soon):
 // - Track memory usage of native objects.
 
-// Log the types involved in a failed downcast and abort.  Out-of-line and not
-// templated, to keep the code that unwrappers inline as small as possible.
-[[noreturn]] void reportWrapperTypeMismatch(
-    const std::type_info& expected, const std::type_info& actual);
 [[noreturn]] void reportWrapperIdentityMismatch();
-
-// Cast an `Object` that came from a wrapper to the type the callsite expects,
-// aborting if the object is not of that type.
-//
-// In-sandbox corruption may allow an attacker to confuse types.  An object's
-// RTTI lives outside the V8 sandbox, out of reach of such a substitution, so
-// use that to confirm the type instead.
-//
-// Defined in jsg.h, where `Object` is complete.
-template <typename T>
-T& downcastObject(Object& object);
-
-// Cast a `Wrappable` taken from a wrapper's internal field to the type the
-// callsite expects, aborting if the object is not of that type.
-template <typename T>
-T& downcastWrappable(Wrappable& wrappable) {
-  if constexpr (kj::canConvert<T&, Object&>()) {
-    // A `dynamic_cast` cannot start from `Wrappable`: the runtime check is
-    // specified to succeed only through a public base, so a
-    // privately-inherited one fails regardless of what access the callsite
-    // has. Every resource type reaches `T` through the public `Object` base,
-    // so start from there. This also lands on the correct address for a `T`
-    // that inherits `Object` at a non-zero offset, which a `reinterpret_cast`
-    // would not.
-    Object* object = wrappable.jsgTryGetObject();
-    if (object == nullptr) {
-      reportWrapperTypeMismatch(typeid(T), typeid(wrappable));
-    }
-    return downcastObject<T>(*object);
-  } else {
-    // Wrappables that are not `Object`s -- `WrappableFunction` and
-    // `OpaqueWrappable` -- inherit `Wrappable` publicly, so they can be cast
-    // directly.
-    const auto& actualType = typeid(wrappable);
-    if (&actualType == &typeid(T) || actualType == typeid(T)) {
-      return static_cast<T&>(wrappable);
-    }
-    T* result = dynamic_cast<T*>(&wrappable);
-    if (result == nullptr) {
-      reportWrapperTypeMismatch(typeid(T), actualType);
-    }
-    return *result;
-  }
-}
 
 // Given a handle to a resource type, extract the raw C++ object pointer.
 //
@@ -633,11 +583,19 @@ T& extractInternalPointer(v8::Isolate* isolate,
     return KJ_ASSERT_NONNULL(
         getAlignedPointerFromEmbedderData<T>(context, ContextPointerSlot::GLOBAL_WRAPPER));
   } else {
+    // We assume that this code path is covered by type checks, which only applies for types that
+    // are convertible to Object. Other types (e.g. WrappableFunction and OpaqueWrappable) are
+    // handled using unwrapWrappableFunction/unwrapOpaque.
+    static_assert(
+        kj::canConvert<T&, Object&>(), "extractInternalPointer() only supports JSG resource types");
+
     // A tag outside the range for the type this dispatch site expects is a memory-safety violation
     // (an object whose CppHeap handle has been redirected to an unrelated type), so this aborts
     // rather than throwing, which JSG would catch and turn into a recoverable JS exception.
     Wrappable* ptr = Wrappable::unwrapFromShimInRangeOrAbort(isolate, object, tagRange);
-    return downcastWrappable<T>(*ptr);
+    Object* resource = ptr->jsgTryGetObject();
+    KJ_ASSERT(resource != nullptr);
+    return *static_cast<T*>(resource);
   }
 }
 


### PR DESCRIPTION
- More granular use of dynamic_cast


- Simplify JSG casts after introducing tag checks

In the previous commit, we stopped calling extractInternalPointer() for
WrappableFunction and OpaqueWrappable and can accordingly simplify it, getting
rid of dynamic_cast. Also clean up other spots where we should no longer need
dynamic casts. Asserts are used so that we will fail loudly if a non-Object ends
up being reported in a code path where it shouldn't be. This partially reverts
https://github.com/cloudflare/workerd/commit/7dca4572763e3c26c97eee5a3805912b083bc8a9.

==========
Applying proposed changes shared in EW-11010. Once we introduce unwrapWrappableFunction, we can get rid of the dynamic_cast and simplify things a bit.
Note: This is currently a bit behind main and has a merge conflicts based on several JSG reverts that have happened since. I assume that those will land again in some capacity, if not I'm happy to rebase on top of main too. You'll find two TODOs for things I wasn't sure about.