### PR TITLE
Update capnp-cpp to v2 head (Executor::isCurrent + setRunnable ordering)

### DIFF
--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -27,10 +27,10 @@ bazel_dep(name = "brotli", version = "1.2.0.bcr.3")
 # capnp-cpp
 http.archive(
     name = "capnp-cpp",
-    sha256 = "1b873e8cf4223f198fed6b0f1b97836ad95203b817eed6bf626099edbb56c8d0",
-    strip_prefix = "capnproto-capnproto-e9a6b56/c++",
+    sha256 = "dcd96af005ea6fab167e63b6d53b05db13c03339766d26c07e0b3cbe54e1982e",
+    strip_prefix = "capnproto-capnproto-851c45b/c++",
     type = "tgz",
-    url = "https://github.com/capnproto/capnproto/tarball/e9a6b56094655765e57b75ebc1c7b002fb036fde",
+    url = "https://github.com/capnproto/capnproto/tarball/851c45bb39c34c3f20f9d9ebe9f34a7e39109b6f",
 )
 use_repo(http, "capnp-cpp")
 


### PR DESCRIPTION
Bumps the `capnp-cpp` pin to the current `v2` head (`851c45b`), a 2-commit forward move from `e9a6b56` that lands [capnproto/capnproto#2814](https://github.com/capnproto/capnproto/pull/2814):

- `kj/async`: a lock-free `Executor::isCurrent()`, and
- `EventLoop::wait()` now reports `setRunnable(false)` to the `EventPort` before calling `port.wait()`.

The upcoming kj-rs / kj-rs-tokio async-bridge work depends on both (a plain `isCurrent()` instead of a duplicate helper, and a non-stale `setRunnable` during a park). Regenerated via `build/deps/update-deps.py capnp-cpp`; `deps.jsonc` is unchanged (it already tracks `v2`).

Validated locally: full `workerd` build and `bazel test //src/rust/...` (36/37, 1 platform-skip) against the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)