### PR TITLE
fix identity transform stream resolve/state change order

### DIFF
--- a/src/tests/streams/identity/AGENTS.md
+++ b/src/tests/streams/identity/AGENTS.md
@@ -244,7 +244,7 @@ pattern; a change to either side fails its cell.
 | `backpressure.js` | writes and close queue unboundedly with settlement on consumption; advisory overfill (negative `desiredSize`); default HWM 1 with divergent accounting (ledger #17); explicit HWM as initial `desiredSize` (negative-zero HWM normalized to +0); byte-level tracking incl. in-flight bytes; string accounting (ledger #7); `ready` replacement and recovery |
 | `close-propagation.js` | pending read resolves done; post-close reads done; buffered data drains before done; `closed` promises settle; writes after a queued close reject (message per impl) without disturbing the close or delivered bytes |
 | `abort-propagation.js` | pending/subsequent reads and both `closed` promises reject (identity per ledger #8); modern abort clears a pending write, rejecting it with the abort reason (undefined or original instance); later writes (ledger #9) |
-| `cancel-propagation.js` | pending write/close reject (ledger #8, #10); canceling reader's reads resolve done |
+| `cancel-propagation.js` | pending write/close reject (ledger #8, #10); canceling reader's reads resolve done; in C++, cancellation of a pending `pipeTo()` sink write establishes the disconnection error before a later readable cancel reason |
 | `fixed-length.js` | exact-length delivery (one and two chunks); `FLS(0)`; HWM capping incl. bigint; capped-HWM data flow |
 | `fixed-length-errors.js` | over/underwrite and close-without-write error the stream with the documented messages (types/surfacing per ledger #11); abort skips the underwrite check |
 | `tee.js` | both branches observe full content (ITS and FLS); single-branch read does not hang |

--- a/src/tests/streams/identity/cancel-propagation.js
+++ b/src/tests/streams/identity/cancel-propagation.js
@@ -59,6 +59,34 @@ export const cancelRejectsSubsequentWrites = {
   },
 };
 
+export const pipeCancellationWinsOverLaterReadableCancel = {
+  async test() {
+    // The C++ implementation cancels the pending sink write when pipeTo() is aborted. That
+    // disconnection must become the transform's terminal error before a later readable.cancel()
+    // can supply a different reason. The TypeScript implementation has no corresponding KJ
+    // operation.
+    if (usingTsImpl) return;
+
+    const source = new Response(new Uint8Array([1])).body;
+    const transform = new IdentityTransformStream();
+    const abortController = new AbortController();
+    const pipePromise = source.pipeTo(transform.writable, {
+      signal: abortController.signal,
+      preventAbort: true,
+      preventCancel: true,
+    });
+
+    await scheduler.wait(0);
+    abortController.abort(new Error('pipe canceled'));
+    await captureRejection(pipePromise);
+
+    await transform.readable.cancel(new Error('later readable cancel'));
+    const writer = transform.writable.getWriter();
+    const error = await captureRejection(writer.write(new Uint8Array([2])));
+    strictEqual(error.message, 'Network connection lost.');
+  },
+};
+
 export const cancelResolvesReaderClosedPromise = {
   async test() {
     // The canceling reader's own closed promise resolves (with undefined),

--- a/src/tests/streams/identity/main.js
+++ b/src/tests/streams/identity/main.js
@@ -101,6 +101,7 @@ export {
 export {
   cancelRejectsPendingWriteAndClose,
   cancelRejectsSubsequentWrites,
+  pipeCancellationWinsOverLaterReadableCancel,
   cancelResolvesReaderClosedPromise,
   cancelledReaderReadsResolveDone,
 } from 'cancel-propagation';

--- a/src/workerd/api/streams/identity-transform-stream.c++
+++ b/src/workerd/api/streams/identity-transform-stream.c++
@@ -21,16 +21,12 @@ struct Idle {
 struct ReadRequest {
   static constexpr kj::StringPtr NAME KJ_UNUSED = "read-request"_kj;
   kj::ArrayPtr<kj::byte> bytes;
-  // WARNING: `bytes` may be invalid if fulfiller->isWaiting() returns false! (This indicates the
-  //   read was canceled.)
   kj::Own<kj::PromiseFulfiller<size_t>> fulfiller;
 };
 
 struct WriteRequest {
   static constexpr kj::StringPtr NAME KJ_UNUSED = "write-request"_kj;
   kj::ArrayPtr<const kj::byte> bytes;
-  // WARNING: `bytes` may be invalid if fulfiller->isWaiting() returns false! (This indicates the
-  //   write was canceled, e.g. via removeSink() destroying the Canceler.)
   kj::Own<kj::PromiseFulfiller<void>> fulfiller;
 };
 
@@ -168,12 +164,21 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
     if (state.is<Closed>()) return;
 
     KJ_IF_SOME(request, state.tryGetUnsafe<ReadRequest>()) {
-      request.fulfiller->fulfill(static_cast<size_t>(0));
-    } else KJ_IF_SOME(request, state.tryGetUnsafe<WriteRequest>()) {
-      request.fulfiller->reject(reason.clone());
+      auto fulfiller = kj::mv(request.fulfiller);
+      state.forceTransitionTo<kj::Exception>(kj::mv(reason));
+      fulfiller->fulfill(static_cast<size_t>(0));
+      return;
     }
-    // Idle state is fine, just transition to error.
 
+    KJ_IF_SOME(request, state.tryGetUnsafe<WriteRequest>()) {
+      auto fulfiller = kj::mv(request.fulfiller);
+      auto writeReason = reason.clone();
+      state.forceTransitionTo<kj::Exception>(kj::mv(reason));
+      fulfiller->reject(kj::mv(writeReason));
+      return;
+    }
+
+    // Idle state is fine, just transition to error.
     state.forceTransitionTo<kj::Exception>(kj::mv(reason));
 
     // TODO(conform): Proactively put WritableStream into Errored state.
@@ -208,16 +213,21 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
     if (state.isErrored()) return;
 
     KJ_IF_SOME(request, state.tryGetUnsafe<ReadRequest>()) {
-      request.fulfiller->reject(reason.clone());
-    } else KJ_IF_SOME(request, state.tryGetUnsafe<WriteRequest>()) {
+      auto fulfiller = kj::mv(request.fulfiller);
+      auto readReason = reason.clone();
+      state.forceTransitionTo<kj::Exception>(kj::mv(reason));
+      fulfiller->reject(kj::mv(readReason));
+      return;
+    }
+
+    KJ_IF_SOME(request, state.tryGetUnsafe<WriteRequest>()) {
       // If the fulfiller is not waiting, the write promise was already
       // canceled and no one is waiting on it.
       KJ_ASSERT(!request.fulfiller->isWaiting(),
           "abort() is supposed to wait for any pending write() to finish");
     }
-    // Idle and Closed states are fine, just transition to error.
-    // (Closed can transition to error via abort)
 
+    // Idle, WriteRequest, and Closed states can transition directly to error.
     state.forceTransitionTo<kj::Exception>(kj::mv(reason));
 
     // TODO(conform): Proactively put ReadableStream into Errored state.
@@ -255,10 +265,11 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
         // The write buffer will entirely fit into our read buffer; fulfill both requests.
         memmove(bytes.begin(), request.bytes.begin(), request.bytes.size());
         auto result = request.bytes.size();
-        request.fulfiller->fulfill();
+        auto fulfiller = kj::mv(request.fulfiller);
 
-        // Switch to idle state.
+        // Release the borrowed write buffer before settling the write promise.
         state.transitionTo<Idle>();
+        fulfiller->fulfill();
 
         return result;
       }
@@ -273,7 +284,14 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
     KJ_ASSERT(state.is<Idle>());
     auto paf = kj::newPromiseAndFulfiller<size_t>();
     state.transitionTo<ReadRequest>(bytes, kj::mv(paf.fulfiller));
-    return kj::mv(paf.promise);
+    return kj::mv(paf.promise).attach(kj::defer([self = kj::addRef(*this)]() mutable {
+      KJ_IF_SOME(request, self->state.tryGetUnsafe<ReadRequest>()) {
+        if (!request.fulfiller->isWaiting()) {
+          self->state.forceTransitionTo<kj::Exception>(
+              KJ_EXCEPTION(DISCONNECTED, "reader canceled"));
+        }
+      }
+    }));
   }
 
   kj::Promise<void> writeHelper(kj::ArrayPtr<const kj::byte> bytes) {
@@ -310,8 +328,9 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
 
       if (bytes.size() == 0) {
         // This is a close operation.
-        request.fulfiller->fulfill(static_cast<size_t>(0));
+        auto fulfiller = kj::mv(request.fulfiller);
         state.transitionTo<Closed>();
+        fulfiller->fulfill(static_cast<size_t>(0));
         return kj::READY_NOW;
       }
 
@@ -320,19 +339,29 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
       if (request.bytes.size() >= bytes.size()) {
         // Our write buffer will entirely fit into the read buffer; fulfill both requests.
         memmove(request.bytes.begin(), bytes.begin(), bytes.size());
-        request.fulfiller->fulfill(bytes.size());
+        auto fulfiller = kj::mv(request.fulfiller);
         state.transitionTo<Idle>();
+        fulfiller->fulfill(bytes.size());
         return kj::READY_NOW;
       }
 
       // Our write buffer won't quite fit into the read buffer; fulfill only the read request.
       memmove(request.bytes.begin(), bytes.begin(), request.bytes.size());
-      bytes = bytes.slice(request.bytes.size(), bytes.size());
-      request.fulfiller->fulfill(request.bytes.size());
+      auto readSize = request.bytes.size();
+      bytes = bytes.slice(readSize, bytes.size());
+      auto readFulfiller = kj::mv(request.fulfiller);
 
       auto paf = kj::newPromiseAndFulfiller<void>();
       state.transitionTo<WriteRequest>(bytes, kj::mv(paf.fulfiller));
-      return kj::mv(paf.promise);
+      readFulfiller->fulfill(kj::mv(readSize));
+      return kj::mv(paf.promise).attach(kj::defer([self = kj::addRef(*this)]() mutable {
+        KJ_IF_SOME(request, self->state.tryGetUnsafe<WriteRequest>()) {
+          if (!request.fulfiller->isWaiting()) {
+            self->state.forceTransitionTo<kj::Exception>(
+                KJ_EXCEPTION(DISCONNECTED, "writer canceled"));
+          }
+        }
+      }));
     }
 
     // Must be idle.
@@ -345,7 +374,14 @@ class IdentityTransformStreamImpl final: public kj::Refcounted,
 
     auto paf = kj::newPromiseAndFulfiller<void>();
     state.transitionTo<WriteRequest>(bytes, kj::mv(paf.fulfiller));
-    return kj::mv(paf.promise);
+    return kj::mv(paf.promise).attach(kj::defer([self = kj::addRef(*this)]() mutable {
+      KJ_IF_SOME(request, self->state.tryGetUnsafe<WriteRequest>()) {
+        if (!request.fulfiller->isWaiting()) {
+          self->state.forceTransitionTo<kj::Exception>(
+              KJ_EXCEPTION(DISCONNECTED, "writer canceled"));
+        }
+      }
+    }));
   }
 
   kj::Maybe<uint64_t> limit;

--- a/src/workerd/api/streams/internal-test.c++
+++ b/src/workerd/api/streams/internal-test.c++
@@ -43,6 +43,99 @@ class NoopSink final: public WritableStreamSink {
   void abort(kj::Exception) override {}
 };
 
+KJ_TEST("IdentityTransformStream records cancellation before a later readable cancel") {
+  kj::EventLoop loop;
+  kj::WaitScope ws(loop);
+
+  auto pipe = newIdentityPipe();
+  auto buffer = kj::heapArray<kj::byte>(64);
+  memset(buffer.begin(), 'x', buffer.size());
+
+  {
+    auto writePromise = pipe.out->write(buffer.asPtr());
+    KJ_EXPECT(!writePromise.poll(ws));
+  }
+
+  // Destroying the pending write promise cancels it. That cancellation must synchronously become
+  // the stream's terminal state rather than allowing a later readable-side cancellation to win.
+  pipe.in->cancel(KJ_EXCEPTION(FAILED, "later readable cancel"));
+  KJ_EXPECT_THROW(DISCONNECTED, pipe.out->write("y"_kjb).wait(ws));
+}
+
+KJ_TEST("IdentityTransformStream records read cancellation before a later writable abort") {
+  kj::EventLoop loop;
+  kj::WaitScope ws(loop);
+
+  auto pipe = newIdentityPipe();
+  auto buffer = kj::heapArray<kj::byte>(64);
+
+  {
+    auto readPromise = pipe.in->tryRead(buffer.begin(), 1, buffer.size());
+    KJ_EXPECT(!readPromise.poll(ws));
+  }
+
+  // Destroying the pending read promise cancels it. A later writable-side abort must not replace
+  // that terminal disconnection state.
+  pipe.out->abort(KJ_EXCEPTION(FAILED, "later writable abort"));
+  KJ_EXPECT_THROW(DISCONNECTED, pipe.in->tryRead(buffer.begin(), 1, buffer.size()).wait(ws));
+}
+
+KJ_TEST("IdentityTransformStream releases a pending read buffer when its promise is canceled") {
+  kj::EventLoop loop;
+  kj::WaitScope ws(loop);
+
+  auto pipe = newIdentityPipe();
+  auto buffer = kj::heapArray<kj::byte>(64);
+
+  {
+    auto readPromise = pipe.in->tryRead(buffer.begin(), 1, buffer.size());
+    KJ_EXPECT(!readPromise.poll(ws));
+  }
+
+  // The transform must leave ReadRequest synchronously when the promise is canceled, before the
+  // storage backing its borrowed destination is released.
+  buffer = nullptr;
+}
+
+KJ_TEST("IdentityTransformStream releases a pending write buffer when its promise is canceled") {
+  kj::EventLoop loop;
+  kj::WaitScope ws(loop);
+
+  auto pipe = newIdentityPipe();
+  auto buffer = kj::heapArray<kj::byte>(64);
+  memset(buffer.begin(), 'x', buffer.size());
+
+  {
+    auto writePromise = pipe.out->write(buffer.asPtr());
+    KJ_EXPECT(!writePromise.poll(ws));
+  }
+
+  // Destroying the pending promise cancels the write. The transform must synchronously leave the
+  // WriteRequest state so that it no longer borrows buffer when the owner is destroyed.
+  buffer = nullptr;
+}
+
+KJ_TEST("IdentityTransformStream releases a partially-consumed write buffer on cancellation") {
+  kj::EventLoop loop;
+  kj::WaitScope ws(loop);
+
+  auto pipe = newIdentityPipe();
+  kj::byte destination[2];
+  auto readPromise = pipe.in->tryRead(destination, 1, sizeof(destination));
+
+  auto buffer = kj::heapArray<kj::byte>(4);
+  memset(buffer.begin(), 'x', buffer.size());
+  {
+    auto writePromise = pipe.out->write(buffer.asPtr());
+    KJ_EXPECT(readPromise.wait(ws) == sizeof(destination));
+    KJ_EXPECT(!writePromise.poll(ws));
+  }
+
+  // The first two bytes completed the pending read, leaving the rest as a pending WriteRequest.
+  // Canceling that write must release the remaining view before its owner is destroyed.
+  buffer = nullptr;
+}
+
 KJ_TEST("IdentityTransformStream declines tryReadSync/tryWriteSync") {
   // IdentityTransformStreamImpl deliberately does not implement the synchronous fast paths:
   // serving the read/write rendezvous synchronously would make the result observable to


### PR DESCRIPTION
Resolving before changing state makes wrong state obsservable.