### PR TITLE
node:net: add net.BoundSocket

### DIFF
--- a/src/cloudflare/internal/http.ts
+++ b/src/cloudflare/internal/http.ts
@@ -11,9 +11,9 @@ export interface FetchHandler {
 type PortEntry = {
   refs: number;
   reusePort: boolean;
-  // Held weakly so the handler's owner can be collected, letting the registry
-  // backstop release the entry.
-  handler?: WeakRef<FetchHandler>;
+  // Held strongly: a listening server the user keeps no reference to must stay
+  // routable for the isolate's lifetime, as it would in Node.
+  handler?: FetchHandler;
 };
 
 const EPHEMERAL_PORT_MIN = 49152;
@@ -27,9 +27,11 @@ const EPHEMERAL_PORT_MAX = 65535;
 export class PortTable {
   #entries = new Map<number, PortEntry>();
   #nextEphemeral = EPHEMERAL_PORT_MIN;
-  // Backstop for owners that are never closed: a request's IoContext teardown
-  // runs no JS, so an owner it strands would otherwise hold its entry for the
-  // isolate's lifetime. Deterministic release by the owner remains primary.
+  // Backstop for socket owners that are never closed: a request's IoContext
+  // teardown runs no JS, so a socket it strands would otherwise hold its entry
+  // for the isolate's lifetime. Deterministic release by the owner remains
+  // primary. Listening servers are not registered; their entry is meant to
+  // outlive any reference to them.
   // FinalizationRegistry is absent on compat dates before enable_weak_ref.
   #registry =
     typeof FinalizationRegistry === 'function'
@@ -83,14 +85,13 @@ export class PortTable {
     this.#registry?.unregister(owner);
   }
 
-  // The caller must keep handler reachable for as long as it should route.
   setHandler(port: number, handler: FetchHandler): void {
     const entry = this.#entries.get(port);
-    if (entry !== undefined) entry.handler = new WeakRef(handler);
+    if (entry !== undefined) entry.handler = handler;
   }
 
   getHandler(port: number): FetchHandler | undefined {
-    return this.#entries.get(port)?.handler?.deref();
+    return this.#entries.get(port)?.handler;
   }
 }
 

--- a/src/cloudflare/internal/http.ts
+++ b/src/cloudflare/internal/http.ts
@@ -11,7 +11,9 @@ export interface FetchHandler {
 type PortEntry = {
   refs: number;
   reusePort: boolean;
-  handler?: FetchHandler;
+  // Held weakly so the handler's owner can be collected, letting the registry
+  // backstop release the entry.
+  handler?: WeakRef<FetchHandler>;
 };
 
 const EPHEMERAL_PORT_MIN = 49152;
@@ -25,6 +27,16 @@ const EPHEMERAL_PORT_MAX = 65535;
 export class PortTable {
   #entries = new Map<number, PortEntry>();
   #nextEphemeral = EPHEMERAL_PORT_MIN;
+  // Backstop for owners that are never closed: a request's IoContext teardown
+  // runs no JS, so an owner it strands would otherwise hold its entry for the
+  // isolate's lifetime. Deterministic release by the owner remains primary.
+  // FinalizationRegistry is absent on compat dates before enable_weak_ref.
+  #registry =
+    typeof FinalizationRegistry === 'function'
+      ? new FinalizationRegistry<number>((port) => {
+          this.release(port);
+        })
+      : undefined;
 
   // Next ephemeral port that is not recorded. This is a label, not a
   // reservation: autobound sockets whose request ends before they are destroyed
@@ -61,13 +73,24 @@ export class PortTable {
     }
   }
 
+  // Releases port when owner is collected without having released it. An owner
+  // must unregister before releasing so the entry is never decremented twice.
+  register(owner: object, port: number): void {
+    this.#registry?.register(owner, port, owner);
+  }
+
+  unregister(owner: object): void {
+    this.#registry?.unregister(owner);
+  }
+
+  // The caller must keep handler reachable for as long as it should route.
   setHandler(port: number, handler: FetchHandler): void {
     const entry = this.#entries.get(port);
-    if (entry !== undefined) entry.handler = handler;
+    if (entry !== undefined) entry.handler = new WeakRef(handler);
   }
 
   getHandler(port: number): FetchHandler | undefined {
-    return this.#entries.get(port)?.handler;
+    return this.#entries.get(port)?.handler?.deref();
   }
 }
 

--- a/src/cloudflare/internal/http.ts
+++ b/src/cloudflare/internal/http.ts
@@ -8,4 +8,67 @@ export interface FetchHandler {
   fetch: (request: Request, env?: unknown, ctx?: unknown) => Promise<Response>;
 }
 
-export const portMapper = new Map<number, FetchHandler>();
+type PortEntry = {
+  refs: number;
+  reusePort: boolean;
+  handler?: FetchHandler;
+};
+
+const EPHEMERAL_PORT_MIN = 49152;
+const EPHEMERAL_PORT_MAX = 65535;
+
+// Per-isolate virtual local port table for one protocol. The underlying
+// transport does not honor local binding, but explicitly bound ports are
+// recorded and conflict-checked so that they are unique within the isolate,
+// and an entry may carry the handler that inbound sockets on that port are
+// routed to.
+export class PortTable {
+  #entries = new Map<number, PortEntry>();
+  #nextEphemeral = EPHEMERAL_PORT_MIN;
+
+  // Next ephemeral port that is not recorded. This is a label, not a
+  // reservation: autobound sockets whose request ends before they are destroyed
+  // never run cleanup, so recording them would leak entries. Returns 0 when the
+  // range is exhausted.
+  ephemeral(): number {
+    for (let i = EPHEMERAL_PORT_MIN; i <= EPHEMERAL_PORT_MAX; i++) {
+      const candidate = this.#nextEphemeral;
+      this.#nextEphemeral =
+        candidate === EPHEMERAL_PORT_MAX ? EPHEMERAL_PORT_MIN : candidate + 1;
+      if (!this.#entries.has(candidate)) return candidate;
+    }
+    return 0;
+  }
+
+  // Records port, or shares it when both the holder and this binder set
+  // reusePort. Returns false on conflict.
+  tryBind(port: number, reusePort = false): boolean {
+    const entry = this.#entries.get(port);
+    if (entry === undefined) {
+      this.#entries.set(port, { refs: 1, reusePort });
+    } else if (entry.reusePort && reusePort) {
+      entry.refs++;
+    } else {
+      return false;
+    }
+    return true;
+  }
+
+  release(port: number): void {
+    const entry = this.#entries.get(port);
+    if (entry !== undefined && --entry.refs === 0) {
+      this.#entries.delete(port);
+    }
+  }
+
+  setHandler(port: number, handler: FetchHandler): void {
+    const entry = this.#entries.get(port);
+    if (entry !== undefined) entry.handler = handler;
+  }
+
+  getHandler(port: number): FetchHandler | undefined {
+    return this.#entries.get(port)?.handler;
+  }
+}
+
+export const tcpPorts = new PortTable();

--- a/src/cloudflare/node.ts
+++ b/src/cloudflare/node.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 import {
-  portMapper,
+  tcpPorts,
   type FetchHandler as Fetcher,
 } from 'cloudflare-internal:http';
 
@@ -39,7 +39,7 @@ export async function handleAsNodeRequest(
   // JavaScript does not enforce this, so we need to check at runtime.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const port = validatePort(desc?.port);
-  const instance = portMapper.get(port);
+  const instance = tcpPorts.getHandler(port);
   if (!instance) {
     const error = new Error(
       `Http server with port ${port} not found. This is likely a bug with your code. ` +

--- a/src/node/internal/http.d.ts
+++ b/src/node/internal/http.d.ts
@@ -10,6 +10,8 @@ export class PortTable {
   ephemeral(): number;
   tryBind(port: number, reusePort?: boolean): boolean;
   release(port: number): void;
+  register(owner: object, port: number): void;
+  unregister(owner: object): void;
   setHandler(port: number, handler: FetchHandler): void;
   getHandler(port: number): FetchHandler | undefined;
 }

--- a/src/node/internal/http.d.ts
+++ b/src/node/internal/http.d.ts
@@ -2,4 +2,16 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-export const portMapper: Map<number, { fetch: typeof fetch }>;
+export interface FetchHandler {
+  fetch: (request: Request, env?: unknown, ctx?: unknown) => Promise<Response>;
+}
+
+export class PortTable {
+  ephemeral(): number;
+  tryBind(port: number, reusePort?: boolean): boolean;
+  release(port: number): void;
+  setHandler(port: number, handler: FetchHandler): void;
+  getHandler(port: number): FetchHandler | undefined;
+}
+
+export const tcpPorts: PortTable;

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -706,6 +706,15 @@ export class ERR_SOCKET_CONNECTING extends NodeError {
   }
 }
 
+export class ERR_SOCKET_HANDLE_ADOPTED extends NodeError {
+  constructor() {
+    super(
+      'ERR_SOCKET_HANDLE_ADOPTED',
+      'The bound socket has already been adopted by a server or socket'
+    );
+  }
+}
+
 export class ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS extends NodeError {
   constructor(arg0: string, arg1: string) {
     super(

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -679,6 +679,18 @@ export class ERR_SOCKET_BAD_PORT extends NodeError {
   }
 }
 
+export class EADDRINUSE extends NodeError {
+  syscall = 'bind';
+  address: string;
+  port: number;
+
+  constructor(address: string, port: number) {
+    super('EADDRINUSE', `bind EADDRINUSE ${address}:${port}`);
+    this.address = address;
+    this.port = port;
+  }
+}
+
 export class EPIPE extends NodeError {
   constructor() {
     super('EPIPE', 'This socket has been ended by the other party');

--- a/src/node/internal/internal_http_server.ts
+++ b/src/node/internal/internal_http_server.ts
@@ -59,7 +59,11 @@ import {
   chunkExpression,
   _checkInvalidHeaderChar,
 } from 'node-internal:internal_http';
-import { _normalizeArgs } from 'node-internal:internal_net';
+import {
+  _normalizeArgs,
+  bindPort,
+  releasePort,
+} from 'node-internal:internal_net';
 import { Buffer } from 'node-internal:internal_buffer';
 
 import type {
@@ -177,6 +181,7 @@ export class Server
     httpServerPreClose(this);
     if (this.#port != null) {
       portMapper.delete(this.#port);
+      releasePort(this.#port);
       this.#port = null;
     }
     if (typeof callback === 'function') {
@@ -293,7 +298,7 @@ export class Server
       port = 0;
     }
 
-    if (this.#port != null || portMapper.has(port)) {
+    if (this.#port != null) {
       throw new ERR_SERVER_ALREADY_LISTEN();
     }
 
@@ -301,7 +306,7 @@ export class Server
       this.once('listening', callback as (...args: unknown[]) => unknown);
     }
 
-    this.#port = this.#findSuitablePort(port);
+    this.#port = bindPort('127.0.0.1', port);
     // @ts-expect-error TS2322 Type mismatch. Not needed.
     portMapper.set(this.#port, { fetch: this.#onRequest.bind(this) });
     queueMicrotask(() => {
@@ -311,26 +316,6 @@ export class Server
       this.emit('listening');
     });
     return this;
-  }
-
-  #findSuitablePort(port: number): number {
-    // We don't have to check if portMapper has it because the caller
-    // already validates the uniqueness of the port and calls this method.
-    if (port !== 0) {
-      return port;
-    }
-
-    // Let's try at most 10 times to find a suitable port.
-    // If we can't find by that time, let's bail and throw an error.
-    for (let i = 0; i < 10; i++) {
-      port = Math.floor(Math.random() * 65535) + 1;
-      if (!portMapper.has(port)) {
-        return port;
-      }
-    }
-
-    // This is unlikely to happen, but just in case.
-    throw new Error('Failed to find a suitable port after 10 attempts');
   }
 
   getConnections(callback?: (err: Error | null, count: number) => void): this {

--- a/src/node/internal/internal_http_server.ts
+++ b/src/node/internal/internal_http_server.ts
@@ -38,7 +38,7 @@ import {
   validatePort,
   validateNumber,
 } from 'node-internal:validators';
-import { portMapper } from 'cloudflare-internal:http';
+import { tcpPorts } from 'cloudflare-internal:http';
 import {
   IncomingMessage,
   setIncomingMessageSocket,
@@ -59,11 +59,7 @@ import {
   chunkExpression,
   _checkInvalidHeaderChar,
 } from 'node-internal:internal_http';
-import {
-  _normalizeArgs,
-  bindPort,
-  releasePort,
-} from 'node-internal:internal_net';
+import { _normalizeArgs, bindPort } from 'node-internal:internal_net';
 import { Buffer } from 'node-internal:internal_buffer';
 
 import type {
@@ -180,8 +176,7 @@ export class Server
   close(callback?: VoidFunction): this {
     httpServerPreClose(this);
     if (this.#port != null) {
-      portMapper.delete(this.#port);
-      releasePort(this.#port);
+      tcpPorts.release(this.#port);
       this.#port = null;
     }
     if (typeof callback === 'function') {
@@ -306,9 +301,11 @@ export class Server
       this.once('listening', callback as (...args: unknown[]) => unknown);
     }
 
-    this.#port = bindPort('127.0.0.1', port);
-    // @ts-expect-error TS2322 Type mismatch. Not needed.
-    portMapper.set(this.#port, { fetch: this.#onRequest.bind(this) });
+    this.#port = bindPort(
+      typeof options.host === 'string' ? options.host : '127.0.0.1',
+      port
+    );
+    tcpPorts.setHandler(this.#port, { fetch: this.#onRequest.bind(this) });
     queueMicrotask(() => {
       // If any of the listening handlers (here and in any of the other queueMicrotask(...) instances here,
       // if the listening handlers throw an error, that will end up being reported to

--- a/src/node/internal/internal_http_server.ts
+++ b/src/node/internal/internal_http_server.ts
@@ -133,12 +133,6 @@ export class Server
   keepAliveTimeoutBuffer: number = 1_000;
   highWaterMark: number = getDefaultHighWaterMark();
   #port: number | null = null;
-  // Owned here so the port table's weak reference to it lives as long as the
-  // server does.
-  #handler = {
-    fetch: (request: Request, env: unknown, ctx: unknown): Promise<Response> =>
-      this.#onRequest(request, env, ctx),
-  };
 
   constructor(options?: ServerOptions, requestListener?: RequestListener) {
     if (!enableNodejsHttpServerModules) {
@@ -182,7 +176,6 @@ export class Server
   close(callback?: VoidFunction): this {
     httpServerPreClose(this);
     if (this.#port != null) {
-      tcpPorts.unregister(this);
       tcpPorts.release(this.#port);
       this.#port = null;
     }
@@ -312,8 +305,7 @@ export class Server
       typeof options.host === 'string' ? options.host : '127.0.0.1',
       port
     );
-    tcpPorts.register(this, this.#port);
-    tcpPorts.setHandler(this.#port, this.#handler);
+    tcpPorts.setHandler(this.#port, { fetch: this.#onRequest.bind(this) });
     queueMicrotask(() => {
       // If any of the listening handlers (here and in any of the other queueMicrotask(...) instances here,
       // if the listening handlers throw an error, that will end up being reported to

--- a/src/node/internal/internal_http_server.ts
+++ b/src/node/internal/internal_http_server.ts
@@ -133,6 +133,12 @@ export class Server
   keepAliveTimeoutBuffer: number = 1_000;
   highWaterMark: number = getDefaultHighWaterMark();
   #port: number | null = null;
+  // Owned here so the port table's weak reference to it lives as long as the
+  // server does.
+  #handler = {
+    fetch: (request: Request, env: unknown, ctx: unknown): Promise<Response> =>
+      this.#onRequest(request, env, ctx),
+  };
 
   constructor(options?: ServerOptions, requestListener?: RequestListener) {
     if (!enableNodejsHttpServerModules) {
@@ -176,6 +182,7 @@ export class Server
   close(callback?: VoidFunction): this {
     httpServerPreClose(this);
     if (this.#port != null) {
+      tcpPorts.unregister(this);
       tcpPorts.release(this.#port);
       this.#port = null;
     }
@@ -305,7 +312,8 @@ export class Server
       typeof options.host === 'string' ? options.host : '127.0.0.1',
       port
     );
-    tcpPorts.setHandler(this.#port, { fetch: this.#onRequest.bind(this) });
+    tcpPorts.register(this, this.#port);
+    tcpPorts.setHandler(this.#port, this.#handler);
     queueMicrotask(() => {
       // If any of the listening handlers (here and in any of the other queueMicrotask(...) instances here,
       // if the listening handlers throw an error, that will end up being reported to

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -40,6 +40,7 @@ import {
   ERR_SOCKET_HANDLE_ADOPTED,
   ERR_INVALID_IP_ADDRESS,
   ERR_INVALID_ADDRESS,
+  EADDRINUSE,
   EPIPE,
 } from 'node-internal:internal_errors';
 
@@ -100,12 +101,56 @@ export const kReinitializeHandle = Symbol('kReinitializeHandle');
 // socket.opened promise will be stored here.
 const kSocketInfo = Symbol('kSocketInfo');
 
-// Holds the bound address of an adopted BoundSocket.
+// The local address reserved for a Socket, either adopted from a BoundSocket or
+// autobound on connect. Released on destroy.
 const kBoundSource = Symbol('kBoundSource');
 const kBoundSocketConsume = Symbol('kBoundSocketConsume');
 
 const DEFAULT_IPV4_ADDR = '0.0.0.0';
 const DEFAULT_IPV6_ADDR = '::';
+
+// Per-isolate virtual local TCP port table shared by net and http servers. The
+// underlying transport does not honor local binding, but ports are allocated
+// and conflict-checked so that a bound port is unique within the isolate.
+const EPHEMERAL_PORT_MIN = 49152;
+const EPHEMERAL_PORT_MAX = 65535;
+const boundPorts = new Map<number, { refs: number; reusePort: boolean }>();
+let nextEphemeralPort = EPHEMERAL_PORT_MIN;
+
+export function bindPort(
+  address: string,
+  port: number,
+  reusePort = false
+): number {
+  if (port === 0) {
+    for (let i = EPHEMERAL_PORT_MIN; i <= EPHEMERAL_PORT_MAX; i++) {
+      const candidate = nextEphemeralPort;
+      nextEphemeralPort =
+        candidate === EPHEMERAL_PORT_MAX ? EPHEMERAL_PORT_MIN : candidate + 1;
+      if (!boundPorts.has(candidate)) {
+        port = candidate;
+        break;
+      }
+    }
+    if (port === 0) throw new EADDRINUSE(address, port);
+  }
+  const entry = boundPorts.get(port);
+  if (entry === undefined) {
+    boundPorts.set(port, { refs: 1, reusePort });
+  } else if (entry.reusePort && reusePort) {
+    entry.refs++;
+  } else {
+    throw new EADDRINUSE(address, port);
+  }
+  return port;
+}
+
+export function releasePort(port: number): void {
+  const entry = boundPorts.get(port);
+  if (entry !== undefined && --entry.refs === 0) {
+    boundPorts.delete(port);
+  }
+}
 
 // IPv4 Segment
 const v4Seg = '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])';
@@ -159,10 +204,8 @@ export type BoundSocketOptions = {
   reusePort?: boolean;
 };
 
-// Workers cannot bind a local endpoint, so the bound address is validated and
-// recorded here, then reported by the adopting Socket as its local address,
-// but the underlying transport does not honor it. With port 0 the port stays 0
-// since no ephemeral port is reserved.
+// Reserves a port in the virtual port table; the adopting Socket reports the
+// bound address as its local address.
 export class BoundSocket {
   #address: AddressInfo | null;
 
@@ -201,7 +244,7 @@ export class BoundSocket {
     this.#address = {
       address: host,
       family: addressType === 6 ? 'IPv6' : 'IPv4',
-      port,
+      port: bindPort(host, port, reusePort),
     };
   }
 
@@ -225,11 +268,14 @@ export class BoundSocket {
     if (this.#address === null) {
       throw new ERR_SOCKET_HANDLE_ADOPTED();
     }
+    releasePort(this.#address.port);
     this.#address = null;
   }
 
   [Symbol.dispose](): void {
-    this.#address = null;
+    if (this.#address !== null) {
+      this.close();
+    }
   }
 
   [kBoundSocketConsume](): AddressInfo {
@@ -298,7 +344,6 @@ export declare class Socket extends _Socket {
       addressType: number;
     };
   };
-  _sockname?: null | AddressInfo;
   _onTimeout(): void;
   _unrefTimer(): void;
   _writeGeneric(
@@ -432,7 +477,6 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
   this.autoSelectFamilyAttemptedAddresses = [];
 
   this._undestroy();
-  this._sockname = null;
   this._pendingData = null;
   this._pendingEncoding = '';
 
@@ -578,15 +622,12 @@ Socket.prototype._getsockname = function (this: Socket): AddressInfo | {} {
   if (this[kBoundSource] != null) {
     return this[kBoundSource];
   }
-  if (this._handle == null) {
-    return {};
+  // A wrapping socket (TLSSocket) shares the local endpoint of the socket it
+  // wraps.
+  if (this._parentWrap != null) {
+    return this._parentWrap._getsockname();
   }
-  this._sockname ??= {
-    address: '0.0.0.0',
-    port: 0,
-    family: 'IPv4',
-  };
-  return this._sockname;
+  return {};
 };
 
 Socket.prototype.address = function (this: Socket): {} | AddressInfo {
@@ -899,6 +940,11 @@ Socket.prototype._destroy = function (
     clearTimeout(s[kTimeout] as unknown as number);
   }
 
+  if (this[kBoundSource] != null) {
+    releasePort(this[kBoundSource].port);
+    this[kBoundSource] = null;
+  }
+
   if (this._handle != null) {
     this._handle.socket.close().then(
       () => {
@@ -1002,7 +1048,6 @@ Socket.prototype[kReinitializeHandle] = function reinitializeHandle(
 
   this._handle = handle;
   this._undestroy();
-  this._sockname = null;
 };
 
 // ======================================================================================
@@ -1326,6 +1371,19 @@ function initializeConnection(
     socket._host = `${host}`;
 
     try {
+      // Autobind the local endpoint, as connect(2) does, unless one was
+      // adopted from a BoundSocket.
+      if (socket[kBoundSource] == null) {
+        const address =
+          localAddress ??
+          (family === 6 ? DEFAULT_IPV6_ADDR : DEFAULT_IPV4_ADDR);
+        socket[kBoundSource] = {
+          address,
+          family: isIP(address) === 6 ? 'IPv6' : 'IPv4',
+          port: bindPort(address, localPort ?? 0),
+        };
+      }
+
       const handle = inner.connect(`${host}:${port}`, {
         allowHalfOpen: socket.allowHalfOpen,
         // A Node.js socket is always capable of being upgraded to the TLS socket.
@@ -1353,7 +1411,6 @@ function initializeConnection(
 
       // We need to undestroy the stream to connect to it.
       socket._undestroy();
-      socket._sockname = null;
 
       handle.opened.then(onConnectionOpened.bind(socket), (err: unknown) => {
         socket.emit('connectionAttemptFailed', host, port, addressType, err);
@@ -1422,7 +1479,6 @@ export function onConnectionOpened(this: Socket): void {
   }
 
   this.connecting = false;
-  this._sockname = null;
   this._unrefTimer();
   this.emit('connect');
   this.emit('ready');

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -131,6 +131,7 @@ export function bindPort(
 
 function releaseBoundSource(socket: Socket): void {
   if (socket[kBoundReserved]) {
+    tcpPorts.unregister(socket);
     tcpPorts.release((socket[kBoundSource] as AddressInfo).port);
     socket[kBoundReserved] = false;
   }
@@ -240,6 +241,7 @@ export class BoundSocket {
       family: addressType === 6 ? 'IPv6' : 'IPv4',
       port: bindPort(host, port, reusePort),
     };
+    tcpPorts.register(this, this.#address.port);
   }
 
   address(): AddressInfo {
@@ -262,6 +264,7 @@ export class BoundSocket {
     if (this.#address === null) {
       throw new ERR_SOCKET_HANDLE_ADOPTED();
     }
+    tcpPorts.unregister(this);
     tcpPorts.release(this.#address.port);
     this.#address = null;
   }
@@ -276,6 +279,7 @@ export class BoundSocket {
     if (this.#address === null) {
       throw new ERR_SOCKET_HANDLE_ADOPTED();
     }
+    tcpPorts.unregister(this);
     const address = this.#address;
     this.#address = null;
     return address;
@@ -486,6 +490,7 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
     if (BoundSocket.isBoundSocket(options.handle)) {
       this[kBoundSource] = options.handle[kBoundSocketConsume]();
       this[kBoundReserved] = true;
+      tcpPorts.register(this, this[kBoundSource].port);
     } else {
       this._handle = options.handle;
     }
@@ -1383,6 +1388,7 @@ function initializeConnection(
             : tcpPorts.ephemeral(),
         };
         socket[kBoundReserved] = reserved;
+        if (reserved) tcpPorts.register(socket, socket[kBoundSource].port);
       }
 
       const handle = inner.connect(`${host}:${port}`, {

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -166,6 +166,10 @@ export type BoundSocketOptions = {
 export class BoundSocket {
   #address: AddressInfo | null;
 
+  static isBoundSocket(value: unknown): value is BoundSocket {
+    return typeof value === 'object' && value !== null && #address in value;
+  }
+
   constructor(options: BoundSocketOptions = {}) {
     validateObject(options, 'options');
 
@@ -439,7 +443,7 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
 
   if (options.handle) {
     validateObject(options.handle, 'options.handle');
-    if (options.handle instanceof BoundSocket) {
+    if (BoundSocket.isBoundSocket(options.handle)) {
       this[kBoundSource] = options.handle[kBoundSocketConsume]();
     } else {
       this._handle = options.handle;

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -1379,13 +1379,13 @@ function initializeConnection(
         const address =
           localAddress ??
           (family === 6 ? DEFAULT_IPV6_ADDR : DEFAULT_IPV4_ADDR);
-        const reserved = localAddress !== undefined || localPort !== undefined;
+        // Only a concrete localPort claims a table entry; localAddress alone
+        // (and localPort 0) autobinds, with the address kept as the label.
+        const reserved = localPort != null && localPort !== 0;
         socket[kBoundSource] = {
           address,
           family: isIP(address) === 6 ? 'IPv6' : 'IPv4',
-          port: reserved
-            ? bindPort(address, localPort ?? 0)
-            : tcpPorts.ephemeral(),
+          port: reserved ? bindPort(address, localPort) : tcpPorts.ephemeral(),
         };
         socket[kBoundReserved] = reserved;
         if (reserved) tcpPorts.register(socket, socket[kBoundSource].port);

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -37,6 +37,7 @@ import {
   ERR_SOCKET_CLOSED,
   ERR_SOCKET_CLOSED_BEFORE_CONNECTION,
   ERR_SOCKET_CONNECTING,
+  ERR_SOCKET_HANDLE_ADOPTED,
   ERR_INVALID_IP_ADDRESS,
   ERR_INVALID_ADDRESS,
   EPIPE,
@@ -99,6 +100,13 @@ export const kReinitializeHandle = Symbol('kReinitializeHandle');
 // socket.opened promise will be stored here.
 const kSocketInfo = Symbol('kSocketInfo');
 
+// Holds the bound address of an adopted BoundSocket.
+const kBoundSource = Symbol('kBoundSource');
+const kBoundSocketConsume = Symbol('kBoundSocketConsume');
+
+const DEFAULT_IPV4_ADDR = '0.0.0.0';
+const DEFAULT_IPV6_ADDR = '::';
+
 // IPv4 Segment
 const v4Seg = '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])';
 const v4Str = `(?:${v4Seg}\\.){3}${v4Seg}`;
@@ -134,7 +142,7 @@ export type SocketOptions = {
   writableObjectMode?: boolean;
   keepAliveInitialDelay?: number;
   fd?: number;
-  handle?: Socket['_handle'];
+  handle?: Socket['_handle'] | BoundSocket;
   noDelay?: boolean;
   keepAlive?: boolean;
   allowHalfOpen?: boolean;
@@ -143,6 +151,92 @@ export type SocketOptions = {
   onread?:
     ({ callback?: () => Uint8Array; buffer?: Uint8Array } & OnReadOpts) | null;
 };
+
+export type BoundSocketOptions = {
+  host?: string | null;
+  port?: number | string;
+  ipv6Only?: boolean;
+  reusePort?: boolean;
+};
+
+// Workers cannot bind a local endpoint, so the bound address is validated and
+// recorded here, then reported by the adopting Socket as its local address,
+// but the underlying transport does not honor it. With port 0 the port stays 0
+// since no ephemeral port is reserved.
+export class BoundSocket {
+  #address: AddressInfo | null;
+
+  constructor(options: BoundSocketOptions = {}) {
+    validateObject(options, 'options');
+
+    const port = validatePort(options.port ?? 0, 'options.port');
+
+    const ipv6Only = options.ipv6Only ?? false;
+    validateBoolean(ipv6Only, 'options.ipv6Only');
+
+    const reusePort = options.reusePort ?? false;
+    validateBoolean(reusePort, 'options.reusePort');
+
+    let { host } = options;
+    let addressType: number;
+    if (host === undefined || host === null) {
+      host = ipv6Only ? DEFAULT_IPV6_ADDR : DEFAULT_IPV4_ADDR;
+      addressType = ipv6Only ? 6 : 4;
+    } else {
+      validateString(host, 'options.host');
+      addressType = isIP(host);
+      if (addressType === 0) {
+        throw new ERR_INVALID_ARG_VALUE(
+          'options.host',
+          host,
+          'must be a numeric IP address; net.BoundSocket does not perform DNS resolution'
+        );
+      }
+    }
+
+    this.#address = {
+      address: host,
+      family: addressType === 6 ? 'IPv6' : 'IPv4',
+      port,
+    };
+  }
+
+  address(): AddressInfo {
+    if (this.#address === null) {
+      throw new ERR_SOCKET_HANDLE_ADOPTED();
+    }
+    return this.#address;
+  }
+
+  // Workers have no file descriptors; -1 matches Node.js on platforms without
+  // socket fds.
+  fd(): number {
+    if (this.#address === null) {
+      throw new ERR_SOCKET_HANDLE_ADOPTED();
+    }
+    return -1;
+  }
+
+  close(): void {
+    if (this.#address === null) {
+      throw new ERR_SOCKET_HANDLE_ADOPTED();
+    }
+    this.#address = null;
+  }
+
+  [Symbol.dispose](): void {
+    this.#address = null;
+  }
+
+  [kBoundSocketConsume](): AddressInfo {
+    if (this.#address === null) {
+      throw new ERR_SOCKET_HANDLE_ADOPTED();
+    }
+    const address = this.#address;
+    this.#address = null;
+    return address;
+  }
+}
 
 export function Server(): void {
   throw new Error('Server is not implemented');
@@ -182,6 +276,7 @@ export declare class Socket extends _Socket {
   };
   [kBytesRead]: number;
   [kBytesWritten]: number;
+  [kBoundSource]: AddressInfo | null;
   [kReinitializeHandle](handle: Socket['_handle']): void;
   _closeAfterHandlingError: boolean;
   _handle: null | {
@@ -327,6 +422,7 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
   this[kSocketInfo] = null;
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
+  this[kBoundSource] = null;
   this._closeAfterHandlingError = false;
   // @ts-expect-error TS2540 Required due to types
   this.autoSelectFamilyAttemptedAddresses = [];
@@ -343,7 +439,11 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
 
   if (options.handle) {
     validateObject(options.handle, 'options.handle');
-    this._handle = options.handle;
+    if (options.handle instanceof BoundSocket) {
+      this[kBoundSource] = options.handle[kBoundSocketConsume]();
+    } else {
+      this._handle = options.handle;
+    }
   }
 
   // We explicitly listen for all 'end' events, not only for once
@@ -471,6 +571,9 @@ Socket.prototype._getpeername = function (
 };
 
 Socket.prototype._getsockname = function (this: Socket): AddressInfo | {} {
+  if (this[kBoundSource] != null) {
+    return this[kBoundSource];
+  }
   if (this._handle == null) {
     return {};
   }
@@ -1147,6 +1250,17 @@ function initializeConnection(
     localPort,
   } = options;
   let { port } = options;
+  if (
+    socket[kBoundSource] != null &&
+    (localAddress !== undefined || localPort !== undefined)
+  ) {
+    throw new ERR_INVALID_ARG_VALUE(
+      'options',
+      options,
+      'localAddress and localPort cannot be used with an adopted bound socket'
+    );
+  }
+
   if (localAddress && !isIP(localAddress)) {
     throw new ERR_INVALID_IP_ADDRESS(localAddress);
   }

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -101,21 +101,36 @@ export const kReinitializeHandle = Symbol('kReinitializeHandle');
 // socket.opened promise will be stored here.
 const kSocketInfo = Symbol('kSocketInfo');
 
-// The local address reserved for a Socket, either adopted from a BoundSocket or
-// autobound on connect. Released on destroy.
+// The local address of a Socket, either adopted from a BoundSocket or autobound
+// on connect. kBoundReserved marks an entry held in the port table that must be
+// released on destroy.
 const kBoundSource = Symbol('kBoundSource');
+const kBoundReserved = Symbol('kBoundReserved');
 const kBoundSocketConsume = Symbol('kBoundSocketConsume');
 
 const DEFAULT_IPV4_ADDR = '0.0.0.0';
 const DEFAULT_IPV6_ADDR = '::';
 
 // Per-isolate virtual local TCP port table shared by net and http servers. The
-// underlying transport does not honor local binding, but ports are allocated
-// and conflict-checked so that a bound port is unique within the isolate.
+// underlying transport does not honor local binding, but explicitly bound ports
+// are recorded and conflict-checked so that they are unique within the isolate.
+// Autobound sockets take an ephemeral label that skips recorded ports without
+// being recorded themselves: a socket whose request ends before it is destroyed
+// never runs its cleanup, so recording autobinds would leak table entries.
 const EPHEMERAL_PORT_MIN = 49152;
 const EPHEMERAL_PORT_MAX = 65535;
 const boundPorts = new Map<number, { refs: number; reusePort: boolean }>();
 let nextEphemeralPort = EPHEMERAL_PORT_MIN;
+
+export function ephemeralPort(): number {
+  for (let i = EPHEMERAL_PORT_MIN; i <= EPHEMERAL_PORT_MAX; i++) {
+    const candidate = nextEphemeralPort;
+    nextEphemeralPort =
+      candidate === EPHEMERAL_PORT_MAX ? EPHEMERAL_PORT_MIN : candidate + 1;
+    if (!boundPorts.has(candidate)) return candidate;
+  }
+  return 0;
+}
 
 export function bindPort(
   address: string,
@@ -123,15 +138,7 @@ export function bindPort(
   reusePort = false
 ): number {
   if (port === 0) {
-    for (let i = EPHEMERAL_PORT_MIN; i <= EPHEMERAL_PORT_MAX; i++) {
-      const candidate = nextEphemeralPort;
-      nextEphemeralPort =
-        candidate === EPHEMERAL_PORT_MAX ? EPHEMERAL_PORT_MIN : candidate + 1;
-      if (!boundPorts.has(candidate)) {
-        port = candidate;
-        break;
-      }
-    }
+    port = ephemeralPort();
     if (port === 0) throw new EADDRINUSE(address, port);
   }
   const entry = boundPorts.get(port);
@@ -150,6 +157,14 @@ export function releasePort(port: number): void {
   if (entry !== undefined && --entry.refs === 0) {
     boundPorts.delete(port);
   }
+}
+
+function releaseBoundSource(socket: Socket): void {
+  if (socket[kBoundReserved]) {
+    releasePort((socket[kBoundSource] as AddressInfo).port);
+    socket[kBoundReserved] = false;
+  }
+  socket[kBoundSource] = null;
 }
 
 // IPv4 Segment
@@ -200,6 +215,7 @@ export type SocketOptions = {
 export type BoundSocketOptions = {
   host?: string | null;
   port?: number | string;
+  path?: string;
   ipv6Only?: boolean;
   reusePort?: boolean;
 };
@@ -215,6 +231,14 @@ export class BoundSocket {
 
   constructor(options: BoundSocketOptions = {}) {
     validateObject(options, 'options');
+
+    if (options.path !== undefined) {
+      throw new ERR_INVALID_ARG_VALUE(
+        'options.path',
+        options.path,
+        'is not supported'
+      );
+    }
 
     const port = validatePort(options.port ?? 0, 'options.port');
 
@@ -327,6 +351,7 @@ export declare class Socket extends _Socket {
   [kBytesRead]: number;
   [kBytesWritten]: number;
   [kBoundSource]: AddressInfo | null;
+  [kBoundReserved]: boolean;
   [kReinitializeHandle](handle: Socket['_handle']): void;
   _closeAfterHandlingError: boolean;
   _handle: null | {
@@ -472,6 +497,7 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
   this[kBoundSource] = null;
+  this[kBoundReserved] = false;
   this._closeAfterHandlingError = false;
   // @ts-expect-error TS2540 Required due to types
   this.autoSelectFamilyAttemptedAddresses = [];
@@ -489,6 +515,7 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
     validateObject(options.handle, 'options.handle');
     if (BoundSocket.isBoundSocket(options.handle)) {
       this[kBoundSource] = options.handle[kBoundSocketConsume]();
+      this[kBoundReserved] = true;
     } else {
       this._handle = options.handle;
     }
@@ -940,10 +967,7 @@ Socket.prototype._destroy = function (
     clearTimeout(s[kTimeout] as unknown as number);
   }
 
-  if (this[kBoundSource] != null) {
-    releasePort(this[kBoundSource].port);
-    this[kBoundSource] = null;
-  }
+  releaseBoundSource(this);
 
   if (this._handle != null) {
     this._handle.socket.close().then(
@@ -1019,6 +1043,9 @@ Socket.prototype.connect = function (
   // Previous connected handle needs to emit "close" event.
   // This ensures that the previous handle is closed before initializing a new one.
   if (this._handle) {
+    // A reconnect is a new underlying socket, so the previous local endpoint
+    // is dropped and the new connection autobinds.
+    releaseBoundSource(this);
     this._handle.socket.close().then(
       () => {
         initializeConnection(this, options);
@@ -1377,11 +1404,13 @@ function initializeConnection(
         const address =
           localAddress ??
           (family === 6 ? DEFAULT_IPV6_ADDR : DEFAULT_IPV4_ADDR);
+        const reserved = localAddress !== undefined || localPort !== undefined;
         socket[kBoundSource] = {
           address,
           family: isIP(address) === 6 ? 'IPv6' : 'IPv4',
-          port: bindPort(address, localPort ?? 0),
+          port: reserved ? bindPort(address, localPort ?? 0) : ephemeralPort(),
         };
+        socket[kBoundReserved] = reserved;
       }
 
       const handle = inner.connect(`${host}:${port}`, {

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -26,6 +26,7 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 
 import inner from 'cloudflare-internal:sockets';
+import { tcpPorts } from 'cloudflare-internal:http';
 
 import {
   AbortError,
@@ -111,57 +112,26 @@ const kBoundSocketConsume = Symbol('kBoundSocketConsume');
 const DEFAULT_IPV4_ADDR = '0.0.0.0';
 const DEFAULT_IPV6_ADDR = '::';
 
-// Per-isolate virtual local TCP port table shared by net and http servers. The
-// underlying transport does not honor local binding, but explicitly bound ports
-// are recorded and conflict-checked so that they are unique within the isolate.
-// Autobound sockets take an ephemeral label that skips recorded ports without
-// being recorded themselves: a socket whose request ends before it is destroyed
-// never runs its cleanup, so recording autobinds would leak table entries.
-const EPHEMERAL_PORT_MIN = 49152;
-const EPHEMERAL_PORT_MAX = 65535;
-const boundPorts = new Map<number, { refs: number; reusePort: boolean }>();
-let nextEphemeralPort = EPHEMERAL_PORT_MIN;
-
-export function ephemeralPort(): number {
-  for (let i = EPHEMERAL_PORT_MIN; i <= EPHEMERAL_PORT_MAX; i++) {
-    const candidate = nextEphemeralPort;
-    nextEphemeralPort =
-      candidate === EPHEMERAL_PORT_MAX ? EPHEMERAL_PORT_MIN : candidate + 1;
-    if (!boundPorts.has(candidate)) return candidate;
-  }
-  return 0;
-}
-
+// Reserves port in the isolate's TCP port table (shared with http servers),
+// allocating an ephemeral port for 0. Throws EADDRINUSE on conflict.
 export function bindPort(
   address: string,
   port: number,
   reusePort = false
 ): number {
   if (port === 0) {
-    port = ephemeralPort();
+    port = tcpPorts.ephemeral();
     if (port === 0) throw new EADDRINUSE(address, port);
   }
-  const entry = boundPorts.get(port);
-  if (entry === undefined) {
-    boundPorts.set(port, { refs: 1, reusePort });
-  } else if (entry.reusePort && reusePort) {
-    entry.refs++;
-  } else {
+  if (!tcpPorts.tryBind(port, reusePort)) {
     throw new EADDRINUSE(address, port);
   }
   return port;
 }
 
-export function releasePort(port: number): void {
-  const entry = boundPorts.get(port);
-  if (entry !== undefined && --entry.refs === 0) {
-    boundPorts.delete(port);
-  }
-}
-
 function releaseBoundSource(socket: Socket): void {
   if (socket[kBoundReserved]) {
-    releasePort((socket[kBoundSource] as AddressInfo).port);
+    tcpPorts.release((socket[kBoundSource] as AddressInfo).port);
     socket[kBoundReserved] = false;
   }
   socket[kBoundSource] = null;
@@ -292,7 +262,7 @@ export class BoundSocket {
     if (this.#address === null) {
       throw new ERR_SOCKET_HANDLE_ADOPTED();
     }
-    releasePort(this.#address.port);
+    tcpPorts.release(this.#address.port);
     this.#address = null;
   }
 
@@ -1408,7 +1378,9 @@ function initializeConnection(
         socket[kBoundSource] = {
           address,
           family: isIP(address) === 6 ? 'IPv6' : 'IPv4',
-          port: reserved ? bindPort(address, localPort ?? 0) : ephemeralPort(),
+          port: reserved
+            ? bindPort(address, localPort ?? 0)
+            : tcpPorts.ephemeral(),
         };
         socket[kBoundReserved] = reserved;
       }

--- a/src/node/net.ts
+++ b/src/node/net.ts
@@ -25,6 +25,7 @@
 
 import {
   BlockList,
+  BoundSocket,
   SocketAddress,
   Server,
   Socket,
@@ -45,6 +46,7 @@ export const Stream = Socket;
 
 export {
   BlockList,
+  BoundSocket,
   SocketAddress,
   Server,
   Socket,
@@ -63,6 +65,7 @@ export {
 
 export default {
   BlockList,
+  BoundSocket,
   SocketAddress,
   Stream: Socket,
   Server,

--- a/src/workerd/api/node/tests/http-server-nodejs-test.js
+++ b/src/workerd/api/node/tests/http-server-nodejs-test.js
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 import http from 'node:http';
+import net from 'node:net';
 import { WorkerEntrypoint } from 'cloudflare:workers';
 import { strictEqual, ok, throws, notStrictEqual, rejects } from 'node:assert';
 import { httpServerHandler, handleAsNodeRequest } from 'cloudflare:node';
@@ -630,6 +631,29 @@ export const testInvalidPorts = {
       });
     }
     strictEqual(server.listening, false);
+  },
+};
+
+// http servers share the isolate's virtual port table with node:net.
+export const testPortTableSharedWithNet = {
+  async test() {
+    const other = http.createServer();
+    await new Promise((resolve) => other.listen(0, resolve));
+    const server = http.createServer();
+    throws(() => server.listen(other.address().port), { code: 'EADDRINUSE' });
+    strictEqual(server.listening, false);
+    other.close();
+
+    const bound = new net.BoundSocket({ port: 0 });
+    const { port } = bound.address();
+    throws(() => server.listen(port), { code: 'EADDRINUSE' });
+    bound.close();
+
+    await new Promise((resolve) => server.listen(port, resolve));
+    strictEqual(server.address().port, port);
+    throws(() => new net.BoundSocket({ port }), { code: 'EADDRINUSE' });
+    server.close();
+    new net.BoundSocket({ port }).close();
   },
 };
 

--- a/src/workerd/api/node/tests/http-server-nodejs-test.js
+++ b/src/workerd/api/node/tests/http-server-nodejs-test.js
@@ -646,7 +646,14 @@ export const testPortTableSharedWithNet = {
 
     const bound = new net.BoundSocket({ port: 0 });
     const { port } = bound.address();
-    throws(() => server.listen(port), { code: 'EADDRINUSE' });
+    throws(() => server.listen(port), {
+      code: 'EADDRINUSE',
+      message: `bind EADDRINUSE 127.0.0.1:${port}`,
+    });
+    throws(() => server.listen(port, '10.0.0.1'), {
+      code: 'EADDRINUSE',
+      message: `bind EADDRINUSE 10.0.0.1:${port}`,
+    });
     bound.close();
 
     await new Promise((resolve) => server.listen(port, resolve));

--- a/src/workerd/api/node/tests/http-server-nodejs-test.js
+++ b/src/workerd/api/node/tests/http-server-nodejs-test.js
@@ -634,6 +634,24 @@ export const testInvalidPorts = {
   },
 };
 
+// A listening server the user keeps no reference to stays routable: the port
+// table entry is the GC root, as the libuv handle is in Node.
+export const testUnreferencedServerSurvivesGc = {
+  async test() {
+    http.createServer((req, res) => res.end('alive')).listen(18080);
+    await scheduler.wait(0);
+    gc();
+    await scheduler.wait(0);
+    gc();
+    await scheduler.wait(0);
+    const res = await handleAsNodeRequest(
+      { port: 18080 },
+      new Request('https://cloudflare.com/')
+    );
+    strictEqual(await res.text(), 'alive');
+  },
+};
+
 // http servers share the isolate's virtual port table with node:net.
 export const testPortTableSharedWithNet = {
   async test() {

--- a/src/workerd/api/node/tests/http-server-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/http-server-nodejs-test.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "http-server-nodejs-test.js")
         ],
-        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "experimental", "enable_nodejs_http_modules", "enable_nodejs_http_server_modules", "streams_enable_constructors"],
+        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "experimental", "enable_nodejs_http_modules", "enable_nodejs_http_server_modules", "streams_enable_constructors", "enable_weak_ref"],
         bindings = [
           ( name = "SERVICE", service = "http-server-nodejs-test" ),
           ( name = "PONG_SERVER_PORT", fromEnvironment = "PONG_SERVER_PORT" ),

--- a/src/workerd/api/node/tests/http-server-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/http-server-nodejs-test.wd-test
@@ -1,13 +1,14 @@
 using Workerd = import "/workerd/workerd.capnp";
 
 const unitTests :Workerd.Config = (
+  v8Flags = ["--expose-gc"],
   services = [
     ( name = "http-server-nodejs-test",
       worker = (
         modules = [
           (name = "worker", esModule = embed "http-server-nodejs-test.js")
         ],
-        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "experimental", "enable_nodejs_http_modules", "enable_nodejs_http_server_modules", "streams_enable_constructors", "enable_weak_ref"],
+        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "experimental", "enable_nodejs_http_modules", "enable_nodejs_http_server_modules", "streams_enable_constructors"],
         bindings = [
           ( name = "SERVICE", service = "http-server-nodejs-test" ),
           ( name = "PONG_SERVER_PORT", fromEnvironment = "PONG_SERVER_PORT" ),

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -23,7 +23,14 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { fail, ok, strictEqual, deepStrictEqual, throws } from 'node:assert';
+import {
+  fail,
+  ok,
+  strictEqual,
+  notStrictEqual,
+  deepStrictEqual,
+  throws,
+} from 'node:assert';
 import { mock } from 'node:test';
 import { once } from 'node:events';
 import * as net from 'node:net';
@@ -1192,6 +1199,39 @@ export const testNetLocalAddressPort = {
       // Released on destroy.
       new net.BoundSocket({ port: 50000 }).close();
     }
+
+    // An autobound port is a label, not a reservation: it skips reserved ports
+    // but can itself be reserved while the socket is live, so sockets that are
+    // never destroyed do not exhaust the table.
+    {
+      const reserved = new net.BoundSocket({ port: 0 });
+      const c = net.connect(env.SERVER_PORT, env.SIDECAR_HOSTNAME);
+      const c2 = net.connect(env.SERVER_PORT, env.SIDECAR_HOSTNAME);
+      notStrictEqual(c.localPort, reserved.address().port);
+      notStrictEqual(c2.localPort, reserved.address().port);
+      notStrictEqual(c.localPort, c2.localPort);
+      new net.BoundSocket({ port: c.localPort }).close();
+      reserved.close();
+      c.destroy();
+      c2.destroy();
+      await Promise.all([once(c, 'close'), once(c2, 'close')]);
+    }
+
+    // A reconnect drops the previous local endpoint, so localPort may be given.
+    {
+      const c = net.connect(Number(env.ECHO_SERVER_PORT), env.SIDECAR_HOSTNAME);
+      await once(c, 'connect');
+      c.connect({
+        port: Number(env.ECHO_SERVER_PORT),
+        host: env.SIDECAR_HOSTNAME,
+        localPort: 50001,
+      });
+      await once(c, 'connect');
+      strictEqual(c.localPort, 50001);
+      c.destroy();
+      await once(c, 'close');
+      new net.BoundSocket({ port: 50001 }).close();
+    }
   },
 };
 
@@ -1325,6 +1365,10 @@ export const testNetBoundSocket = {
     throws(() => new net.BoundSocket(0), { code: 'ERR_INVALID_ARG_TYPE' });
     throws(() => new net.BoundSocket({ port: 65536 }), {
       code: 'ERR_SOCKET_BAD_PORT',
+    });
+    // Pipes are not supported; rejected rather than silently binding TCP.
+    throws(() => new net.BoundSocket({ path: '/tmp/sock' }), {
+      code: 'ERR_INVALID_ARG_VALUE',
     });
 
     // Symbol.dispose closes an un-adopted handle and is a no-op afterwards.

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -1148,17 +1148,50 @@ export const testNetLargeString = {
 };
 
 // test/parallel/test-net-local-address-port.js
-// The localAddress information is a non-op in our implementation
+// The local endpoint is autobound in the isolate's virtual port table; the
+// transport does not honor it.
 export const testNetLocalAddressPort = {
   async test(ctrl, env, ctx) {
-    const { promise, resolve } = Promise.withResolvers();
-    const c = net.connect(env.SERVER_PORT, env.SIDECAR_HOSTNAME);
-    c.on('connect', () => {
-      strictEqual(c.localAddress, '0.0.0.0');
-      strictEqual(c.localPort, 0);
-      resolve();
-    });
-    await promise;
+    {
+      const { promise, resolve } = Promise.withResolvers();
+      const c = net.connect(env.SERVER_PORT, env.SIDECAR_HOSTNAME);
+      c.on('connect', () => {
+        strictEqual(c.localAddress, '0.0.0.0');
+        strictEqual(c.localFamily, 'IPv4');
+        ok(c.localPort >= 49152 && c.localPort <= 65535);
+        resolve();
+      });
+      await promise;
+    }
+
+    // localAddress/localPort are reserved when given; a conflict is reported
+    // via 'error'.
+    {
+      const { promise, resolve } = Promise.withResolvers();
+      const c = net.connect({
+        port: env.SERVER_PORT,
+        host: env.SIDECAR_HOSTNAME,
+        localAddress: '127.0.0.1',
+        localPort: 50000,
+      });
+      strictEqual(c.localAddress, '127.0.0.1');
+      strictEqual(c.localPort, 50000);
+      const c2 = net.connect({
+        port: env.SERVER_PORT,
+        host: env.SIDECAR_HOSTNAME,
+        localPort: 50000,
+      });
+      c2.on('error', (err) => {
+        strictEqual(err.code, 'EADDRINUSE');
+        strictEqual(err.syscall, 'bind');
+        resolve();
+      });
+      await promise;
+      c.destroy();
+      await once(c, 'close');
+      // Released on destroy.
+      new net.BoundSocket({ port: 50000 }).close();
+    }
   },
 };
 
@@ -1192,10 +1225,12 @@ export const testNetLocalError = {
 };
 
 // test/parallel/test-net-boundsocket.js
-// Workers cannot bind local endpoints, so the bound address is recorded and
-// reported but not honored by the transport, and port 0 stays 0.
+// Ports are reserved in the isolate's virtual port table; the transport does
+// not honor the local binding.
 export const testNetBoundSocket = {
   test() {
+    const isEphemeral = (port) => port >= 49152 && port <= 65535;
+
     {
       const bound = new net.BoundSocket({ host: '127.0.0.1', port: 8080 });
       deepStrictEqual(bound.address(), {
@@ -1210,43 +1245,46 @@ export const testNetBoundSocket = {
       throws(() => bound.close(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
     }
 
-    // Defaults: IPv4 wildcard, port 0.
+    // Defaults: IPv4 wildcard, ephemeral port; ports are distinct while held.
     {
-      const bound = new net.BoundSocket({ port: 0 });
-      deepStrictEqual(bound.address(), {
-        address: '0.0.0.0',
-        family: 'IPv4',
-        port: 0,
-      });
-      bound.close();
+      const a = new net.BoundSocket({ port: 0 });
+      const b = new net.BoundSocket();
+      strictEqual(a.address().address, '0.0.0.0');
+      strictEqual(a.address().family, 'IPv4');
+      ok(isEphemeral(a.address().port));
+      ok(isEphemeral(b.address().port));
+      ok(a.address().port !== b.address().port);
+      a.close();
+      b.close();
     }
+
+    // EADDRINUSE on an explicit port that is held; released on close().
     {
-      const bound = new net.BoundSocket();
-      deepStrictEqual(bound.address(), {
-        address: '0.0.0.0',
-        family: 'IPv4',
-        port: 0,
+      const bound = new net.BoundSocket({ host: '127.0.0.1', port: 8081 });
+      throws(() => new net.BoundSocket({ host: '127.0.0.1', port: 8081 }), {
+        code: 'EADDRINUSE',
+        syscall: 'bind',
+        address: '127.0.0.1',
+        port: 8081,
       });
       bound.close();
+      const again = new net.BoundSocket({ host: '127.0.0.1', port: 8081 });
+      strictEqual(again.address().port, 8081);
+      again.close();
     }
 
     // IPv6 binds and ipv6Only default host.
     {
       const bound = new net.BoundSocket({ host: '::1', port: 0 });
-      deepStrictEqual(bound.address(), {
-        address: '::1',
-        family: 'IPv6',
-        port: 0,
-      });
+      strictEqual(bound.address().address, '::1');
+      strictEqual(bound.address().family, 'IPv6');
+      ok(isEphemeral(bound.address().port));
       bound.close();
     }
     {
       const bound = new net.BoundSocket({ ipv6Only: true, port: 0 });
-      deepStrictEqual(bound.address(), {
-        address: '::',
-        family: 'IPv6',
-        port: 0,
-      });
+      strictEqual(bound.address().address, '::');
+      strictEqual(bound.address().family, 'IPv6');
       bound.close();
     }
     {
@@ -1255,11 +1293,19 @@ export const testNetBoundSocket = {
       bound.close();
     }
 
-    // reusePort is accepted and validated.
+    // reusePort permits sharing a port only when all binders set it.
     {
-      const bound = new net.BoundSocket({ port: 0, reusePort: true });
-      strictEqual(bound.address().port, 0);
-      bound.close();
+      const first = new net.BoundSocket({ port: 8082, reusePort: true });
+      const second = new net.BoundSocket({ port: 8082, reusePort: true });
+      throws(() => new net.BoundSocket({ port: 8082 }), {
+        code: 'EADDRINUSE',
+      });
+      first.close();
+      throws(() => new net.BoundSocket({ port: 8082 }), {
+        code: 'EADDRINUSE',
+      });
+      second.close();
+      new net.BoundSocket({ port: 8082 }).close();
       throws(() => new net.BoundSocket({ reusePort: 'yes' }), {
         code: 'ERR_INVALID_ARG_TYPE',
       });
@@ -1283,10 +1329,11 @@ export const testNetBoundSocket = {
 
     // Symbol.dispose closes an un-adopted handle and is a no-op afterwards.
     {
-      const bound = new net.BoundSocket();
+      const bound = new net.BoundSocket({ port: 8083 });
       bound[Symbol.dispose]();
       bound[Symbol.dispose]();
       throws(() => bound.address(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+      new net.BoundSocket({ port: 8083 }).close();
     }
     {
       const bound = new net.BoundSocket();
@@ -1342,6 +1389,9 @@ export const testNetBoundSocketClientAdoption = {
     client.on('close', resolve);
     await promise;
     strictEqual(response, 'ping');
+
+    // The adopted port is released when the socket is destroyed.
+    new net.BoundSocket({ host: '127.0.0.1', port: 4321 }).close();
   },
 };
 
@@ -1349,6 +1399,7 @@ export const testNetBoundSocketClientAdoption = {
 export const testNetBoundSocketConnectOptions = {
   async test(ctrl, env, ctx) {
     const bound = new net.BoundSocket({ host: '::1', port: 0 });
+    const { port: localPort } = bound.address();
     const { promise, resolve } = Promise.withResolvers();
     const client = net.connect({
       handle: bound,
@@ -1358,7 +1409,7 @@ export const testNetBoundSocketConnectOptions = {
     throws(() => bound.address(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
     strictEqual(client.localAddress, '::1');
     strictEqual(client.localFamily, 'IPv6');
-    strictEqual(client.localPort, 0);
+    strictEqual(client.localPort, localPort);
     client.on('connect', () => client.end());
     client.resume();
     client.on('close', resolve);

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -1191,6 +1191,210 @@ export const testNetLocalError = {
   },
 };
 
+// test/parallel/test-net-boundsocket.js
+// Workers cannot bind local endpoints, so the bound address is recorded and
+// reported but not honored by the transport, and port 0 stays 0.
+export const testNetBoundSocket = {
+  test() {
+    {
+      const bound = new net.BoundSocket({ host: '127.0.0.1', port: 8080 });
+      deepStrictEqual(bound.address(), {
+        address: '127.0.0.1',
+        family: 'IPv4',
+        port: 8080,
+      });
+      strictEqual(bound.fd(), -1);
+      bound.close();
+      throws(() => bound.address(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+      throws(() => bound.fd(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+      throws(() => bound.close(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+    }
+
+    // Defaults: IPv4 wildcard, port 0.
+    {
+      const bound = new net.BoundSocket({ port: 0 });
+      deepStrictEqual(bound.address(), {
+        address: '0.0.0.0',
+        family: 'IPv4',
+        port: 0,
+      });
+      bound.close();
+    }
+    {
+      const bound = new net.BoundSocket();
+      deepStrictEqual(bound.address(), {
+        address: '0.0.0.0',
+        family: 'IPv4',
+        port: 0,
+      });
+      bound.close();
+    }
+
+    // IPv6 binds and ipv6Only default host.
+    {
+      const bound = new net.BoundSocket({ host: '::1', port: 0 });
+      deepStrictEqual(bound.address(), {
+        address: '::1',
+        family: 'IPv6',
+        port: 0,
+      });
+      bound.close();
+    }
+    {
+      const bound = new net.BoundSocket({ ipv6Only: true, port: 0 });
+      deepStrictEqual(bound.address(), {
+        address: '::',
+        family: 'IPv6',
+        port: 0,
+      });
+      bound.close();
+    }
+    {
+      const bound = new net.BoundSocket({ host: '::', port: 0 });
+      strictEqual(bound.address().family, 'IPv6');
+      bound.close();
+    }
+
+    // reusePort is accepted and validated.
+    {
+      const bound = new net.BoundSocket({ port: 0, reusePort: true });
+      strictEqual(bound.address().port, 0);
+      bound.close();
+      throws(() => new net.BoundSocket({ reusePort: 'yes' }), {
+        code: 'ERR_INVALID_ARG_TYPE',
+      });
+      throws(() => new net.BoundSocket({ ipv6Only: 1 }), {
+        code: 'ERR_INVALID_ARG_TYPE',
+      });
+    }
+
+    // Non-numeric host (no DNS resolution), non-string host, bad options.
+    throws(() => new net.BoundSocket({ host: 'localhost', port: 0 }), {
+      code: 'ERR_INVALID_ARG_VALUE',
+      name: 'TypeError',
+    });
+    throws(() => new net.BoundSocket({ host: 1234 }), {
+      code: 'ERR_INVALID_ARG_TYPE',
+    });
+    throws(() => new net.BoundSocket(0), { code: 'ERR_INVALID_ARG_TYPE' });
+    throws(() => new net.BoundSocket({ port: 65536 }), {
+      code: 'ERR_SOCKET_BAD_PORT',
+    });
+
+    // Symbol.dispose closes an un-adopted handle and is a no-op afterwards.
+    {
+      const bound = new net.BoundSocket();
+      bound[Symbol.dispose]();
+      bound[Symbol.dispose]();
+      throws(() => bound.address(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+    }
+    {
+      const bound = new net.BoundSocket();
+      bound.close();
+      bound[Symbol.dispose]();
+    }
+
+    // Server is not implemented, so a bound socket cannot be adopted by one.
+    throws(() => net.createServer());
+  },
+};
+
+// Client adoption: new net.Socket({ handle: boundSocket }) consumes the bound
+// socket and exposes its address as the local address before and after
+// connect().
+export const testNetBoundSocketClientAdoption = {
+  async test(ctrl, env, ctx) {
+    const bound = new net.BoundSocket({ host: '127.0.0.1', port: 4321 });
+    const client = new net.Socket({ handle: bound });
+
+    throws(() => bound.address(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+    throws(() => bound.close(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+    throws(() => new net.Socket({ handle: bound }), {
+      code: 'ERR_SOCKET_HANDLE_ADOPTED',
+    });
+    bound[Symbol.dispose]();
+
+    strictEqual(client.localAddress, '127.0.0.1');
+    strictEqual(client.localPort, 4321);
+    strictEqual(client.localFamily, 'IPv4');
+    deepStrictEqual(client.address(), {
+      address: '127.0.0.1',
+      family: 'IPv4',
+      port: 4321,
+    });
+
+    const { promise, resolve } = Promise.withResolvers();
+    client.connect(Number(env.ECHO_SERVER_PORT), env.SIDECAR_HOSTNAME, () => {
+      client.end('ping');
+    });
+
+    // Available synchronously after connect() returns.
+    strictEqual(client.localAddress, '127.0.0.1');
+    strictEqual(client.localPort, 4321);
+
+    let response = '';
+    client.setEncoding('utf8');
+    client.on('data', (data) => (response += data));
+    client.on('connect', () => {
+      strictEqual(client.localAddress, '127.0.0.1');
+      strictEqual(client.localPort, 4321);
+    });
+    client.on('close', resolve);
+    await promise;
+    strictEqual(response, 'ping');
+  },
+};
+
+// net.connect({ handle }) adopts through the options path.
+export const testNetBoundSocketConnectOptions = {
+  async test(ctrl, env, ctx) {
+    const bound = new net.BoundSocket({ host: '::1', port: 0 });
+    const { promise, resolve } = Promise.withResolvers();
+    const client = net.connect({
+      handle: bound,
+      host: env.SIDECAR_HOSTNAME,
+      port: Number(env.ECHO_SERVER_PORT),
+    });
+    throws(() => bound.address(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+    strictEqual(client.localAddress, '::1');
+    strictEqual(client.localFamily, 'IPv6');
+    strictEqual(client.localPort, 0);
+    client.on('connect', () => client.end());
+    client.resume();
+    client.on('close', resolve);
+    await promise;
+  },
+};
+
+// connect() rejects localAddress/localPort when adopting a bound socket.
+export const testNetBoundSocketLocalAddressConflict = {
+  test() {
+    {
+      const bound = new net.BoundSocket({ host: '127.0.0.1', port: 0 });
+      const client = new net.Socket({ handle: bound });
+      throws(
+        () => client.connect({ host: '127.0.0.1', port: 1, localPort: 0 }),
+        { code: 'ERR_INVALID_ARG_VALUE' }
+      );
+      client.destroy();
+    }
+    {
+      const bound = new net.BoundSocket({ host: '127.0.0.1', port: 0 });
+      const client = new net.Socket({ handle: bound });
+      throws(
+        () =>
+          client.connect({
+            host: '127.0.0.1',
+            port: 1,
+            localAddress: '127.0.0.1',
+          }),
+        { code: 'ERR_INVALID_ARG_VALUE' }
+      );
+      client.destroy();
+    }
+  },
+};
+
 // test/parallel/test-net-onread-static-buffer.js
 export const testNetOnReadStaticBuffer = {
   async test(ctrl, env, ctx) {

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -1436,6 +1436,24 @@ export const testNetBoundSocketClientAdoption = {
 
     // The adopted port is released when the socket is destroyed.
     new net.BoundSocket({ host: '127.0.0.1', port: 4321 }).close();
+
+    // Adoption transfers a reusePort share to the socket, which releases it
+    // exactly once on destroy: the other holder keeps the port.
+    {
+      const a = new net.BoundSocket({ port: 4322, reusePort: true });
+      const b = new net.BoundSocket({ port: 4322, reusePort: true });
+      const s = new net.Socket({ handle: a });
+      throws(() => a.close(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+      const closed = once(s, 'close');
+      s.destroy();
+      await closed;
+      throws(() => new net.BoundSocket({ port: 4322 }), {
+        code: 'EADDRINUSE',
+      });
+      new net.BoundSocket({ port: 4322, reusePort: true }).close();
+      b.close();
+      new net.BoundSocket({ port: 4322 }).close();
+    }
   },
 };
 

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -1217,6 +1217,30 @@ export const testNetLocalAddressPort = {
       await Promise.all([once(c, 'close'), once(c2, 'close')]);
     }
 
+    // localAddress alone, or localPort 0, is not a reservation: the address is
+    // reported but the port is an autobound label.
+    {
+      const c = net.connect({
+        port: env.SERVER_PORT,
+        host: env.SIDECAR_HOSTNAME,
+        localAddress: '127.0.0.1',
+        localPort: 0,
+      });
+      strictEqual(c.localAddress, '127.0.0.1');
+      ok(c.localPort >= 49152);
+      new net.BoundSocket({ port: c.localPort }).close();
+      const c2 = net.connect({
+        port: env.SERVER_PORT,
+        host: env.SIDECAR_HOSTNAME,
+        localAddress: null,
+        localPort: null,
+      });
+      strictEqual(c2.localAddress, '0.0.0.0');
+      c.destroy();
+      c2.destroy();
+      await Promise.all([once(c, 'close'), once(c2, 'close')]);
+    }
+
     // A reconnect drops the previous local endpoint, so localPort may be given.
     {
       const c = net.connect(Number(env.ECHO_SERVER_PORT), env.SIDECAR_HOSTNAME);

--- a/src/workerd/api/node/tests/net-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/net-nodejs-test.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "net-nodejs-test.js")
         ],
-        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "url_standard"],
+        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "url_standard", "enable_weak_ref"],
         bindings = [
           (name = "SIDECAR_HOSTNAME", fromEnvironment = "SIDECAR_HOSTNAME"),
           (name = "SERVER_PORT", fromEnvironment = "SERVER_PORT"),

--- a/src/workerd/api/node/tests/net-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/net-nodejs-test.wd-test
@@ -7,7 +7,7 @@ const unitTests :Workerd.Config = (
         modules = [
           (name = "worker", esModule = embed "net-nodejs-test.js")
         ],
-        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "url_standard", "enable_weak_ref"],
+        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "url_standard"],
         bindings = [
           (name = "SIDECAR_HOSTNAME", fromEnvironment = "SIDECAR_HOSTNAME"),
           (name = "SERVER_PORT", fromEnvironment = "SERVER_PORT"),


### PR DESCRIPTION
This implements `net.BoundSocket` from Node.js 26.4 (nodejs/node#63951, nodejs/node#64375).

Workers cannot bind a physical local endpoint, so local ports are modelled as a per-isolate virtual port table, shared between `node:net` and `node:http` servers. The bound address is surfaced as the adopting Socket's local address without being applied to the underlying transport; port allocation and conflicts follow Node's model, with the table keyed by port only.

* `new net.BoundSocket({ host, port, ipv6Only, reusePort })` with Node's validation (numeric IP host only, wildcard defaults); `path` is rejected since pipes cannot be supported
* `address()` reports the reserved port, ephemeral (49152–65535) for `port: 0`; binding a held port throws `EADDRINUSE` synchronously; `reusePort` permits sharing when all binders set it
* `fd()` (returns `-1`, as on platforms without socket fds), `close()`, `Symbol.dispose` release the port
* `new net.Socket({ handle: bound })` / `net.connect({ handle })` adopt the bound socket; `localAddress`/`localPort`/`localFamily` reflect it synchronously including immediately after `connect()`, and the port is released on destroy
* Adoption consumes the bound socket; further use throws the new `ERR_SOCKET_HANDLE_ADOPTED`
* `localAddress`/`localPort` connect options are rejected on an adopted bound socket

Port table: a `PortTable` class in `cloudflare-internal:http` (one instance per protocol; `tcpPorts` today, so `dgram` can add a UDP table later) replaces the http-only `portMapper`. Entries carry the inbound routing handler, so `http.Server.listen()` is bind + set-handler and `httpServerHandler` looks the port up in the same table; http servers and net sockets therefore conflict with each other. Only explicit reservations enter the table: `BoundSocket`, a concrete `localPort` connect option (previously validated but ignored), and `http.Server.listen()`. Ordinary connections autobind as `connect(2)` does but take an ephemeral *label* that skips reserved ports without being recorded, since a socket whose request ends before it is destroyed never runs cleanup. Socket reservations are additionally registered with a `FinalizationRegistry` backstop that releases the entry if the owner is collected without closing; the registry is optional as `FinalizationRegistry` only exists on compat dates with `enable_weak_ref`. Listening http servers are held strongly by their entry, so a server the user keeps no reference to stays routable, as in Node. A reconnect on a live socket drops the previous local endpoint.

Observable changes for existing code: `socket.localPort` is now a non-zero ephemeral port rather than `0`; `http.Server.listen()` on a port held by another server throws `EADDRINUSE` rather than `ERR_SERVER_ALREADY_LISTEN` (which remains for re-listening the same server), and the message reflects the given host.

`server.listen(bound)` is not applicable as `net.Server` is not implemented.

Tests adapted from `test-net-boundsocket.js` in `net-nodejs-test.js`, covering construction/validation/dispose, `EADDRINUSE`/`reusePort`/release, autobind labels not being recorded, `localAddress`-only not reserving, reconnect with `localPort`, release-once through adoption of a `reusePort` share, client adoption round-trip against the echo sidecar, `net.connect({ handle })`, and the localAddress conflict; `http-server-nodejs-test.js` covers the shared table, host in the conflict message, and an unreferenced listening server surviving GC.
