### PR TITLE
Make skill reference links portable

### DIFF
--- a/.opencode/skills/kj-style/SKILL.md
+++ b/.opencode/skills/kj-style/SKILL.md
@@ -3,4 +3,4 @@ name: kj-style
 description: KJ/workerd C++ style guidelines for code review. Covers naming, type usage, memory management, error handling, inheritance, constness, and formatting conventions. Load this skill when reviewing or writing C++ code in the workerd codebase.
 ---
 
-**Always** use the `docs/reference/kj-style.md` file when reviewing or writing C++ code.
+**Always** use the [KJ style reference](../../../docs/reference/kj-style.md) when reviewing or writing C++ code.

--- a/.opencode/skills/rust-review/SKILL.md
+++ b/.opencode/skills/rust-review/SKILL.md
@@ -3,4 +3,4 @@ name: rust-review
 description: Rust code review for workerd. Covers CXX FFI safety, unsafe code patterns, JSG resource conventions, error handling, and a review checklist adapted from the C++ review skills. Load this skill when reviewing Rust code in src/rust/.
 ---
 
-**Always** use the `docs/reference/rust-review-checklist.md` file when reviewing Rust code.
+**Always** use the [Rust review checklist](../../../docs/reference/rust-review-checklist.md) when reviewing Rust code.

--- a/.opencode/skills/ts-style/SKILL.md
+++ b/.opencode/skills/ts-style/SKILL.md
@@ -3,4 +3,4 @@ name: ts-style
 description: JS/TS style guidelines and review checklist for workerd. Covers TypeScript strictness, import conventions, export patterns, private field syntax, error handling, feature gating, and test structure. Load this skill when reviewing or writing JavaScript or TypeScript code in src/node/, src/cloudflare/, or JS/TS test files under src/workerd/.
 ---
 
-**Always** use the `docs/reference/ts-style.md` file when reviewing or writing JavaScript and TypeScript code.
+**Always** use the [TypeScript style reference](../../../docs/reference/ts-style.md) when reviewing or writing JavaScript and TypeScript code.

--- a/.opencode/skills/update-v8/SKILL.md
+++ b/.opencode/skills/update-v8/SKILL.md
@@ -7,7 +7,7 @@ description: Step-by-step guide for updating the V8 JavaScript engine in workerd
 
 V8 updates are high-risk changes that require careful patch management and human judgment for merge conflicts. This skill covers the full process. **Always confirm the target version with the developer before starting.**
 
-See also: `docs/v8-updates.md` for the original reference document.
+See also the [V8 update reference](../../../docs/v8-updates.md).
 
 **Always** communicate and confirm with the developer at each step.
 **Never** take irreversible actions (like dropping patches or updating hashes) without explicit confirmation.

--- a/.opencode/skills/wd-test-format/SKILL.md
+++ b/.opencode/skills/wd-test-format/SKILL.md
@@ -20,7 +20,7 @@ patterns and fields required. Skipping it WILL lead to incorrect configs that fa
 
 | File                            | MUST load when...                                            |
 | ------------------------------- | ------------------------------------------------------------ |
-| `reference/advanced-configs.md` | Test involves Durable Objects, multiple services             |
+| [Advanced configurations](reference/advanced-configs.md) | Test involves Durable Objects, multiple services             |
 |                                 | communicating via service bindings, outbound network access, |
 |                                 | external services/sockets, or TypeScript source files        |
 

--- a/.opencode/skills/workerd-api-review/SKILL.md
+++ b/.opencode/skills/workerd-api-review/SKILL.md
@@ -3,4 +3,4 @@ name: workerd-api-review
 description: Performance optimization, API design & compatibility, security vulnerabilities, and standards spec compliance for workerd code review. Covers tcmalloc-aware perf analysis, compat flags, autogates, web standards adherence, and security patterns. Load this skill when reviewing API changes, performance-sensitive code, security-relevant code, or standards implementations.
 ---
 
-**Always** use the `docs/reference/api-review-checklist.md` file for detailed checklists on performance optimization, API design, security vulnerabilities, and standards compliance when planning, writing, or reviewing code changes.
+**Always** use the [API review checklist](../../../docs/reference/api-review-checklist.md) for detailed checklists on performance optimization, API design, security vulnerabilities, and standards compliance when planning, writing, or reviewing code changes.

--- a/.opencode/skills/workerd-safety-review/SKILL.md
+++ b/.opencode/skills/workerd-safety-review/SKILL.md
@@ -3,5 +3,4 @@ name: workerd-safety-review
 description: Memory safety, thread safety, concurrency, and critical detection patterns for workerd code review. Covers V8/KJ boundary hazards, lifetime management, cross-thread safety, and coroutine pitfalls. Load this skill when reviewing any C++ code.
 ---
 
-**Always** use the `docs/reference/cpp-safety-review-checklist.md` file for detailed checklists on memory safety, thread safety, and concurrency correctness when planning, writing, or reviewing code changes.
-
+**Always** use the [C++ safety review checklist](../../../docs/reference/cpp-safety-review-checklist.md) for detailed checklists on memory safety, thread safety, and concurrency correctness when planning, writing, or reviewing code changes.


### PR DESCRIPTION
Resolve each bundled skill reference relative to its `SKILL.md` location so Codex can load the skills outside a workerd-root session.

Validation:

- Ran the skill creator validator on all seven changed skills.
- Resolved every changed link from `/tmp` and confirmed its target exists.
- Ran `git diff --check`.

Assisted-by: Codex:gpt-5.6-sol