### PR TITLE
feat: expose client IP and port as remoteAddress in TCP connect() handler

### DIFF
--- a/build/deps/gen/deps.MODULE.bazel
+++ b/build/deps/gen/deps.MODULE.bazel
@@ -27,10 +27,10 @@ bazel_dep(name = "brotli", version = "1.2.0.bcr.3")
 # capnp-cpp
 http.archive(
     name = "capnp-cpp",
-    sha256 = "dcd96af005ea6fab167e63b6d53b05db13c03339766d26c07e0b3cbe54e1982e",
-    strip_prefix = "capnproto-capnproto-851c45b/c++",
+    sha256 = "9addcc52046fa8073adcd41975fd353004871d6ed58ab460bce7ccf7b39a45fe",
+    strip_prefix = "capnproto-capnproto-a836bf0/c++",
     type = "tgz",
-    url = "https://github.com/capnproto/capnproto/tarball/851c45bb39c34c3f20f9d9ebe9f34a7e39109b6f",
+    url = "https://github.com/capnproto/capnproto/tarball/a836bf03b31934d5289db1158e1436e8b67ef984",
 )
 use_repo(http, "capnp-cpp")
 

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -218,6 +218,7 @@ void ServiceWorkerGlobalScope::clear() {
 }
 
 kj::Promise<void> ServiceWorkerGlobalScope::connect(kj::String host,
+    kj::Maybe<kj::String> clientIp,
     const kj::HttpHeaders& headers,
     kj::AsyncIoStream& connection,
     kj::HttpService::ConnectResponse& response,
@@ -252,9 +253,9 @@ kj::Promise<void> ServiceWorkerGlobalScope::connect(kj::String host,
     // The handler is the server side of this connection: the peer half-closing means it has
     // finished sending, not that the reply is over, so the write side stays open until the handler
     // closes it or returns.
-    jsg::Ref<Socket> jsSocket = setupSocket(js, ownConnection.addRef().toOwn(),
-        kj::none /* remoteAddress */, kj::mv(host), SocketOptions{.allowHalfOpen = true},
-        kj::mv(nullTlsStarter), SecureTransportKind::OFF, kj::none, false, kj::none);
+    jsg::Ref<Socket> jsSocket = setupSocket(js, ownConnection.addRef().toOwn(), kj::mv(clientIp),
+        kj::mv(host), SocketOptions{.allowHalfOpen = true}, kj::mv(nullTlsStarter),
+        SecureTransportKind::OFF, kj::none, false, kj::none);
     // handleProxyStatus() is required to indicate that the socket was opened properly. Since the
     // connection is already open at this point, exception handling is not required.
     jsSocket->handleProxyStatus(js, kj::Promise<kj::Maybe<kj::Exception>>(kj::none));

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -218,7 +218,7 @@ void ServiceWorkerGlobalScope::clear() {
 }
 
 kj::Promise<void> ServiceWorkerGlobalScope::connect(kj::String host,
-    kj::Maybe<kj::String> clientIp,
+    kj::Maybe<kj::String> clientAddress,
     const kj::HttpHeaders& headers,
     kj::AsyncIoStream& connection,
     kj::HttpService::ConnectResponse& response,
@@ -253,9 +253,9 @@ kj::Promise<void> ServiceWorkerGlobalScope::connect(kj::String host,
     // The handler is the server side of this connection: the peer half-closing means it has
     // finished sending, not that the reply is over, so the write side stays open until the handler
     // closes it or returns.
-    jsg::Ref<Socket> jsSocket = setupSocket(js, ownConnection.addRef().toOwn(), kj::mv(clientIp),
-        kj::mv(host), SocketOptions{.allowHalfOpen = true}, kj::mv(nullTlsStarter),
-        SecureTransportKind::OFF, kj::none, false, kj::none);
+    jsg::Ref<Socket> jsSocket = setupSocket(js, ownConnection.addRef().toOwn(),
+        kj::mv(clientAddress), kj::mv(host), SocketOptions{.allowHalfOpen = true},
+        kj::mv(nullTlsStarter), SecureTransportKind::OFF, kj::none, false, kj::none);
     // handleProxyStatus() is required to indicate that the socket was opened properly. Since the
     // connection is already open at this point, exception handling is not required.
     jsSocket->handleProxyStatus(js, kj::Promise<kj::Maybe<kj::Exception>>(kj::none));

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -691,6 +691,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
 
   // Received TCP/socket ingress (called from C++, not JS).
   kj::Promise<void> connect(kj::String host,
+      kj::Maybe<kj::String> clientIp,
       const kj::HttpHeaders& headers,
       kj::AsyncIoStream& connection,
       kj::HttpService::ConnectResponse& response,

--- a/src/workerd/api/global-scope.h
+++ b/src/workerd/api/global-scope.h
@@ -691,7 +691,7 @@ class ServiceWorkerGlobalScope: public WorkerGlobalScope {
 
   // Received TCP/socket ingress (called from C++, not JS).
   kj::Promise<void> connect(kj::String host,
-      kj::Maybe<kj::String> clientIp,
+      kj::Maybe<kj::String> clientAddress,
       const kj::HttpHeaders& headers,
       kj::AsyncIoStream& connection,
       kj::HttpService::ConnectResponse& response,

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -30,6 +30,10 @@ struct SocketAddress {
 };
 
 struct SocketInfo {
+  // The remote address — i.e. the address on the other side of the socket. For outbound sockets
+  // created via `connect()`, this is the "host:port" string that was passed to `connect()`. For
+  // inbound sockets delivered to a worker's `connect(socket)` handler, this is the address of the
+  // client on whose behalf the tunnel was established, when the peer supplied one.
   jsg::Optional<kj::String> remoteAddress;
 
   // The local address — i.e. the address on this side of the socket. For outbound sockets created

--- a/src/workerd/api/tests/connect-handler-test-proxy.js
+++ b/src/workerd/api/tests/connect-handler-test-proxy.js
@@ -25,14 +25,21 @@ export class ConnectEndpoint extends WorkerEntrypoint {
 }
 
 // Reached via a service binding from connect-handler-test.js. Awaits socket.opened and echoes back
-// the observed localAddress, which on the service-binding path is the verbatim authority string
-// the caller passed to fetcher.connect(...). The client test asserts strict equality.
+// the observed addresses. On the service-binding path localAddress is the verbatim authority
+// string the caller passed to fetcher.connect(...), and no client IP is supplied.
 export class LocalAddressEndpoint extends WorkerEntrypoint {
   async connect(socket) {
-    const { localAddress } = await socket.opened;
+    const { localAddress, remoteAddress } = await socket.opened;
     const enc = new TextEncoder();
     const writer = socket.writable.getWriter();
-    await writer.write(enc.encode(`OK:${localAddress}`));
+    await writer.write(
+      enc.encode(
+        JSON.stringify({
+          localAddress: localAddress ?? null,
+          remoteAddress: remoteAddress ?? null,
+        })
+      )
+    );
     await writer.close();
   }
 }

--- a/src/workerd/api/tests/connect-handler-test.js
+++ b/src/workerd/api/tests/connect-handler-test.js
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 import { connect } from 'cloudflare:sockets';
-import { strictEqual } from 'assert';
+import { ok, strictEqual } from 'assert';
 
 export const connectHandler = {
   async test() {
@@ -15,7 +15,19 @@ export const connectHandler = {
       result += dec.decode(chunk, { stream: true });
     }
     result += dec.decode();
-    strictEqual(result, 'hello');
+
+    // The TCP listener reports the accepted connection's peer address, which for this loopback
+    // connection is an ephemeral port on some spelling of localhost.
+    const prefix = 'hello:';
+    ok(result.startsWith(prefix), result);
+    const remoteAddress = result.slice(prefix.length);
+    ok(
+      /^(127\.0\.0\.1|\[(::1|::ffff:127\.0\.0\.1)\]):[0-9]+$/.test(
+        remoteAddress
+      ),
+      `Unexpected remote address: ${remoteAddress}`
+    );
+
     await socket.closed;
   },
 };
@@ -54,16 +66,22 @@ export const localAddressViaServiceBinding = {
       result += dec.decode(chunk, { stream: true });
     }
     result += dec.decode();
-    strictEqual(result, `OK:${AUTHORITY}`);
+
+    const { localAddress, remoteAddress } = JSON.parse(result);
+    strictEqual(localAddress, AUTHORITY);
+    // The service-binding path supplies no client IP.
+    strictEqual(remoteAddress, null);
+
     await socket.closed;
   },
 };
 
 export default {
   async connect(socket) {
+    const { remoteAddress } = await socket.opened;
     const enc = new TextEncoder();
     let writer = socket.writable.getWriter();
-    await writer.write(enc.encode('hello'));
+    await writer.write(enc.encode(`hello:${remoteAddress}`));
     await writer.close();
   },
 };

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -188,8 +188,8 @@ class IoChannelFactory: public virtual kj::Refcounted {
     // `WorkerEntrypoint::construct()`.
     Persistent fromPersistentStub = Persistent::NO;
 
-    // Address of the client on whose behalf this request is being made.
-    kj::Maybe<kj::String> clientIp;
+    // Address of the client as IP:port on whose behalf this request is being made.
+    kj::Maybe<kj::String> clientAddress;
   };
 
   // Parameters that can influence the version of a worker that is used to serve a subrequest.

--- a/src/workerd/io/io-channels.h
+++ b/src/workerd/io/io-channels.h
@@ -187,6 +187,9 @@ class IoChannelFactory: public virtual kj::Refcounted {
     // `allow_irrevocable_stub_storage` compat flag enabled; if not, it rejects the request. See
     // `WorkerEntrypoint::construct()`.
     Persistent fromPersistentStub = Persistent::NO;
+
+    // Address of the client on whose behalf this request is being made.
+    kj::Maybe<kj::String> clientIp;
   };
 
   // Parameters that can influence the version of a worker that is used to serve a subrequest.

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -70,7 +70,8 @@ class WorkerEntrypoint final: public WorkerInterface {
       bool isDynamicDispatch,
       kj::Maybe<kj::Own<AccessInfo>> accessInfo,
       kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory,
-      Persistent fromPersistentStub);
+      Persistent fromPersistentStub,
+      kj::Maybe<kj::String> clientIp);
 
   kj::Promise<void> request(kj::HttpMethod method,
       kj::StringPtr url,
@@ -104,6 +105,7 @@ class WorkerEntrypoint final: public WorkerInterface {
   Frankenvalue props;
   kj::Maybe<kj::String> cfBlobJson;
   kj::Maybe<Worker::VersionInfo> versionInfo;
+  kj::Maybe<kj::String> clientIp;
 
   // Hacky members used to hold some temporary state while processing a request.
   // See gory details in WorkerEntrypoint::request().
@@ -154,7 +156,8 @@ class WorkerEntrypoint final: public WorkerInterface {
       kj::Maybe<kj::String> entrypointName,
       Frankenvalue props,
       kj::Maybe<kj::String> cfBlobJson,
-      kj::Maybe<Worker::VersionInfo> versionInfo);
+      kj::Maybe<Worker::VersionInfo> versionInfo,
+      kj::Maybe<kj::String> clientIp);
 };
 
 // Simple wrapper around `HttpService::Response` to let us know if the response was sent
@@ -212,7 +215,8 @@ kj::Own<WorkerInterface> WorkerEntrypoint::construct(ThreadContext& threadContex
     bool isDynamicDispatch,
     kj::Maybe<kj::Own<AccessInfo>> accessInfo,
     kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory,
-    Persistent fromPersistentStub) {
+    Persistent fromPersistentStub,
+    kj::Maybe<kj::String> clientIp) {
   TRACE_EVENT("workerd", "WorkerEntrypoint::construct()");
 
   // If this request came from a stored ("persistent") stub, re-verify that the target worker still
@@ -235,7 +239,7 @@ kj::Own<WorkerInterface> WorkerEntrypoint::construct(ThreadContext& threadContex
 
   auto obj = kj::heap<WorkerEntrypoint>(kj::Badge<WorkerEntrypoint>(), threadContext,
       waitUntilTasks, canceler, tunnelExceptions, isDynamicDispatch, kj::mv(entrypointName),
-      kj::mv(props), kj::mv(cfBlobJson), kj::mv(versionInfo));
+      kj::mv(props), kj::mv(cfBlobJson), kj::mv(versionInfo), kj::mv(clientIp));
   obj->init(kj::mv(worker), kj::mv(actor), kj::mv(limitEnforcer), kj::mv(ioContextDependency),
       kj::mv(ioChannelFactory), kj::addRef(*metrics), kj::mv(workerTracer),
       kj::mv(maybeTriggerInvocationSpan), kj::mv(accessInfo), kj::mv(selfTokenFactory));
@@ -252,7 +256,8 @@ WorkerEntrypoint::WorkerEntrypoint(kj::Badge<WorkerEntrypoint> badge,
     kj::Maybe<kj::String> entrypointName,
     Frankenvalue props,
     kj::Maybe<kj::String> cfBlobJson,
-    kj::Maybe<Worker::VersionInfo> versionInfo)
+    kj::Maybe<Worker::VersionInfo> versionInfo,
+    kj::Maybe<kj::String> clientIp)
     : threadContext(threadContext),
       waitUntilTasks(waitUntilTasks),
       canceler(canceler),
@@ -261,7 +266,8 @@ WorkerEntrypoint::WorkerEntrypoint(kj::Badge<WorkerEntrypoint> badge,
       entrypointName(kj::mv(entrypointName)),
       props(kj::mv(props)),
       cfBlobJson(kj::mv(cfBlobJson)),
-      versionInfo(kj::mv(versionInfo)) {}
+      versionInfo(kj::mv(versionInfo)),
+      clientIp(kj::mv(clientIp)) {}
 
 void WorkerEntrypoint::init(kj::Own<const Worker> worker,
     kj::Maybe<kj::Own<Worker::Actor>> actor,
@@ -732,12 +738,13 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
   return wrapWithCanceler(
       context
           .run([this, &headers, &connection, &response, entrypointName = entrypointName.clone(),
-                   versionInfo = kj::mv(versionInfo),
-                   host = kj::str(host)](Worker::Lock& lock, IoContext& context) mutable {
+                   versionInfo = kj::mv(versionInfo), host = kj::str(host),
+                   clientIp = kj::mv(clientIp)](Worker::Lock& lock, IoContext& context) mutable {
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
     jsg::AsyncContextFrame::StorageScope userTraceScope = context.makeUserAsyncTraceScope(lock);
 
-    return lock.getGlobalScope().connect(kj::mv(host), headers, connection, response, lock,
+    return lock.getGlobalScope().connect(kj::mv(host), kj::mv(clientIp), headers, connection,
+        response, lock,
         lock.getExportedHandler(asPtr(entrypointName), kj::mv(versionInfo), kj::mv(props),
             context.getActor(), isDynamicDispatch));
   })
@@ -1124,13 +1131,14 @@ kj::Own<WorkerInterface> newWorkerEntrypoint(ThreadContext& threadContext,
     bool isDynamicDispatch,
     kj::Maybe<kj::Own<AccessInfo>> accessInfo,
     kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory,
-    Persistent fromPersistentStub) {
+    Persistent fromPersistentStub,
+    kj::Maybe<kj::String> clientIp) {
   return WorkerEntrypoint::construct(threadContext, kj::mv(worker), kj::mv(entrypointName),
       kj::mv(props), kj::mv(actor), kj::mv(limitEnforcer), kj::mv(ioContextDependency),
       kj::mv(ioChannelFactory), kj::mv(metrics), waitUntilTasks, tunnelExceptions,
       kj::mv(workerTracer), kj::mv(cfBlobJson), kj::mv(versionInfo),
       kj::mv(maybeTriggerInvocationSpan), isDynamicDispatch, kj::mv(accessInfo),
-      kj::mv(selfTokenFactory), fromPersistentStub);
+      kj::mv(selfTokenFactory), fromPersistentStub, kj::mv(clientIp));
 }
 
 }  // namespace workerd

--- a/src/workerd/io/worker-entrypoint.c++
+++ b/src/workerd/io/worker-entrypoint.c++
@@ -71,7 +71,7 @@ class WorkerEntrypoint final: public WorkerInterface {
       kj::Maybe<kj::Own<AccessInfo>> accessInfo,
       kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory,
       Persistent fromPersistentStub,
-      kj::Maybe<kj::String> clientIp);
+      kj::Maybe<kj::String> clientAddress);
 
   kj::Promise<void> request(kj::HttpMethod method,
       kj::StringPtr url,
@@ -105,7 +105,7 @@ class WorkerEntrypoint final: public WorkerInterface {
   Frankenvalue props;
   kj::Maybe<kj::String> cfBlobJson;
   kj::Maybe<Worker::VersionInfo> versionInfo;
-  kj::Maybe<kj::String> clientIp;
+  kj::Maybe<kj::String> clientAddress;
 
   // Hacky members used to hold some temporary state while processing a request.
   // See gory details in WorkerEntrypoint::request().
@@ -157,7 +157,7 @@ class WorkerEntrypoint final: public WorkerInterface {
       Frankenvalue props,
       kj::Maybe<kj::String> cfBlobJson,
       kj::Maybe<Worker::VersionInfo> versionInfo,
-      kj::Maybe<kj::String> clientIp);
+      kj::Maybe<kj::String> clientAddress);
 };
 
 // Simple wrapper around `HttpService::Response` to let us know if the response was sent
@@ -216,7 +216,7 @@ kj::Own<WorkerInterface> WorkerEntrypoint::construct(ThreadContext& threadContex
     kj::Maybe<kj::Own<AccessInfo>> accessInfo,
     kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory,
     Persistent fromPersistentStub,
-    kj::Maybe<kj::String> clientIp) {
+    kj::Maybe<kj::String> clientAddress) {
   TRACE_EVENT("workerd", "WorkerEntrypoint::construct()");
 
   // If this request came from a stored ("persistent") stub, re-verify that the target worker still
@@ -239,7 +239,7 @@ kj::Own<WorkerInterface> WorkerEntrypoint::construct(ThreadContext& threadContex
 
   auto obj = kj::heap<WorkerEntrypoint>(kj::Badge<WorkerEntrypoint>(), threadContext,
       waitUntilTasks, canceler, tunnelExceptions, isDynamicDispatch, kj::mv(entrypointName),
-      kj::mv(props), kj::mv(cfBlobJson), kj::mv(versionInfo), kj::mv(clientIp));
+      kj::mv(props), kj::mv(cfBlobJson), kj::mv(versionInfo), kj::mv(clientAddress));
   obj->init(kj::mv(worker), kj::mv(actor), kj::mv(limitEnforcer), kj::mv(ioContextDependency),
       kj::mv(ioChannelFactory), kj::addRef(*metrics), kj::mv(workerTracer),
       kj::mv(maybeTriggerInvocationSpan), kj::mv(accessInfo), kj::mv(selfTokenFactory));
@@ -257,7 +257,7 @@ WorkerEntrypoint::WorkerEntrypoint(kj::Badge<WorkerEntrypoint> badge,
     Frankenvalue props,
     kj::Maybe<kj::String> cfBlobJson,
     kj::Maybe<Worker::VersionInfo> versionInfo,
-    kj::Maybe<kj::String> clientIp)
+    kj::Maybe<kj::String> clientAddress)
     : threadContext(threadContext),
       waitUntilTasks(waitUntilTasks),
       canceler(canceler),
@@ -267,7 +267,7 @@ WorkerEntrypoint::WorkerEntrypoint(kj::Badge<WorkerEntrypoint> badge,
       props(kj::mv(props)),
       cfBlobJson(kj::mv(cfBlobJson)),
       versionInfo(kj::mv(versionInfo)),
-      clientIp(kj::mv(clientIp)) {}
+      clientAddress(kj::mv(clientAddress)) {}
 
 void WorkerEntrypoint::init(kj::Own<const Worker> worker,
     kj::Maybe<kj::Own<Worker::Actor>> actor,
@@ -739,11 +739,12 @@ kj::Promise<void> WorkerEntrypoint::connect(kj::StringPtr host,
       context
           .run([this, &headers, &connection, &response, entrypointName = entrypointName.clone(),
                    versionInfo = kj::mv(versionInfo), host = kj::str(host),
-                   clientIp = kj::mv(clientIp)](Worker::Lock& lock, IoContext& context) mutable {
+                   clientAddress = kj::mv(clientAddress)](
+                   Worker::Lock& lock, IoContext& context) mutable {
     jsg::AsyncContextFrame::StorageScope traceScope = context.makeAsyncTraceScope(lock);
     jsg::AsyncContextFrame::StorageScope userTraceScope = context.makeUserAsyncTraceScope(lock);
 
-    return lock.getGlobalScope().connect(kj::mv(host), kj::mv(clientIp), headers, connection,
+    return lock.getGlobalScope().connect(kj::mv(host), kj::mv(clientAddress), headers, connection,
         response, lock,
         lock.getExportedHandler(asPtr(entrypointName), kj::mv(versionInfo), kj::mv(props),
             context.getActor(), isDynamicDispatch));
@@ -1132,13 +1133,13 @@ kj::Own<WorkerInterface> newWorkerEntrypoint(ThreadContext& threadContext,
     kj::Maybe<kj::Own<AccessInfo>> accessInfo,
     kj::Maybe<kj::Own<IoChannelFactory::SelfTokenFactory>> selfTokenFactory,
     Persistent fromPersistentStub,
-    kj::Maybe<kj::String> clientIp) {
+    kj::Maybe<kj::String> clientAddress) {
   return WorkerEntrypoint::construct(threadContext, kj::mv(worker), kj::mv(entrypointName),
       kj::mv(props), kj::mv(actor), kj::mv(limitEnforcer), kj::mv(ioContextDependency),
       kj::mv(ioChannelFactory), kj::mv(metrics), waitUntilTasks, tunnelExceptions,
       kj::mv(workerTracer), kj::mv(cfBlobJson), kj::mv(versionInfo),
       kj::mv(maybeTriggerInvocationSpan), isDynamicDispatch, kj::mv(accessInfo),
-      kj::mv(selfTokenFactory), fromPersistentStub, kj::mv(clientIp));
+      kj::mv(selfTokenFactory), fromPersistentStub, kj::mv(clientAddress));
 }
 
 }  // namespace workerd

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -57,6 +57,8 @@ kj::Own<WorkerInterface> newWorkerEntrypoint(ThreadContext& threadContext,
     // `Persistent::YES` if this request was started on a channel reconstructed from a stored
     // ("persistent") stub. The entrypoint re-verifies that the target worker still has the
     // `allow_irrevocable_stub_storage` compat flag enabled and rejects the request otherwise.
-    Persistent fromPersistentStub = Persistent::NO);
+    Persistent fromPersistentStub = Persistent::NO,
+    // Address of the client on whose behalf this event is being delivered.
+    kj::Maybe<kj::String> clientIp = kj::none);
 
 }  // namespace workerd

--- a/src/workerd/io/worker-entrypoint.h
+++ b/src/workerd/io/worker-entrypoint.h
@@ -58,7 +58,7 @@ kj::Own<WorkerInterface> newWorkerEntrypoint(ThreadContext& threadContext,
     // ("persistent") stub. The entrypoint re-verifies that the target worker still has the
     // `allow_irrevocable_stub_storage` compat flag enabled and rejects the request otherwise.
     Persistent fromPersistentStub = Persistent::NO,
-    // Address of the client on whose behalf this event is being delivered.
-    kj::Maybe<kj::String> clientIp = kj::none);
+    // Address of the client as IP:port on whose behalf this event is being delivered.
+    kj::Maybe<kj::String> clientAddress = kj::none);
 
 }  // namespace workerd

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3965,7 +3965,8 @@ class Server::WorkerService final: public Service,
         kj::none,  // versionInfo
         kj::mv(triggerContext),
         false,  // isDynamicDispatch
-        kj::mv(accessInfo), kj::mv(metadata.restoredSelfTokenFactory), metadata.fromPersistentStub);
+        kj::mv(accessInfo), kj::mv(metadata.restoredSelfTokenFactory), metadata.fromPersistentStub,
+        kj::mv(metadata.clientIp));
   }
 
  private:
@@ -6666,7 +6667,18 @@ class Server::TcpListener final: public kj::Refcounted {
       kj::AuthenticatedStream stream = co_await listener->acceptAuthenticated();
       TRACE_EVENT("workerd", "TcpListener handle connection");
 
+      kj::PeerIdentity* peerId;
+      KJ_IF_SOME(tlsId, kj::tryDowncast<kj::TlsPeerIdentity>(*stream.peerIdentity)) {
+        peerId = &tlsId.getNetworkIdentity();
+      } else {
+        peerId = stream.peerIdentity;
+      }
+
       IoChannelFactory::SubrequestMetadata metadata;
+      KJ_IF_SOME(remote, kj::tryDowncast<kj::NetworkPeerIdentity>(*peerId)) {
+        metadata.clientIp = remote.toString();
+      }
+
       auto req = service->startRequest(kj::mv(metadata));
       auto response = kj::heap<ResponseWrapper>();
       kj::HttpHeaders headers(headerTable);

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -3966,7 +3966,7 @@ class Server::WorkerService final: public Service,
         kj::mv(triggerContext),
         false,  // isDynamicDispatch
         kj::mv(accessInfo), kj::mv(metadata.restoredSelfTokenFactory), metadata.fromPersistentStub,
-        kj::mv(metadata.clientIp));
+        kj::mv(metadata.clientAddress));
   }
 
  private:
@@ -6676,7 +6676,7 @@ class Server::TcpListener final: public kj::Refcounted {
 
       IoChannelFactory::SubrequestMetadata metadata;
       KJ_IF_SOME(remote, kj::tryDowncast<kj::NetworkPeerIdentity>(*peerId)) {
-        metadata.clientIp = remote.toString();
+        metadata.clientAddress = remote.toString();
       }
 
       auto req = service->startRequest(kj::mv(metadata));


### PR DESCRIPTION
This change exposes the IP:port that the client used to initiate a TCP connection, in the TCP connect() handler.
This change is only valid for top-level requests made from workerd (at the moment at least), service binding subrequests will show a `remoteAddress` being `undefined`

Example code showcasing the addition:
```js
// worker-a.js
export default {
  async connect(inbound, env) {
    const inboundInfo = await inbound.opened;

    console.log("Worker A", {
      localAddress: inboundInfo.localAddress,
      remoteAddress: inboundInfo.remoteAddress, // Client IP:port, e.g. 127.0.0.1:49153
    });

    const outbound = env.WORKER_B.connect("worker-b.internal:443");

    await Promise.all([
      inbound.readable.pipeTo(outbound.writable),
      outbound.readable.pipeTo(inbound.writable),
    ]);
  },
};

// worker-b.js
export default {
  async connect(socket) {
    const info = await socket.opened;

    console.log("Worker B", {
      localAddress: info.localAddress,
      remoteAddress: info.remoteAddress, // undefined for subrequest
    });

    await socket.readable.pipeTo(socket.writable);
  },
};
```