### PR TITLE
node:net: add net.Server and cloudflare:node connectHandler

### DIFF
--- a/src/cloudflare/internal/http.ts
+++ b/src/cloudflare/internal/http.ts
@@ -2,43 +2,83 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
+import sockets from 'cloudflare-internal:sockets';
+
 export interface FetchHandler {
   // We don't use typeof fetch here because that would use the client-side signature,
   // which is different from the server-side signature.
   fetch: (request: Request, env?: unknown, ctx?: unknown) => Promise<Response>;
 }
 
+// The platform socket delivered to a worker's connect() handler.
+export interface InboundSocket {
+  opened: Promise<{
+    remoteAddress?: string | null;
+    localAddress?: string | null;
+  }>;
+}
+
+export interface ConnectHandler {
+  // Resolves when the connection is finished; the inbound request lives that long.
+  connect: (
+    socket: InboundSocket,
+    env?: unknown,
+    ctx?: unknown
+  ) => Promise<void>;
+}
+
+export type PortHandler = FetchHandler | ConnectHandler;
+
 type PortEntry = {
+  // 0 for a declared port that no one has claimed.
   refs: number;
   reusePort: boolean;
+  // A port the platform delivers inbound connections on; the entry outlives its binders.
+  declared: boolean;
   // Held strongly: a listening server the user keeps no reference to must stay
-  // routable for the isolate's lifetime, as it would in Node.
-  handler?: FetchHandler;
+  // routable for the scope's lifetime, as it would in Node. Several handlers
+  // share a reusePort entry and are selected round-robin, as SO_REUSEPORT
+  // balances across listeners.
+  handlers: PortHandler[];
 };
 
 const EPHEMERAL_PORT_MIN = 49152;
 const EPHEMERAL_PORT_MAX = 65535;
 
-// Per-isolate virtual local port table for one protocol. The underlying
+// Synthetic addresses from 240.1.0.0/16, a reserved block that is never routed
+// (Hyperdrive's synthetic hosts use 240.0.0.0/16). Every namespace gets a host
+// address so that a connected or accepted socket never reports the unspecified
+// address as its own, and peers the platform does not identify appear behind a
+// single gateway address with distinct ports, as they would behind a NAT.
+const HOST_PREFIX = '240.1.';
+export const GATEWAY_ADDRESS = '240.1.255.254';
+let nextHostSuffix = 1;
+
+function allocateHostAddress(): string {
+  const suffix = nextHostSuffix;
+  // Stay below the gateway at .255.254.
+  nextHostSuffix = suffix >= 0xfffd ? 1 : suffix + 1;
+  return `${HOST_PREFIX}${suffix >> 8}.${suffix & 0xff}`;
+}
+
+// Virtual local port table for one protocol within one scope. The underlying
 // transport does not honor local binding, but explicitly bound ports are
-// recorded and conflict-checked so that they are unique within the isolate,
-// and an entry may carry the handler that inbound sockets on that port are
-// routed to.
+// recorded and conflict-checked so that they are unique within the scope, and
+// an entry may carry the handlers that inbound sockets on that port are routed
+// to.
 export class PortTable {
+  // The namespace's own address, reported where Linux would report the
+  // interface a connection actually uses.
+  readonly hostAddress = allocateHostAddress();
   #entries = new Map<number, PortEntry>();
   #nextEphemeral = EPHEMERAL_PORT_MIN;
   // Backstop for socket owners that are never closed: a request's IoContext
   // teardown runs no JS, so a socket it strands would otherwise hold its entry
-  // for the isolate's lifetime. Deterministic release by the owner remains
+  // for the scope's lifetime. Deterministic release by the owner remains
   // primary. Listening servers are not registered; their entry is meant to
   // outlive any reference to them.
   // FinalizationRegistry is absent on compat dates before enable_weak_ref.
-  #registry =
-    typeof FinalizationRegistry === 'function'
-      ? new FinalizationRegistry<number>((port) => {
-          this.release(port);
-        })
-      : undefined;
+  #registry: FinalizationRegistry<number> | undefined;
 
   // Next ephemeral port that is not recorded. This is a label, not a
   // reservation: autobound sockets whose request ends before they are destroyed
@@ -54,12 +94,52 @@ export class PortTable {
     return 0;
   }
 
+  // Marks port as one the platform delivers inbound connections on.
+  declare(port: number): void {
+    if (!this.#entries.has(port)) {
+      this.#entries.set(port, {
+        refs: 0,
+        reusePort: false,
+        declared: true,
+        handlers: [],
+      });
+    }
+  }
+
+  hasDeclared(): boolean {
+    for (const entry of this.#entries.values()) {
+      if (entry.declared) return true;
+    }
+    return false;
+  }
+
+  isDeclared(port: number): boolean {
+    return this.#entries.get(port)?.declared ?? false;
+  }
+
+  // The first declared port with no binder, or 0.
+  unclaimedDeclared(): number {
+    for (const [port, entry] of this.#entries) {
+      if (entry.declared && entry.refs === 0) return port;
+    }
+    return 0;
+  }
+
   // Records port, or shares it when both the holder and this binder set
-  // reusePort. Returns false on conflict.
+  // reusePort. An unclaimed declared port is claimable. Returns false on
+  // conflict.
   tryBind(port: number, reusePort = false): boolean {
     const entry = this.#entries.get(port);
     if (entry === undefined) {
-      this.#entries.set(port, { refs: 1, reusePort });
+      this.#entries.set(port, {
+        refs: 1,
+        reusePort,
+        declared: false,
+        handlers: [],
+      });
+    } else if (entry.refs === 0) {
+      entry.refs = 1;
+      entry.reusePort = reusePort;
     } else if (entry.reusePort && reusePort) {
       entry.refs++;
     } else {
@@ -71,28 +151,75 @@ export class PortTable {
   release(port: number): void {
     const entry = this.#entries.get(port);
     if (entry !== undefined && --entry.refs === 0) {
-      this.#entries.delete(port);
+      if (entry.declared) {
+        entry.handlers = [];
+      } else {
+        this.#entries.delete(port);
+      }
     }
   }
 
   // Releases port when owner is collected without having released it. An owner
   // must unregister before releasing so the entry is never decremented twice.
   register(owner: object, port: number): void {
-    this.#registry?.register(owner, port, owner);
+    if (this.#registry === undefined) {
+      if (typeof FinalizationRegistry !== 'function') return;
+      this.#registry = new FinalizationRegistry<number>((p) => {
+        this.release(p);
+      });
+    }
+    this.#registry.register(owner, port, owner);
   }
 
   unregister(owner: object): void {
     this.#registry?.unregister(owner);
   }
 
-  setHandler(port: number, handler: FetchHandler): void {
-    const entry = this.#entries.get(port);
-    if (entry !== undefined) entry.handler = handler;
+  setHandler(port: number, handler: PortHandler): void {
+    this.#entries.get(port)?.handlers.push(handler);
   }
 
-  getHandler(port: number): FetchHandler | undefined {
-    return this.#entries.get(port)?.handler;
+  clearHandler(port: number, handler: PortHandler): void {
+    const entry = this.#entries.get(port);
+    if (entry === undefined) return;
+    const i = entry.handlers.indexOf(handler);
+    if (i !== -1) entry.handlers.splice(i, 1);
+  }
+
+  getHandler(port: number): PortHandler | undefined {
+    const entry = this.#entries.get(port);
+    if (entry === undefined || entry.handlers.length === 0) return undefined;
+    const handler = entry.handlers.shift() as PortHandler;
+    entry.handlers.push(handler);
+    return handler;
   }
 }
 
-export const tcpPorts = new PortTable();
+// A Durable Object instance has its own table for its lifetime and binds ports
+// as a separate host would; everything else in the isolate shares one table,
+// seeded with the ports the platform delivers inbound connections on, so that a
+// server is reachable from every request.
+const isolateTcpPorts = new PortTable();
+for (const listener of sockets.getInboundListeners()) {
+  if (listener.protocol === 'tcp') isolateTcpPorts.declare(listener.port);
+}
+const scopedTcpPorts = new WeakMap<object, PortTable>();
+
+// The TCP port table for the current scope. Owners capture the table they bound
+// in and release through it: release may run in another request's context, or
+// in none at all.
+export function tcpPorts(): PortTable {
+  const key = sockets.getPortScopeKey();
+  if (key === undefined) return isolateTcpPorts;
+  let table = scopedTcpPorts.get(key);
+  if (table === undefined) {
+    table = new PortTable();
+    scopedTcpPorts.set(key, table);
+  }
+  return table;
+}
+
+// Inbound routing: a Durable Object's table shadows the isolate table.
+export function lookupHandler(port: number): PortHandler | undefined {
+  return tcpPorts().getHandler(port) ?? isolateTcpPorts.getHandler(port);
+}

--- a/src/cloudflare/internal/sockets.d.ts
+++ b/src/cloudflare/internal/sockets.d.ts
@@ -34,3 +34,15 @@ export function connect(
 ): Socket;
 
 export function internalNewHttpClient(socket: Socket): Promise<ServiceStub>;
+
+// Identity for the current Durable Object's port scope; undefined when not in one.
+export function getPortScopeKey(): object | undefined;
+
+export type InboundListener = {
+  protocol: 'tcp' | 'udp';
+  address: string;
+  port: number;
+};
+
+// The inbound socket listeners configured to deliver connections to this worker.
+export function getInboundListeners(): InboundListener[];

--- a/src/cloudflare/node.ts
+++ b/src/cloudflare/node.ts
@@ -4,6 +4,8 @@
 import {
   lookupHandler,
   type FetchHandler as Fetcher,
+  type ConnectHandler,
+  type InboundSocket,
 } from 'cloudflare-internal:http';
 
 interface ServerDescriptor {
@@ -12,7 +14,7 @@ interface ServerDescriptor {
 
 interface NodeStyleServer {
   listen(...args: unknown[]): this;
-  address(): { port?: number | null | undefined };
+  address(): { port?: number | null | undefined } | null;
 }
 
 function validatePort(port: unknown): number {
@@ -24,6 +26,65 @@ function validatePort(port: unknown): number {
     throw new Error('Failed to determine port for server');
   }
   return port as number;
+}
+
+function invalidArg(message: string): Error {
+  const error = new Error(message);
+  // @ts-expect-error TS2339 We're imitating Node.js errors.
+  error.code = 'ERR_INVALID_ARG_VALUE';
+  return error;
+}
+
+// Resolves the port a descriptor refers to: a number, { port }, or a Node-style
+// server, which is started with listen() if it has no address yet.
+function resolvePort(
+  desc: number | ServerDescriptor | NodeStyleServer
+): number {
+  if (typeof desc === 'number') {
+    desc = { port: desc };
+  }
+  // While the TypeScript type system prevents `desc` from being null or undefined,
+  // JavaScript does not, so we need to check for it at runtime.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (desc == null) {
+    throw new Error('Server descriptor cannot be null or undefined');
+  }
+
+  let port: number | null = null;
+  if (
+    (desc as ServerDescriptor).port == null &&
+    typeof (desc as NodeStyleServer).listen === 'function'
+  ) {
+    const server = desc as NodeStyleServer;
+    let serverPort = server.address()?.port;
+    if (typeof serverPort === 'number') {
+      port = serverPort;
+    } else {
+      // listen() assigns the port synchronously.
+      server.listen();
+      serverPort = server.address()?.port;
+      if (typeof serverPort === 'number') {
+        port = serverPort;
+      }
+    }
+  } else if (typeof (desc as ServerDescriptor).port === 'number') {
+    port = (desc as ServerDescriptor).port as number;
+  }
+
+  return validatePort(port);
+}
+
+// The port of an inbound socket is the port of its declared local address: the
+// CONNECT authority for a service binding, or the listener address for a
+// sockets entry.
+function portFromAuthority(authority: string | null | undefined): number {
+  const m = typeof authority === 'string' ? /:(\d+)$/.exec(authority) : null;
+  if (m === null) {
+    throw new Error(
+      `Failed to determine port for inbound socket from local address ${String(authority)}`
+    );
+  }
+  return validatePort(Number(m[1]));
 }
 
 export async function handleAsNodeRequest(
@@ -41,75 +102,51 @@ export async function handleAsNodeRequest(
   const port = validatePort(desc?.port);
   const instance = lookupHandler(port);
   if (!instance || !('fetch' in instance)) {
-    const error = new Error(
+    throw invalidArg(
       `Http server with port ${port} not found. This is likely a bug with your code. ` +
         `You should check if server.listen() was called with the same port (${port})`
     );
-    // @ts-expect-error TS2339 We're imitating Node.js errors.
-    error.code = 'ERR_INVALID_ARG_VALUE';
-    throw error;
   }
   return await instance.fetch(request, env, ctx);
+}
+
+// Routes an inbound platform socket to the net.Server listening on the port the
+// socket arrived on. Resolves when the connection is finished.
+export async function handleAsNodeConnection(
+  socket: InboundSocket,
+  env?: unknown,
+  ctx?: unknown
+): Promise<void> {
+  const port = portFromAuthority((await socket.opened).localAddress);
+  const instance = lookupHandler(port);
+  if (!instance || !('connect' in instance)) {
+    throw invalidArg(
+      `No net.Server is listening on port ${port}. Call server.listen(${port}) to accept ` +
+        `connections arriving on that port.`
+    );
+  }
+  await instance.connect(socket, env, ctx);
+}
+
+export function connectHandler(): ConnectHandler {
+  return {
+    async connect(
+      socket: InboundSocket,
+      env?: unknown,
+      ctx?: unknown
+    ): Promise<void> {
+      await handleAsNodeConnection(socket, env, ctx);
+    },
+  };
 }
 
 export function httpServerHandler(
   desc: number | ServerDescriptor | NodeStyleServer
 ): Fetcher {
-  if (typeof desc === 'number') {
-    desc = { port: desc };
-  }
-  // While the TypeScript type system prevents `desc` from being null or undefined,
-  // JavaScript does not, so we need to check for it at runtime.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (desc == null) {
-    throw new Error('Server descriptor cannot be null or undefined');
-  }
-
-  // The desc can be a ServerDescriptor or a Server (where "Server" is defined
-  // as a type that has a "listen()" method and an "address()" method).
-  let port: number | null = null;
-
-  // If there is no port defined and desc has a listen method, we will try to
-  // access it as a Server, calling listen() if necessary to determine the port.
-  if (
-    (desc as ServerDescriptor).port == null &&
-    typeof (desc as NodeStyleServer).listen === 'function'
-  ) {
-    const server = desc as NodeStyleServer;
-    // First, let's see if the server-like thing already has a port.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    let serverPort = server.address()?.port;
-    if (typeof serverPort === 'number') {
-      // Nice, we're already bound to a port.
-      port = serverPort;
-    } else {
-      // We're not yet bound to a port. Try calling listen() to start the server
-      // and determine the port.
-      server.listen();
-      // Did it work? We do expect the listen in this case to synchronously
-      // assign the port so we can check it immediately.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      serverPort = server.address()?.port;
-      if (typeof serverPort === 'number') {
-        // Nice. We've got a port now.
-        port = serverPort;
-      }
-    }
-  } else if (typeof (desc as ServerDescriptor).port === 'number') {
-    // We're a ServerDescriptor with a port defined.
-    port = (desc as ServerDescriptor).port as number;
-  }
-
-  port = validatePort(port);
-
+  const port = resolvePort(desc);
   return {
     async fetch(req: Request, env?: unknown, ctx?: unknown): Promise<Response> {
-      return await handleAsNodeRequest(
-        { port: validatePort(port) },
-        req,
-        env,
-        ctx
-      );
+      return await handleAsNodeRequest({ port }, req, env, ctx);
     },
   };
 }

--- a/src/cloudflare/node.ts
+++ b/src/cloudflare/node.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 import {
-  tcpPorts,
+  lookupHandler,
   type FetchHandler as Fetcher,
 } from 'cloudflare-internal:http';
 
@@ -39,8 +39,8 @@ export async function handleAsNodeRequest(
   // JavaScript does not enforce this, so we need to check at runtime.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const port = validatePort(desc?.port);
-  const instance = tcpPorts.getHandler(port);
-  if (!instance) {
+  const instance = lookupHandler(port);
+  if (!instance || !('fetch' in instance)) {
     const error = new Error(
       `Http server with port ${port} not found. This is likely a bug with your code. ` +
         `You should check if server.listen() was called with the same port (${port})`

--- a/src/node/internal/http.d.ts
+++ b/src/node/internal/http.d.ts
@@ -6,14 +6,40 @@ export interface FetchHandler {
   fetch: (request: Request, env?: unknown, ctx?: unknown) => Promise<Response>;
 }
 
+export interface InboundSocket {
+  opened: Promise<{
+    remoteAddress?: string | null;
+    localAddress?: string | null;
+  }>;
+}
+
+export interface ConnectHandler {
+  connect: (
+    socket: InboundSocket,
+    env?: unknown,
+    ctx?: unknown
+  ) => Promise<void>;
+}
+
+export type PortHandler = FetchHandler | ConnectHandler;
+
+export const GATEWAY_ADDRESS: string;
+
 export class PortTable {
+  readonly hostAddress: string;
   ephemeral(): number;
+  declare(port: number): void;
+  hasDeclared(): boolean;
+  isDeclared(port: number): boolean;
+  unclaimedDeclared(): number;
   tryBind(port: number, reusePort?: boolean): boolean;
   release(port: number): void;
   register(owner: object, port: number): void;
   unregister(owner: object): void;
-  setHandler(port: number, handler: FetchHandler): void;
-  getHandler(port: number): FetchHandler | undefined;
+  setHandler(port: number, handler: PortHandler): void;
+  clearHandler(port: number, handler: PortHandler): void;
+  getHandler(port: number): PortHandler | undefined;
 }
 
-export const tcpPorts: PortTable;
+export function tcpPorts(): PortTable;
+export function lookupHandler(port: number): PortHandler | undefined;

--- a/src/node/internal/internal_errors.ts
+++ b/src/node/internal/internal_errors.ts
@@ -691,6 +691,18 @@ export class EADDRINUSE extends NodeError {
   }
 }
 
+export class EADDRNOTAVAIL extends NodeError {
+  syscall = 'bind';
+  address: string;
+  port: number;
+
+  constructor(address: string, port: number) {
+    super('EADDRNOTAVAIL', `bind EADDRNOTAVAIL ${address}:${port}`);
+    this.address = address;
+    this.port = port;
+  }
+}
+
 export class EPIPE extends NodeError {
   constructor() {
     super('EPIPE', 'This socket has been ended by the other party');
@@ -1023,6 +1035,12 @@ export class ERR_SERVER_ALREADY_LISTEN extends NodeError {
       'ERR_SERVER_ALREADY_LISTEN',
       'Listen method has been called more than once without closing.'
     );
+  }
+}
+
+export class ERR_SERVER_NOT_RUNNING extends NodeError {
+  constructor() {
+    super('ERR_SERVER_NOT_RUNNING', 'Server is not running.');
   }
 }
 

--- a/src/node/internal/internal_http_server.ts
+++ b/src/node/internal/internal_http_server.ts
@@ -22,6 +22,7 @@ import {
   ERR_OUT_OF_RANGE,
   ERR_OPTION_NOT_IMPLEMENTED,
   ERR_SERVER_ALREADY_LISTEN,
+  EADDRINUSE,
 } from 'node-internal:internal_errors';
 import { EventEmitter } from 'node-internal:events';
 import { getDefaultHighWaterMark } from 'node-internal:streams_state';
@@ -38,7 +39,7 @@ import {
   validatePort,
   validateNumber,
 } from 'node-internal:validators';
-import { tcpPorts } from 'cloudflare-internal:http';
+import { tcpPorts, type PortTable } from 'cloudflare-internal:http';
 import {
   IncomingMessage,
   setIncomingMessageSocket,
@@ -133,6 +134,9 @@ export class Server
   keepAliveTimeoutBuffer: number = 1_000;
   highWaterMark: number = getDefaultHighWaterMark();
   #port: number | null = null;
+  // The port table the server bound in; release goes through it since close()
+  // may run in another request's context.
+  #table: PortTable | null = null;
 
   constructor(options?: ServerOptions, requestListener?: RequestListener) {
     if (!enableNodejsHttpServerModules) {
@@ -176,8 +180,9 @@ export class Server
   close(callback?: VoidFunction): this {
     httpServerPreClose(this);
     if (this.#port != null) {
-      tcpPorts.release(this.#port);
+      (this.#table as PortTable).release(this.#port);
       this.#port = null;
+      this.#table = null;
     }
     if (typeof callback === 'function') {
       this.once('close', callback);
@@ -301,11 +306,17 @@ export class Server
       this.once('listening', callback as (...args: unknown[]) => unknown);
     }
 
-    this.#port = bindPort(
-      typeof options.host === 'string' ? options.host : '127.0.0.1',
-      port
-    );
-    tcpPorts.setHandler(this.#port, { fetch: this.#onRequest.bind(this) });
+    const table = tcpPorts();
+    const host = typeof options.host === 'string' ? options.host : '127.0.0.1';
+    // An http server is reached through httpServerHandler rather than an
+    // inbound connect listener, so port 0 never takes a declared port.
+    if (port === 0) {
+      port = table.ephemeral();
+      if (port === 0) throw new EADDRINUSE(host, port);
+    }
+    this.#port = bindPort(table, host, port);
+    this.#table = table;
+    table.setHandler(this.#port, { fetch: this.#onRequest.bind(this) });
     queueMicrotask(() => {
       // If any of the listening handlers (here and in any of the other queueMicrotask(...) instances here,
       // if the listening handlers throw an error, that will end up being reported to

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -26,7 +26,14 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 
 import inner from 'cloudflare-internal:sockets';
-import { tcpPorts, type PortTable } from 'cloudflare-internal:http';
+import {
+  tcpPorts,
+  GATEWAY_ADDRESS,
+  type ConnectHandler,
+  type InboundSocket,
+  type PortTable,
+} from 'cloudflare-internal:http';
+import { EventEmitter } from 'node-internal:events';
 
 import {
   AbortError,
@@ -39,9 +46,12 @@ import {
   ERR_SOCKET_CLOSED_BEFORE_CONNECTION,
   ERR_SOCKET_CONNECTING,
   ERR_SOCKET_HANDLE_ADOPTED,
+  ERR_SERVER_ALREADY_LISTEN,
+  ERR_SERVER_NOT_RUNNING,
   ERR_INVALID_IP_ADDRESS,
   ERR_INVALID_ADDRESS,
   EADDRINUSE,
+  EADDRNOTAVAIL,
   EPIPE,
 } from 'node-internal:internal_errors';
 
@@ -112,9 +122,29 @@ const kBoundSocketConsume = Symbol('kBoundSocketConsume');
 const DEFAULT_IPV4_ADDR = '0.0.0.0';
 const DEFAULT_IPV6_ADDR = '::';
 
-// Reserves port in table (shared with http servers). Port 0 takes an unclaimed
-// declared port when the platform declares any, else an ephemeral one. Throws
-// EADDRINUSE on conflict.
+function isWildcard(address: string): boolean {
+  return address === DEFAULT_IPV4_ADDR || address === DEFAULT_IPV6_ADDR;
+}
+
+// A synthetic IPv4 address in the form the given family reports it.
+function forFamily(address: string, family: string | undefined): string {
+  return family === 'IPv6' ? `::ffff:${address}` : address;
+}
+
+// The concrete address a socket bound to the wildcard reports once connected
+// or accepted: the namespace's host address, as Linux reports the interface
+// the connection uses.
+function concreteLocal(
+  bound: LocalAddressInfo,
+  table: PortTable
+): LocalAddressInfo {
+  if (!isWildcard(bound.address)) return bound;
+  return { ...bound, address: forFamily(table.hostAddress, bound.family) };
+}
+
+// Reserves port in table (shared with http servers), allocating an ephemeral
+// port for 0. Throws EADDRINUSE on conflict. Binding is role-neutral, so a
+// declared listener port is never taken here; Server.listen() claims one.
 export function bindPort(
   table: PortTable,
   address: string,
@@ -122,7 +152,7 @@ export function bindPort(
   reusePort = false
 ): number {
   if (port === 0) {
-    port = table.hasDeclared() ? table.unclaimedDeclared() : table.ephemeral();
+    port = table.ephemeral();
     if (port === 0) throw new EADDRINUSE(address, port);
   }
   if (!table.tryBind(port, reusePort)) {
@@ -135,7 +165,7 @@ function releaseBoundSource(socket: Socket): void {
   const table = socket[kBoundTable];
   if (table !== null) {
     table.unregister(socket);
-    table.release((socket[kBoundSource] as AddressInfo).port);
+    table.release((socket[kBoundSource] as LocalAddressInfo).port);
     socket[kBoundTable] = null;
   }
   socket[kBoundSource] = null;
@@ -199,6 +229,9 @@ export type BoundSocketOptions = {
 export class BoundSocket {
   #address: AddressInfo | null;
   #table = tcpPorts();
+  // Bound with port 0, so a server adopting it may re-home it onto a declared
+  // listener port.
+  #ephemeral: boolean;
 
   static isBoundSocket(value: unknown): value is BoundSocket {
     return typeof value === 'object' && value !== null && #address in value;
@@ -216,6 +249,7 @@ export class BoundSocket {
     }
 
     const port = validatePort(options.port ?? 0, 'options.port');
+    this.#ephemeral = port === 0;
 
     const ipv6Only = options.ipv6Only ?? false;
     validateBoolean(ipv6Only, 'options.ipv6Only');
@@ -280,19 +314,381 @@ export class BoundSocket {
   }
 
   // Transfers the reservation, and the table it lives in, to the adopter.
-  [kBoundSocketConsume](): { address: AddressInfo; table: PortTable } {
+  [kBoundSocketConsume](): {
+    address: AddressInfo;
+    table: PortTable;
+    ephemeral: boolean;
+  } {
     if (this.#address === null) {
       throw new ERR_SOCKET_HANDLE_ADOPTED();
     }
     this.#table.unregister(this);
     const address = this.#address;
     this.#address = null;
-    return { address, table: this.#table };
+    return { address, table: this.#table, ephemeral: this.#ephemeral };
   }
 }
 
-export function Server(): void {
-  throw new Error('Server is not implemented');
+// A local endpoint label. The address may be a hostname when it came from a
+// CONNECT authority or a listen() host, in which case the family is unknown.
+export type LocalAddressInfo = Omit<AddressInfo, 'family'> & {
+  family?: string;
+};
+
+function familyOf(address: string): string | undefined {
+  switch (isIP(address)) {
+    case 4:
+      return 'IPv4';
+    case 6:
+      return 'IPv6';
+    default:
+      return undefined;
+  }
+}
+
+// Splits a "host:port" / "[v6]:port" authority; "*" is the wildcard.
+function parseAuthority(
+  authority: string | null | undefined
+): LocalAddressInfo | null {
+  if (typeof authority !== 'string') return null;
+  const m = /^\[?([^\]]*?)\]?:(\d+)$/.exec(authority);
+  if (m === null) return null;
+  const address = m[1] === '*' ? DEFAULT_IPV4_ADDR : (m[1] as string);
+  const info: LocalAddressInfo = { address, port: Number(m[2]) };
+  const family = familyOf(address);
+  if (family !== undefined) info.family = family;
+  return info;
+}
+
+export type ServerOptions = {
+  allowHalfOpen?: boolean;
+  pauseOnConnect?: boolean;
+  noDelay?: boolean;
+  keepAlive?: boolean;
+  keepAliveInitialDelay?: number;
+  highWaterMark?: number;
+};
+
+type ListenOptions = {
+  port?: number | string;
+  host?: string;
+  path?: string;
+  backlog?: number;
+  exclusive?: boolean;
+  ipv6Only?: boolean;
+  reusePort?: boolean;
+  handle?: unknown;
+  fd?: number;
+};
+
+// A listening server reserves its port in the isolate's TCP port table and
+// installs a connect handler there. Inbound platform sockets are routed to it
+// by local port (see connectHandler in cloudflare:node) and wrapped as
+// net.Sockets; the platform owns the local endpoint, so nothing is released
+// per connection.
+export class Server extends EventEmitter {
+  #address: LocalAddressInfo | null = null;
+  #table: PortTable | null = null;
+  #connections = 0;
+  #closing = false;
+  #handler: ConnectHandler = {
+    connect: (socket: InboundSocket): Promise<void> =>
+      this.#onConnection(socket as ReturnType<typeof inner.connect>),
+  };
+
+  allowHalfOpen: boolean;
+  pauseOnConnect: boolean;
+  noDelay: boolean;
+  keepAlive: boolean;
+  keepAliveInitialDelay: number;
+  highWaterMark: number | undefined;
+  maxConnections: number | undefined = undefined;
+
+  constructor(
+    options?: ServerOptions | ((socket: Socket) => void),
+    connectionListener?: (socket: Socket) => void
+  ) {
+    super();
+    if (typeof options === 'function') {
+      connectionListener = options;
+      options = {};
+    } else if (options == null) {
+      options = {};
+    } else {
+      validateObject(options, 'options');
+    }
+    if (connectionListener !== undefined) {
+      validateFunction(connectionListener, 'connectionListener');
+      this.on('connection', connectionListener);
+    }
+    let keepAliveInitialDelay = options.keepAliveInitialDelay;
+    if (keepAliveInitialDelay !== undefined) {
+      validateNumber(keepAliveInitialDelay, 'options.keepAliveInitialDelay');
+      if (keepAliveInitialDelay < 0) keepAliveInitialDelay = 0;
+    }
+    this.allowHalfOpen = options.allowHalfOpen ?? false;
+    this.pauseOnConnect = Boolean(options.pauseOnConnect);
+    this.noDelay = Boolean(options.noDelay);
+    this.keepAlive = Boolean(options.keepAlive);
+    this.keepAliveInitialDelay = ~~((keepAliveInitialDelay ?? 0) / 1000);
+    this.highWaterMark = options.highWaterMark;
+  }
+
+  listen(...args: unknown[]): this {
+    const [options, cb] = _normalizeArgs(args) as [
+      ListenOptions | BoundSocket,
+      ((...args: unknown[]) => void) | null,
+    ];
+    if (this.#address !== null) {
+      throw new ERR_SERVER_ALREADY_LISTEN();
+    }
+    if (cb !== null) {
+      this.once('listening', cb);
+    }
+
+    let bound: BoundSocket | null = null;
+    if (BoundSocket.isBoundSocket(options)) {
+      bound = options;
+    } else if (BoundSocket.isBoundSocket(options.handle)) {
+      bound = options.handle;
+    }
+
+    const fail = (err: Error): this => {
+      queueMicrotask(() => {
+        this.emit('error', err);
+      });
+      return this;
+    };
+
+    let address: LocalAddressInfo;
+    let table: PortTable;
+    if (bound !== null) {
+      // Adoption transfers the reservation to the server.
+      let ephemeral: boolean;
+      ({ address, table, ephemeral } = bound[kBoundSocketConsume]());
+      if (table.hasDeclared() && !table.isDeclared(address.port)) {
+        table.release(address.port);
+        if (!ephemeral) {
+          return fail(new EADDRNOTAVAIL(address.address, address.port));
+        }
+        // A socket bound with port 0 becomes a listener on a declared port,
+        // so new BoundSocket() + listen(bound) lands where connections arrive.
+        const declared = table.unclaimedDeclared();
+        if (declared === 0 || !table.tryBind(declared)) {
+          return fail(new EADDRINUSE(address.address, 0));
+        }
+        address = { ...address, port: declared };
+      }
+    } else {
+      const opts = options as ListenOptions;
+      if (opts.path != null) {
+        throw new ERR_INVALID_ARG_VALUE(
+          'options.path',
+          opts.path,
+          'is not supported'
+        );
+      }
+      if (opts.handle != null || opts.fd != null) {
+        throw new ERR_INVALID_ARG_VALUE(
+          'options',
+          options,
+          'only a net.BoundSocket handle is supported'
+        );
+      }
+      let port =
+        opts.port == null ? 0 : validatePort(opts.port, 'options.port');
+      const reusePort = opts.reusePort ?? false;
+      validateBoolean(reusePort, 'options.reusePort');
+      let host = opts.host;
+      if (host === undefined) {
+        host = opts.ipv6Only ? DEFAULT_IPV6_ADDR : DEFAULT_IPV4_ADDR;
+      } else {
+        validateString(host, 'options.host');
+        if (host === 'localhost') host = '127.0.0.1';
+      }
+      table = tcpPorts();
+      // Where the platform declares the ports it delivers connections on, a
+      // server can only listen on one of them, and port 0 takes the first
+      // unclaimed one.
+      if (table.hasDeclared()) {
+        if (port === 0) {
+          port = table.unclaimedDeclared();
+          if (port === 0) return fail(new EADDRINUSE(host, 0));
+        } else if (!table.isDeclared(port)) {
+          return fail(new EADDRNOTAVAIL(host, port));
+        }
+      }
+      let boundPort: number;
+      try {
+        boundPort = bindPort(table, host, port, reusePort);
+      } catch (err) {
+        return fail(err as Error);
+      }
+      address = { address: host, port: boundPort };
+      const family = familyOf(host);
+      if (family !== undefined) address.family = family;
+    }
+
+    this.#address = address;
+    this.#table = table;
+    // A pending close from a previous listen is cancelled.
+    this.#closing = false;
+    table.setHandler(address.port, this.#handler);
+    queueMicrotask(() => {
+      this.emit('listening');
+    });
+    return this;
+  }
+
+  address(): LocalAddressInfo | null {
+    return this.#address === null ? null : { ...this.#address };
+  }
+
+  get listening(): boolean {
+    return this.#address !== null;
+  }
+
+  close(cb?: (err?: Error) => void): this {
+    if (typeof cb === 'function') {
+      if (this.#address === null) {
+        this.once('close', () => {
+          cb(new ERR_SERVER_NOT_RUNNING());
+        });
+      } else {
+        this.once('close', cb);
+      }
+    }
+    if (this.#address !== null) {
+      const table = this.#table as PortTable;
+      table.clearHandler(this.#address.port, this.#handler);
+      table.release(this.#address.port);
+      this.#address = null;
+      this.#table = null;
+    }
+    this.#closing = true;
+    this.#maybeEmitClose();
+    return this;
+  }
+
+  // 'close' fires once the server is not listening and no connection remains.
+  #maybeEmitClose(): void {
+    if (this.#closing && this.#address === null && this.#connections === 0) {
+      this.#closing = false;
+      queueMicrotask(() => {
+        this.emit('close');
+      });
+    }
+  }
+
+  getConnections(cb: (err: Error | null, count: number) => void): this {
+    validateFunction(cb, 'cb');
+    const count = this.#connections;
+    queueMicrotask(() => {
+      cb(null, count);
+    });
+    return this;
+  }
+
+  ref(): this {
+    return this;
+  }
+
+  unref(): this {
+    return this;
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    if (this.#address === null) return;
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    const { promise, resolve } = Promise.withResolvers<void>();
+    this.close(() => {
+      resolve();
+    });
+    await promise;
+  }
+
+  async #onConnection(handle: ReturnType<typeof inner.connect>): Promise<void> {
+    const info = await handle.opened;
+    if (this.#address === null) {
+      await handle.close();
+      return;
+    }
+    // The accepted socket's local endpoint is the server's bound address, as
+    // with an accepted fd; the CONNECT authority only routed it here. A peer
+    // the platform does not report (a service binding's) appears behind the
+    // gateway address with its own port, since a connected socket always has
+    // a distinct peer.
+    const table = this.#table as PortTable;
+    const localAddress = concreteLocal(this.#address, table);
+    const remoteAddress: LocalAddressInfo = parseAuthority(
+      info.remoteAddress
+    ) ?? {
+      address: forFamily(GATEWAY_ADDRESS, localAddress.family),
+      family: localAddress.family ?? 'IPv4',
+      port: table.ephemeral(),
+    };
+    if (
+      this.maxConnections !== undefined &&
+      this.#connections >= this.maxConnections
+    ) {
+      this.emit('drop', {
+        localAddress: localAddress.address,
+        localPort: localAddress.port,
+        localFamily: localAddress.family,
+        remoteAddress: remoteAddress.address,
+        remotePort: remoteAddress.port,
+        remoteFamily: remoteAddress.family,
+      });
+      await handle.close();
+      return;
+    }
+
+    const socket = new Socket({
+      allowHalfOpen: this.allowHalfOpen,
+      highWaterMark: this.highWaterMark,
+    } as SocketOptions);
+    socket._handle = {
+      socket: handle,
+      writer: handle.writable.getWriter(),
+      reader: handle.readable.getReader({ mode: 'byob' }),
+      bytesRead: 0,
+      bytesWritten: 0,
+      reading: false,
+      options: {
+        host: remoteAddress.address,
+        port: remoteAddress.port,
+        addressType: isIP(remoteAddress.address),
+      },
+    };
+    socket[kSocketInfo] = { remoteAddress: { ...remoteAddress } };
+    socket[kBoundSource] = localAddress;
+    socket.server = this;
+    socket._server = this;
+    socket.connecting = false;
+    socket._undestroy();
+
+    this.#connections++;
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    socket.once('close', () => {
+      resolve();
+    });
+    handle.closed.then(onConnectionClosed.bind(socket), (err: unknown) => {
+      socket.destroy(err as Error);
+    });
+
+    if (this.pauseOnConnect) {
+      socket.pause();
+    }
+    this.emit('connection', socket);
+    if (!socket.isPaused() && !socket._handle.reading) {
+      tryReadStart(socket);
+    }
+
+    await closed;
+    this.#connections--;
+    this.#maybeEmitClose();
+  }
 }
 
 export type SocketWriteData = Array<{
@@ -329,8 +725,10 @@ export declare class Socket extends _Socket {
   };
   [kBytesRead]: number;
   [kBytesWritten]: number;
-  [kBoundSource]: AddressInfo | null;
+  [kBoundSource]: LocalAddressInfo | null;
   [kBoundTable]: PortTable | null;
+  server: Server | null;
+  _server: Server | null;
   [kReinitializeHandle](handle: Socket['_handle']): void;
   _closeAfterHandlingError: boolean;
   _handle: null | {
@@ -477,6 +875,8 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
   this[kBytesWritten] = 0;
   this[kBoundSource] = null;
   this[kBoundTable] = null;
+  this.server = null;
+  this._server = null;
   this._closeAfterHandlingError = false;
   // @ts-expect-error TS2540 Required due to types
   this.autoSelectFamilyAttemptedAddresses = [];
@@ -1407,6 +1807,14 @@ function initializeConnection(
           table.register(socket, socket[kBoundSource].port);
         }
       }
+      // connect(2) resolves a wildcard bind to the source address actually
+      // used. The platform does not report an outbound socket's source
+      // (SocketInfo.localAddress is empty for outbound sockets); if it did, it
+      // would replace the synthetic host address here, from handle.opened.
+      socket[kBoundSource] = concreteLocal(
+        socket[kBoundSource],
+        socket[kBoundTable] ?? tcpPorts()
+      );
 
       const handle = inner.connect(`${host}:${port}`, {
         allowHalfOpen: socket.allowHalfOpen,
@@ -1802,8 +2210,11 @@ export function connect(...args: unknown[]): Socket {
 
 export const createConnection = connect;
 
-export function createServer(): void {
-  throw new Error('createServer() is not implemented');
+export function createServer(
+  options?: ServerOptions | ((socket: Socket) => void),
+  connectionListener?: (socket: Socket) => void
+): Server {
+  return new Server(options, connectionListener);
 }
 
 export function getDefaultAutoSelectFamily(): boolean {

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -1019,9 +1019,15 @@ Socket.prototype.connect = function (
   // This ensures that the previous handle is closed before initializing a new one.
   if (this._handle) {
     // A reconnect is a new underlying socket, so the previous local endpoint
-    // is dropped and the new connection autobinds.
+    // is dropped and the new connection autobinds. The old handle is detached
+    // first so that its EOF and close do not end this socket; writes buffer
+    // until the new connection opens.
     releaseBoundSource(this);
-    this._handle.socket.close().then(
+    const old = this._handle;
+    this._handle = null;
+    old.reading = false;
+    this.connecting = true;
+    old.socket.close().then(
       () => {
         initializeConnection(this, options);
       },
@@ -1425,7 +1431,13 @@ function initializeConnection(
       });
 
       handle.closed.then(
-        onConnectionClosed.bind(socket),
+        (): void => {
+          // A reconnect may have replaced the handle by the time the previous
+          // one reports closed.
+          if (socket._handle?.socket === handle) {
+            onConnectionClosed.call(socket);
+          }
+        },
         (error: unknown): void => {
           // Do not call socket.destroy.bind(socket) since user can override it.
           socket.destroy(error as Error);
@@ -1506,17 +1518,21 @@ export function onConnectionClosed(this: Socket): void {
   }
 
   if (!this.destroyed) {
-    // We have to manually trigger an 'end' event because we are using
-    // BYOB buffers with Socket class.
-    this.emit('end');
+    // The read loop may not observe EOF itself (it is idle while paused or
+    // waiting, and read errors are swallowed), so end the readable here;
+    // push(null) is a no-op if it already has. read(0) lets 'end' fire on a
+    // socket nobody is reading, as in Node.
+    this.push(null);
+    this.read(0);
   }
 }
 
 async function startRead(socket: Socket): Promise<void> {
-  if (!socket._handle) return;
-  const reader = socket._handle.reader;
+  const handle = socket._handle;
+  if (!handle) return;
+  const reader = handle.reader;
   try {
-    while (socket._handle.reading === true) {
+    while (handle.reading && socket._handle === handle) {
       const generatedBuffer = socket[kBufferGen]?.();
 
       // Let's be extra cautious here and handle nullish values.
@@ -1537,10 +1553,10 @@ async function startRead(socket: Socket): Promise<void> {
         generatedBuffer as Uint8Array<ArrayBuffer>
       );
 
-      // Make sure the socket was not destroyed while we were waiting.
-      // If it was, we're going to throw away the chunk of data we just
-      // read.
-      if (socket.destroyed) {
+      // Make sure the socket was not destroyed or reconnected while we were
+      // waiting. If it was, we're going to throw away the chunk of data we
+      // just read.
+      if (socket.destroyed || socket._handle !== handle) {
         // Doh! Well, this is awkward. Let's just stop reading and return.
         // There's really nothing else we should try to do here.
         break;
@@ -1562,7 +1578,7 @@ async function startRead(socket: Socket): Promise<void> {
       if (value.byteLength === 0) {
         continue;
       }
-      socket._handle.bytesRead += value.byteLength;
+      handle.bytesRead += value.byteLength;
 
       // The socket API is expected to produce Buffer instances, not Uint8Arrays
       const buffer = Buffer.from(
@@ -1594,11 +1610,7 @@ async function startRead(socket: Socket): Promise<void> {
     // This is mostly triggered for invalid sockets with following errors:
     // - "This ReadableStream belongs to an object that is closing."
   } finally {
-    // Disable eslint to match Node.js behavior
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (socket._handle != null) {
-      socket._handle.reading = false;
-    }
+    handle.reading = false;
   }
 }
 

--- a/src/node/internal/internal_net.ts
+++ b/src/node/internal/internal_net.ts
@@ -26,7 +26,7 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 
 import inner from 'cloudflare-internal:sockets';
-import { tcpPorts } from 'cloudflare-internal:http';
+import { tcpPorts, type PortTable } from 'cloudflare-internal:http';
 
 import {
   AbortError,
@@ -103,37 +103,40 @@ export const kReinitializeHandle = Symbol('kReinitializeHandle');
 const kSocketInfo = Symbol('kSocketInfo');
 
 // The local address of a Socket, either adopted from a BoundSocket or autobound
-// on connect. kBoundReserved marks an entry held in the port table that must be
-// released on destroy.
+// on connect. kBoundTable is the port table holding its reservation, to be
+// released on destroy; null when the address is only a label.
 const kBoundSource = Symbol('kBoundSource');
-const kBoundReserved = Symbol('kBoundReserved');
+const kBoundTable = Symbol('kBoundTable');
 const kBoundSocketConsume = Symbol('kBoundSocketConsume');
 
 const DEFAULT_IPV4_ADDR = '0.0.0.0';
 const DEFAULT_IPV6_ADDR = '::';
 
-// Reserves port in the isolate's TCP port table (shared with http servers),
-// allocating an ephemeral port for 0. Throws EADDRINUSE on conflict.
+// Reserves port in table (shared with http servers). Port 0 takes an unclaimed
+// declared port when the platform declares any, else an ephemeral one. Throws
+// EADDRINUSE on conflict.
 export function bindPort(
+  table: PortTable,
   address: string,
   port: number,
   reusePort = false
 ): number {
   if (port === 0) {
-    port = tcpPorts.ephemeral();
+    port = table.hasDeclared() ? table.unclaimedDeclared() : table.ephemeral();
     if (port === 0) throw new EADDRINUSE(address, port);
   }
-  if (!tcpPorts.tryBind(port, reusePort)) {
+  if (!table.tryBind(port, reusePort)) {
     throw new EADDRINUSE(address, port);
   }
   return port;
 }
 
 function releaseBoundSource(socket: Socket): void {
-  if (socket[kBoundReserved]) {
-    tcpPorts.unregister(socket);
-    tcpPorts.release((socket[kBoundSource] as AddressInfo).port);
-    socket[kBoundReserved] = false;
+  const table = socket[kBoundTable];
+  if (table !== null) {
+    table.unregister(socket);
+    table.release((socket[kBoundSource] as AddressInfo).port);
+    socket[kBoundTable] = null;
   }
   socket[kBoundSource] = null;
 }
@@ -195,6 +198,7 @@ export type BoundSocketOptions = {
 // bound address as its local address.
 export class BoundSocket {
   #address: AddressInfo | null;
+  #table = tcpPorts();
 
   static isBoundSocket(value: unknown): value is BoundSocket {
     return typeof value === 'object' && value !== null && #address in value;
@@ -239,9 +243,9 @@ export class BoundSocket {
     this.#address = {
       address: host,
       family: addressType === 6 ? 'IPv6' : 'IPv4',
-      port: bindPort(host, port, reusePort),
+      port: bindPort(this.#table, host, port, reusePort),
     };
-    tcpPorts.register(this, this.#address.port);
+    this.#table.register(this, this.#address.port);
   }
 
   address(): AddressInfo {
@@ -264,8 +268,8 @@ export class BoundSocket {
     if (this.#address === null) {
       throw new ERR_SOCKET_HANDLE_ADOPTED();
     }
-    tcpPorts.unregister(this);
-    tcpPorts.release(this.#address.port);
+    this.#table.unregister(this);
+    this.#table.release(this.#address.port);
     this.#address = null;
   }
 
@@ -275,14 +279,15 @@ export class BoundSocket {
     }
   }
 
-  [kBoundSocketConsume](): AddressInfo {
+  // Transfers the reservation, and the table it lives in, to the adopter.
+  [kBoundSocketConsume](): { address: AddressInfo; table: PortTable } {
     if (this.#address === null) {
       throw new ERR_SOCKET_HANDLE_ADOPTED();
     }
-    tcpPorts.unregister(this);
+    this.#table.unregister(this);
     const address = this.#address;
     this.#address = null;
-    return address;
+    return { address, table: this.#table };
   }
 }
 
@@ -325,7 +330,7 @@ export declare class Socket extends _Socket {
   [kBytesRead]: number;
   [kBytesWritten]: number;
   [kBoundSource]: AddressInfo | null;
-  [kBoundReserved]: boolean;
+  [kBoundTable]: PortTable | null;
   [kReinitializeHandle](handle: Socket['_handle']): void;
   _closeAfterHandlingError: boolean;
   _handle: null | {
@@ -471,7 +476,7 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
   this[kBytesRead] = 0;
   this[kBytesWritten] = 0;
   this[kBoundSource] = null;
-  this[kBoundReserved] = false;
+  this[kBoundTable] = null;
   this._closeAfterHandlingError = false;
   // @ts-expect-error TS2540 Required due to types
   this.autoSelectFamilyAttemptedAddresses = [];
@@ -488,9 +493,10 @@ export function Socket(this: Socket, options?: SocketOptions): Socket {
   if (options.handle) {
     validateObject(options.handle, 'options.handle');
     if (BoundSocket.isBoundSocket(options.handle)) {
-      this[kBoundSource] = options.handle[kBoundSocketConsume]();
-      this[kBoundReserved] = true;
-      tcpPorts.register(this, this[kBoundSource].port);
+      const { address, table } = options.handle[kBoundSocketConsume]();
+      this[kBoundSource] = address;
+      this[kBoundTable] = table;
+      table.register(this, address.port);
     } else {
       this._handle = options.handle;
     }
@@ -1387,14 +1393,19 @@ function initializeConnection(
           (family === 6 ? DEFAULT_IPV6_ADDR : DEFAULT_IPV4_ADDR);
         // Only a concrete localPort claims a table entry; localAddress alone
         // (and localPort 0) autobinds, with the address kept as the label.
+        const table = tcpPorts();
         const reserved = localPort != null && localPort !== 0;
         socket[kBoundSource] = {
           address,
           family: isIP(address) === 6 ? 'IPv6' : 'IPv4',
-          port: reserved ? bindPort(address, localPort) : tcpPorts.ephemeral(),
+          port: reserved
+            ? bindPort(table, address, localPort)
+            : table.ephemeral(),
         };
-        socket[kBoundReserved] = reserved;
-        if (reserved) tcpPorts.register(socket, socket[kBoundSource].port);
+        if (reserved) {
+          socket[kBoundTable] = table;
+          table.register(socket, socket[kBoundSource].port);
+        }
       }
 
       const handle = inner.connect(`${host}:${port}`, {

--- a/src/workerd/api/global-scope.c++
+++ b/src/workerd/api/global-scope.c++
@@ -249,9 +249,12 @@ kj::Promise<void> ServiceWorkerGlobalScope::connect(kj::String host,
     // We set isDefaultFetchPort to false here – sockets.c++ sets it for ports 443 and 8080 to
     // provide a more descriptive error message for HTTP, but this is not relevant on the TCP server
     // side.
-    jsg::Ref<Socket> jsSocket =
-        setupSocket(js, ownConnection.addRef().toOwn(), kj::none /* remoteAddress */, kj::mv(host),
-            kj::none, kj::mv(nullTlsStarter), SecureTransportKind::OFF, kj::none, false, kj::none);
+    // The handler is the server side of this connection: the peer half-closing means it has
+    // finished sending, not that the reply is over, so the write side stays open until the handler
+    // closes it or returns.
+    jsg::Ref<Socket> jsSocket = setupSocket(js, ownConnection.addRef().toOwn(),
+        kj::none /* remoteAddress */, kj::mv(host), SocketOptions{.allowHalfOpen = true},
+        kj::mv(nullTlsStarter), SecureTransportKind::OFF, kj::none, false, kj::none);
     // handleProxyStatus() is required to indicate that the socket was opened properly. Since the
     // connection is already open at this point, exception handling is not required.
     jsSocket->handleProxyStatus(js, kj::Promise<kj::Maybe<kj::Exception>>(kj::none));

--- a/src/workerd/api/node/tests/BUILD.bazel
+++ b/src/workerd/api/node/tests/BUILD.bazel
@@ -428,6 +428,12 @@ js_binary(
 )
 
 wd_test(
+    src = "net-server-nodejs-test.wd-test",
+    args = ["--experimental"],
+    data = ["net-server-nodejs-test.js"],
+)
+
+wd_test(
     size = "large",
     src = "net-nodejs-test.wd-test",
     args = ["--experimental"],

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -1414,9 +1414,174 @@ export const testNetBoundSocket = {
       bound.close();
       bound[Symbol.dispose]();
     }
+  },
+};
 
-    // Server is not implemented, so a bound socket cannot be adopted by one.
-    throws(() => net.createServer());
+// test/parallel/test-net-server-listen-*.js, test-net-boundsocket.js
+export const testNetServerListen = {
+  async test() {
+    // listen(port) reserves the port and emits 'listening'.
+    {
+      const server = net.createServer();
+      strictEqual(server.listening, false);
+      strictEqual(server.address(), null);
+      const listening = once(server, 'listening');
+      strictEqual(
+        server.listen(8090, () => {}),
+        server
+      );
+      await listening;
+      ok(server.listening);
+      deepStrictEqual(server.address(), {
+        address: '0.0.0.0',
+        family: 'IPv4',
+        port: 8090,
+      });
+      throws(() => new net.BoundSocket({ port: 8090 }), {
+        code: 'EADDRINUSE',
+      });
+      throws(() => server.listen(8091), { code: 'ERR_SERVER_ALREADY_LISTEN' });
+      const closed = once(server, 'close');
+      server.close();
+      await closed;
+      strictEqual(server.listening, false);
+      new net.BoundSocket({ port: 8090 }).close();
+    }
+
+    // listen() / listen(0) take an ephemeral port; host and ipv6Only are
+    // reflected in address().
+    {
+      const a = net.createServer().listen();
+      const b = net.createServer().listen(0, '::1');
+      const c = net.createServer().listen({ port: 0, ipv6Only: true });
+      const d = net.createServer().listen(0, 'localhost');
+      ok(a.address().port >= 49152);
+      notStrictEqual(a.address().port, b.address().port);
+      deepStrictEqual(b.address(), {
+        address: '::1',
+        family: 'IPv6',
+        port: b.address().port,
+      });
+      strictEqual(c.address().address, '::');
+      strictEqual(d.address().address, '127.0.0.1');
+      a.close();
+      b.close();
+      c.close();
+      d.close();
+    }
+
+    // An in-use port is reported via 'error', as in Node.
+    {
+      const bound = new net.BoundSocket({ port: 8092 });
+      const server = net.createServer();
+      const listeningFn = mock.fn();
+      server.on('listening', listeningFn);
+      server.listen(8092);
+      const [err] = await once(server, 'error');
+      strictEqual(err.code, 'EADDRINUSE');
+      strictEqual(err.message, 'bind EADDRINUSE 0.0.0.0:8092');
+      strictEqual(server.listening, false);
+      strictEqual(listeningFn.mock.callCount(), 0);
+      bound.close();
+    }
+
+    // reusePort shares a port between servers.
+    {
+      const a = net.createServer().listen({ port: 8093, reusePort: true });
+      const b = net.createServer().listen({ port: 8093, reusePort: true });
+      strictEqual(a.address().port, 8093);
+      strictEqual(b.address().port, 8093);
+      a.close();
+      b.close();
+    }
+
+    // Server options are validated as in Node.
+    {
+      strictEqual(
+        net.createServer({ keepAliveInitialDelay: -5 }).keepAliveInitialDelay,
+        0
+      );
+      strictEqual(
+        net.createServer({ keepAliveInitialDelay: 2500 }).keepAliveInitialDelay,
+        2
+      );
+      throws(() => net.createServer({ keepAliveInitialDelay: 'x' }), {
+        code: 'ERR_INVALID_ARG_TYPE',
+      });
+      throws(() => net.createServer(1), { code: 'ERR_INVALID_ARG_TYPE' });
+    }
+
+    // Pipes and foreign handles are rejected.
+    {
+      const server = net.createServer();
+      throws(() => server.listen('/tmp/sock'), {
+        code: 'ERR_INVALID_ARG_VALUE',
+      });
+      throws(() => server.listen({ path: '/tmp/sock' }), {
+        code: 'ERR_INVALID_ARG_VALUE',
+      });
+      throws(() => server.listen({ fd: 3 }), { code: 'ERR_INVALID_ARG_VALUE' });
+      throws(() => server.listen({ port: 65536 }), {
+        code: 'ERR_SOCKET_BAD_PORT',
+      });
+      strictEqual(server.listening, false);
+    }
+
+    // close() on a server that is not listening reports ERR_SERVER_NOT_RUNNING.
+    {
+      const server = net.createServer();
+      const { promise, resolve } = Promise.withResolvers();
+      server.close((err) => resolve(err));
+      strictEqual((await promise).code, 'ERR_SERVER_NOT_RUNNING');
+    }
+
+    // Explicit resource management.
+    {
+      let port;
+      {
+        await using server = net.createServer().listen();
+        port = server.address().port;
+      }
+      new net.BoundSocket({ port }).close();
+    }
+  },
+};
+
+// Server adoption: server.listen(boundSocket) and listen({ handle }) consume
+// the bound socket, which can no longer be used.
+export const testNetServerListenBoundSocket = {
+  async test() {
+    {
+      const bound = new net.BoundSocket({ host: '127.0.0.1', port: 8094 });
+      const server = net.createServer();
+      const listening = once(server, 'listening');
+      server.listen(bound);
+      await listening;
+      deepStrictEqual(server.address(), {
+        address: '127.0.0.1',
+        family: 'IPv4',
+        port: 8094,
+      });
+      throws(() => bound.address(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+      throws(() => bound.fd(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+      throws(() => bound.close(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+      throws(() => net.createServer().listen(bound), {
+        code: 'ERR_SOCKET_HANDLE_ADOPTED',
+      });
+      throws(() => new net.BoundSocket({ port: 8094 }), {
+        code: 'EADDRINUSE',
+      });
+      server.close();
+      await once(server, 'close');
+      new net.BoundSocket({ port: 8094 }).close();
+    }
+    {
+      const bound = new net.BoundSocket({ port: 0 });
+      const { port } = bound.address();
+      const server = net.createServer().listen({ handle: bound });
+      strictEqual(server.address().port, port);
+      server.close();
+    }
   },
 };
 

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -1252,6 +1252,12 @@ export const testNetLocalAddressPort = {
       });
       await once(c, 'connect');
       strictEqual(c.localPort, 50001);
+      // The reconnected socket is fully usable: the old handle's EOF did not
+      // end it.
+      c.setEncoding('utf8');
+      c.write('again');
+      const [echoed] = await once(c, 'data');
+      strictEqual(echoed, 'again');
       c.destroy();
       await once(c, 'close');
       new net.BoundSocket({ port: 50001 }).close();

--- a/src/workerd/api/node/tests/net-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-nodejs-test.js
@@ -35,6 +35,31 @@ import { mock } from 'node:test';
 import { once } from 'node:events';
 import * as net from 'node:net';
 import * as tls from 'node:tls';
+import { connectHandler } from 'cloudflare:node';
+
+// Inbound sockets from env.SELF.connect('host:port') are routed to the
+// net.Server listening on that port.
+export default connectHandler();
+
+// Sends data over a platform socket to the worker's own net.Server on port,
+// half-closes, and returns everything read back until the server closes.
+async function inbound(env, port, data) {
+  const socket = env.SELF.connect(`localhost:${port}`);
+  const writer = socket.writable.getWriter();
+  if (data !== undefined) await writer.write(new TextEncoder().encode(data));
+  await writer.close();
+  const decoder = new TextDecoder();
+  let out = '';
+  for await (const chunk of socket.readable)
+    out += decoder.decode(chunk, { stream: true });
+  out += decoder.decode();
+  await socket.closed;
+  return out;
+}
+
+async function drain(socket) {
+  for await (const chunk of socket.readable) void chunk;
+}
 
 export const checkPortsSetCorrectly = {
   test(ctrl, env, ctx) {
@@ -1162,8 +1187,11 @@ export const testNetLocalAddressPort = {
     {
       const { promise, resolve } = Promise.withResolvers();
       const c = net.connect(env.SERVER_PORT, env.SIDECAR_HOSTNAME);
+      // The wildcard bind resolves to the namespace's synthetic host address
+      // at connect, as connect(2) resolves it to the interface used.
+      strictEqual(c.localAddress, '240.1.0.1');
       c.on('connect', () => {
-        strictEqual(c.localAddress, '0.0.0.0');
+        strictEqual(c.localAddress, '240.1.0.1');
         strictEqual(c.localFamily, 'IPv4');
         ok(c.localPort >= 49152 && c.localPort <= 65535);
         resolve();
@@ -1235,7 +1263,7 @@ export const testNetLocalAddressPort = {
         localAddress: null,
         localPort: null,
       });
-      strictEqual(c2.localAddress, '0.0.0.0');
+      strictEqual(c2.localAddress, '240.1.0.1');
       c.destroy();
       c2.destroy();
       await Promise.all([once(c, 'close'), once(c2, 'close')]);
@@ -1419,7 +1447,7 @@ export const testNetBoundSocket = {
 
 // test/parallel/test-net-server-listen-*.js, test-net-boundsocket.js
 export const testNetServerListen = {
-  async test() {
+  async test(ctrl, env) {
     // listen(port) reserves the port and emits 'listening'.
     {
       const server = net.createServer();
@@ -1527,12 +1555,37 @@ export const testNetServerListen = {
       strictEqual(server.listening, false);
     }
 
-    // close() on a server that is not listening reports ERR_SERVER_NOT_RUNNING.
+    // close() on a server that is not listening passes ERR_SERVER_NOT_RUNNING
+    // to its callback, as in Node.
     {
       const server = net.createServer();
-      const { promise, resolve } = Promise.withResolvers();
-      server.close((err) => resolve(err));
-      strictEqual((await promise).code, 'ERR_SERVER_NOT_RUNNING');
+      const { promise: callbackError, resolve } = Promise.withResolvers();
+      server.close(resolve);
+      const err = await callbackError;
+      strictEqual(err.code, 'ERR_SERVER_NOT_RUNNING');
+    }
+
+    // 'close' is not emitted while listening: a listen() before draining
+    // connections cancels the pending close.
+    {
+      const server = net.createServer((s) => s.on('data', () => {})).listen(0);
+      const a = env.SELF.connect(`localhost:${server.address().port}`);
+      await a.opened;
+      await scheduler.wait(10);
+      let closeEvents = 0;
+      server.on('close', () => closeEvents++);
+      server.close();
+      strictEqual(server.listening, false);
+      server.listen(0);
+      strictEqual(server.listening, true);
+      await a.writable.close();
+      await drain(a);
+      await scheduler.wait(20);
+      strictEqual(closeEvents, 0);
+      strictEqual(server.listening, true);
+      server.close();
+      await scheduler.wait(0);
+      strictEqual(closeEvents, 1);
     }
 
     // Explicit resource management.
@@ -1580,6 +1633,141 @@ export const testNetServerListenBoundSocket = {
       const { port } = bound.address();
       const server = net.createServer().listen({ handle: bound });
       strictEqual(server.address().port, port);
+      server.close();
+    }
+  },
+};
+
+// Inbound connections are wrapped as net.Sockets and round-trip through the
+// server; the connection keeps the inbound request alive until it closes.
+export const testNetServerConnection = {
+  async test(ctrl, env) {
+    // With allowHalfOpen the reply may follow the peer's FIN.
+    const peerPorts = [];
+    const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+      ok(socket instanceof net.Socket);
+      strictEqual(socket.server, server);
+      strictEqual(socket.connecting, false);
+      // The local endpoint is the server's wildcard bind resolved to the
+      // namespace's host address, not the CONNECT authority that routed the
+      // connection here.
+      strictEqual(socket.localAddress, '240.1.0.1');
+      strictEqual(socket.localPort, server.address().port);
+      strictEqual(socket.localFamily, 'IPv4');
+      // A service binding reports no peer: it appears behind the gateway
+      // address with a port of its own.
+      strictEqual(socket.remoteAddress, '240.1.255.254');
+      ok(socket.remotePort >= 49152);
+      strictEqual(socket.remoteFamily, 'IPv4');
+      peerPorts.push(socket.remotePort);
+      socket.setEncoding('utf8');
+      let data = '';
+      socket.on('data', (chunk) => (data += chunk));
+      socket.on('end', () => socket.end(data.toUpperCase()));
+    });
+    server.listen(0);
+    await once(server, 'listening');
+    const { port } = server.address();
+
+    strictEqual(await inbound(env, port, 'ping'), 'PING');
+    strictEqual(await inbound(env, port, 'pong'), 'PONG');
+    // Distinct peers have distinct (address, port) tuples.
+    strictEqual(peerPorts.length, 2);
+    notStrictEqual(peerPorts[0], peerPorts[1]);
+
+    // Two concurrent connections are tracked and released; close() waits for
+    // them to finish before emitting 'close'.
+    const s2 = net.createServer((socket) => {
+      socket.on('data', () => {});
+    });
+    s2.listen(0);
+    const p2 = s2.address().port;
+    const a = env.SELF.connect(`localhost:${p2}`);
+    const b = env.SELF.connect(`localhost:${p2}`);
+    await Promise.all([a.opened, b.opened]);
+    await scheduler.wait(10);
+    const counts = [];
+    s2.getConnections((err, count) => counts.push(count));
+    await scheduler.wait(0);
+    deepStrictEqual(counts, [2]);
+    let closedEarly = false;
+    const s2Closed = once(s2, 'close').then(() => (closedEarly = true));
+    s2.close();
+    strictEqual(s2.listening, false);
+    await scheduler.wait(10);
+    strictEqual(closedEarly, false);
+    await a.writable.close();
+    await b.writable.close();
+    await Promise.all([drain(a), drain(b)]);
+    await s2Closed;
+    s2.getConnections((err, count) => counts.push(count));
+    await scheduler.wait(0);
+    deepStrictEqual(counts, [2, 0]);
+    server.close();
+  },
+};
+
+// reusePort servers share inbound connections round-robin, and closing one
+// leaves the other routable.
+export const testNetServerReusePortRouting = {
+  async test(ctrl, env) {
+    const a = net
+      .createServer((s) => s.end('a'))
+      .listen({ port: 8095, reusePort: true });
+    const b = net
+      .createServer((s) => s.end('b'))
+      .listen({ port: 8095, reusePort: true });
+    const seen = new Set();
+    for (let i = 0; i < 4; i++) seen.add(await inbound(env, 8095, undefined));
+    deepStrictEqual([...seen].sort(), ['a', 'b']);
+    // close() unroutes synchronously; 'close' itself fires from the last
+    // connection's request context, so it is not awaited here.
+    b.close();
+    strictEqual(await inbound(env, 8095, undefined), 'a');
+    strictEqual(await inbound(env, 8095, undefined), 'a');
+    a.close();
+  },
+};
+
+// pauseOnConnect defers reading until resume().
+export const testNetServerPauseOnConnect = {
+  async test(ctrl, env) {
+    const server = net.createServer({ pauseOnConnect: true }, (socket) => {
+      strictEqual(socket.isPaused(), true);
+      setTimeout(() => {
+        socket.on('data', (d) => socket.end(d));
+        socket.resume();
+      }, 10);
+    });
+    server.listen(0);
+    strictEqual(await inbound(env, server.address().port, 'later'), 'later');
+    server.close();
+  },
+};
+
+// maxConnections drops extra connections with a 'drop' event.
+export const testNetServerMaxConnections = {
+  async test(ctrl, env) {
+    {
+      const server = net.createServer((socket) => {
+        socket.on('data', () => {});
+      });
+      server.maxConnections = 1;
+      server.listen(0);
+      const { port } = server.address();
+      // 'drop' fires in the dropped connection's own request context, so it is
+      // recorded rather than awaited from here.
+      const drops = [];
+      server.on('drop', (data) => drops.push(data));
+      const first = env.SELF.connect(`localhost:${port}`);
+      await first.opened;
+      await scheduler.wait(10);
+      const second = env.SELF.connect(`localhost:${port}`);
+      await drain(second);
+      strictEqual(drops.length, 1);
+      strictEqual(drops[0].localPort, port);
+      await first.writable.close();
+      await drain(first);
       server.close();
     }
   },

--- a/src/workerd/api/node/tests/net-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/net-nodejs-test.wd-test
@@ -16,6 +16,7 @@ const unitTests :Workerd.Config = (
           (name = "END_SERVER_PORT", fromEnvironment = "END_SERVER_PORT"),
           (name = "SERVER_THAT_DIES_PORT", fromEnvironment = "SERVER_THAT_DIES_PORT"),
           (name = "RECONNECT_SERVER_PORT", fromEnvironment = "RECONNECT_SERVER_PORT"),
+          (name = "SELF", service = "net-nodejs-test"),
         ]
       )
     ),

--- a/src/workerd/api/node/tests/net-server-nodejs-test.js
+++ b/src/workerd/api/node/tests/net-server-nodejs-test.js
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+import {
+  ok,
+  strictEqual,
+  notStrictEqual,
+  deepStrictEqual,
+  throws,
+} from 'node:assert';
+import { once } from 'node:events';
+import * as net from 'node:net';
+import * as http from 'node:http';
+import { connect } from 'cloudflare:sockets';
+import { DurableObject } from 'cloudflare:workers';
+import { connectHandler, handleAsNodeConnection } from 'cloudflare:node';
+
+// Inbound connections on this worker's two declared TCP listeners are routed to
+// whichever net.Server listens on the port they arrived on.
+export default connectHandler();
+
+async function readAll(socket) {
+  const decoder = new TextDecoder();
+  let out = '';
+  for await (const chunk of socket.readable)
+    out += decoder.decode(chunk, { stream: true });
+  return out + decoder.decode();
+}
+
+async function listenError(server, ...args) {
+  const errored = once(server, 'error');
+  server.listen(...args);
+  const [err] = await errored;
+  return err;
+}
+
+// The isolate's port table is seeded with the two listener ports from the
+// config: listen(0) claims them in order, further servers must use one of them.
+export const testDeclaredPorts = {
+  async test() {
+    const a = net.createServer().listen(0);
+    const b = net.createServer().listen(0);
+    const portA = a.address().port;
+    const portB = b.address().port;
+    ok(portA > 0 && portB > 0);
+    notStrictEqual(portA, portB);
+    strictEqual(a.address().address, '0.0.0.0');
+
+    // Both declared ports are claimed.
+    strictEqual((await listenError(net.createServer(), 0)).code, 'EADDRINUSE');
+    // Only declared ports may be listened on at the entrypoint.
+    const err = await listenError(net.createServer(), 8090);
+    strictEqual(err.code, 'EADDRNOTAVAIL');
+    strictEqual(err.message, 'bind EADDRNOTAVAIL 0.0.0.0:8090');
+    strictEqual(
+      (await listenError(net.createServer(), portA)).code,
+      'EADDRINUSE'
+    );
+
+    // close() returns the declared port; listen(declared) takes it explicitly.
+    a.close();
+    const c = net.createServer().listen(portA);
+    strictEqual(c.address().port, portA);
+    c.close();
+
+    // Binding is role-neutral: a BoundSocket with port 0 takes an ephemeral
+    // port, never a listener port, so egress binders cannot starve servers.
+    const egress = [
+      new net.BoundSocket(),
+      new net.BoundSocket(),
+      new net.BoundSocket(),
+    ];
+    for (const e of egress) ok(e.address().port >= 49152);
+    const e1 = net.createServer().listen(0);
+    strictEqual(e1.address().port, portA);
+    e1.close();
+    for (const e of egress) e.close();
+
+    // Adopting a port-0 BoundSocket as a server re-homes it onto a declared
+    // port, so Node's new BoundSocket() + listen(bound) idiom lands where
+    // connections arrive.
+    const bound = new net.BoundSocket();
+    const ephemeralPort = bound.address().port;
+    ok(ephemeralPort >= 49152);
+    const d = net.createServer().listen(bound);
+    strictEqual(d.address().port, portA);
+    // The ephemeral port was released by the re-home.
+    new net.BoundSocket({ port: ephemeralPort }).close();
+    // With every declared port claimed, adoption fails with EADDRINUSE.
+    strictEqual(
+      (await listenError(net.createServer(), new net.BoundSocket())).code,
+      'EADDRINUSE'
+    );
+    d.close();
+    // A BoundSocket on an undeclared port can be adopted by a client but not a
+    // server; the failed adoption releases it.
+    const stray = new net.BoundSocket({ port: 8091 });
+    strictEqual(
+      (await listenError(net.createServer(), stray)).code,
+      'EADDRNOTAVAIL'
+    );
+    throws(() => stray.address(), { code: 'ERR_SOCKET_HANDLE_ADOPTED' });
+    new net.BoundSocket({ port: 8091 }).close();
+
+    // http servers are reached through httpServerHandler, not a listener, so
+    // they are unconstrained and listen(0) never takes a declared port.
+    const h1 = http.createServer().listen(8080);
+    strictEqual(h1.address().port, 8080);
+    const h2 = http.createServer().listen(0);
+    ok(h2.address().port >= 49152);
+    h1.close();
+    h2.close();
+
+    // Client-side reservations are egress and never constrained.
+    new net.BoundSocket({ host: '127.0.0.1', port: 8092 }).close();
+
+    b.close();
+  },
+};
+
+// A real inbound connection on a declared listener reaches the net.Server that
+// listen(0)'d on it, with the socket's local port being that port.
+export const testInboundOnDeclaredPort = {
+  async test() {
+    const server = net.createServer((socket) => {
+      socket.on('data', (chunk) =>
+        socket.end(
+          `${socket.localAddress}:${socket.localPort}:${String(chunk).toUpperCase()}`
+        )
+      );
+    });
+    server.listen(0);
+    await once(server, 'listening');
+    const { port } = server.address();
+
+    const socket = connect(`127.0.0.1:${port}`);
+    const writer = socket.writable.getWriter();
+    await writer.write(new TextEncoder().encode('ping'));
+    // The wildcard bind resolved to the namespace's host address, not the
+    // listener's 127.0.0.1 authority.
+    strictEqual(await readAll(socket), `240.1.0.1:${port}:PING`);
+    await socket.closed;
+    server.close();
+  },
+};
+
+// Each Durable Object instance is its own host: both bind 25565 and the caller
+// picks the port via the CONNECT authority.
+export class PortHost extends DurableObject {
+  #server = null;
+  #bound = null;
+
+  async connect(socket) {
+    if (this.#server === null) {
+      this.#server = net
+        .createServer((s) =>
+          s.end(
+            `${this.ctx.id.toString()} ${s.localAddress} ${s.remoteAddress}`
+          )
+        )
+        .listen(25565);
+    }
+    try {
+      await handleAsNodeConnection(socket);
+    } catch (err) {
+      const writer = socket.writable.getWriter();
+      await writer.write(new TextEncoder().encode(err.message));
+      await writer.close();
+    }
+  }
+
+  reserve(port) {
+    this.#bound = new net.BoundSocket({ port });
+    return this.#bound.address().port;
+  }
+
+  release() {
+    this.#bound.close();
+    this.#bound = null;
+  }
+
+  // Whether port is free in this instance's table.
+  probe(port) {
+    try {
+      new net.BoundSocket({ port }).close();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export const testDurableObjectScoping = {
+  async test(ctrl, env) {
+    const a = env.HOSTS.get(env.HOSTS.idFromName('a'));
+    const b = env.HOSTS.get(env.HOSTS.idFromName('b'));
+
+    const [aId, aHost, aPeer] = (await readAll(a.connect('world:25565'))).split(
+      ' '
+    );
+    const [bId, bHost] = (await readAll(b.connect('world:25565'))).split(' ');
+    strictEqual(aId, env.HOSTS.idFromName('a').toString());
+    strictEqual(bId, env.HOSTS.idFromName('b').toString());
+    // Each instance is its own host with its own synthetic address, distinct
+    // from the entrypoint's; the stub caller appears behind the gateway.
+    ok(aHost.startsWith('240.1.') && bHost.startsWith('240.1.'));
+    notStrictEqual(aHost, bHost);
+    notStrictEqual(aHost, '240.1.0.1');
+    strictEqual(aPeer, '240.1.255.254');
+    // Servers persist across requests to the same instance.
+    strictEqual(
+      (await readAll(a.connect('world:25565'))).split(' ')[0],
+      env.HOSTS.idFromName('a').toString()
+    );
+    ok(
+      (await readAll(a.connect('world:1'))).startsWith(
+        'No net.Server is listening on port 1.'
+      )
+    );
+
+    // A reservation made in one request to an instance is released in that
+    // instance's table from a later request, and never leaks to another
+    // instance or the entrypoint.
+    strictEqual(await a.reserve(9000), 9000);
+    strictEqual(await a.probe(9000), false);
+    strictEqual(await b.probe(9000), true);
+    new net.BoundSocket({ port: 9000 }).close();
+    await a.release();
+    strictEqual(await a.probe(9000), true);
+
+    // Entrypoint bindings are invisible inside an instance.
+    deepStrictEqual(await b.probe(25565), false);
+    const held = new net.BoundSocket({ port: 9001 });
+    strictEqual(await a.probe(9001), true);
+    held.close();
+  },
+};

--- a/src/workerd/api/node/tests/net-server-nodejs-test.wd-test
+++ b/src/workerd/api/node/tests/net-server-nodejs-test.wd-test
@@ -1,0 +1,29 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "net-server-nodejs-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "net-server-nodejs-test.js")
+        ],
+        compatibilityFlags = ["nodejs_compat", "nodejs_compat_v2", "experimental", "enable_nodejs_http_modules", "enable_nodejs_http_server_modules"],
+        durableObjectNamespaces = [
+          (className = "PortHost", uniqueKey = "e6b1f7d6a2c04f0e9a3b5c7d8e9f0a1b"),
+        ],
+        durableObjectStorage = (inMemory = void),
+        bindings = [
+          (name = "SELF", service = "net-server-nodejs-test"),
+          (name = "HOSTS", durableObjectNamespace = "PortHost"),
+        ],
+      )
+    ),
+    ( name = "internet", network = ( allow = ["private"] ) ),
+  ],
+  # Port 0 so that the concurrent test variants never collide; the worker
+  # learns the bound ports as its declared inbound listeners.
+  sockets = [
+    (name = "tcp-a", address = "127.0.0.1:0", tcp = (), service = "net-server-nodejs-test"),
+    (name = "tcp-b", address = "127.0.0.1:0", tcp = (), service = "net-server-nodejs-test"),
+  ],
+);

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -781,8 +781,9 @@ jsg::Promise<void> Socket::maybeCloseWriteSide(jsg::Lock& js) {
   KJ_ASSERT(!getAllowHalfOpen(options));
 
   // Do not call `close` on a stream that has already been closed or is in the process
-  // of closing.
+  // of closing. Both sides are done at this point, so `closed` settles here as it does below.
   if (writable.isClosedOrClosing(js)) {
+    closedResolver.resolve(js);
     return js.resolvedPromise();
   }
 

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -1054,6 +1054,28 @@ jsg::Optional<kj::StringPtr> SocketsModule::getCallerDnsOverride(
   return ioContext.getCurrentLock().getGlobalScope().getDnsOverride(hostname);
 }
 
+jsg::Optional<jsg::JsObject> SocketsModule::getPortScopeKey(jsg::Lock& js) {
+  // A Durable Object instance is its own host for port binding; a stateless worker's host is
+  // the isolate, since a server it listens on must be reachable from every request.
+  KJ_IF_SOME(ioContext, IoContext::tryCurrent()) {
+    if (ioContext.getActor() != kj::none) {
+      return ioContext.getPortScopeKey(js);
+    }
+  }
+  return kj::none;
+}
+
+kj::Array<SocketsModule::InboundListener> SocketsModule::getInboundListeners(jsg::Lock& js) {
+  auto listeners = Worker::Api::current().getInboundListeners();
+  return KJ_MAP(l, listeners) {
+    return InboundListener{
+      .protocol = kj::str(l.protocol),
+      .address = kj::str(l.address),
+      .port = l.port,
+    };
+  };
+}
+
 kj::Own<kj::AsyncIoStream> Socket::takeConnectionStream(jsg::Lock& js) {
   // Set this so that if `close` is called after this, that no closure steps are taken and instead
   // the `close` is a no-op.

--- a/src/workerd/api/sockets.h
+++ b/src/workerd/api/sockets.h
@@ -331,9 +331,23 @@ class SocketsModule final: public jsg::Object {
   // Returns the synthetic IP registered for a magic hostname, or undefined. Used by node:dns.
   jsg::Optional<kj::StringPtr> getCallerDnsOverride(jsg::Lock& js, kj::String hostname);
 
+  // Identity for the current Durable Object's port scope, or undefined when not in one.
+  jsg::Optional<jsg::JsObject> getPortScopeKey(jsg::Lock& js);
+
+  struct InboundListener {
+    kj::String protocol;
+    kj::String address;
+    uint16_t port;
+    JSG_STRUCT(protocol, address, port);
+  };
+  // The inbound socket listeners configured to deliver connections to this worker.
+  kj::Array<InboundListener> getInboundListeners(jsg::Lock& js);
+
   JSG_RESOURCE_TYPE(SocketsModule, CompatibilityFlags::Reader flags) {
     JSG_METHOD(connect);
     JSG_METHOD(getCallerDnsOverride);
+    JSG_METHOD(getPortScopeKey);
+    JSG_METHOD(getInboundListeners);
 
     if (flags.getWorkerdExperimental()) {
       JSG_METHOD(internalNewHttpClient);
@@ -358,7 +372,7 @@ kj::Own<jsg::modules::ModuleBundle> getInternalSocketModuleBundle(auto featureFl
 
 #define EW_SOCKETS_ISOLATE_TYPES                                                                   \
   api::Socket, api::SocketOptions, api::SocketAddress, api::TlsOptions, api::SocketsModule,        \
-      api::SocketInfo
+      api::SocketInfo, api::SocketsModule::InboundListener
 
 // The list of sockets.h types that are added to worker.c++'s JSG_DECLARE_ISOLATE_TYPE
 }  // namespace workerd::api

--- a/src/workerd/api/tests/BUILD.bazel
+++ b/src/workerd/api/tests/BUILD.bazel
@@ -132,6 +132,12 @@ wd_test(
     data = ["connect-neuter-test.js"],
 )
 
+wd_test(
+    src = "connect-half-open-test.wd-test",
+    args = ["--experimental"],
+    data = ["connect-half-open-test.js"],
+)
+
 # Regression test for AUTOVULN-EW-EDGEWORKER-17: Socket::close() bare-this UAF.
 wd_test(
     src = "socket-close-gc-test.wd-test",

--- a/src/workerd/api/tests/connect-half-open-test.js
+++ b/src/workerd/api/tests/connect-half-open-test.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+import { strictEqual } from 'assert';
+
+// An inbound socket is half-open: the handler can still reply after the peer
+// has finished sending. The client half-closes before reading, and its `closed`
+// settles once it has read to EOF.
+export const replyAfterPeerHalfClose = {
+  async test(ctrl, env) {
+    const socket = env.SELF.connect('example.com:1');
+    const writer = socket.writable.getWriter();
+    await writer.write(new TextEncoder().encode('ping'));
+    await writer.close();
+    const dec = new TextDecoder();
+    let result = '';
+    for await (const chunk of socket.readable) {
+      result += dec.decode(chunk, { stream: true });
+    }
+    result += dec.decode();
+    strictEqual(result, 'echo:ping');
+    await socket.closed;
+  },
+};
+
+// Reads everything the peer sends, then replies after the peer has half-closed.
+export default {
+  async connect(socket) {
+    const dec = new TextDecoder();
+    let received = '';
+    for await (const chunk of socket.readable) {
+      received += dec.decode(chunk, { stream: true });
+    }
+    received += dec.decode();
+    const writer = socket.writable.getWriter();
+    await writer.write(new TextEncoder().encode(`echo:${received}`));
+    await writer.close();
+  },
+};

--- a/src/workerd/api/tests/connect-half-open-test.wd-test
+++ b/src/workerd/api/tests/connect-half-open-test.wd-test
@@ -1,0 +1,17 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "connect-half-open-test",
+      worker = (
+        modules = [
+          (name = "worker", esModule = embed "connect-half-open-test.js"),
+        ],
+        compatibilityFlags = ["nodejs_compat_v2"],
+        bindings = [
+          (name = "SELF", service = "connect-half-open-test"),
+        ],
+      )
+    ),
+  ],
+);

--- a/src/workerd/io/io-context.c++
+++ b/src/workerd/io/io-context.c++
@@ -1741,6 +1741,13 @@ jsg::JsObject IoContext::getPromiseContextTag(jsg::Lock& js) {
   return KJ_REQUIRE_NONNULL(promiseContextTag).getHandle(js);
 }
 
+jsg::JsObject IoContext::getPortScopeKey(jsg::Lock& js) {
+  if (portScopeKey == kj::none) {
+    portScopeKey = jsg::JsRef(js, js.obj());
+  }
+  return KJ_REQUIRE_NONNULL(portScopeKey).getHandle(js);
+}
+
 kj::Promise<void> IoContext::startDeleteQueueSignalTask(IoContext* context) {
   // The promise that is returned is held by the IoContext itself, so when the
   // IoContext is destroyed, the promise will be canceled and the loop will

--- a/src/workerd/io/io-context.h
+++ b/src/workerd/io/io-context.h
@@ -1150,6 +1150,11 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
 
   jsg::JsObject getPromiseContextTag(jsg::Lock& js);
 
+  // An object whose identity stands for this IoContext, for JS-side state scoped to it (a
+  // Durable Object's virtual port table, for instance). Created lazily; lives as long as the
+  // IoContext.
+  jsg::JsObject getPortScopeKey(jsg::Lock& js);
+
   // The IoChannelFactory must be accessed through the
   // currentIncomingRequest because it has some tracing context built in.
   //
@@ -1260,6 +1265,7 @@ class IoContext final: public kj::Refcounted, private kj::TaskSet::ErrorHandler 
   void checkFarGet(const DeleteQueue& expectedQueue, const std::type_info& type);
 
   kj::Maybe<jsg::JsRef<jsg::JsObject>> promiseContextTag;
+  kj::Maybe<jsg::JsRef<jsg::JsObject>> portScopeKey;
   kj::Maybe<jsg::JsRef<jsg::JsObject>> entrypointHandler;
 
   class Runnable {

--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -609,6 +609,19 @@ class Worker::Api {
   // Api.
   virtual CompatibilityFlags::Reader getFeatureFlags() const = 0;
 
+  // An inbound socket listener configured to deliver connections to this worker, as bound.
+  struct InboundListener {
+    kj::String protocol;  // "tcp" | "udp"
+    kj::String address;   // host part as configured
+    uint16_t port;        // as bound, so resolved for a configured port of 0
+  };
+  // The inbound listeners targeting this worker. Their ports seed the worker's virtual port
+  // table so that a server listening in the worker takes the port connections actually arrive
+  // on. Empty when the embedder does not declare listeners.
+  virtual kj::ArrayPtr<const InboundListener> getInboundListeners() const {
+    return nullptr;
+  }
+
   struct NewContextOptions {
     // If the worker is using the new module registry system, this is the registry to
     // install on the newly created context. If null, the old system is assumed.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -5745,9 +5745,19 @@ kj::Promise<kj::Own<Server::WorkerService>> Server::makeWorkerImpl(kj::StringPtr
   }
 
   auto isolateGroup = v8::IsolateGroup::GetDefault();
+  kj::Array<Worker::Api::InboundListener> listeners;
+  KJ_IF_SOME(l, inboundListeners.find(name)) {
+    listeners = KJ_MAP(listener, l) {
+      return Worker::Api::InboundListener{
+        .protocol = kj::str(listener.protocol),
+        .address = kj::str(listener.address),
+        .port = listener.port,
+      };
+    };
+  }
   auto api = kj::heap<WorkerdApi>(globalContext->v8System, def.featureFlags, extensions,
       limitEnforcer->getCreateParams(), isolateGroup, kj::mv(jsgobserver), *memoryCacheProvider,
-      pythonConfig);
+      pythonConfig, kj::mv(listeners));
 
   auto inspectorPolicy = Worker::Isolate::InspectorPolicy::DISALLOW;
   if (inspectorOverride != kj::none) {
@@ -7192,6 +7202,20 @@ kj::Promise<void> Server::bindSockets(config::Config::Reader config) {
     } else {
       auto parsed = co_await network.parseAddress(addrStr, defaultPortFor(sock));
       listener = parsed->listen();
+    }
+
+    if (sock.which() == config::Socket::TCP && sock.getService().hasName()) {
+      inboundListeners
+          .findOrCreate(sock.getService().getName(),
+              [&]() {
+        return decltype(inboundListeners)::Entry{
+          kj::str(sock.getService().getName()), kj::Vector<Worker::Api::InboundListener>()};
+      })
+          .add(Worker::Api::InboundListener{
+            .protocol = kj::str("tcp"),
+            .address = hostOfAddress(addrStr),
+            .port = static_cast<uint16_t>(listener->getPort()),
+          });
     }
 
     boundSockets.add(BoundSocket{kj::mv(listener), kj::mv(addrStr)});

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -6643,12 +6643,12 @@ class Server::TcpListener final: public kj::Refcounted {
       kj::Own<kj::ConnectionReceiver> listener,
       kj::Own<Service> service,
       kj::HttpHeaderTable& headerTable,
-      kj::StringPtr addrStr)
+      kj::String authority)
       : owner(owner),
         listener(kj::mv(listener)),
         service(kj::mv(service)),
         headerTable(headerTable),
-        addrStr(addrStr) {}
+        authority(kj::mv(authority)) {}
 
   kj::Promise<void> run() {
     TRACE_EVENT("workerd", "TcpListener::run");
@@ -6660,7 +6660,7 @@ class Server::TcpListener final: public kj::Refcounted {
       auto req = service->startRequest(kj::mv(metadata));
       auto response = kj::heap<ResponseWrapper>();
       kj::HttpHeaders headers(headerTable);
-      owner.tasks.add(req->connect(addrStr, headers, *stream.stream, *response, {})
+      owner.tasks.add(req->connect(authority, headers, *stream.stream, *response, {})
                           .attach(kj::mv(stream.stream), kj::mv(response))
                           .attach(kj::mv(req)));
     }
@@ -6671,7 +6671,7 @@ class Server::TcpListener final: public kj::Refcounted {
   kj::Own<kj::ConnectionReceiver> listener;
   kj::Own<Service> service;
   kj::HttpHeaderTable& headerTable;
-  kj::StringPtr addrStr;
+  kj::String authority;
 
   struct ResponseWrapper final: public kj::HttpService::ConnectResponse {
     void accept(
@@ -6699,9 +6699,9 @@ kj::Promise<void> Server::listenHttp(kj::Own<kj::ConnectionReceiver> listener,
 }
 
 kj::Promise<void> Server::listenTcp(
-    kj::Own<kj::ConnectionReceiver> listener, kj::Own<Service> service, kj::StringPtr addrStr) {
+    kj::Own<kj::ConnectionReceiver> listener, kj::Own<Service> service, kj::String authority) {
   auto obj = kj::refcounted<TcpListener>(
-      *this, kj::mv(listener), kj::mv(service), globalContext->headerTable, addrStr);
+      *this, kj::mv(listener), kj::mv(service), globalContext->headerTable, kj::mv(authority));
   co_return co_await obj->run();
 }
 
@@ -6887,6 +6887,7 @@ kj::Promise<void> Server::run(
 
   auto forkedDrainWhen = handleDrain(kj::mv(drainWhen)).fork();
 
+  co_await bindSockets(config);
   co_await startServices(v8System, config, headerTableBuilder, forkedDrainWhen);
 
   auto listenPromise = listenOnSockets(config, headerTableBuilder, forkedDrainWhen);
@@ -7094,12 +7095,41 @@ kj::Promise<void> Server::startServices(jsg::V8System& v8System,
   }
 }
 
+namespace {
+
+// The host part of a "host[:port]" listen address ("*", "127.0.0.1", "[::1]"). Unix socket
+// addresses have no host and are returned whole.
+kj::String hostOfAddress(kj::StringPtr addrStr) {
+  if (addrStr.startsWith("unix:")) return kj::str(addrStr);
+  KJ_IF_SOME(colon, addrStr.findLast(':')) {
+    // A bare IPv6 literal without brackets contains colons but no port.
+    if (addrStr.startsWith("[") || addrStr.findFirst(':') == colon) {
+      return kj::str(addrStr.first(colon));
+    }
+  }
+  return kj::str(addrStr);
+}
+
+uint defaultPortFor(config::Socket::Reader sock) {
+  switch (sock.which()) {
+    case config::Socket::HTTP:
+      return 80;
+    case config::Socket::HTTPS:
+      return 443;
+    case config::Socket::TCP:
+      return 0;
+  }
+  return 0;
+}
+
+}  // namespace
+
 kj::Maybe<Server::SocketTypeConfig> Server::parseSocketType(
     config::Socket::Reader sock, kj::StringPtr name) {
   switch (sock.which()) {
     case config::Socket::HTTP: {
       SocketTypeConfig result;
-      result.defaultPort = 80;
+      result.defaultPort = defaultPortFor(sock);
       result.httpOptions = sock.getHttp();
       result.physicalProtocol = "http";
       return kj::mv(result);
@@ -7107,7 +7137,7 @@ kj::Maybe<Server::SocketTypeConfig> Server::parseSocketType(
     case config::Socket::HTTPS: {
       auto https = sock.getHttps();
       SocketTypeConfig result;
-      result.defaultPort = 443;
+      result.defaultPort = defaultPortFor(sock);
       result.httpOptions = https.getOptions();
       result.tls = makeTlsContext(https.getTlsOptions());
       result.physicalProtocol = "https";
@@ -7127,19 +7157,12 @@ kj::Maybe<Server::SocketTypeConfig> Server::parseSocketType(
   return kj::none;
 }
 
-kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
-    kj::HttpHeaderTable::Builder& headerTableBuilder,
-    kj::ForkedPromise<void>& forkedDrainWhen,
-    bool forTest) {
-  // ---------------------------------------------------------------------------
-  // Start sockets
-  TRACE_EVENT("workerd", "listenOnSockets");
+kj::Promise<void> Server::bindSockets(config::Config::Reader config) {
+  TRACE_EVENT("workerd", "bindSockets");
   for (auto sock: config.getSockets()) {
     kj::String name = kj::str(sock.getName());
     kj::String addrStr;
     kj::Maybe<kj::Own<kj::ConnectionReceiver>> listenerOverride;
-
-    kj::Own<Service> service = lookupService(sock.getService(), kj::str("Socket \"", name, "\""));
 
     KJ_IF_SOME(override, socketOverrides.findEntry(name)) {
       KJ_SWITCH_ONEOF(override.value) {
@@ -7159,48 +7182,71 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
       reportConfigError(kj::str("Socket \"", name,
           "\" has no address in the config, so must be specified on the "
           "command line with `--socket-addr`."));
+      boundSockets.add(kj::none);
       continue;
     }
+
+    kj::Own<kj::ConnectionReceiver> listener;
+    KJ_IF_SOME(l, listenerOverride) {
+      listener = kj::mv(l);
+    } else {
+      auto parsed = co_await network.parseAddress(addrStr, defaultPortFor(sock));
+      listener = parsed->listen();
+    }
+
+    boundSockets.add(BoundSocket{kj::mv(listener), kj::mv(addrStr)});
+  }
+}
+
+kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
+    kj::HttpHeaderTable::Builder& headerTableBuilder,
+    kj::ForkedPromise<void>& forkedDrainWhen,
+    bool forTest) {
+  // ---------------------------------------------------------------------------
+  // Start sockets
+  TRACE_EVENT("workerd", "listenOnSockets");
+  auto sockets = config.getSockets();
+  KJ_ASSERT(boundSockets.size() == sockets.size());
+  for (auto i: kj::indices(sockets)) {
+    auto sock = sockets[i];
+    kj::String name = kj::str(sock.getName());
+
+    // Sockets that failed to bind have already reported a config error.
+    kj::Own<kj::ConnectionReceiver> listener;
+    kj::String addrStr;
+    KJ_IF_SOME(bound, boundSockets[i]) {
+      listener = kj::mv(bound.listener);
+      addrStr = kj::mv(bound.addrStr);
+      boundSockets[i] = kj::none;
+    } else {
+      continue;
+    }
+
+    kj::Own<Service> service = lookupService(sock.getService(), kj::str("Socket \"", name, "\""));
 
     auto maybeSocketConfig = parseSocketType(sock, name);
     if (maybeSocketConfig == kj::none) continue;
     auto& socketConfig = KJ_ASSERT_NONNULL(maybeSocketConfig);
 
-    using PromisedReceived = kj::Promise<kj::Own<kj::ConnectionReceiver>>;
-    PromisedReceived listener = nullptr;
-    KJ_IF_SOME(l, listenerOverride) {
-      listener = kj::mv(l);
-    } else {
-      listener = ([](kj::Promise<kj::Own<kj::NetworkAddress>> promise) -> PromisedReceived {
-        auto parsed = co_await promise;
-        co_return parsed->listen();
-      })(network.parseAddress(addrStr, socketConfig.defaultPort));
-    }
-
     KJ_IF_SOME(t, socketConfig.tls) {
-      listener = ([](kj::Promise<kj::Own<kj::ConnectionReceiver>> promise,
-                      kj::Own<kj::TlsContext> tls) -> PromisedReceived {
-        auto port = co_await promise;
-        co_return tls->wrapPort(kj::mv(port)).attach(kj::mv(tls));
-      })(kj::mv(listener), kj::mv(t));
+      listener = t->wrapPort(kj::mv(listener)).attach(kj::mv(t));
     }
 
     // Need to create rewriter before waiting on anything since `headerTableBuilder` will no longer
     // be available later.
     auto rewriter = kj::heap<HttpRewriter>(socketConfig.httpOptions, headerTableBuilder);
 
-    auto handle = kj::coCapture(
-        [this, service = kj::mv(service), rewriter = kj::mv(rewriter),
-            physicalProtocol = socketConfig.physicalProtocol, name = kj::mv(name),
-            isHttp = sock.which() != config::Socket::TCP, addrStr = kj::mv(addrStr)](
-            kj::Promise<kj::Own<kj::ConnectionReceiver>> promise) mutable -> kj::Promise<void> {
+    auto handle =
+        kj::coCapture([this, service = kj::mv(service), rewriter = kj::mv(rewriter),
+                          physicalProtocol = socketConfig.physicalProtocol, name = kj::mv(name),
+                          isHttp = sock.which() != config::Socket::TCP, addrStr = kj::mv(addrStr)](
+                          kj::Own<kj::ConnectionReceiver> listener) mutable -> kj::Promise<void> {
       if (isHttp) {
         TRACE_EVENT("workerd", "setup listenHttp");
       } else {
         TRACE_EVENT("workerd", "setup listenTcp");
       }
 
-      auto listener = co_await promise;
       KJ_IF_SOME(stream, controlOverride) {
         auto message = kj::str("{\"event\":\"listen\",\"socket\":\"", name,
             "\",\"port\":", listener->getPort(), "}\n");
@@ -7214,7 +7260,10 @@ kj::Promise<void> Server::listenOnSockets(config::Config::Reader config,
       if (isHttp) {
         co_await listenHttp(kj::mv(listener), kj::mv(service), physicalProtocol, kj::mv(rewriter));
       } else {
-        co_await listenTcp(kj::mv(listener), kj::mv(service), addrStr);
+        // The authority handed to the connect() handler is the endpoint as bound, so it is
+        // truthful for a configured port of 0.
+        auto authority = kj::str(hostOfAddress(addrStr), ":", listener->getPort());
+        co_await listenTcp(kj::mv(listener), kj::mv(service), kj::mv(authority));
       }
     });
     tasks.add(handle(kj::mv(listener)).exclusiveJoin(forkedDrainWhen.addBranch()));
@@ -7313,6 +7362,7 @@ kj::Promise<bool> Server::test(jsg::V8System& v8System,
 
   auto forkedDrainWhen = kj::Promise<void>(kj::NEVER_DONE).fork();
 
+  co_await bindSockets(config);
   co_await startServices(v8System, config, headerTableBuilder, forkedDrainWhen);
 
   // Tests usually do not configure sockets, but they can, especially loopback sockets. Arrange

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -167,6 +167,15 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
   kj::HashMap<kj::String, kj::OneOf<kj::String, kj::Own<kj::ConnectionReceiver>>> socketOverrides;
   kj::HashMap<kj::String, kj::String> directoryOverrides;
 
+  // Sockets are bound before services start so that the ports they actually got are known while
+  // workers are created. Indexed by position in the config's socket list (names may repeat); none
+  // for a socket that failed to bind. Consumed by listenOnSockets().
+  struct BoundSocket {
+    kj::Own<kj::ConnectionReceiver> listener;
+    kj::String addrStr;
+  };
+  kj::Vector<kj::Maybe<BoundSocket>> boundSockets;
+
   // Overrides from the command line.
   //
   // String overrides are left as strings rather than parsed by the caller in order to reuse the
@@ -308,7 +317,7 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
       kj::Own<HttpRewriter> rewriter);
 
   kj::Promise<void> listenTcp(
-      kj::Own<kj::ConnectionReceiver> listener, kj::Own<Service> service, kj::StringPtr addrStr);
+      kj::Own<kj::ConnectionReceiver> listener, kj::Own<Service> service, kj::String authority);
 
   kj::Promise<void> listenDebugPort(kj::Own<kj::ConnectionReceiver> listener);
   rpc::WorkerdDebugPort::Client makeWorkerdDebugPortClient();
@@ -340,6 +349,8 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
       config::Config::Reader config,
       kj::HttpHeaderTable::Builder& headerTableBuilder,
       kj::ForkedPromise<void>& forkedDrainWhen);
+
+  kj::Promise<void> bindSockets(config::Config::Reader config);
 
   kj::Promise<void> listenOnSockets(config::Config::Reader config,
       kj::HttpHeaderTable::Builder& headerTableBuilder,

--- a/src/workerd/server/server.h
+++ b/src/workerd/server/server.h
@@ -167,14 +167,17 @@ class Server final: private kj::TaskSet::ErrorHandler, private ChannelTokenHandl
   kj::HashMap<kj::String, kj::OneOf<kj::String, kj::Own<kj::ConnectionReceiver>>> socketOverrides;
   kj::HashMap<kj::String, kj::String> directoryOverrides;
 
-  // Sockets are bound before services start so that the ports they actually got are known while
-  // workers are created. Indexed by position in the config's socket list (names may repeat); none
-  // for a socket that failed to bind. Consumed by listenOnSockets().
+  // Sockets are bound before services start so that a worker can learn the actual port of each
+  // inbound listener that targets it (Worker::Api::getInboundListeners()). Indexed by position in
+  // the config's socket list (names may repeat); none for a socket that failed to bind. Consumed
+  // by listenOnSockets().
   struct BoundSocket {
     kj::Own<kj::ConnectionReceiver> listener;
     kj::String addrStr;
   };
   kj::Vector<kj::Maybe<BoundSocket>> boundSockets;
+  // Bound TCP listeners by the name of the service they deliver to.
+  kj::HashMap<kj::String, kj::Vector<Worker::Api::InboundListener>> inboundListeners;
 
   // Overrides from the command line.
   //

--- a/src/workerd/server/workerd-api.c++
+++ b/src/workerd/server/workerd-api.c++
@@ -289,7 +289,8 @@ WorkerdApi::WorkerdApi(jsg::V8System& v8System,
     v8::IsolateGroup group,
     kj::Own<JsgIsolateObserver> observer,
     api::MemoryCacheProvider& memoryCacheProvider,
-    const PythonConfig& pythonConfig)
+    const PythonConfig& pythonConfig,
+    kj::Array<Worker::Api::InboundListener> inboundListeners)
     : impl(kj::heap<Impl>(v8System,
           features,
           extensions,
@@ -297,7 +298,8 @@ WorkerdApi::WorkerdApi(jsg::V8System& v8System,
           group,
           kj::mv(observer),
           memoryCacheProvider,
-          pythonConfig)) {}
+          pythonConfig)),
+      inboundListeners(kj::mv(inboundListeners)) {}
 WorkerdApi::~WorkerdApi() noexcept(false) {}
 
 kj::Own<jsg::Lock> WorkerdApi::lock(jsg::V8StackScope& stackScope) const {
@@ -305,6 +307,9 @@ kj::Own<jsg::Lock> WorkerdApi::lock(jsg::V8StackScope& stackScope) const {
 }
 CompatibilityFlags::Reader WorkerdApi::getFeatureFlags() const {
   return *impl->features;
+}
+kj::ArrayPtr<const Worker::Api::InboundListener> WorkerdApi::getInboundListeners() const {
+  return inboundListeners;
 }
 jsg::JsContext<api::ServiceWorkerGlobalScope> WorkerdApi::newContext(
     jsg::Lock& lock, Worker::Api::NewContextOptions options) const {

--- a/src/workerd/server/workerd-api.h
+++ b/src/workerd/server/workerd-api.h
@@ -43,13 +43,15 @@ class WorkerdApi final: public Worker::Api {
       v8::IsolateGroup group,
       kj::Own<JsgIsolateObserver> observer,
       api::MemoryCacheProvider& memoryCacheProvider,
-      const PythonConfig& pythonConfig);
+      const PythonConfig& pythonConfig,
+      kj::Array<Worker::Api::InboundListener> inboundListeners = nullptr);
   ~WorkerdApi() noexcept(false);
 
   static const WorkerdApi& from(const Worker::Api&);
 
   kj::Own<jsg::Lock> lock(jsg::V8StackScope& stackScope) const override;
   CompatibilityFlags::Reader getFeatureFlags() const override;
+  kj::ArrayPtr<const Worker::Api::InboundListener> getInboundListeners() const override;
   jsg::JsContext<api::ServiceWorkerGlobalScope> newContext(
       jsg::Lock& lock, Worker::Api::NewContextOptions options = {}) const override;
   jsg::Dict<NamedExport> unwrapExports(
@@ -343,6 +345,7 @@ class WorkerdApi final: public Worker::Api {
  private:
   struct Impl;
   kj::Own<Impl> impl;
+  kj::Array<Worker::Api::InboundListener> inboundListeners;
 };
 
 // An ActorStorage implementation which will always respond to reads as if the state is empty,

--- a/types/defines/node.d.ts
+++ b/types/defines/node.d.ts
@@ -1,10 +1,39 @@
 declare module 'cloudflare:node' {
   interface NodeStyleServer {
     listen(...args: unknown[]): this;
-    address(): { port?: number | null | undefined };
+    address(): { port?: number | null | undefined } | null;
   }
 
   export function httpServerHandler(port: number): ExportedHandler;
   export function httpServerHandler(options: { port: number }): ExportedHandler;
   export function httpServerHandler(server: NodeStyleServer): ExportedHandler;
+
+  /**
+   * Dispatches a request to the `http.Server` listening on the given port and
+   * resolves with its response. The direct form of `httpServerHandler()`.
+   */
+  export function handleAsNodeRequest(
+    port: number | { port: number },
+    request: Request,
+    env?: unknown,
+    ctx?: ExecutionContext
+  ): Promise<Response>;
+
+  /**
+   * Routes inbound sockets to the `net.Server` listening on the port each
+   * socket arrived on.
+   */
+  export function connectHandler(): ExportedHandler;
+
+  /**
+   * Dispatches an inbound socket to the `net.Server` listening on the port it
+   * arrived on, resolving when the connection has closed. The direct form of
+   * `connectHandler()`, for use inside a `connect()` handler, such as a
+   * Durable Object's.
+   */
+  export function handleAsNodeConnection(
+    socket: Socket,
+    env?: unknown,
+    ctx?: ExecutionContext
+  ): Promise<void>;
 }

--- a/types/generated-snapshot/experimental/index.d.ts
+++ b/types/generated-snapshot/experimental/index.d.ts
@@ -15555,11 +15555,41 @@ declare module "cloudflare:node" {
     listen(...args: unknown[]): this;
     address(): {
       port?: number | null | undefined;
-    };
+    } | null;
   }
   export function httpServerHandler(port: number): ExportedHandler;
   export function httpServerHandler(options: { port: number }): ExportedHandler;
   export function httpServerHandler(server: NodeStyleServer): ExportedHandler;
+  /**
+   * Dispatches a request to the `http.Server` listening on the given port and
+   * resolves with its response. The direct form of `httpServerHandler()`.
+   */
+  export function handleAsNodeRequest(
+    port:
+      | number
+      | {
+          port: number;
+        },
+    request: Request,
+    env?: unknown,
+    ctx?: ExecutionContext,
+  ): Promise<Response>;
+  /**
+   * Routes inbound sockets to the `net.Server` listening on the port each
+   * socket arrived on.
+   */
+  export function connectHandler(): ExportedHandler;
+  /**
+   * Dispatches an inbound socket to the `net.Server` listening on the port it
+   * arrived on, resolving when the connection has closed. The direct form of
+   * `connectHandler()`, for use inside a `connect()` handler, such as a
+   * Durable Object's.
+   */
+  export function handleAsNodeConnection(
+    socket: Socket,
+    env?: unknown,
+    ctx?: ExecutionContext,
+  ): Promise<void>;
 }
 type Params<P extends string = any> = Record<P, string | string[]>;
 type EventContext<Env, P extends string, Data> = {

--- a/types/generated-snapshot/index.d.ts
+++ b/types/generated-snapshot/index.d.ts
@@ -15278,11 +15278,41 @@ declare module "cloudflare:node" {
     listen(...args: unknown[]): this;
     address(): {
       port?: number | null | undefined;
-    };
+    } | null;
   }
   export function httpServerHandler(port: number): ExportedHandler;
   export function httpServerHandler(options: { port: number }): ExportedHandler;
   export function httpServerHandler(server: NodeStyleServer): ExportedHandler;
+  /**
+   * Dispatches a request to the `http.Server` listening on the given port and
+   * resolves with its response. The direct form of `httpServerHandler()`.
+   */
+  export function handleAsNodeRequest(
+    port:
+      | number
+      | {
+          port: number;
+        },
+    request: Request,
+    env?: unknown,
+    ctx?: ExecutionContext,
+  ): Promise<Response>;
+  /**
+   * Routes inbound sockets to the `net.Server` listening on the port each
+   * socket arrived on.
+   */
+  export function connectHandler(): ExportedHandler;
+  /**
+   * Dispatches an inbound socket to the `net.Server` listening on the port it
+   * arrived on, resolving when the connection has closed. The direct form of
+   * `connectHandler()`, for use inside a `connect()` handler, such as a
+   * Durable Object's.
+   */
+  export function handleAsNodeConnection(
+    socket: Socket,
+    env?: unknown,
+    ctx?: ExecutionContext,
+  ): Promise<void>;
 }
 type Params<P extends string = any> = Record<P, string | string[]>;
 type EventContext<Env, P extends string, Data> = {


### PR DESCRIPTION
Follows #7299.

This implements `net.Server` over the virtual port table from #7299, and a `connectHandler` in `cloudflare:node` that routes inbound platform sockets to it, the `connect()` analogue of `httpServerHandler`. `listen(N)` means what it means on Linux: the accepted socket's local port is N, and each Durable Object instance is its own host.

Scoping: a Durable Object instance has its own port table for its lifetime, so two instances in one isolate each bind 25565 with no conflict and the table dies with the instance. Everything else in the isolate shares one table, so a server listened on in one request is reachable from every other (`httpServerHandler` lookups are scope-aware too: an `http.Server` listening inside a Durable Object is found from that object's requests). Owners capture the table they bound in and release through it, since release may run in another request's context or in the finalization backstop with none.

Declared listeners: the isolate table is seeded with the ports the platform delivers inbound connections on (workerd's `sockets` entries targeting the worker, as bound, so a configured port of 0 is resolved; production would fill this from the wrangler `connect[]` triggers). With a declared set, `net.Server.listen(N)` at the entrypoint must use a declared port (`EADDRNOTAVAIL` otherwise), `listen(0)` takes the first unclaimed declared port, and every declared port claimed makes `listen(0)` `EADDRINUSE`. Binding itself is role-neutral: `new BoundSocket()` (port 0) always takes an ephemeral port, so egress binders such as Emscripten's per-connection `bind(0.0.0.0:0)` can never starve servers; when a server adopts such a socket (`listen(bound)`) it is re-homed onto an unclaimed declared port, so Node's `new BoundSocket()` + `listen(bound)` idiom lands where connections arrive. Inside a Durable Object no ports are declared, so the port is chosen freely and matched by the caller's `stub.connect('host:N')`. `http.Server` is reached through `httpServerHandler`, not a listener, so it is unconstrained and its `listen(0)` never takes a declared port. Client-side reservations (`new BoundSocket({ port })` adopted by a client, `net.connect({ localPort })`) are egress and not constrained, which also means an explicitly named declared port can be taken for egress; likewise `http.Server.listen(<declared>)` claims it, after which inbound TCP on that port finds no `net.Server`.

`net.Server`:

* `listen(port | options | boundSocket)` reserves the port and installs a connect handler; `listen(boundSocket)` / `listen({ handle })` adopt the reservation (re-homing a port-0 socket onto a declared port where one exists), giving the `bind(2)` / `listen(2)` split directly. `server.address()` and accepted sockets' `localAddress` report the bound label (the host as given, `0.0.0.0` by default)
* `host`, `ipv6Only`, `reusePort` honored as in #7299; `reusePort` listeners share connections round-robin; an in-use port is reported via `'error'` (`EADDRINUSE`) as in Node; `path` and foreign handles are rejected
* `'listening'` / `'connection'` / `'close'` / `'drop'`, `address()`, `listening`, `close()` (waits for open connections; `ERR_SERVER_NOT_RUNNING` when not listening; a `listen()` before the drain completes cancels the pending `'close'`), `maxConnections`, `getConnections()`, `pauseOnConnect`, `allowHalfOpen`, `keepAliveInitialDelay` validation, `ref()`/`unref()` no-ops, `Symbol.asyncDispose`
* Inbound platform sockets are wrapped as `net.Socket`s: same `_handle` shape as an outbound connection, `localAddress`/`localPort` are the server's bound address, as with an accepted fd (the CONNECT authority only routes the connection; the platform owns that endpoint, nothing is released per connection), `remoteAddress` from `opened.remoteAddress`, or the gateway address with a port of its own when the platform reports no peer, `socket.server` set, read loop started unless paused. The handler promise resolves on the socket's `'close'`, keeping the inbound request alive for the connection's lifetime

`cloudflare:node`:

```js
import net from 'node:net';
import { connectHandler } from 'cloudflare:node';

net.createServer((socket) => socket.pipe(socket)).listen(25565);
export default connectHandler();
```

Addressing: every namespace owns a synthetic host address from `240.1.0.0/16` (reserved and never routed; Hyperdrive's synthetic hosts use `240.0.0.0/16`), and `240.1.255.254` is a gateway standing for peers the platform does not identify (service bindings, Durable Object stubs). Where Linux reports the interface a connection actually uses, that is what a socket reports: a wildcard bind resolves to the host address at `connect(2)` and on accepted sockets, and an unidentified peer appears behind the gateway with a distinct port per connection, as behind a NAT. `server.address()` and a pre-connect `BoundSocket.address()` keep reporting the wildcard, as Linux does. A connected or accepted socket therefore never reports the unspecified address as its own or its peer's, which systems software treats as "no address". If the platform later reports an outbound socket's real source (`SocketInfo.localAddress` is empty for outbound sockets today) or the real peer (#7304 for the TCP listener path), those replace the synthetic values.

`connectHandler()` takes no arguments: routing is by the port the socket arrived on, so `socket.localPort === server.address().port` by construction. `handleAsNodeConnection(socket, env, ctx)` is the direct form.

Runtime: sockets are now bound before services start, so the ports they actually got are known while workers are created, and a TCP socket's `connect()` handler receives the bound endpoint as its CONNECT authority (truthful for port 0). `IoContext` gains a scope identity object and `Worker::Api` a `getInboundListeners()` (default empty; `WorkerdApi` fills it from the bound sockets targeting the worker), exposed through `cloudflare-internal:sockets`.

Observable changes for existing code:

* Inbound `connect()` sockets are half-open. Before, the peer's FIN force-closed the handler's writable and settled `socket.closed`; after, the writable stays open until the handler closes it or returns, so a handler can reply after the peer has finished sending (any send-then-shutdown protocol was previously unservable). A handler that reads to EOF and then awaits `socket.closed` without closing its writer now waits for the peer's full close or its own return.
* `Socket.closed` settles when the readable hits EOF after the writable was already closed (`maybeCloseWriteSide` returned early without resolving it). This can settle `closed` while a `writer.close()` flush is still in flight; callers that await `writer.close()` first are unaffected.
* `httpServerHandler` lookups are scope-aware (Durable Object table first, then isolate).
* `socket.localAddress` on an outbound `net.connect()` is the namespace's synthetic host address (`240.1.0.1` for the isolate) once connecting, rather than `0.0.0.0`.

Two latent `net.Socket` issues surfaced by the prompt `closed` are fixed: `onConnectionClosed` emitted `'end'` directly and could duplicate the read loop's own EOF (now `push(null)` + `read(0)`, Node's model), and `connect()` on a live socket left the old handle attached so its EOF ended the reconnected socket and the Duplex auto-end closed the new connection's writable (the old handle is detached first; the read loop and close continuation are bound to their handle).

Tests: `net-nodejs-test.js` (no declared listeners, arbitrary ports) covers listen variants and errors, `listen(boundSocket)` adoption, a reply-after-FIN round-trip, connection counting and deferred `'close'`, no `'close'` while re-listening, `pauseOnConnect`, `maxConnections` / `'drop'`, `reusePort` round-robin routing, and a write after reconnect. New `net-server-nodejs-test.js` declares two `sockets` entries on port 0 and covers the declared-port rules (`listen(0)` claiming in order, `EADDRINUSE` when exhausted, `EADDRNOTAVAIL` for undeclared, role-neutral ephemeral `new BoundSocket()` and its re-home on `listen(bound)`, `http.Server` unconstrained), a real inbound TCP connection on a port-0 listener reaching the server that `listen(0)`'d with `socket.localPort === server.address().port`, and Durable Object scoping (two instances binding 25565 with distinct host addresses, the stub caller behind the gateway, reservations released across requests in the right table, entrypoint bindings invisible inside an instance). `connect-half-open-test.js` covers the half-open reply and `closed` settling at the platform level.

Follow-ups, not in this PR: loopback, so that `net.connect()` to `127.0.0.1` / the host address with a port in the current namespace reaches the namespace's own `net.Server` (the one structural gap in the Linux picture); real peer identity on inbound sockets (#7304 for the TCP listener path; service bindings and stubs stay behind the gateway) and a real egress source, both platform work at the commented hook points; UDP tables once #7130 lands. The `Run workers-sdk tests` job asserts the former `createServer()` stub and passes once cloudflare/workers-sdk#15601 lands.
