### PR TITLE
CC-8364 Allow containers without imageName

### DIFF
--- a/src/workerd/api/container-test.c++
+++ b/src/workerd/api/container-test.c++
@@ -40,6 +40,7 @@ struct CapturedInstance {
   bool isCustom = false;
   kj::String named;
   kj::String image;
+  kj::String containerSnapshotId;
   double vcpu = 0;
   uint64_t memoryMib = 0;
   uint64_t diskMb = 0;
@@ -60,6 +61,8 @@ class MockContainerServer final: public rpc::Container::Server {
     auto source = params.getSource();
     if (source.which() == rpc::Container::StartParams::Source::IMAGE) {
       captured.image = kj::str(source.getImage());
+    } else if (source.which() == rpc::Container::StartParams::Source::CONTAINER_SNAPSHOT_ID) {
+      captured.containerSnapshotId = kj::str(source.getContainerSnapshotId());
     }
     switch (instance.which()) {
       case rpc::Container::StartInstance::NAMED:
@@ -783,6 +786,26 @@ KJ_TEST("Container::start forwards an image") {
     return kj::mv(promise)
         .then([](CapturedInstance captured) {
       KJ_EXPECT(captured.image == "registry.example.com/image:tag");
+    }).attach(kj::mv(container));
+  });
+}
+
+KJ_TEST("Container::start forwards a container snapshot") {
+  auto fixture = makeFixture();
+  auto paf = kj::newPromiseAndFulfiller<CapturedInstance>();
+  auto promise = kj::mv(paf.promise);
+
+  fixture.runInIoContext([promise = kj::mv(promise), fulfiller = kj::mv(paf.fulfiller)](
+                             const TestFixture::Environment& env) mutable {
+    auto container = kj::rc<Container>(
+        rpc::Container::Client(kj::heap<MockContainerServer>(kj::mv(fulfiller))), false);
+    container->start(env.js,
+        Container::StartupOptions{
+          .containerSnapshot = Container::SnapshotRestoreParams{.id = kj::str("snapshot-id")},
+        });
+    return kj::mv(promise)
+        .then([](CapturedInstance captured) {
+      KJ_EXPECT(captured.containerSnapshotId == "snapshot-id");
     }).attach(kj::mv(container));
   });
 }

--- a/src/workerd/api/container.c++
+++ b/src/workerd/api/container.c++
@@ -346,9 +346,21 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
   auto flags = FeatureFlags::get(js);
   JSG_REQUIRE(
       !getRunning(), Error, "start() cannot be called on a container that is already running.");
-  invalidateTcpPortStates();
 
   StartupOptions options = kj::mv(maybeOptions).orDefault({});
+
+  JSG_REQUIRE(options.image == kj::none || options.containerSnapshot == kj::none, TypeError,
+      "`image` and `containerSnapshot` are mutually exclusive.");
+
+  KJ_IF_SOME(image, options.image) {
+    JSG_REQUIRE(image.size() > 0, TypeError, "Container image reference cannot be empty.");
+  }
+  KJ_IF_SOME(containerSnapshot, options.containerSnapshot) {
+    JSG_REQUIRE(
+        containerSnapshot.id.size() > 0, TypeError, "Container snapshot ID cannot be empty.");
+  }
+
+  invalidateTcpPortStates();
 
   auto req = rpcClient->startRequest();
   KJ_IF_SOME(spanContext, IoContext::current().getCurrentTraceSpan().toSpanContext()) {
@@ -372,8 +384,6 @@ void Container::start(jsg::Lock& js, jsg::Optional<StartupOptions> maybeOptions)
     }
   }
 
-  JSG_REQUIRE(options.image == kj::none || options.containerSnapshot == kj::none, TypeError,
-      "`image` and `containerSnapshot` are mutually exclusive.");
   if (flags.getWorkerdExperimental()) {
     KJ_IF_SOME(hardTimeoutMs, options.hardTimeout) {
       JSG_REQUIRE(hardTimeoutMs > 0, RangeError, "Hard timeout must be greater than 0");

--- a/src/workerd/server/container-client.c++
+++ b/src/workerd/server/container-client.c++
@@ -57,8 +57,6 @@ constexpr kj::StringPtr SNAPSHOT_VOLUME_PREFIX = "workerd-snap-"_kj;
 constexpr kj::StringPtr SNAPSHOT_CLONE_VOLUME_PREFIX = "workerd-snap-clone-"_kj;
 constexpr kj::StringPtr CONTAINER_SNAPSHOT_IMAGE_PREFIX = "workerd-container-snap-"_kj;
 constexpr kj::StringPtr SNAPSHOT_VOLUME_CREATED_AT_LABEL = "dev.workerd.snapshot-created-at"_kj;
-constexpr size_t MAX_SNAPSHOT_IMAGE_ANCESTRY_DEPTH = 128;
-
 constexpr auto SNAPSHOT_STALE_AGE = 30 * kj::DAYS;
 
 // Maximum size of a snapshot tar archive held in memory during snapshot create/restore.
@@ -1034,7 +1032,7 @@ ContainerClient::ContainerClient(capnp::ByteStreamFactory& byteStreamFactory,
     kj::Network& network,
     kj::String dockerPath,
     kj::String containerName,
-    kj::String imageName,
+    kj::Maybe<kj::String> imageName,
     kj::String containerEgressInterceptorImage,
     kj::TaskSet& waitUntilTasks,
     kj::Promise<void> pendingCleanup,
@@ -2221,8 +2219,7 @@ kj::Promise<void> ContainerClient::commitContainer(kj::StringPtr imageRef) {
       "': ", response.statusCode, " ", response.body);
 }
 
-kj::Promise<ContainerClient::ImageInspectResponse> ContainerClient::inspectImage(
-    kj::StringPtr imageRef) {
+kj::Promise<uint64_t> ContainerClient::inspectImageSize(kj::StringPtr imageRef) {
   auto response = co_await dockerApiRequest(network, kj::str(dockerPath), kj::HttpMethod::GET,
       kj::str("/images/", kj::encodeUriComponent(imageRef), "/json"));
   JSG_REQUIRE(response.statusCode == 200, Error, "Failed to inspect Docker image '", imageRef,
@@ -2230,7 +2227,7 @@ kj::Promise<ContainerClient::ImageInspectResponse> ContainerClient::inspectImage
 
   auto message = decodeJsonResponse<docker_api::Docker::ImageInspectResponse>(response.body);
   auto root = message->getRoot<docker_api::Docker::ImageInspectResponse>();
-  co_return ImageInspectResponse{kj::str(root.getId()), root.getSize(), kj::str(root.getParent())};
+  co_return root.getSize();
 }
 
 kj::Promise<void> ContainerClient::deleteImage(kj::String imageRef) {
@@ -2246,7 +2243,9 @@ kj::Promise<kj::String> ContainerClient::createTempContainerWithVolume(
   codec.handleByAnnotation<docker_api::Docker::ContainerCreateRequest>();
   capnp::MallocMessageBuilder message;
   auto jsonRoot = message.initRoot<docker_api::Docker::ContainerCreateRequest>();
-  jsonRoot.setImage(imageName);
+  // This helper only provides filesystem access to snapshot volumes, so it uses the infrastructure
+  // sidecar image.
+  jsonRoot.setImage(containerEgressInterceptorImage);
 
   auto hostConfig = jsonRoot.initHostConfig();
   auto binds = hostConfig.initBinds(1);
@@ -2447,6 +2446,34 @@ kj::Promise<void> ContainerClient::start(StartContext context) {
     environment = params.getEnvironmentVariables();
   }
 
+  kj::String snapshotImageRef;
+  kj::Maybe<kj::StringPtr> effectiveImage =
+      imageName.map([](kj::String& image) -> kj::StringPtr { return image; });
+  auto source = params.getSource();
+  switch (source.which()) {
+    case rpc::Container::StartParams::Source::IMAGE:
+      JSG_REQUIRE(
+          source.getImage().size() > 0, Error, "Container image reference cannot be empty.");
+      effectiveImage = source.getImage();
+      break;
+    case rpc::Container::StartParams::Source::CONTAINER_SNAPSHOT_ID: {
+      if (!source.hasContainerSnapshotId()) break;
+
+      auto snapshotRef = source.getContainerSnapshotId();
+      JSG_REQUIRE(snapshotRef.size() > 0, Error, "Container snapshot ID cannot be empty.");
+
+      auto snapshotId = parseSnapshotId(snapshotRef);
+      snapshotImageRef = kj::str(CONTAINER_SNAPSHOT_IMAGE_PREFIX, snapshotId);
+      // Snapshot existence is validated before sidecar and directory-volume setup.
+      co_await inspectImageSize(snapshotImageRef);
+      effectiveImage = snapshotImageRef;
+      break;
+    }
+  }
+
+  auto image = JSG_REQUIRE_NONNULL(
+      effectiveImage, Error, "Container.start() requires an image or container snapshot.");
+
   internetEnabled = params.getEnableInternet();
 
   labels.clear();
@@ -2455,33 +2482,6 @@ kj::Promise<void> ContainerClient::start(StartContext context) {
     labels.reserve(lbls.size());
     for (auto i: kj::zeroTo(lbls.size())) {
       labels.insert(kj::str(lbls[i].getName()), kj::str(lbls[i].getValue()));
-    }
-  }
-
-  kj::String snapshotImageRef;
-  kj::StringPtr effectiveImage = imageName;
-  auto source = params.getSource();
-  switch (source.which()) {
-    case rpc::Container::StartParams::Source::IMAGE:
-      effectiveImage = source.getImage();
-      break;
-    case rpc::Container::StartParams::Source::CONTAINER_SNAPSHOT_ID: {
-      if (!source.hasContainerSnapshotId()) break;
-
-      auto selectedImage = co_await inspectImage(effectiveImage);
-      auto snapshotId = parseSnapshotId(source.getContainerSnapshotId());
-      snapshotImageRef = kj::str(CONTAINER_SNAPSHOT_IMAGE_PREFIX, snapshotId);
-      auto snapshotImage = co_await inspectImage(snapshotImageRef);
-      for (size_t depth = 0;
-           snapshotImage.id != selectedImage.id && snapshotImage.parent.size() > 0; ++depth) {
-        JSG_REQUIRE(depth < MAX_SNAPSHOT_IMAGE_ANCESTRY_DEPTH, Error,
-            "Container snapshot image ancestry is too deep");
-        snapshotImage = co_await inspectImage(snapshotImage.parent);
-      }
-      JSG_REQUIRE(snapshotImage.id == selectedImage.id, Error,
-          "Container snapshot does not match the requested image");
-      effectiveImage = snapshotImageRef;
-      break;
     }
   }
 
@@ -2534,7 +2534,7 @@ kj::Promise<void> ContainerClient::start(StartContext context) {
   }
 
   caCertInjected.store(false, std::memory_order_release);
-  co_await createContainer(effectiveImage, entrypoint, environment, restoreMounts.asPtr(), params);
+  co_await createContainer(image, entrypoint, environment, restoreMounts.asPtr(), params);
 
   for (auto& mapping: egressState->mappings) {
     if (mapping.protocol == EgressProtocol::HTTPS) {
@@ -2797,11 +2797,11 @@ kj::Promise<void> ContainerClient::snapshotContainer(SnapshotContainerContext co
   co_await commitContainer(imageRef);
   imageCommitted = true;
 
-  auto image = co_await inspectImage(imageRef);
+  auto imageSize = co_await inspectImageSize(imageRef);
 
   auto result = context.getResults().initSnapshot();
   result.setId(snapshotId);
-  result.setSize(image.size);
+  result.setSize(imageSize);
   if (params.hasName() && params.getName().size() > 0) {
     result.setName(params.getName());
   }

--- a/src/workerd/server/container-client.h
+++ b/src/workerd/server/container-client.h
@@ -86,7 +86,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
       kj::Network& network,
       kj::String dockerPath,
       kj::String containerName,
-      kj::String imageName,
+      kj::Maybe<kj::String> imageName,
       kj::String containerEgressInterceptorImage,
       kj::TaskSet& waitUntilTasks,
       kj::Promise<void> pendingCleanup,
@@ -124,7 +124,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   kj::String dockerPath;
   kj::String containerName;
   kj::String sidecarContainerName;
-  kj::String imageName;
+  kj::Maybe<kj::String> imageName;
 
   // Container egress interceptor image name (sidecar for egress proxy)
   kj::String containerEgressInterceptorImage;
@@ -172,12 +172,6 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
     kj::String cloneVolume;
   };
 
-  struct ImageInspectResponse {
-    kj::String id;
-    uint64_t size;
-    kj::String parent;
-  };
-
   struct ExecInspectResponse {
     int32_t exitCode;
     bool running;
@@ -213,7 +207,7 @@ class ContainerClient final: public rpc::Container::Server, public kj::Refcounte
   kj::Promise<void> createVolume(kj::StringPtr volumeName);
   kj::Promise<void> deleteVolume(kj::String volumeName);
   kj::Promise<void> commitContainer(kj::StringPtr imageRef);
-  kj::Promise<ImageInspectResponse> inspectImage(kj::StringPtr imageRef);
+  kj::Promise<uint64_t> inspectImageSize(kj::StringPtr imageRef);
   kj::Promise<void> deleteImage(kj::String imageRef);
   kj::Promise<kj::String> createTempContainerWithVolume(
       kj::StringPtr volumeName, kj::StringPtr mountPath);

--- a/src/workerd/server/server-test.c++
+++ b/src/workerd/server/server-test.c++
@@ -2391,6 +2391,96 @@ KJ_TEST("Server: configuring a DO namespace with no class export is not an error
     Internal Server Error)"_blockquote);
 }
 
+KJ_TEST("Server: named images and directory snapshots are not startup sources") {
+  TestServer test(R"((
+    services = [
+      ( name = "hello",
+        worker = (
+          compatibilityDate = "2026-08-01",
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `import { DurableObject } from "cloudflare:workers";
+                `export default {
+                `  fetch(request, env) {
+                `    return env.ns.get(env.ns.idFromName("test")).fetch(request);
+                `  }
+                `}
+                `export class NamedImageContainer extends DurableObject {
+                `  async fetch() {
+                `    const before = Number(await (await this.env.dockerCheck.fetch(
+                `        "http://docker/check")).text());
+                `    this.ctx.container.start({
+                `      directorySnapshots: [{
+                `        snapshot: {id: "unused", size: 0, dir: "/data"},
+                `      }],
+                `    });
+                `    try {
+                `      await this.ctx.container.monitor();
+                `      return new Response("no error");
+                `    } catch (error) {
+                `      const response = await this.env.dockerCheck.fetch("http://docker/check");
+                `      const requests = Number(await response.text()) - before;
+                `      return new Response(`${error.message}; Docker requests: ${requests}`);
+                `    }
+                `  }
+                `}
+            )
+          ],
+          bindings = [
+            (name = "ns", durableObjectNamespace = "NamedImageContainer"),
+            (name = "dockerCheck", service = "docker"),
+          ],
+          durableObjectNamespaces = [
+            ( className = "NamedImageContainer",
+              uniqueKey = "named-image-container",
+              container = (
+                images = [(name = "app", image = "registry.example.com/app:latest")],
+              ),
+            ),
+          ],
+          durableObjectStorage = (inMemory = void),
+          containerEngine = (localDocker = (
+            socketPath = "docker-addr",
+            containerEgressInterceptorImage = "unused",
+          )),
+        )
+      ),
+      ( name = "docker",
+        worker = (
+          compatibilityDate = "2026-08-01",
+          modules = [
+            ( name = "main.js",
+              esModule =
+                `let requests = 0;
+                `export default {
+                `  fetch(request) {
+                `    const path = new URL(request.url).pathname;
+                `    if (path === "/check") {
+                `      return new Response(String(requests));
+                `    }
+                `    // The process-wide stale-volume scan is not part of container startup.
+                `    if (path !== "/volumes") ++requests;
+                `    return new Response(null, {status: 404});
+                `  }
+                `}
+            )
+          ],
+        )
+      ),
+    ],
+    sockets = [
+      ( name = "main", address = "test-addr", service = "hello" ),
+      ( name = "docker", address = "docker-addr", service = "docker" ),
+    ],
+  ))"_kj);
+
+  test.server.allowExperimental();
+  test.start();
+  auto conn = test.connect("test-addr");
+  conn.httpGet200("/", "Container failed to start; Docker requests: 0");
+}
+
 KJ_TEST("Server: call queue handler on service binding") {
   TestServer test(R"((
     services = [

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1323,8 +1323,10 @@ class Server::ActorNamespace final {
       kj::Maybe<rpc::Container::Client> container = kj::none;
       jsg::Dict<kj::String> containerImages;
       KJ_IF_SOME(config, containerOptions) {
-        KJ_ASSERT(config.hasImageName(), "Image name is required");
-        auto imageName = config.getImageName();
+        kj::Maybe<kj::StringPtr> imageName = kj::none;
+        if (config.hasImageName() && config.getImageName().size() > 0) {
+          imageName = config.getImageName();
+        }
         containerImages.fields = KJ_MAP(image, config.getImages()) {
           return jsg::Dict<kj::String>::Field{
             .name = kj::str(image.getName()),
@@ -1423,8 +1425,9 @@ class Server::ActorNamespace final {
     })->addRef();
   }
 
-  kj::Own<ContainerClient> getContainerClient(
-      kj::StringPtr containerId, kj::StringPtr imageName, ContainerPrivileges privileges) {
+  kj::Own<ContainerClient> getContainerClient(kj::StringPtr containerId,
+      kj::Maybe<kj::StringPtr> imageName,
+      ContainerPrivileges privileges) {
     KJ_IF_SOME(existingClient, containerClients.find(containerId)) {
       return existingClient->addRef();
     }
@@ -1479,7 +1482,8 @@ class Server::ActorNamespace final {
     };
 
     auto client = kj::refcounted<ContainerClient>(byteStreamFactory, timer, dockerNetwork,
-        kj::str(dockerPathRef), kj::str(containerId), kj::str(imageName),
+        kj::str(dockerPathRef), kj::str(containerId),
+        imageName.map([](kj::StringPtr image) { return kj::str(image); }),
         kj::str(KJ_ASSERT_NONNULL(containerEgressInterceptorImage,
             "containerEgressInterceptorImage must be configured for containers.")),
         waitUntilTasks, kj::mv(previousCleanup), kj::mv(cleanupCallback), channelTokenHandler,

--- a/src/workerd/server/tests/container-client/container-client.wd-test
+++ b/src/workerd/server/tests/container-client/container-client.wd-test
@@ -37,11 +37,32 @@ const unitTests :Workerd.Config = (
                 ),
               ],
             ) ),
+          ( className = "NamedImagesOnlyDurableObject",
+            uniqueKey = "container-client-test-NamedImagesOnlyDurableObject",
+            container = (
+              images = [
+                (
+                  name = "app",
+                  image = "cloudflare/workerd/container-client-test",
+                ),
+              ],
+            ) ),
+          ( className = "EmptyContainerDurableObject",
+            uniqueKey = "container-client-test-EmptyContainerDurableObject",
+            container = () ),
+          ( className = "SnapshotRestoreWithDifferentDefaultDurableObject",
+            uniqueKey = "container-client-test-SnapshotRestoreWithDifferentDefaultDurableObject",
+            container = (
+              imageName = "cloudflare/proxy-everything:main",
+            ) ),
         ],
         durableObjectStorage = (localDisk = "TEST_TMPDIR"),
         bindings = [
           ( name = "MY_CONTAINER", durableObjectNamespace = "DurableObjectExample" ),
           ( name = "MY_DUPLICATE_CONTAINER", durableObjectNamespace = "DurableObjectExample2" ),
+          ( name = "MY_NAMED_IMAGES_ONLY_CONTAINER", durableObjectNamespace = "NamedImagesOnlyDurableObject" ),
+          ( name = "MY_EMPTY_CONTAINER", durableObjectNamespace = "EmptyContainerDurableObject" ),
+          ( name = "MY_DIFFERENT_DEFAULT_CONTAINER", durableObjectNamespace = "SnapshotRestoreWithDifferentDefaultDurableObject" ),
         ],
       )
     ),

--- a/src/workerd/server/tests/container-client/test.js
+++ b/src/workerd/server/tests/container-client/test.js
@@ -121,6 +121,8 @@ export class DurableObjectExample extends DurableObject {
     const monitor = container.monitor().catch((_err) => {});
 
     await this.waitUntilContainerIsHealthy();
+    const info = await container.inspect();
+    assert.match(info.image, /container-client-test(?::latest)?$/);
 
     await container.destroy();
 
@@ -1352,7 +1354,7 @@ export class DurableObjectExample extends DurableObject {
     await monitor;
   }
 
-  async createContainerSnapshotForTransfer() {
+  async createContainerSnapshotForTransfer(startOptions = {}) {
     const container = this.ctx.container;
     if (container.running) {
       const monitor = container.monitor().catch((_err) => {});
@@ -1360,7 +1362,7 @@ export class DurableObjectExample extends DurableObject {
       await monitor;
     }
 
-    container.start({ enableInternet: true });
+    container.start({ enableInternet: true, ...startOptions });
     const monitor = container.monitor().catch((_err) => {});
     await this.waitUntilContainerIsHealthy();
 
@@ -1867,7 +1869,7 @@ export class DurableObjectExample extends DurableObject {
     await container.destroy();
   }
 
-  async testSnapshotRoundTrip() {
+  async testSnapshotRoundTrip(startOptions = {}) {
     const container = this.ctx.container;
     if (container.running) {
       const monitor = container.monitor().catch((_err) => {});
@@ -1877,7 +1879,7 @@ export class DurableObjectExample extends DurableObject {
 
     assert.strictEqual(container.running, false);
 
-    container.start({ enableInternet: true });
+    container.start({ enableInternet: true, ...startOptions });
     const monitor = container.monitor().catch((_err) => {});
     await this.waitUntilContainerIsHealthy();
 
@@ -1903,6 +1905,7 @@ export class DurableObjectExample extends DurableObject {
 
     container.start({
       enableInternet: true,
+      ...startOptions,
       directorySnapshots: [{ snapshot }],
     });
     const monitor2 = container.monitor().catch((_err) => {});
@@ -2898,6 +2901,50 @@ export class TestService extends WorkerEntrypoint {
 
 export class DurableObjectExample2 extends DurableObjectExample {}
 
+export class SnapshotRestoreWithDifferentDefaultDurableObject extends DurableObjectExample {}
+
+function assertInvalidExplicitStartupSources(container) {
+  assert.throws(() => container.start({ image: '' }), {
+    message: 'Container image reference cannot be empty.',
+  });
+  assert.throws(() => container.start({ containerSnapshot: { id: '' } }), {
+    message: 'Container snapshot ID cannot be empty.',
+  });
+}
+
+export class NamedImagesOnlyDurableObject extends DurableObjectExample {
+  async testExplicitImageAndSnapshots() {
+    const container = this.ctx.container;
+    assert.deepStrictEqual(container.images, {
+      app: 'cloudflare/workerd/container-client-test',
+    });
+    const startOptions = { image: container.images.app };
+
+    await this.testSnapshotRoundTrip(startOptions);
+    const containerSnapshot =
+      await this.createContainerSnapshotForTransfer(startOptions);
+    await this.restoreTransferredContainerSnapshot(containerSnapshot);
+  }
+}
+
+export class EmptyContainerDurableObject extends DurableObjectExample {
+  async testExplicitImage() {
+    const container = this.ctx.container;
+    assert.deepStrictEqual(container.images, {});
+    assertInvalidExplicitStartupSources(container);
+
+    container.start({
+      enableInternet: true,
+      image: 'cloudflare/workerd/container-client-test',
+    });
+    const monitor = container.monitor().catch((_err) => {});
+    await this.waitUntilContainerIsHealthy();
+
+    await container.destroy();
+    await monitor;
+  }
+}
+
 export const testImages = {
   async test(_ctrl, env) {
     const cases = [
@@ -2920,6 +2967,26 @@ export const testImages = {
       const id = namespace.idFromName(getRandomDurableObjectName('testImages'));
       await namespace.get(id).testImages(expected);
     }
+  },
+};
+
+export const testNamedImagesOnlyExplicitImageAndSnapshots = {
+  async test(_ctrl, env) {
+    const id = env.MY_NAMED_IMAGES_ONLY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testNamedImagesOnlyExplicitImageAndSnapshots')
+    );
+    await env.MY_NAMED_IMAGES_ONLY_CONTAINER.get(
+      id
+    ).testExplicitImageAndSnapshots();
+  },
+};
+
+export const testEmptyContainerExplicitImage = {
+  async test(_ctrl, env) {
+    const id = env.MY_EMPTY_CONTAINER.idFromName(
+      getRandomDurableObjectName('testEmptyContainerExplicitImage')
+    );
+    await env.MY_EMPTY_CONTAINER.get(id).testExplicitImage();
   },
 };
 
@@ -3615,6 +3682,31 @@ export const testContainerSnapshotCrossDoRestore = {
 
     const snapshot = await source.createContainerSnapshotForTransfer();
     assert.strictEqual(snapshot.name, 'cross-do-container-snapshot');
+
+    await target.restoreTransferredContainerSnapshot(snapshot);
+  },
+};
+
+// A full container snapshot supplies its own image, regardless of the restoring DO's configured
+// default.
+export const testContainerSnapshotRestoreWithDifferentDefaultImage = {
+  async test(_ctrl, env) {
+    const sourceId = env.MY_EMPTY_CONTAINER.idFromName(
+      getRandomDurableObjectName(
+        'testContainerSnapshotRestoreWithDifferentDefaultImage-source'
+      )
+    );
+    const targetId = env.MY_DIFFERENT_DEFAULT_CONTAINER.idFromName(
+      getRandomDurableObjectName(
+        'testContainerSnapshotRestoreWithDifferentDefaultImage-target'
+      )
+    );
+
+    const source = env.MY_EMPTY_CONTAINER.get(sourceId);
+    const target = env.MY_DIFFERENT_DEFAULT_CONTAINER.get(targetId);
+    const snapshot = await source.createContainerSnapshotForTransfer({
+      image: 'cloudflare/workerd/container-client-test',
+    });
 
     await target.restoreTransferredContainerSnapshot(snapshot);
   },

--- a/src/workerd/server/workerd.capnp
+++ b/src/workerd/server/workerd.capnp
@@ -660,14 +660,16 @@ struct Worker {
 
     container @5 :ContainerOptions;
     # If present, Durable Objects in this namespace have attached containers.
-    # workerd will talk to the configured container engine to start containers for each
-    # Durable Object based on the given image. The Durable Object can access the container via the
-    # ctx.container API. TODO(CloudChamber): add link to docs.
+    # workerd will talk to the configured container engine to start containers for each Durable
+    # Object from a configured default, a runtime-selected image, or a full container snapshot. The
+    # Durable Object can access the container via the ctx.container API.
+    # TODO(CloudChamber): add link to docs.
 
     struct ContainerOptions {
       imageName @0 :Text;
-      # Image name to be used to create the container using supported provider.
-      # By default, we pull the "latest" tag of this image.
+      # Optional default image used when start() does not specify an image or full container
+      # snapshot. An empty value means that no default image is configured.
+      # When imageName omits a tag, Docker uses the "latest" tag.
 
       privileges @1 :ContainerPrivileges;
       # Extra Docker HostConfig privileges applied when creating the container.
@@ -678,7 +680,9 @@ struct Worker {
 
       images @2 :List(NamedImage);
       # Named image references exposed to the Durable Object through ctx.container.images.
-      # These do not change imageName, which remains the default when start() omits an image.
+      # These are optional; Worker code can instead supply an image reference from another source.
+      # When imageName is empty, the local container backend requires start() to specify an image or
+      # full container snapshot.
 
       struct NamedImage {
         name @0 :Text;


### PR DESCRIPTION
Container Apps have a namespace-level image. workerd models that as `imageName`, and currently requires it on every Container-enabled Durable Object namespace.

Container Instances do not have a namespace-level image. Worker code chooses the image on start(), and a full container snapshot is also a valid source. Local development cannot represent Instances today.

This change makes `imageName` optional. Namespaces that still set it keep no-argument start() behavior. Namespaces that omit it must pass an image or a full container snapshot to start(). Named images stay on `ctx.container.images` so Worker code can pass them to start(). They are not a replacement for `imageName`.

A full container snapshot replaces the image, so restore starts from the snapshot even when the namespace has a different `imageName`. Directory snapshots only overlay files, so they still need an image or full snapshot underneath.

Tests cover API validation, named-image and empty configurations, direct image selection, missing sources, directory snapshots as a non-source, and Docker-backed snapshot restore against a different `imageName`.