### PR TITLE
Add clang-tidy check for stream creation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,6 +68,7 @@ Checks: >
   jsg-visit-for-gc,
   workerd-angled-includes,
   workerd-consume,
+  workerd-legacy-stream-alloc,
   workerd-promise-ignore-result,
   workerd-unsafe-continuation-capture,
   custom-iocontext-run-manual-capture

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -43,6 +43,15 @@ that adds workerd-specific static checks:
 - `workerd-consume`: flags calls to methods annotated with `WD_CONSUME` when
   the call is made directly through `kj::Ptr` instead of through
   `consume(kj::mv(ptr))->method(...)`.
+- `workerd-legacy-stream-alloc`: flags direct allocation of the legacy C++
+  `ReadableStream` / `WritableStream` (`js.alloc<ReadableStream>(...)`,
+  `js.allocAccounted<...>`, `jsg::alloc<...>`) anywhere other than inside
+  `JsReadableStream::create()` / `JsWritableStream::create()`, the dispatch
+  points that select the stream implementation by the
+  `typescript_implemented_streams` compatibility flag. The legacy
+  implementation's own internals and tests of the legacy implementation
+  suppress it with `NOLINT(workerd-legacy-stream-alloc)` plus a comment
+  explaining why the allocation has to be legacy.
 - `workerd-promise-ignore-result` - warns on superfluous `ignoreResult()` calls:
   on promises that are immediately `co_await`ed, and on `capnp::Request::send()`
   results, which should use `sendIgnoringResult()` instead
@@ -53,9 +62,11 @@ that adds workerd-specific static checks:
 Usage:
 
 - Run via `just clang-tidy <target>` (e.g., `just clang-tidy //src/workerd/api/...`).
-- Plugin sources live in `tools/clang-tidy/workerd-lint.c++` and
-  `tools/clang-tidy/unsafe-continuation-capture.c++`, built as a
-  `cc_shared_library` target `//tools/clang-tidy:workerd-lint`. The sources are
+- Plugin sources live in `tools/clang-tidy/`: one `.h`/`.c++` pair per check,
+  registered in `workerd-lint.c++`, built as a `cc_shared_library` target
+  `//tools/clang-tidy:workerd-lint`. Each check has a `<check>-test.sh` runner
+  driving `<check>-positive-test.c++` / `<check>-negative-test.c++` fixtures
+  (`bazel test //tools/clang-tidy/...`). The sources are
   also exported via `exports_files` so downstream projects can rebuild
   against their own clang/LLVM headers.
 - The clang-tidy binary itself is published to `cloudflare/workerd-tools`

--- a/src/workerd/api/AGENTS.md
+++ b/src/workerd/api/AGENTS.md
@@ -36,7 +36,7 @@ tests/               # JS integration tests (238 entries); each test = .js + .wd
 | KV / SyncKV                    | `kv.h`, `sync-kv.h`                                   |
 | SQL (DO)                       | `sql.h`                                               |
 | Body mixin (shared Req/Res)    | `http.h` — `Body` class, `Body::Initializer` OneOf    |
-| Readable/WritableStream from C++ | `js-readable-stream.{h,c++}` + `js-writable-stream.{h,c++}` — `JsReadableStream`/`JsWritableStream` abstractions, plus `JsReadableWritablePair` and `pipeTo`/`pipeThrough`; ALWAYS use these (not `jsg::Ref<ReadableStream>`/`jsg::Ref<WritableStream>`) outside `streams/` |
+| Readable/WritableStream from C++ | `js-readable-stream.{h,c++}` + `js-writable-stream.{h,c++}` — `JsReadableStream`/`JsWritableStream` abstractions, plus `JsReadableWritablePair` and `pipeTo`/`pipeThrough`; ALWAYS use these (not `jsg::Ref<ReadableStream>`/`jsg::Ref<WritableStream>`) outside `streams/`. New streams are minted with `JsReadableStream::create()`/`JsWritableStream::create()`; the `workerd-legacy-stream-alloc` clang-tidy check rejects `js.alloc<ReadableStream>`/`js.alloc<WritableStream>` anywhere else |
 
 ## CONVENTIONS
 

--- a/src/workerd/api/js-readable-stream.c++
+++ b/src/workerd/api/js-readable-stream.c++
@@ -512,6 +512,8 @@ JsReadableStream::StreamImpl newBackingStream(
     auto constructor = webstreams::getCppExport(js, "ReadableStream");
     return JsReadableStream::StreamImpl(constructor.newInstance(js, sourceObj).addRef(js));
   }
+  // The legacy arm of the dispatch that JsReadableStream::create() delegates to.
+  // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
   return JsReadableStream::StreamImpl(js.alloc<ReadableStream>(ioContext, kj::mv(source)));
 }
 

--- a/src/workerd/api/js-writable-stream-test.c++
+++ b/src/workerd/api/js-writable-stream-test.c++
@@ -254,8 +254,9 @@ KJ_TEST("JsWritableStream flush rejects when a writer is held; forceFlush succee
   testFixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto& js = env.js;
 
-    // Pre-lock the stream by attaching a writer to the underlying WritableStream before adopting
-    // it into the abstraction.
+    // Pre-lock the stream by attaching a writer to the underlying legacy WritableStream before
+    // adopting it into the abstraction.
+    // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
     auto ws = js.alloc<WritableStream>(env.context, state.makeSink(), kj::none);
     auto writer = ws->getWriter(js);
     JsWritableStream stream(kj::mv(ws));
@@ -281,6 +282,8 @@ KJ_TEST("JsWritableStream forceAbort succeeds despite a held writer") {
   testFixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto& js = env.js;
 
+    // Pre-lock the stream via the legacy WritableStream's writer before adopting it.
+    // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
     auto ws = js.alloc<WritableStream>(env.context, state.makeSink(), kj::none);
     auto writer = ws->getWriter(js);
     JsWritableStream stream(kj::mv(ws));
@@ -297,6 +300,8 @@ KJ_TEST("JsWritableStream forceClose succeeds despite a held writer") {
   testFixture.runInIoContext([&](const TestFixture::Environment& env) -> kj::Promise<void> {
     auto& js = env.js;
 
+    // Pre-lock the stream via the legacy WritableStream's writer before adopting it.
+    // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
     auto ws = js.alloc<WritableStream>(env.context, state.makeSink(), kj::none);
     auto writer = ws->getWriter(js);
     JsWritableStream stream(kj::mv(ws));
@@ -335,6 +340,8 @@ KJ_TEST("JsWritableStream detach throws when a writer is held") {
   testFixture.runInIoContext([&](const TestFixture::Environment& env) {
     auto& js = env.js;
 
+    // Pre-lock the stream via the legacy WritableStream's writer before adopting it.
+    // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
     auto ws = js.alloc<WritableStream>(env.context, state.makeSink(), kj::none);
     auto writer = ws->getWriter(js);
     JsWritableStream stream(kj::mv(ws));
@@ -483,6 +490,8 @@ KJ_TEST("JsReadableStream pipeTo rejects when the destination is locked") {
     auto& js = env.js;
 
     JsReadableStream source(js, kj::str(kData));
+    // Pre-lock the destination via the legacy WritableStream's writer before adopting it.
+    // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
     auto ws = js.alloc<WritableStream>(env.context, state.makeSink(), kj::none);
     auto writer = ws->getWriter(js);
     JsWritableStream destination(kj::mv(ws));

--- a/src/workerd/api/streams-test.c++
+++ b/src/workerd/api/streams-test.c++
@@ -5,6 +5,10 @@
 
 #include <kj/test.h>
 
+// These tests exercise the legacy C++ streams implementation directly, so they allocate the
+// legacy ReadableStream rather than going through the JsReadableStream implementation dispatch.
+// NOLINTBEGIN(workerd-legacy-stream-alloc)
+
 namespace workerd::api {
 
 namespace {
@@ -199,3 +203,5 @@ KJ_TEST("ReadableStream pumpTo pending write cancellation regression") {
 
 }  // namespace
 }  // namespace workerd::api
+
+// NOLINTEND(workerd-legacy-stream-alloc)

--- a/src/workerd/api/streams/AGENTS.md
+++ b/src/workerd/api/streams/AGENTS.md
@@ -13,6 +13,14 @@ implementation backs a given stream (and provide `JsReadableWritablePair` +
 `pipeTo`/`pipeThrough` for abstraction-level pipelines). New C++ consumers of streams should use
 those abstractions, not the types defined here.
 
+Allocating the types defined here directly (`js.alloc<ReadableStream>(...)` and friends) is
+rejected by the `workerd-legacy-stream-alloc` clang-tidy check everywhere except inside
+`JsReadableStream::create()` / `JsWritableStream::create()`, which dispatch on the
+`typescript_implemented_streams` compatibility flag. The legacy implementation's own internals
+that necessarily produce legacy streams (`tee()`, `detach()`, the legacy JS constructors, the
+`deserialize()` legacy fallbacks) and tests that exercise this implementation directly carry
+`NOLINT(workerd-legacy-stream-alloc)` with a comment saying why.
+
 Dual implementation behind unified API:
 
 - **Internal** (`internal.h`): kj-backed, byte-only, single pending read, no JS queue

--- a/src/workerd/api/streams/compression.c++
+++ b/src/workerd/api/streams/compression.c++
@@ -372,6 +372,12 @@ class CompressionStreamAdapter final: public kj::Refcounted,
 
 }  // namespace
 
+// These are the legacy implementation's JS constructors, so the readable and writable sides they
+// build are legacy streams by construction; under typescript_implemented_streams the global
+// CompressionStream / DecompressionStream are the TypeScript classes and these constructors are
+// not reachable.
+// NOLINTBEGIN(workerd-legacy-stream-alloc)
+
 jsg::Ref<CompressionStream> CompressionStream::constructor(jsg::Lock& js, kj::String format) {
   JSG_REQUIRE(format == "deflate" || format == "gzip" || format == "deflate-raw", TypeError,
       "The compression format must be either 'deflate', 'deflate-raw' or 'gzip'.");
@@ -411,5 +417,7 @@ jsg::Ref<DecompressionStream> DecompressionStream::constructor(jsg::Lock& js, kj
       js.alloc<WritableStream>(ioContext, kj::mv(writableSide),
           ioContext.getMetrics().tryCreateWritableByteStreamObserver()));
 }
+
+// NOLINTEND(workerd-legacy-stream-alloc)
 
 }  // namespace workerd::api

--- a/src/workerd/api/streams/draining-read-uaf-test.c++
+++ b/src/workerd/api/streams/draining-read-uaf-test.c++
@@ -33,6 +33,10 @@
 #include <workerd/jsg/jsg.h>
 #include <workerd/tests/test-fixture.h>
 
+// This test exercises the legacy C++ streams implementation directly, so it allocates the legacy
+// ReadableStream rather than going through the JsReadableStream implementation dispatch.
+// NOLINTBEGIN(workerd-legacy-stream-alloc)
+
 namespace workerd::api {
 namespace {
 
@@ -171,3 +175,5 @@ KJ_TEST("wrapDrainingRead ref prevents UAF when DrainingReader is dropped (byte 
 
 }  // namespace
 }  // namespace workerd::api
+
+// NOLINTEND(workerd-legacy-stream-alloc)

--- a/src/workerd/api/streams/identity-transform-stream.c++
+++ b/src/workerd/api/streams/identity-transform-stream.c++
@@ -399,6 +399,12 @@ Pair newIdentityPair(kj::Maybe<uint64_t> expectedLength = kj::none) {
 }
 }  // namespace
 
+// These are the legacy implementation's JS constructors, so the readable and writable sides they
+// build are legacy streams by construction; under typescript_implemented_streams the global
+// IdentityTransformStream / FixedLengthStream are the TypeScript classes and these constructors are
+// not reachable.
+// NOLINTBEGIN(workerd-legacy-stream-alloc)
+
 jsg::Ref<IdentityTransformStream> IdentityTransformStream::constructor(
     jsg::Lock& js, jsg::Optional<IdentityTransformStream::QueuingStrategy> maybeQueuingStrategy) {
 
@@ -436,6 +442,8 @@ jsg::Ref<FixedLengthStream> FixedLengthStream::constructor(jsg::Lock& js,
       js.alloc<WritableStream>(ioContext, kj::mv(pipe.out),
           ioContext.getMetrics().tryCreateWritableByteStreamObserver(), maybeHighWaterMark));
 }
+
+// NOLINTEND(workerd-legacy-stream-alloc)
 
 OneWayPipe newIdentityPipe(kj::Maybe<uint64_t> expectedLength) {
   auto pair = newIdentityPair(kj::mv(expectedLength));

--- a/src/workerd/api/streams/internal-test.c++
+++ b/src/workerd/api/streams/internal-test.c++
@@ -14,6 +14,11 @@
 
 #include <openssl/rand.h>
 
+// These tests exercise the legacy C++ streams implementation directly, so they allocate the
+// legacy ReadableStream / WritableStream rather than going through the JsReadableStream /
+// JsWritableStream implementation dispatch.
+// NOLINTBEGIN(workerd-legacy-stream-alloc)
+
 namespace workerd::api {
 namespace {
 
@@ -1248,3 +1253,5 @@ KJ_TEST("internal pipe force-cancel drops pending read before destroying source"
 
 }  // namespace
 }  // namespace workerd::api
+
+// NOLINTEND(workerd-legacy-stream-alloc)

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -1067,6 +1067,10 @@ ReadableStreamController::Tee ReadableStreamInternalController::tee(jsg::Lock& j
       !isPendingClosure, TypeError, "This ReadableStream belongs to an object that is closing.");
   readState.transitionTo<Locked>();
   disturbed = true;
+  // The branches of a legacy stream are legacy streams by construction: they are built directly
+  // over this controller's state and sources, not through the implementation dispatch in
+  // JsReadableStream::create().
+  // NOLINTBEGIN(workerd-legacy-stream-alloc)
   KJ_SWITCH_ONEOF(state) {
     KJ_CASE_ONEOF(closed, StreamStates::Closed) {
       // Create two closed ReadableStreams.
@@ -1108,6 +1112,7 @@ ReadableStreamController::Tee ReadableStreamInternalController::tee(jsg::Lock& j
           kj::heap<TeeBranch>(newTeeErrorAdapter(kj::mv(tee.branches[1]))));
     }
   }
+  // NOLINTEND(workerd-legacy-stream-alloc)
 
   KJ_UNREACHABLE;
 }

--- a/src/workerd/api/streams/readable.c++
+++ b/src/workerd/api/streams/readable.c++
@@ -583,6 +583,9 @@ jsg::Ref<ReadableStream> ReadableStream::detach(jsg::Lock& js, bool ignoreDistur
   JSG_REQUIRE(
       !isDisturbed() || ignoreDisturbed, TypeError, "The ReadableStream has already been read.");
   JSG_REQUIRE(!isLocked(), TypeError, "The ReadableStream has been locked to a reader.");
+  // The detached stream takes over this legacy stream's controller, so it is a legacy stream by
+  // construction.
+  // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
   return js.alloc<ReadableStream>(getController().detach(js, ignoreDisturbed));
 }
 
@@ -609,6 +612,10 @@ jsg::Ref<ReadableStream> ReadableStream::constructor(jsg::Lock& js,
   // We account for the memory usage of the ReadableStream and its controller together because their
   // lifetimes are identical and memory accounting itself has a memory overhead.
   auto controller = newReadableStreamJsController();
+  // This is the legacy ReadableStream's own JS constructor, which necessarily produces the legacy
+  // type; under typescript_implemented_streams the global ReadableStream is the TypeScript class
+  // and this constructor is not reachable.
+  // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
   auto stream = js.allocAccounted<ReadableStream>(
       sizeof(ReadableStream) + controller->jsgGetMemorySelfSize(), kj::mv(controller));
   stream->getController().setup(js, kj::mv(underlyingSource), kj::mv(queuingStrategy));
@@ -821,6 +828,9 @@ JsReadableStream ReadableStream::deserialize(
 
   kj::Own<kj::AsyncInputStream> in = ioctx.getExternalPusher()->unwrapStream(rs.getStream());
 
+  // Legacy-streams isolates only (see above), and JsReadableStream::create() may run JS, which is
+  // forbidden here.
+  // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
   return JsReadableStream(js.alloc<ReadableStream>(ioctx,
       kj::heap<NoDeferredProxyReadableStream>(
           newSystemStream(kj::mv(in), encoding, ioctx), ioctx)));

--- a/src/workerd/api/streams/standard-test.c++
+++ b/src/workerd/api/streams/standard-test.c++
@@ -7,6 +7,11 @@
 #include <workerd/jsg/observer.h>
 #include <workerd/tests/test-fixture.h>
 
+// These tests exercise the legacy C++ streams implementation directly, so they allocate the
+// legacy ReadableStream / WritableStream rather than going through the JsReadableStream /
+// JsWritableStream implementation dispatch.
+// NOLINTBEGIN(workerd-legacy-stream-alloc)
+
 namespace workerd::api {
 namespace {
 
@@ -2524,3 +2529,5 @@ KJ_TEST("DrainingReader: controller closes promptly after drainingRead done (byt
 
 }  // namespace
 }  // namespace workerd::api
+
+// NOLINTEND(workerd-legacy-stream-alloc)

--- a/src/workerd/api/streams/standard.c++
+++ b/src/workerd/api/streams/standard.c++
@@ -3061,6 +3061,11 @@ ReadableStreamController::Tee ReadableStreamJsController::tee(jsg::Lock& js) {
 
   // This will leave this stream locked, disturbed, and closed.
 
+  // The branches of a legacy stream are legacy streams by construction: they are built directly
+  // over clones of this controller's state, not through the implementation dispatch in
+  // JsReadableStream::create().
+  // NOLINTBEGIN(workerd-legacy-stream-alloc)
+
   // Check for pending state first (deferred close/error during a prior read operation)
   if (state.pendingStateIs<StreamStates::Closed>()) {
     return Tee{
@@ -3129,6 +3134,7 @@ ReadableStreamController::Tee ReadableStreamJsController::tee(jsg::Lock& js) {
       };
     }
   }
+  // NOLINTEND(workerd-legacy-stream-alloc)
   KJ_UNREACHABLE;
 }
 

--- a/src/workerd/api/streams/writable.c++
+++ b/src/workerd/api/streams/writable.c++
@@ -251,6 +251,11 @@ jsg::Ref<WritableStream> WritableStream::constructor(jsg::Lock& js,
   auto controller = newWritableStreamJsController();
   // We account for the memory usage of the WritableStream and its controller together because their
   // lifetimes are identical and memory accounting itself has a memory overhead.
+  //
+  // This is the legacy WritableStream's own JS constructor, which necessarily produces the legacy
+  // type; under typescript_implemented_streams the global WritableStream is the TypeScript class
+  // and this constructor is not reachable.
+  // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
   auto stream = js.allocAccounted<WritableStream>(
       sizeof(WritableStream) + controller->jsgGetMemorySelfSize(), kj::mv(controller));
   stream->getController().setup(js, kj::mv(underlyingSink), kj::mv(queuingStrategy));
@@ -613,6 +618,9 @@ JsWritableStream WritableStream::deserialize(
   auto stream = ioctx.getByteStreamFactory().capnpToKjExplicitEnd(ws.getByteStream());
   auto sink = newSystemStream(kj::mv(stream), encoding, ioctx);
 
+  // Legacy-streams isolates only (see above), and JsWritableStream::create() may run JS, which is
+  // forbidden here.
+  // NOLINTNEXTLINE(workerd-legacy-stream-alloc)
   return JsWritableStream(js.alloc<WritableStream>(
       ioctx, kj::mv(sink), ioctx.getMetrics().tryCreateWritableByteStreamObserver()));
 }

--- a/tools/clang-tidy/BUILD.bazel
+++ b/tools/clang-tidy/BUILD.bazel
@@ -8,6 +8,10 @@
     different directories to use angled brackets
   - `workerd-consume`: validates that calls to methods annotated with
     WD_CONSUME are made through consume() when invoked on kj::Ptr.
+  - `workerd-legacy-stream-alloc`: flags direct allocation of the legacy C++
+    ReadableStream / WritableStream (`js.alloc<ReadableStream>(...)`) outside
+    JsReadableStream::create() / JsWritableStream::create(), the dispatch
+    points that select the stream implementation by compatibility flag.
   - `workerd-promise-ignore-result` - warns on superfluous `ignoreResult()`
     calls: on promises that are immediately `co_await`ed, and on
     `capnp::Request::send()` results, which should use `sendIgnoringResult()`
@@ -33,6 +37,7 @@ filegroup(
     srcs = [
         "angled-includes.c++",
         "consume.c++",
+        "legacy-stream-alloc.c++",
         "promise-ignore-result.c++",
         "unsafe-continuation-capture.c++",
         "visit-for-gc.c++",
@@ -46,6 +51,7 @@ filegroup(
     srcs = [
         "angled-includes.h",
         "consume.h",
+        "legacy-stream-alloc.h",
         "promise-ignore-result.h",
         "unsafe-continuation-capture.h",
         "visit-for-gc.h",
@@ -103,6 +109,22 @@ sh_test(
     data = [
         ":consume-negative-test.c++",
         ":consume-positive-test.c++",
+        ":workerd-lint",
+        "//tools:clang-tidy",
+    ],
+    tags = ["no-asan"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+sh_test(
+    name = "legacy-stream-alloc-test",
+    srcs = ["legacy-stream-alloc-test.sh"],
+    data = [
+        ":legacy-stream-alloc-negative-test.c++",
+        ":legacy-stream-alloc-positive-test.c++",
         ":workerd-lint",
         "//tools:clang-tidy",
     ],

--- a/tools/clang-tidy/legacy-stream-alloc-negative-test.c++
+++ b/tools/clang-tidy/legacy-stream-alloc-negative-test.c++
@@ -1,0 +1,140 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Negative fixtures for workerd-legacy-stream-alloc: none of these may produce
+// a diagnostic.
+
+namespace workerd::jsg {
+
+template <typename T>
+class Ref {
+ public:
+  explicit Ref(T* ptr): ptr(ptr) {}
+
+ private:
+  T* ptr;
+};
+
+class Lock {
+ public:
+  template <typename T, typename... Params>
+  Ref<T> alloc(Params&&... params) {
+    return Ref<T>(new T(static_cast<Params&&>(params)...));
+  }
+
+  template <typename T, typename... Params>
+  Ref<T> allocAccounted(unsigned long accountedSize, Params&&... params) {
+    return Ref<T>(new T(static_cast<Params&&>(params)...));
+  }
+};
+
+template <typename T, typename... Params>
+Ref<T> alloc(Params&&... params) {
+  return Ref<T>(new T(static_cast<Params&&>(params)...));
+}
+
+}  // namespace workerd::jsg
+
+namespace workerd::api {
+
+namespace jsg = workerd::jsg;
+
+class ReadableStreamSource {};
+class WritableStreamSink {};
+
+class ReadableStream {
+ public:
+  explicit ReadableStream(ReadableStreamSource* source) {}
+};
+
+class WritableStream {
+ public:
+  explicit WritableStream(WritableStreamSink* sink) {}
+};
+
+// Types whose names merely contain "ReadableStream" / "WritableStream".
+class ReadableStreamDefaultReader {
+ public:
+  explicit ReadableStreamDefaultReader(ReadableStreamSource* source) {}
+};
+
+class WritableStreamDefaultWriter {
+ public:
+  explicit WritableStreamDefaultWriter(WritableStreamSink* sink) {}
+};
+
+template <typename... T>
+void use(T&&...) {}
+
+class TransformStream {
+ public:
+  TransformStream(jsg::Ref<ReadableStream> readable, jsg::Ref<WritableStream> writable) {}
+};
+
+class JsReadableStream {
+ public:
+  explicit JsReadableStream(jsg::Ref<ReadableStream> stream) {}
+  static JsReadableStream create(jsg::Lock& js, ReadableStreamSource* source);
+};
+
+class JsWritableStream {
+ public:
+  explicit JsWritableStream(jsg::Ref<WritableStream> stream) {}
+  static JsWritableStream create(jsg::Lock& js, WritableStreamSink* sink);
+};
+
+// Case N1: the dispatch point itself may allocate the legacy stream.
+JsReadableStream JsReadableStream::create(jsg::Lock& js, ReadableStreamSource* source) {
+  // ... including through a lambda defined inside it.
+  auto legacy = [&]() { return js.alloc<ReadableStream>(source); };
+  if (source == nullptr) {
+    return JsReadableStream(legacy());
+  }
+  return JsReadableStream(js.allocAccounted<ReadableStream>(sizeof(ReadableStream), source));
+}
+
+// Case N2: same for the writable dispatch point.
+JsWritableStream JsWritableStream::create(jsg::Lock& js, WritableStreamSink* sink) {
+  return JsWritableStream(js.alloc<WritableStream>(sink));
+}
+
+// Case N3: the recommended way to obtain a stream from C++.
+JsReadableStream negativeCreate(jsg::Lock& js, ReadableStreamSource* source) {
+  return JsReadableStream::create(js, source);
+}
+
+// Case N4: allocating unrelated JSG types, including ones whose names contain
+// the stream type names, is fine.
+void negativeOtherTypes(jsg::Lock& js, ReadableStreamSource* source, WritableStreamSink* sink) {
+  use(js.alloc<ReadableStreamDefaultReader>(source),
+      js.allocAccounted<WritableStreamDefaultWriter>(sizeof(WritableStreamDefaultWriter), sink),
+      jsg::alloc<ReadableStreamDefaultReader>(source));
+}
+
+// Case N5: a same-named type in a different namespace is not the legacy stream.
+namespace other {
+class ReadableStream {};
+class WritableStream {};
+}  // namespace other
+
+void negativeOtherNamespace(jsg::Lock& js) {
+  use(js.alloc<other::ReadableStream>(), jsg::alloc<other::WritableStream>());
+}
+
+// Case N6: the legacy implementation's own internals suppress the check
+// explicitly, both per line and per block.
+jsg::Ref<ReadableStream> negativeSuppressedLine(jsg::Lock& js, ReadableStreamSource* source) {
+  // The legacy stream's tee() hands out legacy branches by construction.
+  return js.alloc<ReadableStream>(source);  // NOLINT(workerd-legacy-stream-alloc)
+}
+
+// NOLINTBEGIN(workerd-legacy-stream-alloc)
+jsg::Ref<TransformStream> negativeSuppressedBlock(
+    jsg::Lock& js, ReadableStreamSource* source, WritableStreamSink* sink) {
+  return js.alloc<TransformStream>(
+      js.alloc<ReadableStream>(source), js.alloc<WritableStream>(sink));
+}
+// NOLINTEND(workerd-legacy-stream-alloc)
+
+}  // namespace workerd::api

--- a/tools/clang-tidy/legacy-stream-alloc-positive-test.c++
+++ b/tools/clang-tidy/legacy-stream-alloc-positive-test.c++
@@ -1,0 +1,124 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// Positive fixtures for workerd-legacy-stream-alloc: each case must produce
+// exactly one diagnostic; legacy-stream-alloc-test.sh asserts the exact total.
+
+namespace workerd::jsg {
+
+template <typename T>
+class Ref {
+ public:
+  explicit Ref(T* ptr): ptr(ptr) {}
+
+ private:
+  T* ptr;
+};
+
+class Lock {
+ public:
+  template <typename T, typename... Params>
+  Ref<T> alloc(Params&&... params) {
+    return Ref<T>(new T(static_cast<Params&&>(params)...));
+  }
+
+  template <typename T, typename... Params>
+  Ref<T> allocAccounted(unsigned long accountedSize, Params&&... params) {
+    return Ref<T>(new T(static_cast<Params&&>(params)...));
+  }
+};
+
+template <typename T, typename... Params>
+Ref<T> alloc(Params&&... params) {
+  return Ref<T>(new T(static_cast<Params&&>(params)...));
+}
+
+}  // namespace workerd::jsg
+
+namespace workerd::api {
+
+namespace jsg = workerd::jsg;
+
+class ReadableStreamSource {};
+class WritableStreamSink {};
+
+class ReadableStream {
+ public:
+  explicit ReadableStream(ReadableStreamSource* source) {}
+};
+
+class WritableStream {
+ public:
+  explicit WritableStream(WritableStreamSink* sink) {}
+};
+
+class JsReadableStream {
+ public:
+  static JsReadableStream create(jsg::Lock& js, ReadableStreamSource* source);
+
+  // A member of the abstraction that is not the dispatch point.
+  static jsg::Ref<ReadableStream> other(jsg::Lock& js, ReadableStreamSource* otherSource);
+};
+
+class JsWritableStream {
+ public:
+  static JsWritableStream create(jsg::Lock& js, WritableStreamSink* sink);
+};
+
+// Case P1: js.alloc<ReadableStream>() in a free function.
+jsg::Ref<ReadableStream> positiveReadable(jsg::Lock& js, ReadableStreamSource* source) {
+  return js.alloc<ReadableStream>(source);
+}
+
+// Case P2: js.alloc<WritableStream>() in a free function.
+jsg::Ref<WritableStream> positiveWritable(jsg::Lock& js, WritableStreamSink* sink) {
+  return js.alloc<WritableStream>(sink);
+}
+
+// Case P3: allocAccounted<ReadableStream>() is an allocation too.
+jsg::Ref<ReadableStream> positiveAccounted(jsg::Lock& js, ReadableStreamSource* source) {
+  return js.allocAccounted<ReadableStream>(sizeof(ReadableStream), source);
+}
+
+// Case P4: the free-function jsg::alloc<WritableStream>() form.
+jsg::Ref<WritableStream> positiveFreeFunction(WritableStreamSink* sink) {
+  return jsg::alloc<WritableStream>(sink);
+}
+
+// Case P5: the type spelled with namespace qualification.
+jsg::Ref<ReadableStream> positiveQualified(jsg::Lock& js, ReadableStreamSource* source) {
+  return js.alloc<::workerd::api::ReadableStream>(source);
+}
+
+// Case P6: inside a lambda defined in a function that is not a dispatch point.
+jsg::Ref<ReadableStream> positiveLambda(jsg::Lock& js, ReadableStreamSource* source) {
+  auto make = [&]() { return js.alloc<ReadableStream>(source); };
+  return make();
+}
+
+// Case P7: a member of JsReadableStream other than create() is not exempt.
+jsg::Ref<ReadableStream> JsReadableStream::other(jsg::Lock& js, ReadableStreamSource* otherSource) {
+  return js.alloc<ReadableStream>(otherSource);
+}
+
+// Case P8: a function named create() on some other class is not exempt.
+class Unrelated {
+ public:
+  static jsg::Ref<WritableStream> create(jsg::Lock& js, WritableStreamSink* unrelatedSink) {
+    return js.alloc<WritableStream>(unrelatedSink);
+  }
+};
+
+// Case P9: a generic helper is reported when instantiated with a legacy stream
+// type. The diagnostic lands on the js.alloc<T>() in the template body.
+template <typename T, typename Arg>
+jsg::Ref<T> makeStream(jsg::Lock& js, Arg* arg) {
+  return js.alloc<T>(arg);
+}
+
+jsg::Ref<ReadableStream> positiveGeneric(jsg::Lock& js, ReadableStreamSource* source) {
+  return makeStream<ReadableStream>(js, source);
+}
+
+}  // namespace workerd::api

--- a/tools/clang-tidy/legacy-stream-alloc-test.sh
+++ b/tools/clang-tidy/legacy-stream-alloc-test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2017-2026 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+set -euo pipefail
+
+readonly ROOT="${TEST_SRCDIR}/${TEST_WORKSPACE}"
+readonly CLANG_TIDY="${ROOT}/tools/clang_tidy"
+readonly PLUGIN="${ROOT}/tools/clang-tidy/libworkerd-lint.so"
+readonly POSITIVE="${ROOT}/tools/clang-tidy/legacy-stream-alloc-positive-test.c++"
+readonly NEGATIVE="${ROOT}/tools/clang-tidy/legacy-stream-alloc-negative-test.c++"
+readonly CHECK="workerd-legacy-stream-alloc"
+readonly CHECKS="-*,${CHECK}"
+
+readonly READABLE_MESSAGE="direct allocation of legacy ReadableStream; use JsReadableStream::create()"
+readonly WRITABLE_MESSAGE="direct allocation of legacy WritableStream; use JsWritableStream::create()"
+
+set +e
+positive_output=$("${CLANG_TIDY}" "--load=${PLUGIN}" --checks="${CHECKS}" \
+  --warnings-as-errors='*' "${POSITIVE}" -- -std=c++23 2>&1)
+positive_status=$?
+set -e
+
+if [[ ${positive_status} -eq 0 ]]; then
+  printf '%s\n' "Expected ${CHECK} to reject the positive fixtures." >&2
+  printf '%s\n' "${positive_output}" >&2
+  exit 1
+fi
+
+# Asserts that a diagnostic with the given message is reported on the given
+# fixture line, identifying the case that produced it.
+expect_diag_at() {
+  local line="$1"
+  local message="$2"
+  local description="$3"
+  if ! grep -qF "legacy-stream-alloc-positive-test.c++:${line}:" <<<"${positive_output}"; then
+    printf 'Missing expected diagnostic (%s) on line %s\n' "${description}" "${line}" >&2
+    printf '%s\n' "${positive_output}" >&2
+    exit 1
+  fi
+  if ! grep -F "legacy-stream-alloc-positive-test.c++:${line}:" <<<"${positive_output}" |
+    grep -qF "${message}"; then
+    printf 'Diagnostic on line %s (%s) has the wrong message; expected: %s\n' \
+      "${line}" "${description}" "${message}" >&2
+    printf '%s\n' "${positive_output}" >&2
+    exit 1
+  fi
+}
+
+# Resolves the line of a fixture case from a unique snippet of its source, so
+# the assertions below do not depend on hard-coded line numbers.
+line_of() {
+  local needle="$1"
+  local line
+  line=$(grep -nF -- "${needle}" "${POSITIVE}" | head -n1 | cut -d: -f1)
+  if [[ -z "${line}" ]]; then
+    printf 'Fixture snippet not found: %s\n' "${needle}" >&2
+    exit 1
+  fi
+  printf '%s' "${line}"
+}
+
+expect_diag_at "$(line_of '  return js.alloc<ReadableStream>(source);')" \
+  "${READABLE_MESSAGE}" "P1: js.alloc<ReadableStream>"
+expect_diag_at "$(line_of '  return js.alloc<WritableStream>(sink);')" \
+  "${WRITABLE_MESSAGE}" "P2: js.alloc<WritableStream>"
+expect_diag_at "$(line_of 'return js.allocAccounted<ReadableStream>(sizeof(ReadableStream), source);')" \
+  "${READABLE_MESSAGE}" "P3: js.allocAccounted<ReadableStream>"
+expect_diag_at "$(line_of 'return jsg::alloc<WritableStream>(sink);')" \
+  "${WRITABLE_MESSAGE}" "P4: free-function jsg::alloc<WritableStream>"
+expect_diag_at "$(line_of 'return js.alloc<::workerd::api::ReadableStream>(source);')" \
+  "${READABLE_MESSAGE}" "P5: namespace-qualified type"
+expect_diag_at "$(line_of 'auto make = [&]() { return js.alloc<ReadableStream>(source); };')" \
+  "${READABLE_MESSAGE}" "P6: lambda in a non-dispatch function"
+expect_diag_at "$(line_of 'return js.alloc<ReadableStream>(otherSource);')" \
+  "${READABLE_MESSAGE}" "P7: JsReadableStream member other than create()"
+expect_diag_at "$(line_of 'return js.alloc<WritableStream>(unrelatedSink);')" \
+  "${WRITABLE_MESSAGE}" "P8: create() on an unrelated class"
+expect_diag_at "$(line_of 'return js.alloc<T>(arg);')" \
+  "${READABLE_MESSAGE}" "P9: generic helper instantiated with ReadableStream"
+
+# Exact-count lock: one diagnostic per positive case, no more, no fewer.
+expected_count=9
+actual_count=$(grep -c "\[${CHECK}" <<<"${positive_output}" || true)
+if [[ "${actual_count}" -ne "${expected_count}" ]]; then
+  printf 'Expected exactly %s %s diagnostics, got %s\n' \
+    "${expected_count}" "${CHECK}" "${actual_count}" >&2
+  printf '%s\n' "${positive_output}" >&2
+  exit 1
+fi
+
+negative_output=$("${CLANG_TIDY}" "--load=${PLUGIN}" --checks="${CHECKS}" \
+  --warnings-as-errors='*' "${NEGATIVE}" -- -std=c++23 2>&1)
+
+if [[ "${negative_output}" == *"${CHECK}"* ]]; then
+  printf '%s\n' "Expected the negative fixtures to be accepted." >&2
+  printf '%s\n' "${negative_output}" >&2
+  exit 1
+fi

--- a/tools/clang-tidy/legacy-stream-alloc.c++
+++ b/tools/clang-tidy/legacy-stream-alloc.c++
@@ -1,0 +1,58 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#include "legacy-stream-alloc.h"
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/Expr.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+
+namespace workerd::clang_tidy {
+
+void LegacyStreamAllocCheck::registerMatchers(clang::ast_matchers::MatchFinder* Finder) {
+  using namespace clang::ast_matchers;
+
+  auto legacyStream =
+      cxxRecordDecl(hasAnyName("::workerd::api::ReadableStream", "::workerd::api::WritableStream"))
+          .bind("stream");
+
+  // jsg::Lock::alloc<T>(), jsg::Lock::allocAccounted<T>() and the free function
+  // jsg::alloc<T>() all take the allocated type as their first template argument;
+  // the remaining arguments are the deduced constructor-parameter pack.
+  auto allocOfLegacyStream =
+      functionDecl(anyOf(cxxMethodDecl(hasAnyName("alloc", "allocAccounted"),
+                             ofClass(cxxRecordDecl(hasName("::workerd::jsg::Lock")))),
+                       hasName("::workerd::jsg::alloc")),
+          hasTemplateArgument(0, refersToType(hasDeclaration(legacyStream))));
+
+  // The compatibility-flag dispatch points. hasAncestor() walks through lambdas
+  // defined inside these functions as well, so helpers written inline there are
+  // covered.
+  auto dispatchPoint = functionDecl(hasAnyName(
+      "::workerd::api::JsReadableStream::create", "::workerd::api::JsWritableStream::create"));
+
+  Finder->addMatcher(
+      callExpr(callee(allocOfLegacyStream), unless(hasAncestor(dispatchPoint))).bind("call"), this);
+}
+
+void LegacyStreamAllocCheck::check(const clang::ast_matchers::MatchFinder::MatchResult& Result) {
+  const auto* call = Result.Nodes.getNodeAs<clang::CallExpr>("call");
+  const auto* stream = Result.Nodes.getNodeAs<clang::CXXRecordDecl>("stream");
+  if (call == nullptr || stream == nullptr) return;
+
+  llvm::StringRef streamName = stream->getName();
+  llvm::StringRef replacement =
+      streamName == "ReadableStream" ? "JsReadableStream::create()" : "JsWritableStream::create()";
+
+  // Point at the `alloc` token so a NOLINT on that line suppresses the report;
+  // the range covers the whole call for context.
+  diag(call->getCallee()->getExprLoc(),
+      "direct allocation of legacy %0; use %1, which selects the stream implementation "
+      "by the typescript_implemented_streams compatibility flag")
+      << streamName << replacement << call->getSourceRange();
+}
+
+}  // namespace workerd::clang_tidy

--- a/tools/clang-tidy/legacy-stream-alloc.h
+++ b/tools/clang-tidy/legacy-stream-alloc.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2017-2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+#pragma once
+
+#include "clang-tidy/ClangTidyCheck.h"
+
+namespace workerd::clang_tidy {
+
+// Flags direct allocation of the legacy C++ ReadableStream and WritableStream:
+// `js.alloc<ReadableStream>(...)`, `js.allocAccounted<WritableStream>(...)` and
+// the free-function form `jsg::alloc<ReadableStream>(...)`.
+//
+// workerd carries two implementations of the web streams: the legacy C++ one in
+// src/workerd/api/streams/ and a TypeScript one, selected per worker by the
+// typescript_implemented_streams compatibility flag. JsReadableStream::create()
+// and JsWritableStream::create() are the dispatch points that pick the
+// implementation, so they are the only functions permitted to allocate the
+// legacy types directly; anywhere else, a direct allocation hands out a legacy
+// stream regardless of the flag.
+//
+// Allocations lexically inside those two functions (including in lambdas
+// defined there) are not reported. The legacy implementation's own internals
+// (tee(), detach(), its JS constructors, ...) necessarily allocate legacy
+// streams too, as do tests that exercise the legacy implementation directly;
+// those sites carry `// NOLINT(workerd-legacy-stream-alloc)` together with a
+// comment explaining why the allocation has to be legacy.
+class LegacyStreamAllocCheck: public clang::tidy::ClangTidyCheck {
+ public:
+  LegacyStreamAllocCheck(clang::StringRef Name, clang::tidy::ClangTidyContext* Context)
+      : ClangTidyCheck(Name, Context) {}
+
+  void registerMatchers(clang::ast_matchers::MatchFinder* Finder) override;
+  void check(const clang::ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
+}  // namespace workerd::clang_tidy

--- a/tools/clang-tidy/workerd-lint.c++
+++ b/tools/clang-tidy/workerd-lint.c++
@@ -7,7 +7,10 @@
 // This file registers all workerd-specific clang-tidy checks into the
 // "workerd-lint" module. The checks themselves are implemented in separate
 // files:
+//   - angled-includes.c++: workerd-angled-includes check
 //   - consume.c++: workerd-consume check
+//   - legacy-stream-alloc.c++: workerd-legacy-stream-alloc check
+//   - promise-ignore-result.c++: workerd-promise-ignore-result check
 //   - visit-for-gc.c++: jsg-visit-for-gc check
 //   - unsafe-continuation-capture.c++: workerd-unsafe-continuation-capture check
 
@@ -15,6 +18,7 @@
 
 #include "angled-includes.h"
 #include "consume.h"
+#include "legacy-stream-alloc.h"
 #include "promise-ignore-result.h"
 #include "unsafe-continuation-capture.h"
 #include "visit-for-gc.h"
@@ -28,6 +32,7 @@ class WorkerdLintModule : public clang::tidy::ClangTidyModule {
     CheckFactories.registerCheck<AngledIncludesCheck>("workerd-angled-includes");
     CheckFactories.registerCheck<VisitForGcCheck>("jsg-visit-for-gc");
     CheckFactories.registerCheck<ConsumeCheck>("workerd-consume");
+    CheckFactories.registerCheck<LegacyStreamAllocCheck>("workerd-legacy-stream-alloc");
     CheckFactories.registerCheck<PromiseIgnoreResultCheck>("workerd-promise-ignore-result");
     CheckFactories.registerCheck<UnsafeContinuationCaptureCheck>(
         "workerd-unsafe-continuation-capture");


### PR DESCRIPTION
Code should be using JsReadableStream::create(...) and JsWritableStream::create(...) now instead of js.alloc<ReadableStream> and js.alloc<WritableStream>