### PR TITLE
[tsan] thread-safe SqliteObserver

### DIFF
--- a/src/workerd/io/worker.h
+++ b/src/workerd/io/worker.h
@@ -855,7 +855,7 @@ class Worker::Actor final: public kj::Refcounted {
       kj::Function<kj::Maybe<kj::Own<ActorCacheInterface>>(const ActorCache::SharedLru& sharedLru,
           OutputGate& outputGate,
           ActorCache::Hooks& hooks,
-          SqliteObserver& sqliteObserver)>;
+          const SqliteObserver& sqliteObserver)>;
 
   // Callback which constructs the `DurableObjectStorage` instance for an actor. This can be used
   // to customize the JavaScript API.

--- a/src/workerd/server/server.c++
+++ b/src/workerd/server/server.c++
@@ -1239,7 +1239,8 @@ class Server::ActorNamespace final {
 
       auto makeActorCache = [this, actorName = kj::mv(actorName)](
                                 const ActorCache::SharedLru& sharedLru, OutputGate& outputGate,
-                                ActorCache::Hooks& hooks, SqliteObserver& sqliteObserver) mutable {
+                                ActorCache::Hooks& hooks,
+                                const SqliteObserver& sqliteObserver) mutable {
         return ns.config.tryGet<Durable>().map(
             [&](const Durable& d) -> kj::Own<ActorCacheInterface> {
           KJ_IF_SOME(as, ns.actorStorage) {

--- a/src/workerd/tests/test-fixture.c++
+++ b/src/workerd/tests/test-fixture.c++
@@ -413,7 +413,7 @@ namespace {
 kj::Maybe<kj::Own<ActorCacheInterface>> actorCacheFactory(const ActorCache::SharedLru& sharedLru,
     OutputGate& outputGate,
     ActorCache::Hooks& hooks,
-    SqliteObserver& sqliteObserver) {
+    const SqliteObserver& sqliteObserver) {
   return kj::heap<ActorCache>(server::newEmptyReadOnlyActorStorage(), sharedLru, outputGate, hooks);
 }
 

--- a/src/workerd/util/sqlite-kv-test.c++
+++ b/src/workerd/util/sqlite-kv-test.c++
@@ -20,13 +20,13 @@ static GlobalInit init;
 KJ_TEST("SQLite-KV") {
   class TestSqliteObserver: public SqliteObserver {
    public:
-    void addQueryStats(uint64_t read, uint64_t written) override {
+    void addQueryStats(uint64_t read, uint64_t written) const override {
       rowsRead += read;
       rowsWritten += written;
     }
 
-    uint64_t rowsRead = 0;
-    uint64_t rowsWritten = 0;
+    mutable uint64_t rowsRead = 0;
+    mutable uint64_t rowsWritten = 0;
   };
 
   auto dir = kj::newInMemoryDirectory(kj::nullClock());
@@ -164,13 +164,13 @@ KJ_TEST("large key") {
 KJ_TEST("SQLite-KV multi-put") {
   class TestSqliteObserver: public SqliteObserver {
    public:
-    void addQueryStats(uint64_t read, uint64_t written) override {
+    void addQueryStats(uint64_t read, uint64_t written) const override {
       rowsRead += read;
       rowsWritten += written;
     }
 
-    uint64_t rowsRead = 0;
-    uint64_t rowsWritten = 0;
+    mutable uint64_t rowsRead = 0;
+    mutable uint64_t rowsWritten = 0;
   };
 
   auto dir = kj::newInMemoryDirectory(kj::nullClock());

--- a/src/workerd/util/sqlite-test.c++
+++ b/src/workerd/util/sqlite-test.c++
@@ -855,16 +855,44 @@ KJ_TEST("reset database") {
   }
 }
 
+KJ_TEST("SQLite observer supports concurrent WAL size access") {
+  const SqliteObserver sqliteObserver;
+  std::atomic<bool> start = false;
+  uint64_t observedWalSize = 0;
+  constexpr uint64_t ITERATION_COUNT = 100000;
+
+  {
+    kj::Thread writer([&]() noexcept {
+      while (!start.load(std::memory_order_acquire)) {}
+      for (uint64_t i = 1; i <= ITERATION_COUNT; ++i) {
+        sqliteObserver.setDbWalSize(i);
+      }
+    });
+
+    kj::Thread reader([&]() noexcept {
+      while (!start.load(std::memory_order_acquire)) {}
+      for (uint64_t i = 0; i < ITERATION_COUNT; ++i) {
+        observedWalSize = sqliteObserver.getDbWalSize();
+      }
+    });
+
+    start.store(true, std::memory_order_release);
+  }
+
+  KJ_EXPECT(observedWalSize <= ITERATION_COUNT);
+  KJ_EXPECT(sqliteObserver.getDbWalSize() == ITERATION_COUNT);
+}
+
 KJ_TEST("SQLite observer addQueryStats") {
   class TestSqliteObserver: public SqliteObserver {
    public:
-    void addQueryStats(uint64_t read, uint64_t written) override {
+    void addQueryStats(uint64_t read, uint64_t written) const override {
       rowsRead += read;
       rowsWritten += written;
     }
 
-    uint64_t rowsRead = 0;
-    uint64_t rowsWritten = 0;
+    mutable uint64_t rowsRead = 0;
+    mutable uint64_t rowsWritten = 0;
   };
 
   class TestQueryStatsRegulator: public SqliteDatabase::Regulator {
@@ -950,7 +978,7 @@ KJ_TEST("SQLite observer addQueryStats") {
 KJ_TEST("SQLite observer reportQueryEvent") {
   class TestSqliteObserver: public SqliteObserver {
    public:
-    int capturedEvents = 0;
+    mutable int capturedEvents = 0;
 
     void reportQueryEvent(kj::Maybe<kj::String> queryStatement,
         uint64_t queryRowsRead,
@@ -960,7 +988,7 @@ KJ_TEST("SQLite observer reportQueryEvent") {
         int queryError,
         int extendedErrorCode,
         bool isInternalQuery,
-        kj::Maybe<kj::String> queryErrorDescription) override {
+        kj::Maybe<kj::String> queryErrorDescription) const override {
       KJ_IF_SOME(err, queryErrorDescription) {
         KJ_ASSERT(err.contains("query canceled because reset()"));
       }

--- a/src/workerd/util/sqlite.c++
+++ b/src/workerd/util/sqlite.c++
@@ -591,14 +591,14 @@ static constexpr PragmaInfo ALLOWED_PRAGMAS[] = {{"data_version"_kj, PragmaSigna
 
 // =======================================================================================
 
-SqliteObserver SqliteObserver::DEFAULT = SqliteObserver{};
+const SqliteObserver SqliteObserver::DEFAULT = SqliteObserver{};
 
 SqliteDatabase::SqliteDatabase(const Vfs& vfs,
     kj::Path path,
     kj::Maybe<kj::WriteMode> maybeMode,
     size_t sqliteMaxMemoryBytes,
     size_t sqliteMaxMemoryPerProcessBytes,
-    SqliteObserver& sqliteObserver,
+    const SqliteObserver& sqliteObserver,
     kj::Maybe<const ActorAccountLimits&> actorAccountLimits)
     : vfs(vfs),
       path(kj::mv(path)),

--- a/src/workerd/util/sqlite.h
+++ b/src/workerd/util/sqlite.h
@@ -13,6 +13,7 @@
 #include <kj/one-of.h>
 #include <kj/string.h>
 
+#include <atomic>
 #include <utility>
 
 struct sqlite3;
@@ -29,18 +30,18 @@ using kj::uint;
 // Used to collect periodic metrics about queries and size of sqlite db
 class SqliteObserver {
  public:
-  void setDbWalSize(uint64_t dbWalSize) {
-    this->dbWalSize = dbWalSize;
+  void setDbWalSize(uint64_t dbWalSize) const {
+    this->dbWalSize.store(dbWalSize, std::memory_order_relaxed);
   }
-  uint64_t getDbWalSize() {
-    return dbWalSize;
+  uint64_t getDbWalSize() const {
+    return dbWalSize.load(std::memory_order_relaxed);
   }
-  kj::TimePoint now() {
+  kj::TimePoint now() const {
     return monotonicClock.now();
   }
-  virtual void addQueryStats(uint64_t rowsRead, uint64_t rowsWritten) {}
+  virtual void addQueryStats(uint64_t rowsRead, uint64_t rowsWritten) const {}
   // The method is not used by the SqliteDatabase, it is added here for convenience
-  virtual void setSqliteStoredBytes(uint64_t sqliteStoredBytes) {}
+  virtual void setSqliteStoredBytes(uint64_t sqliteStoredBytes) const {}
 
   virtual void reportQueryEvent(kj::Maybe<kj::String> queryStatement,
       uint64_t queryRowsRead,
@@ -50,12 +51,12 @@ class SqliteObserver {
       int queryResult,
       int extendedErrorCode,
       bool isInternalQuery,
-      kj::Maybe<kj::String> queryErrorDescription) {}
+      kj::Maybe<kj::String> queryErrorDescription) const {}
 
-  static SqliteObserver DEFAULT;
+  static const SqliteObserver DEFAULT;
 
  private:
-  uint64_t dbWalSize = 0;
+  mutable std::atomic<uint64_t> dbWalSize = 0;
   const kj::MonotonicClock& monotonicClock = kj::systemPreciseMonotonicClock();
 };
 
@@ -116,7 +117,7 @@ class SqliteDatabase {
       kj::Maybe<kj::WriteMode> maybeMode = kj::none,
       size_t sqliteMaxMemoryBytes = kj::maxValue,
       size_t sqliteMaxMemoryPerProcessBytes = kj::maxValue,
-      SqliteObserver& sqliteObserver = SqliteObserver::DEFAULT,
+      const SqliteObserver& sqliteObserver = SqliteObserver::DEFAULT,
       kj::Maybe<const ActorAccountLimits&> actorAccountLimits = kj::none);
 
   // Returns the current value of the per-actor SQLite memory byte counter for metrics reporting.
@@ -349,7 +350,7 @@ class SqliteDatabase {
   const Vfs& vfs;
   kj::Path path;
   bool readOnly;
-  SqliteObserver& sqliteObserver;
+  const SqliteObserver& sqliteObserver;
 
   // The amount of memory in bytes used by this database for use by sqlite3_mem_methods.
   size_t sqliteMemoryBytes = 0;
@@ -647,7 +648,7 @@ class SqliteDatabase::Query final: private ResetListener {
  private:
   class QueryEvent {
    public:
-    explicit QueryEvent(SqliteObserver& sqliteObserver)
+    explicit QueryEvent(const SqliteObserver& sqliteObserver)
         : observer(sqliteObserver),
           dbWalSizeBefore(sqliteObserver.getDbWalSize()),
           startTime(sqliteObserver.now()) {}
@@ -685,7 +686,7 @@ class SqliteDatabase::Query final: private ResetListener {
     }
 
    private:
-    SqliteObserver& observer;
+    const SqliteObserver& observer;
     kj::Maybe<kj::String> queryStatement = kj::none;
     bool isInternalQuery = false;
     uint64_t dbWalSizeBefore;


### PR DESCRIPTION
The observer is used by metrics, which runs in a separate thread.