### PR TITLE
sockets: close() with a pipe close in flight logged an uncaught exception

### DIFF
--- a/src/tests/streams/sockets/main.js
+++ b/src/tests/streams/sockets/main.js
@@ -16,4 +16,6 @@ export {
   pipeSocketToSocket,
   cancelReadableSettlesSocket,
   largeEchoVolume,
+  closeWithPipeCloseInFlight,
 } from 'socket-streams';
+export { default } from 'socket-streams';

--- a/src/tests/streams/sockets/socket-streams.js
+++ b/src/tests/streams/sockets/socket-streams.js
@@ -283,50 +283,54 @@ export const largeEchoVolume = {
 export default {
   async connect(socket, env) {
     const { localAddress } = await socket.opened;
-    void socket.closed.catch(() => {});
     if (localAddress.startsWith('echo:')) {
       // Explicit loop: a same-socket pipeTo over an in-process pipe splices,
       // so the peer's write could not complete before it reads the echo.
-      const reader = socket.readable.getReader();
       const writer = socket.writable.getWriter();
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        await writer.write(value);
+      for await (const chunk of socket.readable) {
+        await writer.write(chunk);
       }
       // The socket closes its write side itself on the peer's FIN; the
       // TypeScript implementation reports a close racing that as an error.
       await writer.close().catch(() => {});
       await socket.close();
+      await socket.closed;
       return;
     }
-    const target = env.SELF.connect('echo:1', { allowHalfOpen: true });
-    void target.closed.catch(() => {});
-    await Promise.allSettled([
-      socket.readable.pipeTo(target.writable),
-      target.readable.pipeTo(socket.writable),
-    ]);
-    const closes = await Promise.allSettled([socket.close(), target.close()]);
-    const abortReasons = [];
-    for (const s of [socket, target]) {
-      let writer;
-      try {
-        writer = s.writable.getWriter();
-      } catch {
-        // Still locked to the pipe (TypeScript); nothing to observe.
-        continue;
+    // Everything observed here is asserted by closeWithPipeCloseInFlight,
+    // which runs in a different request.
+    const outcome = {};
+    globalThis.proxyOutcome = outcome;
+    try {
+      const target = env.SELF.connect('echo:1', { allowHalfOpen: true });
+      const pipes = await Promise.allSettled([
+        socket.readable.pipeTo(target.writable),
+        target.readable.pipeTo(socket.writable),
+      ]);
+      outcome.pipes = pipes.map((r) => r.status);
+      const closes = await Promise.allSettled([socket.close(), target.close()]);
+      outcome.closes = closes.map((r) => r.status);
+      outcome.abortReasons = [];
+      for (const s of [socket, target]) {
+        let writer;
+        try {
+          writer = s.writable.getWriter();
+        } catch {
+          // Still locked to the pipe (TypeScript); nothing to observe.
+          continue;
+        }
+        outcome.abortReasons.push(
+          await writer.closed.then(
+            () => 'resolved',
+            (e) => e
+          )
+        );
       }
-      abortReasons.push(
-        await writer.closed.then(
-          () => 'resolved',
-          (e) => e
-        )
-      );
+      await Promise.all([socket.closed, target.closed]);
+      outcome.closed = 'resolved';
+    } catch (e) {
+      outcome.error = e;
     }
-    globalThis.proxyOutcome = {
-      closes: closes.map((r) => r.status),
-      abortReasons,
-    };
   },
 };
 
@@ -342,11 +346,18 @@ export const closeWithPipeCloseInFlight = {
     await writer.close();
     strictEqual((await drainToBytes(socket.readable)).length, 0);
     // The handler runs in its own request; give its closes a moment.
-    for (let i = 0; i < 50 && globalThis.proxyOutcome === undefined; i++) {
+    for (
+      let i = 0;
+      i < 100 && globalThis.proxyOutcome?.closed === undefined;
+      i++
+    ) {
       await scheduler.wait(10);
     }
     const outcome = globalThis.proxyOutcome;
+    strictEqual(outcome.error, undefined, String(outcome.error));
+    deepStrictEqual(outcome.pipes, ['fulfilled', 'fulfilled']);
     deepStrictEqual(outcome.closes, ['fulfilled', 'fulfilled']);
+    strictEqual(outcome.closed, 'resolved');
     for (const reason of outcome.abortReasons) {
       // Resolved when the queued close completed before the abort took effect
       // (compat dates before internal_writable_stream_abort_clears_queue).

--- a/src/tests/streams/sockets/socket-streams.js
+++ b/src/tests/streams/sockets/socket-streams.js
@@ -273,3 +273,86 @@ export const largeEchoVolume = {
     await socket.close();
   },
 };
+
+// CLOSE WITH A PIPE CLOSE IN FLIGHT: a connect() handler pipes an inbound
+// socket to an outbound one; once the pipes settle it closes both. Under the
+// C++ implementation the pipe's close of the writable may still be queued at
+// that point (pipeTo resolves before it completes; TypeScript resolves after),
+// and socket.close() aborts it. Whatever a later writer's closed promise then
+// reports must be a real error, never undefined.
+export default {
+  async connect(socket, env) {
+    const { localAddress } = await socket.opened;
+    void socket.closed.catch(() => {});
+    if (localAddress.startsWith('echo:')) {
+      // Explicit loop: a same-socket pipeTo over an in-process pipe splices,
+      // so the peer's write could not complete before it reads the echo.
+      const reader = socket.readable.getReader();
+      const writer = socket.writable.getWriter();
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        await writer.write(value);
+      }
+      // The socket closes its write side itself on the peer's FIN; the
+      // TypeScript implementation reports a close racing that as an error.
+      await writer.close().catch(() => {});
+      await socket.close();
+      return;
+    }
+    const target = env.SELF.connect('echo:1', { allowHalfOpen: true });
+    void target.closed.catch(() => {});
+    await Promise.allSettled([
+      socket.readable.pipeTo(target.writable),
+      target.readable.pipeTo(socket.writable),
+    ]);
+    const closes = await Promise.allSettled([socket.close(), target.close()]);
+    const abortReasons = [];
+    for (const s of [socket, target]) {
+      let writer;
+      try {
+        writer = s.writable.getWriter();
+      } catch {
+        // Still locked to the pipe (TypeScript); nothing to observe.
+        continue;
+      }
+      abortReasons.push(
+        await writer.closed.then(
+          () => 'resolved',
+          (e) => e
+        )
+      );
+    }
+    globalThis.proxyOutcome = {
+      closes: closes.map((r) => r.status),
+      abortReasons,
+    };
+  },
+};
+
+export const closeWithPipeCloseInFlight = {
+  async test(ctrl, env) {
+    const socket = env.SELF.connect('proxy:1');
+    const writer = socket.writable.getWriter();
+    await writer.write(new TextEncoder().encode('hello'));
+    const reader = socket.readable.getReader();
+    const { value } = await reader.read();
+    strictEqual(new TextDecoder().decode(value), 'hello');
+    reader.releaseLock();
+    await writer.close();
+    strictEqual((await drainToBytes(socket.readable)).length, 0);
+    // The handler runs in its own request; give its closes a moment.
+    for (let i = 0; i < 50 && globalThis.proxyOutcome === undefined; i++) {
+      await scheduler.wait(10);
+    }
+    const outcome = globalThis.proxyOutcome;
+    deepStrictEqual(outcome.closes, ['fulfilled', 'fulfilled']);
+    for (const reason of outcome.abortReasons) {
+      // Resolved when the queued close completed before the abort took effect
+      // (compat dates before internal_writable_stream_abort_clears_queue).
+      if (reason === 'resolved') continue;
+      ok(reason instanceof TypeError, String(reason));
+      strictEqual(reason.message, 'This socket has been closed.');
+    }
+  },
+};

--- a/src/tests/streams/sockets/sockets-cpp.wd-test
+++ b/src/tests/streams/sockets/sockets-cpp.wd-test
@@ -20,6 +20,7 @@ const unitTests :Workerd.Config = (
           (name = "SIDECAR_HOSTNAME", fromEnvironment = "SIDECAR_HOSTNAME"),
           (name = "STREAMS_ECHO_PORT", fromEnvironment = "STREAMS_ECHO_PORT"),
           (name = "STREAMS_GREET_PORT", fromEnvironment = "STREAMS_GREET_PORT"),
+          (name = "SELF", service = "streams-sockets-cpp"),
         ],
       )
     ),

--- a/src/tests/streams/sockets/sockets-ts.wd-test
+++ b/src/tests/streams/sockets/sockets-ts.wd-test
@@ -19,6 +19,7 @@ const unitTests :Workerd.Config = (
           (name = "SIDECAR_HOSTNAME", fromEnvironment = "SIDECAR_HOSTNAME"),
           (name = "STREAMS_ECHO_PORT", fromEnvironment = "STREAMS_ECHO_PORT"),
           (name = "STREAMS_GREET_PORT", fromEnvironment = "STREAMS_GREET_PORT"),
+          (name = "SELF", service = "streams-sockets-ts"),
         ],
       )
     ),

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -498,9 +498,12 @@ jsg::Promise<void> Socket::close(jsg::Lock& js) {
   })
       .then(js,
           [self = JSG_THIS](jsg::Lock& js) mutable {
-    // Forcibly abort the readable/writable streams.
-    auto cancelPromise = self->readable.forceCancel(js, kj::none);
-    auto abortPromise = self->writable.forceAbort(js, kj::none);
+    // Forcibly abort the readable/writable streams. Operations still queued on them (a pipe's
+    // pending close, for instance) are rejected with this reason, so it must be a real error
+    // rather than the undefined that a reasonless abort() produces.
+    auto reason = jsg::JsValue(js.typeError("This socket has been closed."_kj));
+    auto cancelPromise = self->readable.forceCancel(js, reason);
+    auto abortPromise = self->writable.forceAbort(js, reason);
 
     // The below is effectively `Promise.all(cancelPromise, abortPromise)`
     return cancelPromise.then(js, [abortPromise = kj::mv(abortPromise)](jsg::Lock& js) mutable {

--- a/src/workerd/api/sockets.c++
+++ b/src/workerd/api/sockets.c++
@@ -501,7 +501,7 @@ jsg::Promise<void> Socket::close(jsg::Lock& js) {
     // Forcibly abort the readable/writable streams. Operations still queued on them (a pipe's
     // pending close, for instance) are rejected with this reason, so it must be a real error
     // rather than the undefined that a reasonless abort() produces.
-    auto reason = jsg::JsValue(js.typeError("This socket has been closed."_kj));
+    auto reason = js.typeError("This socket has been closed."_kj);
     auto cancelPromise = self->readable.forceCancel(js, reason);
     auto abortPromise = self->writable.forceAbort(js, reason);
 

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -2099,7 +2099,8 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
         // If the source is closed, the spec requires us to close the destination
         // unless the preventClose option is true.
         // The close is its own request with its own write loop; its outcome is not this
-        // loop's, so a forced abort that rejects it while in flight does not fail this task.
+        // loop's. Returning its promise would make a forced abort that rejects it while in
+        // flight fail this loop's awaitJs task, which is logged as an uncaught exception.
         if (!preventClose && !isClosedOrClosing()) {
           close(js, true);
         }
@@ -2203,7 +2204,8 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
           controller.writeState.transitionTo<Unlocked>();
 
           // The close is its own request with its own write loop; its outcome is not this
-          // loop's, so a forced abort that rejects it while in flight does not fail this task.
+          // loop's. Returning its promise would make a forced abort that rejects it while in
+          // flight fail this loop's awaitJs task, which is logged as an uncaught exception.
           if (!preventClose) {
             controller.close(js, true);
           }

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -2099,7 +2099,7 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
         // If the source is closed, the spec requires us to close the destination
         // unless the preventClose option is true.
         if (!preventClose && !isClosedOrClosing()) {
-          return close(js, true);
+          return close(js, true).catch_(js, [](jsg::Lock&, jsg::Value) {});
         }
         return js.resolvedPromise();
       }
@@ -2201,8 +2201,9 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
           controller.writeState.transitionTo<Unlocked>();
 
           if (!preventClose) {
-            // Note: unlike a real Close request, it's not possible for us to have been aborted.
-            return controller.close(js, true);
+            // The close's outcome belongs to its own request; a forced abort (Socket::close())
+            // that rejects it while it is in flight must not fail this write-loop task.
+            return controller.close(js, true).catch_(js, [](jsg::Lock&, jsg::Value) {});
           }
           return js.resolvedPromise();
         }),

--- a/src/workerd/api/streams/internal.c++
+++ b/src/workerd/api/streams/internal.c++
@@ -2098,8 +2098,10 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
         writeState.transitionTo<Unlocked>();
         // If the source is closed, the spec requires us to close the destination
         // unless the preventClose option is true.
+        // The close is its own request with its own write loop; its outcome is not this
+        // loop's, so a forced abort that rejects it while in flight does not fail this task.
         if (!preventClose && !isClosedOrClosing()) {
-          return close(js, true).catch_(js, [](jsg::Lock&, jsg::Value) {});
+          close(js, true);
         }
         return js.resolvedPromise();
       }
@@ -2200,10 +2202,10 @@ jsg::Promise<void> WritableStreamInternalController::writeLoopAfterFrontOutputLo
           // unlocked after the pipe completes.
           controller.writeState.transitionTo<Unlocked>();
 
+          // The close is its own request with its own write loop; its outcome is not this
+          // loop's, so a forced abort that rejects it while in flight does not fail this task.
           if (!preventClose) {
-            // The close's outcome belongs to its own request; a forced abort (Socket::close())
-            // that rejects it while it is in flight must not fail this write-loop task.
-            return controller.close(js, true).catch_(js, [](jsg::Lock&, jsg::Value) {});
+            controller.close(js, true);
           }
           return js.resolvedPromise();
         }),

--- a/src/workerd/server/tests/socket-close/BUILD.bazel
+++ b/src/workerd/server/tests/socket-close/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+
+js_test(
+    name = "socket-close-test",
+    data = [
+        ":socket-close-pending-pipe.js",
+        ":socket-close-pending-pipe.wd-test",
+        "//src/workerd/server:workerd",
+    ],
+    entry_point = "socket-close-test.mjs",
+    env = {
+        "WORKERD_BINARY": "$(rootpath //src/workerd/server:workerd)",
+        "WD_TEST_CONFIG": "$(rootpath :socket-close-pending-pipe.wd-test)",
+    },
+)

--- a/src/workerd/server/tests/socket-close/socket-close-pending-pipe.js
+++ b/src/workerd/server/tests/socket-close/socket-close-pending-pipe.js
@@ -1,36 +1,42 @@
 // Copyright (c) 2026 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-import { strictEqual } from 'node:assert';
+import { strictEqual, deepStrictEqual } from 'node:assert';
 
 // 'echo:*' echoes with an explicit read/write loop (a same-socket pipeTo over
 // an in-process pipe would splice, so the peer's write could not complete
 // before it reads). 'proxy:*' pipes the inbound socket to an echo connection
 // and closes both once the pipes finish, while the pipe's close of the inbound
-// writable may still be in flight.
+// writable may still be in flight. Assertion failures here surface as uncaught
+// exceptions in workerd's log, which socket-close-test.mjs checks.
 export default {
   async connect(socket, env) {
     const { localAddress } = await socket.opened;
-    void socket.closed.catch(() => {});
     if (localAddress.startsWith('echo:')) {
-      const reader = socket.readable.getReader();
       const writer = socket.writable.getWriter();
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        await writer.write(value);
+      for await (const chunk of socket.readable) {
+        await writer.write(chunk);
       }
       await writer.close();
       await socket.close();
+      await socket.closed;
       return;
     }
     const target = env.SELF.connect('echo:1', { allowHalfOpen: true });
-    void target.closed.catch(() => {});
-    await Promise.allSettled([
+    const pipes = await Promise.allSettled([
       socket.readable.pipeTo(target.writable),
       target.readable.pipeTo(socket.writable),
     ]);
-    await Promise.allSettled([socket.close(), target.close()]);
+    deepStrictEqual(
+      pipes.map((r) => r.status),
+      ['fulfilled', 'fulfilled']
+    );
+    const closes = await Promise.allSettled([socket.close(), target.close()]);
+    deepStrictEqual(
+      closes.map((r) => r.status),
+      ['fulfilled', 'fulfilled']
+    );
+    await Promise.all([socket.closed, target.closed]);
   },
 };
 
@@ -44,7 +50,9 @@ export const proxiedEchoThenClose = {
     strictEqual(new TextDecoder().decode(value), 'hello');
     reader.releaseLock();
     await writer.close();
-    for await (const chunk of socket.readable) void chunk;
+    let rest = 0;
+    for await (const chunk of socket.readable) rest += chunk.byteLength;
+    strictEqual(rest, 0);
     // Let the handlers' closes and any late rejection surface before exit.
     await scheduler.wait(300);
   },

--- a/src/workerd/server/tests/socket-close/socket-close-pending-pipe.js
+++ b/src/workerd/server/tests/socket-close/socket-close-pending-pipe.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+import { strictEqual } from 'node:assert';
+
+// 'echo:*' echoes with an explicit read/write loop (a same-socket pipeTo over
+// an in-process pipe would splice, so the peer's write could not complete
+// before it reads). 'proxy:*' pipes the inbound socket to an echo connection
+// and closes both once the pipes finish, while the pipe's close of the inbound
+// writable may still be in flight.
+export default {
+  async connect(socket, env) {
+    const { localAddress } = await socket.opened;
+    void socket.closed.catch(() => {});
+    if (localAddress.startsWith('echo:')) {
+      const reader = socket.readable.getReader();
+      const writer = socket.writable.getWriter();
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        await writer.write(value);
+      }
+      await writer.close();
+      await socket.close();
+      return;
+    }
+    const target = env.SELF.connect('echo:1', { allowHalfOpen: true });
+    void target.closed.catch(() => {});
+    await Promise.allSettled([
+      socket.readable.pipeTo(target.writable),
+      target.readable.pipeTo(socket.writable),
+    ]);
+    await Promise.allSettled([socket.close(), target.close()]);
+  },
+};
+
+export const proxiedEchoThenClose = {
+  async test(ctrl, env) {
+    const socket = env.SELF.connect('proxy:1');
+    const writer = socket.writable.getWriter();
+    await writer.write(new TextEncoder().encode('hello'));
+    const reader = socket.readable.getReader();
+    const { value } = await reader.read();
+    strictEqual(new TextDecoder().decode(value), 'hello');
+    reader.releaseLock();
+    await writer.close();
+    for await (const chunk of socket.readable) void chunk;
+    // Let the handlers' closes and any late rejection surface before exit.
+    await scheduler.wait(300);
+  },
+};

--- a/src/workerd/server/tests/socket-close/socket-close-pending-pipe.wd-test
+++ b/src/workerd/server/tests/socket-close/socket-close-pending-pipe.wd-test
@@ -1,0 +1,18 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+# A connect() handler that pipes an inbound socket to an outbound one and then
+# closes both concurrently, with the pipe's close of the writable still in
+# flight. Exercised by socket-close-test.mjs, which asserts that workerd logs
+# no uncaught exception; the test framework itself does not observe those.
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "main",
+      worker = (
+        modules = [(name = "worker", esModule = embed "socket-close-pending-pipe.js")],
+        compatibilityDate = "2025-06-01",
+        compatibilityFlags = ["nodejs_compat"],
+        bindings = [(name = "SELF", service = "main")],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/socket-close/socket-close-test.mjs
+++ b/src/workerd/server/tests/socket-close/socket-close-test.mjs
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+import { spawn } from 'node:child_process';
+import { env } from 'node:process';
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+assert(env.WORKERD_BINARY !== undefined, 'WORKERD_BINARY must be set.');
+assert(env.WD_TEST_CONFIG !== undefined, 'WD_TEST_CONFIG must be set.');
+
+test('closing a socket with a pipe close in flight logs no uncaught exception', async () => {
+  const { output, code } = await new Promise((resolve) => {
+    let output = '';
+    const child = spawn(
+      env.WORKERD_BINARY,
+      ['test', env.WD_TEST_CONFIG, '--experimental', '--verbose'],
+      { stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    child.stdout.on('data', (data) => (output += data));
+    child.stderr.on('data', (data) => (output += data));
+    child.on('close', (code) => resolve({ output, code }));
+  });
+
+  assert.strictEqual(code, 0, output);
+  assert.match(output, /\[ PASS \] main:proxiedEchoThenClose/, output);
+  assert.doesNotMatch(output, /uncaught exception/, output);
+  assert.doesNotMatch(output, /undefined/, output);
+});


### PR DESCRIPTION
A `connect()` handler that pipes an inbound socket to another and then closes both concurrently logged `Uncaught (in promise): undefined` and an internal-error line (`jsg.Error: undefined`) on every connection, or `Network connection lost` under a peer disconnect, with nothing actually unhandled and the handler completing normally.

Two causes:

* `Socket::close()` aborted its streams with no reason, which `WritableStreamInternalController::abort()` turns into `undefined` (as the spec requires for the user-facing call), so everything that abort rejected rejected with a bare `undefined`. It now aborts with a real `TypeError`.
* When a pipe into the socket had just completed, its close of the writable was still queued; the forced abort drained it, and the write loop's pipe-completion path returned that close's promise, so the rejection failed the loop's `awaitJs` task and was reported as uncaught. The close's outcome belongs to the close request alone, so the loop no longer propagates it.

A genuine throw from a `connect()` handler is still reported as uncaught.

Tests: `closeWithPipeCloseInFlight` in the streams sockets suite runs the scenario under both stream implementations and asserts the observable half, that the abort reason a later writer sees is a real `TypeError` and never `undefined`; it fails on main under C++ at the current compat date, and passes where the race cannot occur (TypeScript resolves `pipeTo` only after the destination close completes; before `internal_writable_stream_abort_clears_queue` the abort defers until the queued close finishes). The logged line itself is `awaitJs`'s `INTERNAL_ASYNC` report of a rejected promise handed to C++, not a V8 unhandled rejection (the promise did have a handler), so `unhandledrejection` never fires and nothing else is JS-observable; `server/tests/socket-close` spawns `workerd test` and asserts the log is clean, and fails on main with the exact reported lines. Streams, sockets, connect and net suites pass.
