### PR TITLE
DRAFT Add vendored packages tests for shapely, pillow and pywavelets

### DIFF
--- a/build/deps/pyodide.MODULE.bazel
+++ b/build/deps/pyodide.MODULE.bazel
@@ -4,6 +4,9 @@
 pyodide = use_extension("@//build/deps:pyodide.bzl", "pyodide")
 use_repo(
     pyodide,
+    "Pillow_src_0.28.2",
+    "Pillow_src_314.0.6",
+    "Pillow_src_development",
     "all_pyodide_wheels_20240829.4",
     "all_pyodide_wheels_20250808",
     "beautifulsoup4_src_0.26.0a2",
@@ -41,6 +44,11 @@ use_repo(
     "python-workers-runtime-sdk_src_314.0.4",
     "python-workers-runtime-sdk_src_314.0.6",
     "python-workers-runtime-sdk_src_development",
+    "pywavelets_src_0.28.2",
+    "pywavelets_src_314.0.6",
+    "pywavelets_src_development",
     "scipy_src_0.26.0a2",
     "shapely_src_0.28.2",
+    "shapely_src_314.0.6",
+    "shapely_src_development",
 )

--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -171,6 +171,16 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
                 "abi": "3.13",
                 "sha256": "2e5c462cb32ee8697b3647dfc9d5c88dcdfd0702da34a2d7dc6b07b8090dd321",
             },
+            {
+                "name": "Pillow",
+                "abi": "3.13",
+                "sha256": "0fcbba0fd1af97d41103bef1fc887a4c0db871af73a4c57112a1c0ddc9af99e0",
+            },
+            {
+                "name": "pywavelets",
+                "abi": "3.13",
+                "sha256": "96ac5c0993549217de48ea762e2fd0cb5847987ee2e043fda58baada5caf258d",
+            },
         ],
     },
     {
@@ -212,6 +222,21 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
                 "name": "numpy",
                 "abi": "3.14",
                 "sha256": "28bea03aa0a18bbc1884ea4cebe8d93a9004455c497417e172c221f0a245b439",
+            },
+            {
+                "name": "shapely",
+                "abi": "3.14",
+                "sha256": "d2106a18c04be9da7bce46488f12b6ee42717eaa99e08904b2419e2f99e0248e",
+            },
+            {
+                "name": "Pillow",
+                "abi": "3.14",
+                "sha256": "c8c11eecbf65007c30342bff5e1e5bb40458f1480e23338ac41a8d3144a7e834",
+            },
+            {
+                "name": "pywavelets",
+                "abi": "3.14",
+                "sha256": "919033aa22e5200a5b3f29f08a0525b465d6d9a6ab15a65012de7c38ef16f93a",
             },
         ],
     },

--- a/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/BUILD
@@ -28,19 +28,36 @@ vendored_py_wd_test(
 vendored_py_wd_test(
     "numpy",
     make_snapshot = True,
-    python_flags = [
-        "0.28.2",
-        "314.0.6",
+    skip_python_flags = [
+        "0.26.0a2",
     ],
     use_snapshot = "baseline",
 )
 
-# vendored_py_wd_test("scipy")
-
 vendored_py_wd_test(
     "shapely",
     make_snapshot = True,
-    python_flags = ["0.28.2"],
+    skip_python_flags = [
+        "0.26.0a2",
+    ],
+    use_snapshot = "baseline",
+)
+
+vendored_py_wd_test(
+    "Pillow",
+    make_snapshot = True,
+    skip_python_flags = [
+        "0.26.0a2",
+    ],
+    use_snapshot = "baseline",
+)
+
+vendored_py_wd_test(
+    "pywavelets",
+    make_snapshot = True,
+    skip_python_flags = [
+        "0.26.0a2",
+    ],
     use_snapshot = "baseline",
 )
 

--- a/src/workerd/server/tests/python/vendor_pkg_tests/Pillow.py
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/Pillow.py
@@ -1,0 +1,8 @@
+from PIL import Image
+from workers import WorkerEntrypoint
+
+
+class Default(WorkerEntrypoint):
+    async def test(self):
+        assert Image.new("RGB", (10, 10))
+        print("Pillow imported successfully!")

--- a/src/workerd/server/tests/python/vendor_pkg_tests/Pillow_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/Pillow_vendor.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "Pillow-vendor-test",
+      worker = (
+        modules = [
+          (name = "main.py", pythonModule = embed "Pillow.py"),
+          %PYTHON_VENDORED_MODULES%
+        ],
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "disable_python_no_global_handlers"],
+      )
+    ),
+  ],
+);

--- a/src/workerd/server/tests/python/vendor_pkg_tests/pywavelets.py
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/pywavelets.py
@@ -1,0 +1,9 @@
+import pywt
+import pywt.data
+from workers import WorkerEntrypoint
+
+
+class Default(WorkerEntrypoint):
+    async def test(self):
+        assert pywt.__version__
+        print("PyWavelets imported successfully!")

--- a/src/workerd/server/tests/python/vendor_pkg_tests/pywavelets_vendor.wd-test
+++ b/src/workerd/server/tests/python/vendor_pkg_tests/pywavelets_vendor.wd-test
@@ -1,0 +1,15 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "pywavelets-vendor-test",
+      worker = (
+        modules = [
+          (name = "main.py", pythonModule = embed "pywavelets.py"),
+          %PYTHON_VENDORED_MODULES%
+        ],
+        compatibilityFlags = [%PYTHON_FEATURE_FLAGS, "disable_python_no_global_handlers"],
+      )
+    ),
+  ],
+);


### PR DESCRIPTION
This would help us reveal snapshot errors in new python versions