### PR TITLE
CI: minimal bridge prerequisites for Tokio I/O

### DIFF
--- a/src/rust/cxx/kj-rs/BUILD.bazel
+++ b/src/rust/cxx/kj-rs/BUILD.bazel
@@ -51,6 +51,10 @@ rust_cxx_bridge(
     deps = [
         "//src/rust/cxx:core",
         "@capnp-cpp//src/kj:kj",
-        "@capnp-cpp//src/kj:kj-async",
+        # kj-rs is the base cxx<->rust Promise/Future bridge: it uses only the abstract async
+        # core (kj::Promise / kj::EventLoop via async.h), no kj OS I/O. Depending on
+        # :kj-async-core (not the :kj-async umbrella) keeps the whole kj-rs stack -- and thus
+        # kj-rs-io / kj-rs-tokio built on it -- off the concrete kj OS event loop (:kj-async-os).
+        "@capnp-cpp//src/kj:kj-async-core",
     ],
 )


### PR DESCRIPTION
This PR limits kj-rs's dependency to KJ's abstract async core, allowing the Tokio-backed layers to choose their own concrete event loop. The single commit changes only the dependency and its explanatory comment in `BUILD.bazel`.

The existing ArcWaker implementation and cold-by-default RustFuture conversion remain unchanged. The Tokio/I/O implementation and its explicit-start adaptations are in the [full-stack draft](https://github.com/cloudflare/workerd/pull/7318); eager-by-default conversion is not a prerequisite.

Linux validation: the full Rust suite passed all 43 executed test targets, with `tsan:race` skipped.

Assisted-by: Codex:gpt-6-astra
