### PR TITLE
CI: Tokio I/O stack with the existing Rust bridge

### DIFF
--- a/deps/rust/Cargo.lock
+++ b/deps/rust/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "scratch",
  "serde",
  "serde_json",
+ "socket2",
  "static_assertions",
  "swc_common",
  "swc_ts_fast_strip",
@@ -549,6 +550,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "fastrand"
@@ -1602,6 +1613,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,11 +2126,25 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/deps/rust/Cargo.toml
+++ b/deps/rust/Cargo.toml
@@ -54,9 +54,9 @@ ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.12.1"
 # param_extractor depends on unbounded_depth feature
 serde_json = { version = "1", features = ["unbounded_depth"] }
 serde = { version = "1", features = ["derive"] }
+socket2 = "0.6"
 thiserror = "2"
-# tokio is huge, let's enable only features when we actually need them.
-tokio = { version = "1", default-features = false, features = ["net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", default-features = false, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = { version = "0", default-features = false, features = ["std"] }
 swc_common = "25"
 swc_ts_fast_strip = "57"

--- a/src/rust/cxx/AGENTS.md
+++ b/src/rust/cxx/AGENTS.md
@@ -36,6 +36,10 @@ Bazel module, Cargo workspace, toolchain configuration, or external `workerd-cxx
 - `kj-rs-tokio/` — `TokioEventPort`: a `kj::EventPort` backed by a per-thread tokio
   `current_thread` runtime, plus `setupTokioAsyncIo()` (no I/O providers) and
   `kj_rs_tokio::spawn()`
+- `kj-rs-io/` — KJ async I/O interfaces over tokio (`kj::AsyncIoStream`, listeners,
+  `kj::Network`, providers, signals, file watching), `kj_rs_io::setupTokioAsyncIo()` as the
+  drop-in `kj::setupAsyncIo()` replacement, the stream unwrap fast path, and
+  `serve_kj_stream()` for Rust servers consuming KJ streams
 - `tests/` and `kj-rs/tests/` — Rust and C++ bridge integration tests
 - `tools/bazel/` — Bazel bridge-generation macro used by this component's tests
 

--- a/src/rust/cxx/AGENTS.md
+++ b/src/rust/cxx/AGENTS.md
@@ -33,6 +33,9 @@ Bazel module, Cargo workspace, toolchain configuration, or external `workerd-cxx
 - `src/` and `include/` — cxx Rust and C++ runtimes
 - `syntax/`, `gen/`, and `macro/` — bridge parser and code generators
 - `kj-rs/` — KJ promises/futures, exceptions, ownership, refcounting, dates, and `Maybe`
+- `kj-rs-tokio/` — `TokioEventPort`: a `kj::EventPort` backed by a per-thread tokio
+  `current_thread` runtime, plus `setupTokioAsyncIo()` (no I/O providers) and
+  `kj_rs_tokio::spawn()`
 - `tests/` and `kj-rs/tests/` — Rust and C++ bridge integration tests
 - `tools/bazel/` — Bazel bridge-generation macro used by this component's tests
 

--- a/src/rust/cxx/kj-rs-io/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/BUILD.bazel
@@ -1,0 +1,96 @@
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
+load("//:build/wd_rust_test.bzl", "wd_rust_test")
+load("//src/rust/cxx/tools/bazel:rust_cxx_bridge.bzl", "rust_cxx_bridge")
+
+wd_cc_library(
+    name = "kj-rs-io-lib",
+    srcs = glob(
+        ["*.c++"],
+        exclude = ["peer-filter.c++"],
+    ),
+    hdrs = glob(
+        ["*.h"],
+        exclude = ["peer-filter.h"],
+    ),
+    include_prefix = "kj-rs-io",
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    strip_include_prefix = "/src/rust/cxx/kj-rs-io",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bridge",
+        ":peer-filter-lib",
+        "//src/rust/cxx/kj-rs-tokio:kj-rs-tokio-lib",
+    ],
+)
+
+wd_cc_library(
+    name = "peer-filter-lib",
+    srcs = ["peer-filter.c++"],
+    hdrs = ["peer-filter.h"],
+    include_prefix = "kj-rs-io",
+    strip_include_prefix = "/src/rust/cxx/kj-rs-io",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj:kj-async-io",
+    ],
+)
+
+rust_library(
+    name = "kj-rs-io",
+    srcs = glob(["*.rs"]),
+    compile_data = glob(["*.h"]),
+    edition = "2024",
+    link_deps = [
+        ":bridge",
+        ":kj-rs-io-lib",
+    ],
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/rust/cxx",
+        "//src/rust/cxx/kj-rs",
+        "//src/rust/cxx/kj-rs-tokio",
+        "@crates_vendor//:bytes",
+        "@crates_vendor//:libc",
+        "@crates_vendor//:socket2",
+        "@crates_vendor//:static_assertions",
+        "@crates_vendor//:tokio",
+    ],
+)
+
+wd_rust_test(
+    name = "kj-rs-io_test",
+    crate = "kj-rs-io",
+    edition = "2024",
+)
+
+rust_cxx_bridge(
+    name = "bridge",
+    src = "ffi.rs",
+    hdrs = ["unwrap.h"],
+    include_prefix = "kj-rs-io",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/rust/cxx/kj-rs",
+        "@capnp-cpp//src/kj:kj",
+        # kj-rs-io IS the kj-side implementation of the rust I/O backend: it derives from the
+        # abstract kj::AsyncIoStream / kj::Network / kj::LowLevelAsyncIoProvider interfaces and
+        # reuses portable helpers (kj::newOneWayPipe, kj::CidrRange, the AsyncInputStream /
+        # AsyncOutputStream default-method vtable slots). Those live in the ABSTRACT layers
+        # :kj-async-core (Promise machinery) + :kj-async-io (abstract streams / Network / CIDR;
+        # no event loop). It does NOT call kj::setupAsyncIo / kj::UnixEventPort, so it never
+        # needs :kj-async-os (the concrete OS event loop) -- the tokio-backed EventPort
+        # (kj-rs-tokio) replaces it. A stray setupAsyncIo would be an undefined-symbol link
+        # error, the intended backstop.
+        "@capnp-cpp//src/kj:kj-async-core",
+        "@capnp-cpp//src/kj:kj-async-io",
+        "//src/rust/cxx:core",
+    ],
+)

--- a/src/rust/cxx/kj-rs-io/async-io.c++
+++ b/src/rust/cxx/kj-rs-io/async-io.c++
@@ -500,6 +500,9 @@ kj::Own<kj::AsyncIoStream> TokioLowLevelAsyncIoProvider::wrapSocketFd(Fd fd, kj:
 kj::Promise<kj::Own<kj::AsyncIoStream>> TokioLowLevelAsyncIoProvider::wrapConnectingSocketFd(
     Fd fd, const struct sockaddr *addr, kj::uint addrlen, kj::uint flags) {
   int64_t prepared = static_cast<int64_t>(prepareFd(fd, flags));
+  // Materialize Rust ownership before any later fallible work. The generated async bridge then
+  // moves this owner into its promise, so cancellation before the first poll still closes it.
+  auto socket = own_connecting_socket(prepared);
   // The Rust side takes an owned copy of the sockaddr: the caller's pointer need not outlive
   // this call (KJ's own implementation copies too).
   ::rust::Vec<uint8_t> addrCopy;
@@ -508,7 +511,7 @@ kj::Promise<kj::Own<kj::AsyncIoStream>> TokioLowLevelAsyncIoProvider::wrapConnec
   for (kj::uint i = 0; i < addrlen; i++) {
     addrCopy.push_back(addrBytes[i]);
   }
-  return wrap_connecting_socket_fd(prepared, kj::mv(addrCopy))
+  return wrap_connecting_socket_fd(kj::mv(socket), kj::mv(addrCopy))
       .then([](::rust::Box<TokioStream> stream) -> kj::Own<kj::AsyncIoStream> {
     return kj::heap<TokioAsyncIoStream>(kj::mv(stream));
   });

--- a/src/rust/cxx/kj-rs-io/async-io.c++
+++ b/src/rust/cxx/kj-rs-io/async-io.c++
@@ -1,0 +1,527 @@
+#include "kj-rs-io/async-io.h"
+
+#include <kj/debug.h>
+
+#include <cstring>
+
+#if _WIN32
+#include <winsock2.h>
+// windows.h (pulled in by winsock2.h) defines ERROR as a macro, which breaks KJ_LOG(ERROR).
+#include <kj/windows-sanity.h>
+#else
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#if __APPLE__ || __FreeBSD__ || __OpenBSD__ || __NetBSD__ || __DragonFly__
+#include <sys/ucred.h>
+#endif
+#endif
+
+namespace kj_rs_io {
+
+// =======================================================================================
+// TokioAsyncIoStream
+
+kj::Promise<size_t> TokioAsyncIoStream::tryRead(void *buffer, size_t minBytes, size_t maxBytes) {
+  return stream_try_read(
+      *inner, ::rust::Slice<uint8_t>(reinterpret_cast<uint8_t *>(buffer), maxBytes), minBytes);
+}
+
+kj::Promise<void> TokioAsyncIoStream::write(kj::ArrayPtr<const kj::byte> buffer) {
+  return stream_write(*inner, ::rust::Slice<const uint8_t>(buffer.begin(), buffer.size()));
+}
+
+kj::Promise<void> TokioAsyncIoStream::write(
+    kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) {
+  return writePieces(pieces);
+}
+
+kj::Promise<void> TokioAsyncIoStream::writePieces(
+    kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) {
+  // One bridged operation for all pieces (writev on the Rust side). The bridged future borrows
+  // the KjPieces it is handed, so it lives in this coroutine's frame; the pieces themselves are
+  // the caller's, valid until the promise settles per the kj::AsyncOutputStream contract.
+  KjPieces owned{pieces};
+  co_await stream_write_pieces(*inner, owned);
+}
+
+kj::Promise<void> TokioAsyncIoStream::whenWriteDisconnected() {
+  return stream_when_write_disconnected(*inner);
+}
+
+void TokioAsyncIoStream::shutdownWrite() {
+  stream_shutdown_write(*inner);
+}
+
+void TokioAsyncIoStream::getsockopt(int level, int option, void *value, kj::uint *length) {
+  // The platform seam lives on the Rust side (stream_getsockopt); errors surface as kj
+  // exceptions, like KJ_SYSCALL. Raw socklen in/out semantics: the syscall's reported length
+  // is mirrored back verbatim.
+  *length = stream_getsockopt(
+      *inner, level, option, ::rust::Slice<uint8_t>(reinterpret_cast<uint8_t *>(value), *length));
+}
+
+void TokioAsyncIoStream::setsockopt(int level, int option, const void *value, kj::uint length) {
+  stream_setsockopt(*inner, level, option,
+      ::rust::Slice<const uint8_t>(reinterpret_cast<const uint8_t *>(value), length));
+}
+
+void TokioAsyncIoStream::getsockname(struct sockaddr *addr, kj::uint *length) {
+  auto bytes = stream_local_addr(*inner);
+  // Mirror the raw syscall's truncation semantics: copy what fits into the caller's buffer,
+  // report the address's full length.
+  memcpy(addr, bytes.data(), kj::min(bytes.size(), *length));
+  *length = bytes.size();
+}
+
+void TokioAsyncIoStream::getpeername(struct sockaddr *addr, kj::uint *length) {
+  auto bytes = stream_peer_addr(*inner);
+  memcpy(addr, bytes.data(), kj::min(bytes.size(), *length));
+  *length = bytes.size();
+}
+
+kj::Maybe<int> TokioAsyncIoStream::getFd() const {
+#if _WIN32
+  // On Windows the underlying handle is a winsock SOCKET, not a Unix fd; it is exposed via
+  // getWin32Handle() below instead. (Validated by Windows CI.)
+  return kj::none;
+#else
+  // On unix the raw socket handle is the fd, widened losslessly to int64 by the bridge; -1
+  // means the wrapper is hollow (unwrapped).
+  int64_t handle = stream_try_raw_handle(*inner);
+  if (handle < 0) return kj::none;
+  return static_cast<int>(handle);
+#endif
+}
+
+#if _WIN32
+// Validated by Windows CI; mirrors the unix getFd() arm (and kj's own win32 AsyncStreamFd,
+// which returns its SOCKET cast to void* -- capnproto async-io-win32.c++).
+kj::Maybe<void *> TokioAsyncIoStream::getWin32Handle() const {
+  int64_t handle = stream_try_raw_handle(*inner);
+  if (handle < 0) return kj::none;
+  return reinterpret_cast<void *>(static_cast<uintptr_t>(handle));
+}
+#endif
+
+::rust::Box<TokioStream> unwrapTokioStream(kj::AsyncIoStream &stream) {
+  KJ_IF_SOME(tokioStream, kj::dynamicDowncastIfAvailable<TokioAsyncIoStream>(stream)) {
+    return tokioStream.unwrap();
+  }
+  KJ_FAIL_REQUIRE("stream is not a kj-rs-io tokio-backed stream; cannot unwrap");
+}
+
+// =======================================================================================
+// TokioConnectionReceiver
+
+namespace {
+
+// Builds the accepted connection's kj::PeerIdentity, mirroring KJ's SocketAddress::getIdentity()
+// (kj/async-io-unix.c++): NetworkPeerIdentity wrapping the peer's address for TCP peers (its
+// toString() is "ip:port" / "[v6]:port", byte-identical to KJ's format -- workerd's HTTP
+// listener puts this string in the cf blob's clientIp), LocalPeerIdentity with the peer's
+// process credentials for unix sockets, UnknownPeerIdentity otherwise.
+kj::Own<kj::PeerIdentity> peerIdentityFromSockaddr(
+    struct sockaddr *sa, kj::uint addrlen, [[maybe_unused]] kj::AsyncIoStream &stream) {
+  switch (sa->sa_family) {
+    case AF_INET:
+    case AF_INET6: {
+      // The identity's NetworkAddress uses an allow-all filter (not the listener's): it exists
+      // for toString()/getAddress(); restrictPeers enforcement on this listener already happened
+      // in the accept loop. (KJ instead threads the listener's filter through, which only
+      // matters if a caller connect()s back through the identity address.) A fresh filter per
+      // identity, NOT a process-wide static: kj::Rc's refcount is not atomic, and accept loops
+      // run on every tokio-ported loop thread, so a shared one would race.
+      auto address = network_get_sockaddr(
+          ::rust::Slice<const uint8_t>(reinterpret_cast<const uint8_t *>(sa), addrlen));
+      return kj::NetworkPeerIdentity::newInstance(
+          kj::heap<TokioNetworkAddress>(kj::mv(address), kj::rc<PeerFilter>()));
+    }
+#if !_WIN32
+    case AF_UNIX: {
+      // Same credential sources and invalid-value handling as KJ (SO_PEERCRED on Linux,
+      // LOCAL_PEERCRED/LOCAL_PEERPID on BSDs/macOS; OpenBSD defines SO_PEERCRED but with a
+      // different interface, so it uses the LOCAL_PEERCRED arm).
+      kj::LocalPeerIdentity::Credentials result;
+#if defined(SO_PEERCRED) && !__OpenBSD__
+      struct ucred creds;
+      kj::uint length = sizeof(creds);
+      stream.getsockopt(SOL_SOCKET, SO_PEERCRED, &creds, &length);
+      if (creds.pid > 0) {
+        result.pid = creds.pid;
+      }
+      if (creds.uid != static_cast<uid_t>(-1)) {
+        result.uid = creds.uid;
+      }
+#elif defined(LOCAL_PEERCRED)
+      struct xucred creds;
+      kj::uint length = sizeof(creds);
+      stream.getsockopt(SOL_LOCAL, LOCAL_PEERCRED, &creds, &length);
+      KJ_ASSERT(length == sizeof(creds));
+      if (creds.cr_uid != static_cast<uid_t>(-1)) {
+        result.uid = creds.cr_uid;
+      }
+#ifdef LOCAL_PEERPID
+      pid_t pid;
+      length = sizeof(pid);
+      stream.getsockopt(SOL_LOCAL, LOCAL_PEERPID, &pid, &length);
+      KJ_ASSERT(length == sizeof(pid));
+      if (pid > 0) {
+        result.pid = pid;
+      }
+#endif
+#endif
+      return kj::LocalPeerIdentity::newInstance(result);
+    }
+#endif  // !_WIN32
+    default:
+      return kj::UnknownPeerIdentity::newInstance();
+  }
+}
+
+}  // namespace
+
+kj::Promise<kj::Own<kj::AsyncIoStream>> TokioConnectionReceiver::accept() {
+  return acceptImpl(false).then(
+      [](kj::AuthenticatedStream authenticated) { return kj::mv(authenticated.stream); });
+}
+
+kj::Promise<kj::AuthenticatedStream> TokioConnectionReceiver::acceptAuthenticated() {
+  return acceptImpl(true);
+}
+
+kj::Promise<kj::AuthenticatedStream> TokioConnectionReceiver::acceptImpl(bool authenticated) {
+  for (;;) {
+    auto stream = co_await listener_accept(*inner);
+    // restrictPeers / NetworkFilter enforcement, mirroring KJ: a connection from a disallowed
+    // peer is silently dropped and we keep accepting.
+    struct sockaddr_storage addr;
+    memset(&addr, 0, sizeof(addr));
+    kj::uint addrlen = 0;
+    KJ_IF_SOME(exception, kj::runCatchingExceptions([&]() {
+      auto bytes = stream_peer_addr(*stream);
+      KJ_ASSERT(bytes.size() <= sizeof(addr), "sockaddr too large");
+      memcpy(&addr, bytes.data(), bytes.size());
+      addrlen = bytes.size();
+    })) {
+      // The peer can reset the connection between tokio's accept() and this call, in which
+      // case getpeername fails (EINVAL on macOS, ENOTCONN elsewhere). The connection is dead;
+      // drop it and keep accepting. This must NOT throw: an exception here propagates out of
+      // the server's accept loop and takes down the whole process (observed as a fatal
+      // uncaught kj::Exception under client abort storms). Unlike KJ's native accept path,
+      // which gets the peer address atomically from accept4(), we re-derive it and so must
+      // tolerate the race. Log at INFO (off by default) for observability under abort storms.
+      KJ_LOG(INFO, "dropping accepted connection; could not read peer address", exception);
+      continue;
+    }
+    if (!filter->shouldAllow(reinterpret_cast<struct sockaddr *>(&addr), addrlen)) {
+      // Drop the disallowed connection and wait for the next one.
+      continue;
+    }
+    kj::AuthenticatedStream result;
+    result.stream = kj::heap<TokioAsyncIoStream>(kj::mv(stream));
+    if (authenticated) {
+      result.peerIdentity = peerIdentityFromSockaddr(
+          reinterpret_cast<struct sockaddr *>(&addr), addrlen, *result.stream);
+    } else {
+      result.peerIdentity = kj::UnknownPeerIdentity::newInstance();
+    }
+    co_return kj::mv(result);
+  }
+}
+
+kj::uint TokioConnectionReceiver::getPort() {
+  return listener_port(*inner);
+}
+
+void TokioConnectionReceiver::getsockopt(int level, int option, void *value, kj::uint *length) {
+  *length = listener_getsockopt(
+      *inner, level, option, ::rust::Slice<uint8_t>(reinterpret_cast<uint8_t *>(value), *length));
+}
+
+void TokioConnectionReceiver::setsockopt(
+    int level, int option, const void *value, kj::uint length) {
+  listener_setsockopt(*inner, level, option,
+      ::rust::Slice<const uint8_t>(reinterpret_cast<const uint8_t *>(value), length));
+}
+
+void TokioConnectionReceiver::getsockname(struct sockaddr *addr, kj::uint *length) {
+  auto bytes = listener_local_addr(*inner);
+  // Mirror the raw syscall's truncation semantics (see TokioAsyncIoStream::getsockname).
+  memcpy(addr, bytes.data(), kj::min(bytes.size(), *length));
+  *length = bytes.size();
+}
+
+// =======================================================================================
+// TokioNetworkAddress / TokioNetwork
+
+kj::Promise<kj::Own<kj::AsyncIoStream>> TokioNetworkAddress::connect() {
+  // KJ contract (NetworkAddressImpl::connect() in kj/async-io-unix.c++): callers may drop the
+  // NetworkAddress while the returned promise is still pending. We honor this by cloning the
+  // resolved address list into a coroutine frame local: the frame owns the copy, so it
+  // survives every co_await and is dropped on completion/cancellation. connect() may be called
+  // repeatedly on the same address, so we clone rather than move `*inner` out of `this`.
+  // The filter share is frame-owned for the same reason: `this` may be gone after the first
+  // co_await, so the frame keeps the chain alive itself rather than reading the member again.
+  auto addr = address_clone(*inner);
+  auto localFilter = filter.addRef();
+  size_t count = address_count(*addr);
+  KJ_REQUIRE(count > 0, "no addresses to connect to");
+
+  // Try each resolved address in order; a filter block or connect error falls through to the
+  // next one, and the last address's exception propagates (KJ parity).
+  kj::Maybe<kj::Exception> lastException;
+  for (size_t i = 0; i < count; i++) {
+    kj::Maybe<kj::Own<kj::AsyncIoStream>> stream;
+    try {
+      auto raw = address_raw_sockaddr(*addr, i);
+      // Copy into sockaddr_storage for alignment (rust::Vec<u8> data is 1-aligned).
+      struct sockaddr_storage storage;
+      memset(&storage, 0, sizeof(storage));
+      KJ_REQUIRE(raw.size() <= sizeof(storage), "sockaddr too large");
+      memcpy(&storage, raw.data(), raw.size());
+      if (!localFilter->shouldAllow(reinterpret_cast<struct sockaddr *>(&storage), raw.size())) {
+        // Exact KJ error text; error-string parity matters to callers.
+        lastException = KJ_EXCEPTION(FAILED, "connect() blocked by restrictPeers()");
+      } else {
+        stream = kj::heap<TokioAsyncIoStream>(co_await address_connect_index(*addr, i));
+      }
+    } catch (...) {
+      // Note: getCaughtExceptionAsKj() rethrows kj::CanceledException, so cancellation still
+      // propagates out of this coroutine instead of being folded into lastException.
+      lastException = kj::getCaughtExceptionAsKj();
+    }
+    KJ_IF_SOME(s, stream) {
+      co_return kj::mv(s);
+    }
+  }
+
+  kj::throwFatalException(kj::mv(KJ_ASSERT_NONNULL(lastException)));
+}
+
+kj::Own<kj::ConnectionReceiver> TokioNetworkAddress::listen() {
+  return kj::heap<TokioConnectionReceiver>(address_listen(*inner), filter.addRef());
+}
+
+kj::Own<kj::NetworkAddress> TokioNetworkAddress::clone() {
+  return kj::heap<TokioNetworkAddress>(address_clone(*inner), filter.addRef());
+}
+
+kj::String TokioNetworkAddress::toString() {
+  auto text = address_to_string(*inner);
+  return kj::heapString(text.data(), text.size());
+}
+
+kj::Promise<kj::Own<kj::NetworkAddress>> TokioNetwork::parseAddress(
+    kj::StringPtr addr, kj::uint portHint) {
+  KJ_REQUIRE(portHint < 65536, "port hint too large", portHint);
+  // The Rust side takes an owned copy: the caller's buffer need not outlive this call.
+  //
+  // Note: unlike KJ, disallowed (restrictPeers) DNS results are not dropped here; they are
+  // rejected at connect()/accept() time instead. See TokioNetworkAddress.
+  return network_parse_address(
+      ::rust::String(addr.begin(), addr.size()), static_cast<uint16_t>(portHint))
+      .then([filter = filter.addRef()](
+                ::rust::Box<TokioAddress> address) mutable -> kj::Own<kj::NetworkAddress> {
+    // The continuation owns its share of the filter chain (no `this` capture): the returned
+    // promise is independent of this network's lifetime.
+    return kj::heap<TokioNetworkAddress>(kj::mv(address), kj::mv(filter));
+  });
+}
+
+kj::Own<kj::NetworkAddress> TokioNetwork::getSockaddr(const void *sockaddr, kj::uint len) {
+  // KJ parity: getSockaddr() rejects filtered addresses eagerly (same error text as KJ).
+  KJ_REQUIRE(filter->shouldAllow(reinterpret_cast<const struct sockaddr *>(sockaddr), len),
+      "address blocked by restrictPeers()");
+  return kj::heap<TokioNetworkAddress>(network_get_sockaddr(::rust::Slice<const uint8_t>(
+                                           reinterpret_cast<const uint8_t *>(sockaddr), len)),
+      filter.addRef());
+}
+
+kj::Own<kj::Network> TokioNetwork::restrictPeers(
+    kj::ArrayPtr<const kj::StringPtr> allow, kj::ArrayPtr<const kj::StringPtr> deny) {
+  // The child owns a share of this network's filter chain (see TokioNetwork's constructor), so
+  // it remains valid even if this network is destroyed first.
+  return kj::heap<TokioNetwork>(*this, allow, deny);
+}
+
+// =======================================================================================
+// TokioLowLevelAsyncIoProvider
+
+namespace {
+
+#if _WIN32
+// Normalizes KJ's fd-wrapping flags so Rust always receives a SOCKET it owns, in non-blocking
+// mode: the windows arm of prepareFd, mirroring the unix arm below in *effect*, not mechanism.
+// kj's own win32 provider (capnproto async-io-win32.c++: OwnedFd, NEW_FD_FLAGS) never dups a
+// borrowed socket -- it merely skips closesocket() on destruction when TAKE_OWNERSHIP is
+// absent -- ignores ALREADY_CLOEXEC entirely (there is no CLOEXEC on Windows; handle
+// inheritance is the analogue), and never toggles non-blocking mode (it uses overlapped I/O,
+// not readiness). Rust's OwnedSocket has no "don't close" mode, so a borrowed socket is
+// duplicated (WSADuplicateSocketW + WSASocketW, non-inheritable) into a handle Rust can own;
+// and tokio/mio's readiness model requires non-blocking sockets, so FIONBIO is set unless the
+// caller declared ALREADY_NONBLOCK (the duplicate shares the underlying socket state, so this
+// is observed through the caller's handle too, matching the unix dup()+O_NONBLOCK behavior).
+// Validated by Windows CI.
+uintptr_t prepareFd(uintptr_t fd, kj::uint flags) {
+  SOCKET sock = static_cast<SOCKET>(fd);
+  if ((flags & kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP) == 0) {
+    WSAPROTOCOL_INFOW info;
+    KJ_WINSOCK(WSADuplicateSocketW(sock, GetCurrentProcessId(), &info));
+    SOCKET duped = WSASocketW(FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO, &info, 0,
+        WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+    if (duped == INVALID_SOCKET) {
+      KJ_FAIL_WIN32("WSASocketW()", WSAGetLastError());
+    }
+    sock = duped;
+  }
+  // ALREADY_NONBLOCK does not exist on Windows (kj declares it under #if !_WIN32), so callers
+  // cannot assert pre-set non-blocking mode; always enable it (idempotent).
+  u_long mode = 1;
+  KJ_WINSOCK(ioctlsocket(sock, FIONBIO, &mode));
+  return static_cast<uintptr_t>(sock);
+}
+#else
+// Normalizes KJ's fd-wrapping flags so Rust always receives an fd it owns, with CLOEXEC set and
+// in non-blocking mode.
+int prepareFd(int fd, kj::uint flags) {
+  if ((flags & kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP) == 0) {
+    // dup() shares the open file description — the O_NONBLOCK set below is observed through the
+    // caller's fd too, matching KJ (which sets O_NONBLOCK on the caller's fd directly) — while
+    // giving Rust a descriptor it can own and close.
+    int duped;
+    KJ_SYSCALL(duped = ::dup(fd));
+    fd = duped;
+    KJ_SYSCALL(fcntl(fd, F_SETFD, FD_CLOEXEC));
+  } else if ((flags & kj::LowLevelAsyncIoProvider::ALREADY_CLOEXEC) == 0) {
+    KJ_SYSCALL(fcntl(fd, F_SETFD, FD_CLOEXEC));
+  }
+  if ((flags & kj::LowLevelAsyncIoProvider::ALREADY_NONBLOCK) == 0) {
+    int fl;
+    KJ_SYSCALL(fl = fcntl(fd, F_GETFL));
+    if ((fl & O_NONBLOCK) == 0) {
+      KJ_SYSCALL(fcntl(fd, F_SETFL, fl | O_NONBLOCK));
+    }
+  }
+  return fd;
+}
+
+// kj::AsyncInputStream over an arbitrary readable fd (pipe, socket, character device).
+class TokioInputStreamFd final: public kj::AsyncInputStream {
+ public:
+  explicit TokioInputStreamFd(::rust::Box<TokioInputFd> inner): inner(kj::mv(inner)) {}
+
+  kj::Promise<size_t> tryRead(void *buffer, size_t minBytes, size_t maxBytes) override {
+    return input_fd_try_read(
+        *inner, ::rust::Slice<uint8_t>(reinterpret_cast<uint8_t *>(buffer), maxBytes), minBytes);
+  }
+
+ private:
+  ::rust::Box<TokioInputFd> inner;
+};
+
+// kj::AsyncOutputStream over an arbitrary writable fd.
+class TokioOutputStreamFd final: public kj::AsyncOutputStream {
+ public:
+  explicit TokioOutputStreamFd(::rust::Box<TokioOutputFd> inner): inner(kj::mv(inner)) {}
+
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
+    return output_fd_write(*inner, ::rust::Slice<const uint8_t>(buffer.begin(), buffer.size()));
+  }
+
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override {
+    for (auto piece: pieces) {
+      co_await write(piece);
+    }
+  }
+
+  // Pipes/arbitrary fds have no portable disconnect detection here; KJ allows a never-resolving
+  // promise for such streams.
+  kj::Promise<void> whenWriteDisconnected() override {
+    return kj::NEVER_DONE;
+  }
+
+ private:
+  ::rust::Box<TokioOutputFd> inner;
+};
+#endif  // _WIN32 (prepareFd platform arms; the pipe-fd stream classes above are unix-only)
+
+}  // namespace
+
+kj::Own<kj::AsyncInputStream> TokioLowLevelAsyncIoProvider::wrapInputFd(Fd fd, kj::uint flags) {
+#if _WIN32
+  // KJ parity: on win32, LowLevelAsyncIoProvider::Fd is documented as a SOCKET (async-io.h:
+  // "On Windows, the `fd` parameter to each of these methods must be a SOCKET"), and kj's own
+  // win32 provider implements wrapInputFd/wrapOutputFd *identically* to wrapSocketFd
+  // (async-io-win32.c++: all three wrap the SOCKET in AsyncStreamFd) -- even kj's "pipes" on
+  // Windows are loopback-TCP socketpairs (newOsSocketpair). So there is no pipe-HANDLE tier to
+  // implement; delegate to the tested socket path. Validated by Windows CI.
+  return kj::heap<TokioAsyncIoStream>(wrap_socket_fd(static_cast<int64_t>(prepareFd(fd, flags))));
+#else
+  return kj::heap<TokioInputStreamFd>(wrap_input_fd(prepareFd(fd, flags)));
+#endif
+}
+
+kj::Own<kj::AsyncOutputStream> TokioLowLevelAsyncIoProvider::wrapOutputFd(Fd fd, kj::uint flags) {
+#if _WIN32
+  // See wrapInputFd above: win32 Fd is a SOCKET and kj's win32 wrapOutputFd == wrapSocketFd.
+  // Validated by Windows CI.
+  return kj::heap<TokioAsyncIoStream>(wrap_socket_fd(static_cast<int64_t>(prepareFd(fd, flags))));
+#else
+  return kj::heap<TokioOutputStreamFd>(wrap_output_fd(prepareFd(fd, flags)));
+#endif
+}
+
+kj::Own<kj::AsyncIoStream> TokioLowLevelAsyncIoProvider::wrapSocketFd(Fd fd, kj::uint flags) {
+  // `Fd` is int on unix and uintptr_t (SOCKET) on win32; the bridge carries it widened to
+  // int64 (a "raw socket handle") either way, with -1 == INVALID_SOCKET as the one sentinel.
+  return kj::heap<TokioAsyncIoStream>(wrap_socket_fd(static_cast<int64_t>(prepareFd(fd, flags))));
+}
+
+kj::Promise<kj::Own<kj::AsyncIoStream>> TokioLowLevelAsyncIoProvider::wrapConnectingSocketFd(
+    Fd fd, const struct sockaddr *addr, kj::uint addrlen, kj::uint flags) {
+  int64_t prepared = static_cast<int64_t>(prepareFd(fd, flags));
+  // The Rust side takes an owned copy of the sockaddr: the caller's pointer need not outlive
+  // this call (KJ's own implementation copies too).
+  ::rust::Vec<uint8_t> addrCopy;
+  addrCopy.reserve(addrlen);
+  const uint8_t *addrBytes = reinterpret_cast<const uint8_t *>(addr);
+  for (kj::uint i = 0; i < addrlen; i++) {
+    addrCopy.push_back(addrBytes[i]);
+  }
+  return wrap_connecting_socket_fd(prepared, kj::mv(addrCopy))
+      .then([](::rust::Box<TokioStream> stream) -> kj::Own<kj::AsyncIoStream> {
+    return kj::heap<TokioAsyncIoStream>(kj::mv(stream));
+  });
+}
+
+kj::Own<kj::ConnectionReceiver> TokioLowLevelAsyncIoProvider::wrapListenSocketFd(
+    Fd fd, NetworkFilter &filter, kj::uint flags) {
+  // `filter` applies to accepted connections (KJ parity); it must outlive the receiver.
+  return kj::heap<TokioConnectionReceiver>(
+      wrap_listen_fd(static_cast<int64_t>(prepareFd(fd, flags))), filter);
+}
+
+// =======================================================================================
+// TokioAsyncIoProvider / setup
+
+kj::AsyncIoProvider::PipeThread TokioAsyncIoProvider::newPipeThread(
+    kj::Function<void(kj::AsyncIoProvider &, kj::AsyncIoStream &, kj::WaitScope &)> startFunc) {
+  KJ_UNIMPLEMENTED("kj-rs-io does not implement newPipeThread() (workerd does not use it)");
+}
+
+TokioAsyncIoContext setupTokioAsyncIo() {
+  return TokioAsyncIoContext();
+}
+
+// =======================================================================================
+// Signals
+
+kj::Promise<void> onSignal(int signum) {
+  // The bridged future is eager-by-default, so the tokio signal handler is registered as soon
+  // as the event loop runs, even if the caller parks the promise without awaiting it immediately.
+  return wait_for_signal(signum);
+}
+
+}  // namespace kj_rs_io

--- a/src/rust/cxx/kj-rs-io/async-io.c++
+++ b/src/rust/cxx/kj-rs-io/async-io.c++
@@ -105,6 +105,10 @@ kj::Maybe<void *> TokioAsyncIoStream::getWin32Handle() const {
 }
 #endif
 
+bool isTokioStream(const kj::AsyncIoStream &stream) {
+  return kj::dynamicDowncastIfAvailable<const TokioAsyncIoStream>(stream) != kj::none;
+}
+
 ::rust::Box<TokioStream> unwrapTokioStream(kj::AsyncIoStream &stream) {
   KJ_IF_SOME(tokioStream, kj::dynamicDowncastIfAvailable<TokioAsyncIoStream>(stream)) {
     return tokioStream.unwrap();

--- a/src/rust/cxx/kj-rs-io/async-io.c++
+++ b/src/rust/cxx/kj-rs-io/async-io.c++
@@ -159,7 +159,7 @@ kj::Own<kj::PeerIdentity> peerIdentityFromSockaddr(
       if (creds.uid != static_cast<uid_t>(-1)) {
         result.uid = creds.uid;
       }
-#elif defined(LOCAL_PEERCRED)
+#elifdef LOCAL_PEERCRED
       struct xucred creds;
       kj::uint length = sizeof(creds);
       stream.getsockopt(SOL_LOCAL, LOCAL_PEERCRED, &creds, &length);

--- a/src/rust/cxx/kj-rs-io/async-io.c++
+++ b/src/rust/cxx/kj-rs-io/async-io.c++
@@ -30,7 +30,10 @@ kj::Promise<size_t> TokioAsyncIoStream::tryRead(void *buffer, size_t minBytes, s
 }
 
 kj::Promise<void> TokioAsyncIoStream::write(kj::ArrayPtr<const kj::byte> buffer) {
-  return stream_write(*inner, ::rust::Slice<const uint8_t>(buffer.begin(), buffer.size()));
+  // KJ's HTTP header queue calls write() without necessarily awaiting its result. Start the
+  // Rust write here so that queuing headers can transmit them without a subsequent body write.
+  return stream_write(*inner, ::rust::Slice<const uint8_t>(buffer.begin(), buffer.size()))
+      .eagerlyEvaluate(nullptr);
 }
 
 kj::Promise<void> TokioAsyncIoStream::write(
@@ -540,8 +543,7 @@ TokioAsyncIoContext setupTokioAsyncIo() {
 // Signals
 
 kj::Promise<void> onSignal(int signum) {
-  // The bridged future is eager-by-default, so the tokio signal handler is registered as soon
-  // as the event loop runs, even if the caller parks the promise without awaiting it immediately.
+  // The handler is installed on the first poll. Merely retaining the promise does not register it.
   return wait_for_signal(signum);
 }
 

--- a/src/rust/cxx/kj-rs-io/async-io.c++
+++ b/src/rust/cxx/kj-rs-io/async-io.c++
@@ -1,6 +1,7 @@
 #include "kj-rs-io/async-io.h"
 
 #include <kj/debug.h>
+#include <kj/io.h>
 
 #include <cstring>
 
@@ -370,7 +371,15 @@ namespace {
 // Validated by Windows CI.
 uintptr_t prepareFd(uintptr_t fd, kj::uint flags) {
   SOCKET sock = static_cast<SOCKET>(fd);
-  if ((flags & kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP) == 0) {
+  bool ownsSocket = (flags & kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP) != 0;
+  auto closeOnFailure = kj::defer([&]() {
+    if (ownsSocket) {
+      KJ_WINSOCK(closesocket(sock)) {
+        break;
+      }
+    }
+  });
+  if (!ownsSocket) {
     WSAPROTOCOL_INFOW info;
     KJ_WINSOCK(WSADuplicateSocketW(sock, GetCurrentProcessId(), &info));
     SOCKET duped = WSASocketW(FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO, &info, 0,
@@ -379,36 +388,41 @@ uintptr_t prepareFd(uintptr_t fd, kj::uint flags) {
       KJ_FAIL_WIN32("WSASocketW()", WSAGetLastError());
     }
     sock = duped;
+    ownsSocket = true;
   }
   // ALREADY_NONBLOCK does not exist on Windows (kj declares it under #if !_WIN32), so callers
   // cannot assert pre-set non-blocking mode; always enable it (idempotent).
   u_long mode = 1;
   KJ_WINSOCK(ioctlsocket(sock, FIONBIO, &mode));
+  closeOnFailure.cancel();
   return static_cast<uintptr_t>(sock);
 }
 #else
 // Normalizes KJ's fd-wrapping flags so Rust always receives an fd it owns, with CLOEXEC set and
 // in non-blocking mode.
 int prepareFd(int fd, kj::uint flags) {
+  kj::OwnFd ownedFd;
   if ((flags & kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP) == 0) {
-    // dup() shares the open file description — the O_NONBLOCK set below is observed through the
-    // caller's fd too, matching KJ (which sets O_NONBLOCK on the caller's fd directly) — while
-    // giving Rust a descriptor it can own and close.
+    // The duplicate shares the open file description, so O_NONBLOCK set below is observed through
+    // the caller's fd too, matching KJ, while Rust receives a descriptor it can own and close.
     int duped;
-    KJ_SYSCALL(duped = ::dup(fd));
-    fd = duped;
-    KJ_SYSCALL(fcntl(fd, F_SETFD, FD_CLOEXEC));
-  } else if ((flags & kj::LowLevelAsyncIoProvider::ALREADY_CLOEXEC) == 0) {
-    KJ_SYSCALL(fcntl(fd, F_SETFD, FD_CLOEXEC));
+    KJ_SYSCALL(duped = fcntl(fd, F_DUPFD_CLOEXEC, 0));
+    ownedFd = kj::OwnFd(duped);
+  } else {
+    ownedFd = kj::OwnFd(fd);
+  }
+  if ((flags & kj::LowLevelAsyncIoProvider::ALREADY_CLOEXEC) == 0 &&
+      (flags & kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP) != 0) {
+    KJ_SYSCALL(fcntl(ownedFd, F_SETFD, FD_CLOEXEC));
   }
   if ((flags & kj::LowLevelAsyncIoProvider::ALREADY_NONBLOCK) == 0) {
     int fl;
-    KJ_SYSCALL(fl = fcntl(fd, F_GETFL));
+    KJ_SYSCALL(fl = fcntl(ownedFd, F_GETFL));
     if ((fl & O_NONBLOCK) == 0) {
-      KJ_SYSCALL(fcntl(fd, F_SETFL, fl | O_NONBLOCK));
+      KJ_SYSCALL(fcntl(ownedFd, F_SETFL, fl | O_NONBLOCK));
     }
   }
-  return fd;
+  return ownedFd.release();
 }
 
 // kj::AsyncInputStream over an arbitrary readable fd (pipe, socket, character device).

--- a/src/rust/cxx/kj-rs-io/async-io.h
+++ b/src/rust/cxx/kj-rs-io/async-io.h
@@ -1,0 +1,286 @@
+#pragma once
+// kj-rs-io: tokio-backed implementations of KJ's async I/O interfaces.
+//
+// Everything here wraps an opaque Rust object (a native tokio TcpStream/UnixStream/TcpListener/
+// address list) and implements the corresponding KJ interface by calling `async fn`s across the
+// cxx bridge, which return kj::Promises. Design points:
+//
+//  - All promises must be awaited on the thread owning the kj_rs_tokio::TokioEventPort: the
+//    tokio I/O driver that delivers readiness for these sockets only runs while that KJ loop
+//    sleeps in the port's wait()/poll().
+//  - Cancellation: dropping a returned kj::Promise drops the underlying Rust future, which
+//    releases the socket's readiness interest. A stream with a canceled read remains usable.
+//  - Unwrap fast path: every Rust-originated stream can be recovered as its native tokio object
+//    (see unwrapTokioStream), so Rust servers can serve a connection natively
+//    instead of crossing the FFI per read. Foreign kj streams are not unwrappable.
+//
+// Known stubs (all throw UNIMPLEMENTED, documented per method): newPipeThread(), capability
+// streams (SCM_RIGHTS fd passing), datagram sockets, and named-service / abstract-unix-socket
+// address forms. restrictPeers() IS implemented (via PeerFilter, a port of KJ's NetworkFilter); see
+// TokioNetwork for enforcement points and the parse-time-filtering deviation.
+
+#include "kj-rs-io/ffi.rs.h"
+#include "kj-rs-io/peer-filter.h"
+#include "kj-rs-tokio/tokio-event-port.h"
+
+#include <kj/async-io.h>
+#include <kj/exception.h>
+#include <kj/timer.h>
+
+namespace kj_rs_io {
+
+// A kj::AsyncIoStream backed by a native tokio TcpStream or UnixStream.
+class TokioAsyncIoStream final: public kj::AsyncIoStream {
+ public:
+  explicit TokioAsyncIoStream(::rust::Box<TokioStream> inner): inner(kj::mv(inner)) {}
+
+  // AsyncInputStream. tryRead honors KJ's min-bytes contract: resolves with >= minBytes unless
+  // EOF is reached first (in which case the short count signals EOF).
+  kj::Promise<size_t> tryRead(void *buffer, size_t minBytes, size_t maxBytes) override;
+
+  // AsyncOutputStream. Both overloads have write-all semantics; the multi-piece overload is one
+  // bridged operation using vectored writes (writev), like KJ's own socket streams.
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override;
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override;
+
+  // Resolves when new writes are doomed (peer reset/hangup observed). Does not fire on a mere
+  // half-close (peer FIN), mirroring KJ. On non-Unix platforms the promise never resolves
+  // (KJ-on-Windows behavior). Safe to call multiple times concurrently.
+  kj::Promise<void> whenWriteDisconnected() override;
+
+  // AsyncIoStream.
+  void shutdownWrite() override;
+  void getsockopt(int level, int option, void *value, kj::uint *length) override;
+  void setsockopt(int level, int option, const void *value, kj::uint length) override;
+  void getsockname(struct sockaddr *addr, kj::uint *length) override;
+  void getpeername(struct sockaddr *addr, kj::uint *length) override;
+  kj::Maybe<int> getFd() const override;
+#if _WIN32
+  // Validated by Windows CI; mirrors getFd(): on Windows the underlying socket is a winsock
+  // SOCKET, exposed as a void* handle (kj convention; getFd() returns none there).
+  kj::Maybe<void *> getWin32Handle() const override;
+#endif
+
+  // Unwrap fast path: moves the native tokio stream out, leaving this wrapper hollow (all
+  // further operations throw). Throws if I/O promises are in flight -- the Rust side tracks
+  // in-flight operations, so this is checked rather than a caller contract. Prefer the free
+  // function unwrapTokioStream() when holding only a kj::AsyncIoStream&.
+  ::rust::Box<TokioStream> unwrap() {
+    return stream_take(*inner);
+  }
+
+ private:
+  kj::Promise<void> writePieces(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces);
+
+  ::rust::Box<TokioStream> inner;
+};
+
+// A kj::ConnectionReceiver backed by a native tokio TcpListener or UnixListener. Incoming
+// connections from peers disallowed by `filter` (restrictPeers) are silently dropped and the
+// accept loop continues, mirroring KJ.
+class TokioConnectionReceiver final: public kj::ConnectionReceiver {
+ public:
+  // Receiver for one of our own networks/addresses: shares ownership of the PeerFilter chain, so
+  // there is no lifetime coupling to the network that created it.
+  TokioConnectionReceiver(::rust::Box<TokioListener> inner, kj::Rc<PeerFilter> filter)
+      : inner(kj::mv(inner)),
+        filter(filter.toOwn()) {}
+
+  // Receiver over a caller-provided filter (the kj::LowLevelAsyncIoProvider::wrapListenSocketFd
+  // entry point). KJ's interface hands the filter by reference and makes the caller responsible
+  // for keeping it alive for the receiver's lifetime, exactly as with KJ's native providers; we
+  // hold it as a kj::Own with kj::NullDisposer, KJ's idiom for an explicitly non-owning Own, so
+  // the receiver has exactly one filter member with one meaning rather than an owning handle and
+  // a reference that may alias it.
+  TokioConnectionReceiver(
+      ::rust::Box<TokioListener> inner, kj::LowLevelAsyncIoProvider::NetworkFilter &filter)
+      : inner(kj::mv(inner)),
+        filter(&filter, kj::NullDisposer::instance) {}
+
+  kj::Promise<kj::Own<kj::AsyncIoStream>> accept() override;
+  kj::Promise<kj::AuthenticatedStream> acceptAuthenticated() override;
+  kj::uint getPort() override;
+  void getsockopt(int level, int option, void *value, kj::uint *length) override;
+  void setsockopt(int level, int option, const void *value, kj::uint length) override;
+  void getsockname(struct sockaddr *addr, kj::uint *length) override;
+
+ private:
+  kj::Promise<kj::AuthenticatedStream> acceptImpl(bool authenticated);
+
+  ::rust::Box<TokioListener> inner;
+  // A share of our PeerFilter chain, or (wrapListenSocketFd) the caller's filter behind a
+  // NullDisposer -- see the constructors.
+  kj::Own<kj::LowLevelAsyncIoProvider::NetworkFilter> filter;
+};
+
+// A kj::NetworkAddress holding pre-resolved socket addresses (DNS happens at parseAddress time,
+// like KJ). connect() tries each address in order; listen() binds the first.
+//
+// connect() honors KJ's lifetime contract (NetworkAddressImpl::connect() in
+// kj/async-io-unix.c++): the returned promise is a coroutine whose frame owns a copy of the
+// resolved address list, so the caller may drop this NetworkAddress while the connect is still
+// pending.
+//
+// `filter` is the restrictPeers filter chain of the kj::Network this address came from
+// (allow-all for an unrestricted network); this address co-owns it, so it stays valid for this
+// address and any promises it returns regardless of the network's lifetime. Filtering is
+// enforced at connect() time per address ("connect() blocked by restrictPeers()", KJ parity)
+// and at accept() time on listeners; unlike KJ, disallowed DNS results are not already dropped
+// at parse time (they fail at connect instead).
+class TokioNetworkAddress final: public kj::NetworkAddress {
+ public:
+  TokioNetworkAddress(::rust::Box<TokioAddress> inner, kj::Rc<PeerFilter> filter)
+      : inner(kj::mv(inner)),
+        filter(kj::mv(filter)) {}
+
+  kj::Promise<kj::Own<kj::AsyncIoStream>> connect() override;
+  kj::Own<kj::ConnectionReceiver> listen() override;
+  kj::Own<kj::NetworkAddress> clone() override;
+  kj::String toString() override;
+
+ private:
+  ::rust::Box<TokioAddress> inner;
+  kj::Rc<PeerFilter> filter;
+};
+
+// The tokio-backed kj::Network. Supports the KJ address grammar subset workerd uses; see
+// net.rs for the exact forms and documented deviations (no named services, no unix-abstract,
+// no IPv6 scope IDs).
+//
+// restrictPeers() uses PeerFilter, a faithful port of KJ's NetworkFilter (semantics identical to
+// kj::setupAsyncIo()'s networks). The returned network owns a share of this one's filter chain
+// (kj::Rc), so derived networks, addresses, and receivers all remain valid regardless of which
+// order the networks are destroyed in. Enforcement points: per-address connect()-time checks and
+// accept()-time peer checks; parse-time DNS-result dropping is NOT implemented (blocked
+// addresses fail at connect instead) -- see TokioNetworkAddress.
+class TokioNetwork final: public kj::Network {
+ public:
+  // Allow-everything root network (matches KJ's root networks).
+  TokioNetwork(): filter(kj::rc<PeerFilter>()) {}
+  TokioNetwork(TokioNetwork &parent,
+      kj::ArrayPtr<const kj::StringPtr> allow,
+      kj::ArrayPtr<const kj::StringPtr> deny)
+      : filter(kj::rc<PeerFilter>(allow, deny, parent.filter.addRef())) {}
+
+  kj::Promise<kj::Own<kj::NetworkAddress>> parseAddress(
+      kj::StringPtr addr, kj::uint portHint) override;
+  kj::Own<kj::NetworkAddress> getSockaddr(const void *sockaddr, kj::uint len) override;
+  kj::Own<kj::Network> restrictPeers(
+      kj::ArrayPtr<const kj::StringPtr> allow, kj::ArrayPtr<const kj::StringPtr> deny) override;
+
+ private:
+  kj::Rc<PeerFilter> filter;
+};
+
+// The tokio-backed kj::LowLevelAsyncIoProvider. Implements the socket-wrapping entry points on
+// Unix and Windows (each wrap*Fd normalizes KJ's TAKE_OWNERSHIP/ALREADY_CLOEXEC/ALREADY_NONBLOCK
+// flags, then hands an owned, non-blocking raw socket handle -- a Unix fd or a win32 SOCKET,
+// widened to int64 -- to Rust). The pipe tier (wrapInputFd/wrapOutputFd) is Unix-only for now.
+// wrapUnixSocketFd (capability streams) and wrapDatagramSocketFd keep their default-throwing
+// implementations.
+class TokioLowLevelAsyncIoProvider final: public kj::LowLevelAsyncIoProvider {
+ public:
+  explicit TokioLowLevelAsyncIoProvider(kj::Timer &timer): timer(timer) {}
+
+  kj::Own<kj::AsyncInputStream> wrapInputFd(Fd fd, kj::uint flags) override;
+  kj::Own<kj::AsyncOutputStream> wrapOutputFd(Fd fd, kj::uint flags) override;
+  kj::Own<kj::AsyncIoStream> wrapSocketFd(Fd fd, kj::uint flags) override;
+  kj::Promise<kj::Own<kj::AsyncIoStream>> wrapConnectingSocketFd(
+      Fd fd, const struct sockaddr *addr, kj::uint addrlen, kj::uint flags) override;
+  // `filter` applies to accepted connections (disallowed peers are dropped and the accept
+  // loop continues, like KJ); it must outlive the returned receiver.
+  kj::Own<kj::ConnectionReceiver> wrapListenSocketFd(
+      Fd fd, NetworkFilter &filter, kj::uint flags) override;
+  kj::Timer &getTimer() override {
+    return timer;
+  }
+
+ private:
+  kj::Timer &timer;
+};
+
+// The tokio-backed kj::AsyncIoProvider. Pipes are KJ's in-memory pipes (port-agnostic, like
+// kj::newOneWayPipe/newTwoWayPipe themselves); newPipeThread throws UNIMPLEMENTED (workerd does
+// not use it); newCapabilityPipe keeps its default-throwing implementation.
+class TokioAsyncIoProvider final: public kj::AsyncIoProvider {
+ public:
+  explicit TokioAsyncIoProvider(kj::Timer &timer): timer(timer) {}
+
+  kj::OneWayPipe newOneWayPipe() override {
+    return kj::newOneWayPipe();
+  }
+  kj::TwoWayPipe newTwoWayPipe() override {
+    return kj::newTwoWayPipe();
+  }
+  kj::Network &getNetwork() override {
+    return network;
+  }
+  PipeThread newPipeThread(
+      kj::Function<void(kj::AsyncIoProvider &, kj::AsyncIoStream &, kj::WaitScope &)> startFunc)
+      override;
+  kj::Timer &getTimer() override {
+    return timer;
+  }
+
+ private:
+  TokioNetwork network;
+  kj::Timer &timer;
+};
+
+// Mirror of kj::AsyncIoContext (kj/async-io.h) for the tokio-backed loop: a drop-in replacement
+// for kj::setupAsyncIo() at workerd.c++:1570. Composes kj_rs_tokio::TokioAsyncIoContext (which
+// owns the event port, the kj::EventLoop and the kj::WaitScope, and orders their teardown) with
+// the tokio-backed I/O providers.
+//
+// Teardown is member order: the providers (which borrow the port's timer) go first, then the
+// base context -- spawned tasks cancelled while the WaitScope is alive, then WaitScope, then the
+// port (loop, runtime, timer). I/O objects created *through* the providers (streams, listeners,
+// addresses) must be destroyed before the context, as with kj::setupAsyncIo().
+struct TokioAsyncIoContext {
+  TokioAsyncIoContext()
+      : base(kj_rs_tokio::setupTokioAsyncIo()),
+        lowLevelProvider(kj::heap<TokioLowLevelAsyncIoProvider>(base.getTimer())),
+        provider(kj::heap<TokioAsyncIoProvider>(base.getTimer())) {}
+  KJ_DISALLOW_COPY_AND_MOVE(TokioAsyncIoContext);
+
+  kj_rs_tokio::TokioAsyncIoContext base;
+  kj::Own<TokioLowLevelAsyncIoProvider> lowLevelProvider;
+  kj::Own<TokioAsyncIoProvider> provider;
+
+  kj_rs_tokio::TokioEventPort &getPort() {
+    return base.getPort();
+  }
+  kj::EventLoop &getLoop() {
+    return base.getLoop();
+  }
+  kj::WaitScope &getWaitScope() {
+    return base.getWaitScope();
+  }
+  kj::Timer &getTimer() {
+    return base.getTimer();
+  }
+  kj::Network &getNetwork() {
+    return provider->getNetwork();
+  }
+  kj::AsyncIoProvider &getProvider() {
+    return *provider;
+  }
+  kj::LowLevelAsyncIoProvider &getLowLevelProvider() {
+    return *lowLevelProvider;
+  }
+};
+
+// Sets up the current thread with a tokio-driven KJ event loop plus tokio-backed I/O providers:
+// the kj::setupAsyncIo() equivalent for the tokio loop. One per thread.
+TokioAsyncIoContext setupTokioAsyncIo();
+
+// Resolves when the process receives signal `signum`: the tokio-loop replacement for
+// kj::UnixEventPort::onSignal() (workerd's SIGTERM graceful drain). Must be awaited on the
+// thread owning the TokioEventPort. Unlike UnixEventPort, KJ does not block/capture the signal
+// beforehand: the tokio handler is registered when the promise is first polled, so a signal
+// delivered before the event loop first runs takes its default disposition (see signal.rs).
+// On Windows, SIGTERM/SIGINT are mapped to the ctrl_shutdown/ctrl_c console control events;
+// the promise rejects for other signums.
+kj::Promise<void> onSignal(int signum);
+
+}  // namespace kj_rs_io

--- a/src/rust/cxx/kj-rs-io/async-io.h
+++ b/src/rust/cxx/kj-rs-io/async-io.h
@@ -278,7 +278,8 @@ TokioAsyncIoContext setupTokioAsyncIo();
 // kj::UnixEventPort::onSignal() (workerd's SIGTERM graceful drain). Must be awaited on the
 // thread owning the TokioEventPort. Unlike UnixEventPort, KJ does not block/capture the signal
 // beforehand: the tokio handler is registered when the promise is first polled, so a signal
-// delivered before the event loop first runs takes its default disposition (see signal.rs).
+// delivered before that first poll takes its default disposition (see signal.rs). Callers that
+// retain the watcher must poll or explicitly start it before relying on signal delivery.
 // On Windows, SIGTERM/SIGINT are mapped to the ctrl_shutdown/ctrl_c console control events;
 // the promise rejects for other signums.
 kj::Promise<void> onSignal(int signum);

--- a/src/rust/cxx/kj-rs-io/error.rs
+++ b/src/rust/cxx/kj-rs-io/error.rs
@@ -1,0 +1,243 @@
+//! Error mapping: `std::io::Error` -> `kj::Exception`, preserving KJ's exception-type taxonomy.
+//!
+//! kj-http and capnp RPC change behavior based on `kj::Exception::Type` (e.g. `DISCONNECTED`
+//! failures are treated as clean peer hangups rather than bugs), so the mapping of connection
+//! errors matters for behavioral parity with `kj::setupAsyncIo()`.
+
+use cxx::IntoKjException;
+use cxx::KjError;
+use cxx::KjException;
+use cxx::KjExceptionType;
+
+pub type Result<T> = std::result::Result<T, KjIoError>;
+
+/// An `std::io::Error` (plus operation context) that converts into a `kj::Exception` with an
+/// appropriate exception type.
+#[derive(Debug)]
+pub struct KjIoError {
+    /// Name of the failing operation, included in the exception description the way KJ's
+    /// `KJ_SYSCALL` includes the syscall name (e.g. "`connect()`: Connection refused ...").
+    op: &'static str,
+    inner: std::io::Error,
+}
+
+impl KjIoError {
+    pub(crate) fn other(op: &'static str, message: impl std::fmt::Display) -> Self {
+        Self {
+            op,
+            inner: std::io::Error::other(message.to_string()),
+        }
+    }
+}
+
+/// Attaches an operation name to `io::Error`s, for use with `Result::map_err`.
+pub fn op(name: &'static str) -> impl Fn(std::io::Error) -> KjIoError {
+    move |inner| KjIoError { op: name, inner }
+}
+
+fn exception_type(error: &std::io::Error) -> KjExceptionType {
+    use std::io::ErrorKind;
+    // Primary classification: by raw errno, mirroring KJ's own table (`typeOfErrno()` in
+    // kj/debug.c++) errno-for-errno. Consumers (kj-http, capnp-rpc) change behavior on the
+    // exception type, so the classes must match `kj::setupAsyncIo()` exactly — e.g. ETIMEDOUT
+    // is OVERLOADED in KJ (retry-later), NOT DISCONNECTED (clean peer hangup), and std's
+    // `ErrorKind` buckets have no stable kinds at all for KJ's fd/memory-exhaustion OVERLOADED
+    // set (EMFILE/ENFILE/ENOBUFS/...), hence the raw match.
+    #[cfg(unix)]
+    if let Some(errno) = error.raw_os_error() {
+        return errno_exception_type(errno);
+    }
+    // Fallback for synthetic (non-OS) errors — and all errors on Windows, where
+    // `raw_os_error()` is a Win32/WSA code, not an errno (KJ classifies those in
+    // `typeOfWin32Error()`; the buckets below agree with it for the kinds tokio surfaces).
+    match error.kind() {
+        // KJ's DISCONNECTED class: connection teardown, treated as a clean peer hangup.
+        ErrorKind::ConnectionRefused
+        | ErrorKind::ConnectionReset
+        | ErrorKind::ConnectionAborted
+        | ErrorKind::BrokenPipe
+        | ErrorKind::NotConnected
+        | ErrorKind::UnexpectedEof
+        | ErrorKind::HostUnreachable
+        | ErrorKind::NetworkUnreachable
+        | ErrorKind::NetworkDown => KjExceptionType::Disconnected,
+        // KJ's OVERLOADED class: temporary lack of resources (ETIMEDOUT/WSAETIMEDOUT and
+        // ENOMEM land here in KJ's tables).
+        ErrorKind::TimedOut | ErrorKind::OutOfMemory => KjExceptionType::Overloaded,
+        ErrorKind::Unsupported => KjExceptionType::Unimplemented,
+        _ => KjExceptionType::Failed,
+    }
+}
+
+/// Exact mirror of KJ's `typeOfErrno()` (kj/debug.c++), so `kj::Exception::Type` matches the
+/// native `kj::setupAsyncIo()` backend errno-for-errno.
+#[cfg(unix)]
+fn errno_exception_type(errno: i32) -> KjExceptionType {
+    // Errnos that are `#ifdef`-conditional in KJ's table for platform reasons, mirrored here
+    // with `cfg`: ENONET exists only on Linux; EOPNOTSUPP aliases ENOTSUP on Linux (KJ compiles
+    // its case only `#if EOPNOTSUPP != ENOTSUP` — an or-pattern with both would be an
+    // unreachable pattern there).
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    if errno == libc::ENONET {
+        return KjExceptionType::Disconnected;
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    if errno == libc::EOPNOTSUPP {
+        return KjExceptionType::Unimplemented;
+    }
+    match errno {
+        // OVERLOADED: the call failed because of a temporary lack of resources.
+        libc::EDQUOT
+        | libc::EMFILE
+        | libc::ENFILE
+        | libc::ENOBUFS
+        | libc::ENOLCK
+        | libc::ENOMEM
+        | libc::ENOSPC
+        | libc::ETIMEDOUT
+        | libc::EUSERS => KjExceptionType::Overloaded,
+        // DISCONNECTED: communication over a connection that has been lost.
+        libc::ENOTCONN
+        | libc::ECONNABORTED
+        | libc::ECONNREFUSED
+        | libc::ECONNRESET
+        | libc::EHOSTDOWN
+        | libc::EHOSTUNREACH
+        | libc::ENETDOWN
+        | libc::ENETRESET
+        | libc::ENETUNREACH
+        | libc::EPIPE => KjExceptionType::Disconnected,
+        // UNIMPLEMENTED: the "not supported" family (ENOTSOCK is really "syscall not
+        // implemented for non-sockets", per KJ's own comment).
+        libc::ENOSYS | libc::ENOTSUP | libc::ENOPROTOOPT | libc::ENOTSOCK => {
+            KjExceptionType::Unimplemented
+        }
+        _ => KjExceptionType::Failed,
+    }
+}
+
+impl From<KjIoError> for KjError {
+    fn from(error: KjIoError) -> Self {
+        let description = format!("{}: {}", error.op, error.inner);
+        Self::new(exception_type(&error.inner), description)
+    }
+}
+
+impl IntoKjException for KjIoError {
+    fn into_kj_exception(self, file: &str, line: u32) -> KjException {
+        KjError::from(self).into_kj_exception(file, line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kind_error(kind: std::io::ErrorKind) -> std::io::Error {
+        std::io::Error::new(kind, "synthetic")
+    }
+
+    #[test]
+    fn errorkind_fallback_matches_kj_classes() {
+        use std::io::ErrorKind;
+        for kind in [
+            ErrorKind::ConnectionRefused,
+            ErrorKind::ConnectionReset,
+            ErrorKind::ConnectionAborted,
+            ErrorKind::BrokenPipe,
+            ErrorKind::NotConnected,
+            ErrorKind::UnexpectedEof,
+        ] {
+            assert_eq!(
+                exception_type(&kind_error(kind)),
+                KjExceptionType::Disconnected,
+                "{kind:?}"
+            );
+        }
+        assert_eq!(
+            exception_type(&kind_error(ErrorKind::TimedOut)),
+            KjExceptionType::Overloaded
+        );
+        assert_eq!(
+            exception_type(&kind_error(ErrorKind::OutOfMemory)),
+            KjExceptionType::Overloaded
+        );
+        assert_eq!(
+            exception_type(&kind_error(ErrorKind::Unsupported)),
+            KjExceptionType::Unimplemented
+        );
+        assert_eq!(
+            exception_type(&kind_error(ErrorKind::Other)),
+            KjExceptionType::Failed
+        );
+        assert_eq!(
+            exception_type(&kind_error(ErrorKind::InvalidInput)),
+            KjExceptionType::Failed
+        );
+    }
+
+    /// The raw-errno table must mirror KJ's `typeOfErrno()` errno-for-errno, since consumers
+    /// (kj-http, capnp-rpc) change behavior on the class. Spot-checks one member of every
+    /// class plus the classic confusables (ETIMEDOUT is OVERLOADED, not DISCONNECTED).
+    #[cfg(unix)]
+    #[test]
+    fn errno_table_matches_kj() {
+        let of = |errno: i32| exception_type(&std::io::Error::from_raw_os_error(errno));
+        // OVERLOADED
+        for errno in [
+            libc::EMFILE,
+            libc::ENFILE,
+            libc::ENOBUFS,
+            libc::ENOMEM,
+            libc::ETIMEDOUT,
+        ] {
+            assert_eq!(of(errno), KjExceptionType::Overloaded, "errno {errno}");
+        }
+        // DISCONNECTED
+        for errno in [
+            libc::ECONNREFUSED,
+            libc::ECONNRESET,
+            libc::EPIPE,
+            libc::ENOTCONN,
+            libc::EHOSTUNREACH,
+            libc::ENETDOWN,
+        ] {
+            assert_eq!(of(errno), KjExceptionType::Disconnected, "errno {errno}");
+        }
+        // UNIMPLEMENTED
+        for errno in [
+            libc::ENOSYS,
+            libc::ENOTSUP,
+            libc::ENOPROTOOPT,
+            libc::ENOTSOCK,
+        ] {
+            assert_eq!(of(errno), KjExceptionType::Unimplemented, "errno {errno}");
+        }
+        // FAILED (everything else)
+        for errno in [libc::EINVAL, libc::EACCES, libc::EBADF, libc::EEXIST] {
+            assert_eq!(of(errno), KjExceptionType::Failed, "errno {errno}");
+        }
+        // Platform-conditional entries mirror KJ's #ifdefs.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        assert_eq!(of(libc::ENONET), KjExceptionType::Disconnected);
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        assert_eq!(of(libc::EOPNOTSUPP), KjExceptionType::Unimplemented);
+    }
+
+    #[test]
+    fn description_is_op_colon_message() {
+        let err = KjIoError::other("connect()", "boom");
+        let kj = KjError::from(err);
+        assert_eq!(kj.description(), "connect(): boom");
+        assert_eq!(kj.exception_type(), KjExceptionType::Failed);
+
+        let err = op("read()")(kind_error(std::io::ErrorKind::ConnectionReset));
+        let kj = KjError::from(err);
+        assert!(
+            kj.description().starts_with("read(): "),
+            "{}",
+            kj.description()
+        );
+        assert_eq!(kj.exception_type(), KjExceptionType::Disconnected);
+    }
+}

--- a/src/rust/cxx/kj-rs-io/error.rs
+++ b/src/rust/cxx/kj-rs-io/error.rs
@@ -47,9 +47,11 @@ fn exception_type(error: &std::io::Error) -> KjExceptionType {
     if let Some(errno) = error.raw_os_error() {
         return errno_exception_type(errno);
     }
-    // Fallback for synthetic (non-OS) errors — and all errors on Windows, where
-    // `raw_os_error()` is a Win32/WSA code, not an errno (KJ classifies those in
-    // `typeOfWin32Error()`; the buckets below agree with it for the kinds tokio surfaces).
+    #[cfg(windows)]
+    if let Some(code) = error.raw_os_error() {
+        return win32_exception_type(code);
+    }
+    // Fallback for synthetic (non-OS) errors.
     match error.kind() {
         // KJ's DISCONNECTED class: connection teardown, treated as a clean peer hangup.
         ErrorKind::ConnectionRefused
@@ -61,12 +63,79 @@ fn exception_type(error: &std::io::Error) -> KjExceptionType {
         | ErrorKind::HostUnreachable
         | ErrorKind::NetworkUnreachable
         | ErrorKind::NetworkDown => KjExceptionType::Disconnected,
-        // KJ's OVERLOADED class: temporary lack of resources (ETIMEDOUT/WSAETIMEDOUT and
-        // ENOMEM land here in KJ's tables).
-        ErrorKind::TimedOut | ErrorKind::OutOfMemory => KjExceptionType::Overloaded,
+        // KJ's OVERLOADED class: temporary lack of resources. A synthetic OutOfMemory has no
+        // Win32 error code, so KJ's Windows table leaves it FAILED.
+        ErrorKind::TimedOut => KjExceptionType::Overloaded,
+        ErrorKind::OutOfMemory if !cfg!(windows) => KjExceptionType::Overloaded,
         ErrorKind::Unsupported => KjExceptionType::Unimplemented,
         _ => KjExceptionType::Failed,
     }
+}
+
+/// Exact mirror of KJ's `typeOfWin32Error()` (kj/debug.c++). Winsock calls report WSA codes,
+/// while overlapped-I/O completion reports Win32 codes for the same conditions, so the table
+/// includes both forms.
+#[cfg(windows)]
+fn win32_exception_type(code: i32) -> KjExceptionType {
+    match code {
+        win32::WSAETIMEDOUT | win32::ERROR_SEM_TIMEOUT => KjExceptionType::Overloaded,
+        win32::WSAENOTCONN
+        | win32::WSAECONNABORTED
+        | win32::WSAECONNREFUSED
+        | win32::WSAECONNRESET
+        | win32::WSAEHOSTDOWN
+        | win32::WSAEHOSTUNREACH
+        | win32::WSAENETDOWN
+        | win32::WSAENETRESET
+        | win32::WSAENETUNREACH
+        | win32::WSAESHUTDOWN
+        | win32::ERROR_NETNAME_DELETED
+        | win32::ERROR_CONNECTION_ABORTED
+        | win32::ERROR_CONNECTION_REFUSED
+        | win32::ERROR_CONNECTION_INVALID
+        | win32::ERROR_HOST_UNREACHABLE
+        | win32::ERROR_NETWORK_UNREACHABLE
+        | win32::ERROR_PORT_UNREACHABLE
+        | win32::ERROR_BROKEN_PIPE
+        | win32::ERROR_NO_DATA
+        | win32::ERROR_PIPE_NOT_CONNECTED => KjExceptionType::Disconnected,
+        win32::WSAEOPNOTSUPP | win32::WSAENOPROTOOPT | win32::WSAENOTSOCK => {
+            KjExceptionType::Unimplemented
+        }
+        _ => KjExceptionType::Failed,
+    }
+}
+
+// Values from WinError.h and WinSock2.h. Keeping this private avoids adding a Windows-only
+// dependency merely to name the constants used by KJ's small classification table.
+#[cfg(windows)]
+mod win32 {
+    pub const ERROR_NETNAME_DELETED: i32 = 64;
+    pub const ERROR_BROKEN_PIPE: i32 = 109;
+    pub const ERROR_SEM_TIMEOUT: i32 = 121;
+    pub const ERROR_NO_DATA: i32 = 232;
+    pub const ERROR_PIPE_NOT_CONNECTED: i32 = 233;
+    pub const ERROR_CONNECTION_REFUSED: i32 = 1225;
+    pub const ERROR_CONNECTION_ABORTED: i32 = 1236;
+    pub const ERROR_CONNECTION_INVALID: i32 = 1229;
+    pub const ERROR_NETWORK_UNREACHABLE: i32 = 1231;
+    pub const ERROR_HOST_UNREACHABLE: i32 = 1232;
+    pub const ERROR_PORT_UNREACHABLE: i32 = 1234;
+
+    pub const WSAENOTSOCK: i32 = 10038;
+    pub const WSAENOPROTOOPT: i32 = 10042;
+    pub const WSAEOPNOTSUPP: i32 = 10045;
+    pub const WSAENETDOWN: i32 = 10050;
+    pub const WSAENETUNREACH: i32 = 10051;
+    pub const WSAENETRESET: i32 = 10052;
+    pub const WSAECONNABORTED: i32 = 10053;
+    pub const WSAECONNRESET: i32 = 10054;
+    pub const WSAENOTCONN: i32 = 10057;
+    pub const WSAESHUTDOWN: i32 = 10058;
+    pub const WSAETIMEDOUT: i32 = 10060;
+    pub const WSAECONNREFUSED: i32 = 10061;
+    pub const WSAEHOSTDOWN: i32 = 10064;
+    pub const WSAEHOSTUNREACH: i32 = 10065;
 }
 
 /// Exact mirror of KJ's `typeOfErrno()` (kj/debug.c++), so `kj::Exception::Type` matches the
@@ -160,7 +229,11 @@ mod tests {
         );
         assert_eq!(
             exception_type(&kind_error(ErrorKind::OutOfMemory)),
-            KjExceptionType::Overloaded
+            if cfg!(windows) {
+                KjExceptionType::Failed
+            } else {
+                KjExceptionType::Overloaded
+            }
         );
         assert_eq!(
             exception_type(&kind_error(ErrorKind::Unsupported)),
@@ -174,6 +247,50 @@ mod tests {
             exception_type(&kind_error(ErrorKind::InvalidInput)),
             KjExceptionType::Failed
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn win32_table_matches_kj() {
+        let of = |code: i32| exception_type(&std::io::Error::from_raw_os_error(code));
+
+        for code in [win32::WSAETIMEDOUT, win32::ERROR_SEM_TIMEOUT] {
+            assert_eq!(of(code), KjExceptionType::Overloaded, "error {code}");
+        }
+        for code in [
+            win32::WSAENOTCONN,
+            win32::WSAECONNABORTED,
+            win32::WSAECONNREFUSED,
+            win32::WSAECONNRESET,
+            win32::WSAEHOSTDOWN,
+            win32::WSAEHOSTUNREACH,
+            win32::WSAENETDOWN,
+            win32::WSAENETRESET,
+            win32::WSAENETUNREACH,
+            win32::WSAESHUTDOWN,
+            win32::ERROR_NETNAME_DELETED,
+            win32::ERROR_CONNECTION_ABORTED,
+            win32::ERROR_CONNECTION_REFUSED,
+            win32::ERROR_CONNECTION_INVALID,
+            win32::ERROR_HOST_UNREACHABLE,
+            win32::ERROR_NETWORK_UNREACHABLE,
+            win32::ERROR_PORT_UNREACHABLE,
+            win32::ERROR_BROKEN_PIPE,
+            win32::ERROR_NO_DATA,
+            win32::ERROR_PIPE_NOT_CONNECTED,
+        ] {
+            assert_eq!(of(code), KjExceptionType::Disconnected, "error {code}");
+        }
+        for code in [
+            win32::WSAEOPNOTSUPP,
+            win32::WSAENOPROTOOPT,
+            win32::WSAENOTSOCK,
+        ] {
+            assert_eq!(of(code), KjExceptionType::Unimplemented, "error {code}");
+        }
+        for code in [0, 5, 8, 87, 10013] {
+            assert_eq!(of(code), KjExceptionType::Failed, "error {code}");
+        }
     }
 
     /// The raw-errno table must mirror KJ's `typeOfErrno()` errno-for-errno, since consumers

--- a/src/rust/cxx/kj-rs-io/ffi.rs
+++ b/src/rust/cxx/kj-rs-io/ffi.rs
@@ -1,0 +1,1071 @@
+//! The FFI island of kj-rs-io: the `#[cxx::bridge]` wire plus the crate's hand-written `unsafe`
+//! boundary, in one dedicated file (file-top `#![allow(unsafe_code)]`).
+//!
+//! It holds:
+//!
+//! - the `#[cxx::bridge] mod bridge` (namespace `kj_rs_io`) — the cxx-generated C++ <-> Rust wire,
+//!   re-exported as `crate::ffi::*`; and
+//! - every hand-written `unsafe` the macro does not generate, so the serve / net / stream modules
+//!   can carry the crate-root `#![deny(unsafe_code)]` and be *compiler-proven* free of hand-written
+//!   unsafe. Three kinds of raw thing cross the FFI boundary and are laundered into safe Rust types
+//!   here:
+//!
+//!   1. **Raw OS socket handles** arriving from C++ as an `i64` (a Unix fd or a win32 `SOCKET`;
+//!      see [`own_socket_from_raw`], the one platform conversion point) — the C++ side has
+//!      already normalized KJ's `TAKE_OWNERSHIP` / `ALREADY_CLOEXEC` flags, dup'ing when not
+//!      transferring ownership — plus [`dup_raw_fd`] (dup a borrowed fd into an owned one; the
+//!      unix-only handle tier of [`take_kj_socket`]) and [`own_fd_from_raw`] (the unix-only
+//!      pipe tier's `i32` fds).
+//!   2. **`struct sockaddr` bytes** crossing in both directions — [`sockaddr_to_bytes`] /
+//!      [`sockaddr_from_bytes`].
+//!   3. **Raw `getsockopt(2)` / `setsockopt(2)`** — the socket-option passthrough behind
+//!      `kj::AsyncIoStream` / `kj::ConnectionReceiver` carries caller-owned option buffers whose
+//!      length semantics (socklen in/out) no safe std/socket2 API expresses, so the raw syscalls
+//!      live here ([`stream_getsockopt`] and friends).
+//!
+//! Because this file opts back into `unsafe` (`#![allow(unsafe_code)]`), it is the one module in
+//! the crate whose soundness must be audited by hand; the rest is enforced by the compiler.
+#![allow(unsafe_code)]
+
+use core::pin::Pin;
+
+/// Opaque binding of `kj::AsyncIoStream`, and the cxx-bridged operations on it (shared-receiver
+/// shims; safe to call). Re-exported as `crate::ffi::*` so the rest of the crate (and the
+/// crate-root re-exports) keep using `ffi::`.
+pub use bridge::KjAsyncIoStream;
+pub use bridge::KjPieces;
+pub use bridge::kj_piece;
+pub use bridge::kj_pieces_count;
+pub use bridge::kj_stream_get_handle;
+pub use bridge::unwrap_tokio_stream;
+use cxx::KjException;
+use kj_rs::KjOwn;
+
+use crate::error::Result;
+use crate::error::op;
+use crate::net::TokioAddress;
+use crate::net::TokioListener;
+use crate::net::address_clone;
+use crate::net::address_connect_index;
+use crate::net::address_count;
+use crate::net::address_listen;
+use crate::net::address_raw_sockaddr;
+use crate::net::address_to_string;
+use crate::net::listener_accept;
+use crate::net::listener_local_addr;
+use crate::net::listener_port;
+use crate::net::network_get_sockaddr;
+use crate::net::network_parse_address;
+use crate::net::wrap_connecting_socket_fd;
+use crate::net::wrap_listen_fd;
+use crate::net::wrap_socket_fd;
+use crate::readiness::TokioFdWatcher;
+use crate::readiness::new_fd_watcher;
+use crate::signal::wait_for_signal;
+use crate::stream::TokioInputFd;
+use crate::stream::TokioOutputFd;
+use crate::stream::TokioStream;
+use crate::stream::input_fd_try_read;
+use crate::stream::output_fd_write;
+use crate::stream::stream_local_addr;
+use crate::stream::stream_peer_addr;
+use crate::stream::stream_raw_handle;
+use crate::stream::stream_shutdown_write;
+use crate::stream::stream_take;
+use crate::stream::stream_try_raw_handle;
+use crate::stream::stream_try_read;
+use crate::stream::stream_when_write_disconnected;
+use crate::stream::stream_write;
+use crate::stream::stream_write_pieces;
+use crate::stream::wrap_input_fd;
+use crate::stream::wrap_output_fd;
+
+#[cxx::bridge(namespace = "kj_rs_io")]
+// FFI island: the cxx bridge macro generates the `unsafe` extern shims, and this module declares
+// the hand-written `unsafe extern "C++"` / `async unsafe fn` bridge surface.
+// unnecessary_box_returns: returning an opaque Rust type to C++ as `Box<T>` is the cxx idiom.
+#[expect(clippy::unnecessary_box_returns)]
+// missing_safety_doc fires (or not) deep inside the macro expansion depending on which bridge
+// items are publicly re-exported, so an `#[expect]` could go unfulfilled.
+#[expect(clippy::allow_attributes)]
+#[allow(clippy::missing_safety_doc)]
+mod bridge {
+    extern "Rust" {
+        type TokioStream;
+        type TokioListener;
+        type TokioAddress;
+        type TokioInputFd;
+        type TokioOutputFd;
+
+        // ==================================================================================
+        // Streams (TCP or Unix domain, behind kj::AsyncIoStream)
+
+        /// Reads until at least `min_bytes` are available (or EOF), up to `buf.len()`. Returns
+        /// the number of bytes read; fewer than `min_bytes` indicates EOF. The kj `tryRead`
+        /// contract.
+        async unsafe fn stream_try_read<'a>(
+            stream: &'a TokioStream,
+            buf: &'a mut [u8],
+            min_bytes: usize,
+        ) -> Result<usize>;
+
+        /// Writes the entire buffer (write-all semantics).
+        async unsafe fn stream_write<'a>(stream: &'a TokioStream, buf: &'a [u8]) -> Result<()>;
+
+        /// Writes every piece, in order, with write-all semantics, using vectored writes
+        /// (`writev`) so a multi-piece `kj::AsyncOutputStream::write()` is one bridged
+        /// operation and as few syscalls as the kernel allows.
+        async unsafe fn stream_write_pieces<'a>(
+            stream: &'a TokioStream,
+            pieces: &'a KjPieces,
+        ) -> Result<()>;
+
+        /// Resolves when the stream has become disconnected such that new writes will fail.
+        /// See `TokioStream::when_write_disconnected` for the mechanism and platform caveats.
+        async unsafe fn stream_when_write_disconnected<'a>(stream: &'a TokioStream) -> Result<()>;
+
+        /// `shutdown(SHUT_WR)`: cleanly shut down the write end, keeping the read end open.
+        fn stream_shutdown_write(stream: &TokioStream) -> Result<()>;
+
+        /// The underlying raw OS socket handle (fd on unix, `SOCKET` on windows) as an `i64`,
+        /// backing `kj::AsyncIoStream::getFd()` / `getWin32Handle()`.
+        fn stream_raw_handle(stream: &TokioStream) -> Result<i64>;
+
+        /// Raw `struct sockaddr` bytes of the socket's locally-bound address (the
+        /// `getsockname()` passthrough).
+        fn stream_local_addr(stream: &TokioStream) -> Result<Vec<u8>>;
+
+        /// Raw `struct sockaddr` bytes of the connected peer's address (the `getpeername()`
+        /// passthrough, also used by the accept-loop peer-filter check).
+        fn stream_peer_addr(stream: &TokioStream) -> Result<Vec<u8>>;
+
+        /// `getsockopt(2)` on the underlying socket. `value.len()` is the caller's in-length
+        /// (the kernel truncates the option value to it); returns the syscall's reported
+        /// out-length, which the caller must mirror back exactly (raw socklen in/out
+        /// semantics).
+        fn stream_getsockopt(
+            stream: &TokioStream,
+            level: i32,
+            option: i32,
+            value: &mut [u8],
+        ) -> Result<usize>;
+
+        /// `setsockopt(2)` on the underlying socket.
+        fn stream_setsockopt(
+            stream: &TokioStream,
+            level: i32,
+            option: i32,
+            value: &[u8],
+        ) -> Result<()>;
+
+        /// Moves the native stream out, leaving `stream` hollow (all further ops error). Fails
+        /// (rather than aliasing live borrows) if any I/O future is in flight on `stream`: the
+        /// `TokioStream` tracks in-flight operations itself, so this is a checked operation,
+        /// not a caller contract.
+        fn stream_take(stream: &TokioStream) -> Result<Box<TokioStream>>;
+        /// Like `stream_raw_handle`, but -1 instead of an error when the wrapper is hollow (for
+        /// the `kj::Maybe`-returning `getFd()`/`getWin32Handle()`).
+        fn stream_try_raw_handle(stream: &TokioStream) -> i64;
+
+        // ==================================================================================
+        // Network addresses (kj::Network::parseAddress grammar subset)
+
+        /// Parses a KJ address string ("1.2.3.4:80", "[::1]:80", "host:80", "*", "*:80",
+        /// "unix:/path"), resolving hostnames via DNS. `port_hint` fills in a missing port.
+        /// (Owned `String`: the future must not borrow the caller's buffer across the DNS
+        /// suspension.)
+        async fn network_parse_address(addr: String, port_hint: u16) -> Result<Box<TokioAddress>>;
+
+        /// Builds an address from a raw `struct sockaddr` (AF_INET / AF_INET6 / AF_UNIX).
+        fn network_get_sockaddr(sockaddr: &[u8]) -> Result<Box<TokioAddress>>;
+
+        /// Connects to exactly the `index`th resolved address (no fallback). The C++ side
+        /// drives the try-each-address loop so it can apply restrictPeers() filtering per
+        /// address (KJ parity).
+        async unsafe fn address_connect_index<'a>(
+            addr: &'a TokioAddress,
+            index: usize,
+        ) -> Result<Box<TokioStream>>;
+
+        /// Number of resolved socket addresses behind this address (>= 1).
+        fn address_count(addr: &TokioAddress) -> usize;
+
+        /// Raw `struct sockaddr` bytes of the `index`th resolved address, for C++-side
+        /// kj::_::NetworkFilter (restrictPeers) checks.
+        fn address_raw_sockaddr(addr: &TokioAddress, index: usize) -> Result<Vec<u8>>;
+
+        /// Binds + listens on the (first) address. Wildcard addresses bind dual-stack.
+        fn address_listen(addr: &TokioAddress) -> Result<Box<TokioListener>>;
+
+        fn address_clone(addr: &TokioAddress) -> Box<TokioAddress>;
+        fn address_to_string(addr: &TokioAddress) -> String;
+
+        // ==================================================================================
+        // Listeners (kj::ConnectionReceiver)
+
+        async unsafe fn listener_accept<'a>(
+            listener: &'a TokioListener,
+        ) -> Result<Box<TokioStream>>;
+
+        /// The locally-bound port (0 for Unix domain sockets, mirroring KJ).
+        fn listener_port(listener: &TokioListener) -> Result<u16>;
+
+        /// Raw `struct sockaddr` bytes of the listener's bound address (the `getsockname()`
+        /// passthrough).
+        fn listener_local_addr(listener: &TokioListener) -> Result<Vec<u8>>;
+
+        /// `getsockopt(2)` on the listening socket; same length semantics as
+        /// `stream_getsockopt`.
+        fn listener_getsockopt(
+            listener: &TokioListener,
+            level: i32,
+            option: i32,
+            value: &mut [u8],
+        ) -> Result<usize>;
+
+        /// `setsockopt(2)` on the listening socket.
+        fn listener_setsockopt(
+            listener: &TokioListener,
+            level: i32,
+            option: i32,
+            value: &[u8],
+        ) -> Result<()>;
+
+        // ==================================================================================
+        // Socket-handle wrapping (kj::LowLevelAsyncIoProvider).
+        //
+        // The `i64` is a raw OS socket handle: a Unix fd or a win32 `SOCKET` (`i64` fits both
+        // losslessly, with `-1` ≡ `INVALID_SOCKET` as the shared sentinel). All of these take
+        // ownership of the handle. The C++ side normalizes
+        // TAKE_OWNERSHIP/ALREADY_CLOEXEC/ALREADY_NONBLOCK flags (dup'ing when not taking
+        // ownership) before calling in; [`own_socket_from_raw`] is the single point where the
+        // raw handle becomes an owned socket.
+
+        /// Wraps a connected stream socket handle (TCP or Unix domain, detected automatically).
+        fn wrap_socket_fd(handle: i64) -> Result<Box<TokioStream>>;
+
+        /// Wraps a bound+listening socket handle (TCP or Unix domain, detected automatically).
+        fn wrap_listen_fd(handle: i64) -> Result<Box<TokioListener>>;
+
+        /// Wraps an unconnected TCP socket handle and connects it to `sockaddr` (a raw
+        /// `struct sockaddr`, AF_INET/AF_INET6 only; owned copy, since the caller's pointer
+        /// need not outlive the call).
+        async fn wrap_connecting_socket_fd(
+            handle: i64,
+            sockaddr: Vec<u8>,
+        ) -> Result<Box<TokioStream>>;
+
+        /// Wraps a readable fd (pipe, character device, socket). Regular files are rejected by
+        /// the OS readiness API (same as KJ's epoll-based provider). Unix only (the pipe tier
+        /// keeps `i32` fds).
+        fn wrap_input_fd(fd: i32) -> Result<Box<TokioInputFd>>;
+
+        async unsafe fn input_fd_try_read<'a>(
+            stream: &'a TokioInputFd,
+            buf: &'a mut [u8],
+            min_bytes: usize,
+        ) -> Result<usize>;
+
+        /// Wraps a writable fd (pipe, character device, socket).
+        fn wrap_output_fd(fd: i32) -> Result<Box<TokioOutputFd>>;
+
+        async unsafe fn output_fd_write<'a>(stream: &'a TokioOutputFd, buf: &'a [u8])
+        -> Result<()>;
+
+        // ==================================================================================
+        // Signals (kj::UnixEventPort::onSignal replacement; see signal.rs for semantics)
+
+        /// Resolves when the process receives signal `signum` (on Windows: the mapped
+        /// SIGTERM/SIGINT console control event).
+        async fn wait_for_signal(signum: i32) -> Result<()>;
+
+        // ==================================================================================
+        // Fd readiness (kj::UnixEventPort::FdObserver::whenBecomesReadable replacement,
+        // backing kj_rs_io::FileWatcher in file-watcher.h; see readiness.rs for semantics)
+
+        /// A readiness watcher over a notification fd (inotify / kqueue). Owns its own dup of
+        /// the fd and a single registration with the I/O driver, so there is no "keep the fd
+        /// open" or "register once" contract for C++ to uphold. Unix only.
+        type TokioFdWatcher;
+        /// Create a watcher for `fd`: the fd is only borrowed for the duration of this call
+        /// (to dup it); the watcher owns the dup.
+        fn new_fd_watcher(fd: i32) -> Result<Box<TokioFdWatcher>>;
+        /// Resolves when the fd becomes readable (readiness already pending is reported
+        /// immediately). Multiple concurrent callers are fine.
+        async unsafe fn readable<'a>(self: &'a TokioFdWatcher) -> Result<()>;
+    }
+
+    unsafe extern "C++" {
+        include!("kj-rs-io/unwrap.h");
+
+        /// The pieces of a `kj::AsyncOutputStream::write(pieces)` call (unwrap.h), read through
+        /// the two accessors below. Owned by the C++ coroutine frame awaiting
+        /// `stream_write_pieces`, so the borrow the bridged future holds is always valid.
+        type KjPieces;
+        #[cxx_name = "kjPiecesCount"]
+        fn kj_pieces_count(pieces: &KjPieces) -> usize;
+        /// The `index`th piece. Borrowed from `pieces`; `index < kj_pieces_count(pieces)`.
+        #[cxx_name = "kjPiece"]
+        fn kj_piece<'a>(pieces: &'a KjPieces, index: usize) -> &'a [u8];
+
+        /// `kj::AsyncIoStream`, opaque. Used by [`unwrap_kj_stream`].
+        #[namespace = "kj"]
+        #[cxx_name = "AsyncIoStream"]
+        type KjAsyncIoStream;
+
+        /// Implemented in `async-io.c++`: downcasts to the kj-rs-io wrapper and moves the native
+        /// stream out. Throws (surfaced as `Err`) for foreign streams.
+        #[cxx_name = "unwrapTokioStream"]
+        fn unwrap_tokio_stream(stream: Pin<&mut KjAsyncIoStream>) -> Result<Box<TokioStream>>;
+
+        // Bridged operations on a foreign `kj::AsyncIoStream`, backing `serve_kj_stream`'s
+        // duplex-pump fallback (serve.rs). Shared receivers (`&KjAsyncIoStream`, const_cast
+        // shims in unwrap.h): a kj two-way stream supports one concurrent read and one write,
+        // which the pump models as concurrent shared borrows of the stream it owns. All
+        // returned futures must be polled on the KJ event-loop thread owning the stream.
+
+        /// Corresponds to `kj::AsyncIoStream::tryRead(buffer, min_bytes, buffer.len())`.
+        #[cxx_name = "kjStreamTryRead"]
+        async fn kj_stream_try_read(
+            stream: &KjAsyncIoStream,
+            buffer: &mut [u8],
+            min_bytes: usize,
+        ) -> Result<usize>;
+
+        /// Corresponds to `kj::AsyncIoStream::write(buffer)` (write-all semantics).
+        #[cxx_name = "kjStreamWrite"]
+        async fn kj_stream_write(stream: &KjAsyncIoStream, buffer: &[u8]) -> Result<()>;
+
+        /// Corresponds to `kj::AsyncIoStream::shutdownWrite()`. `Result`: the C++ side can
+        /// throw (e.g. `shutdown(2)` on an already-reset socket), and a C++ exception crossing a
+        /// non-`Result` shim would abort the process.
+        #[cxx_name = "kjStreamShutdownWrite"]
+        fn kj_stream_shutdown_write(stream: &KjAsyncIoStream) -> Result<()>;
+
+        /// The stream's underlying raw OS socket handle (fd on unix, `SOCKET` on windows;
+        /// `kj::AsyncIoStream::getFd()` / `getWin32Handle()`) as an `i64`, or -1 if it exposes
+        /// none. Backs the handle tier of [`take_kj_socket`].
+        #[cxx_name = "kjStreamGetHandle"]
+        fn kj_stream_get_handle(stream: &KjAsyncIoStream) -> i64;
+    }
+}
+
+// ======================================================================================
+// Raw socket handles / file descriptors.
+
+/// Materializes an owned file descriptor from a raw `i32` that arrived across the FFI bridge
+/// (the unix-only pipe tier — `wrap_input_fd`/`wrap_output_fd`; sockets go through
+/// [`own_socket_from_raw`]).
+///
+/// Callable from safe code: the invariant it relies on (`fd` is open and its ownership has been
+/// transferred to us) is structurally upheld by the cxx bridge — the C++ side normalizes KJ's
+/// `TAKE_OWNERSHIP` / `ALREADY_CLOEXEC` flags and dup's the fd when the caller is not handing
+/// over ownership. The returned `OwnedFd` becomes the sole owner and closes it on drop.
+#[cfg(unix)]
+#[must_use]
+pub fn own_fd_from_raw(fd: i32) -> std::os::fd::OwnedFd {
+    use std::os::fd::FromRawFd;
+    // `OwnedFd`'s invariant is "an open fd, never -1" (-1 is its niche), so a negative value
+    // here would be library-level UB rather than an error. C++ callers normalize through
+    // prepareFd, but its all-flags-set path (TAKE_OWNERSHIP|ALREADY_CLOEXEC|ALREADY_NONBLOCK)
+    // performs no syscall that would catch a bad fd — enforce the contract at THE conversion
+    // point instead of inheriting the UB.
+    assert!(fd >= 0, "invalid fd crossed the FFI bridge: {fd}");
+    // Safety: per the bridge contract `fd` is open and owned by us from this point on.
+    unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) }
+}
+
+/// Materializes an owned socket from a raw OS socket handle that arrived across the FFI bridge
+/// as an `i64`: a Unix fd here, a win32 `SOCKET` in the `cfg(windows)` twin below. This is THE
+/// one platform conversion point — behind it everything is a uniform `socket2::Socket` /
+/// std/tokio socket type.
+///
+/// Callable from safe code: the invariant it relies on (`handle` is an open socket whose
+/// ownership has been transferred to us) is structurally upheld by the cxx bridge — the C++
+/// side normalizes KJ's fd-wrapping flags, dup'ing when the caller is not handing over
+/// ownership. The returned socket becomes the sole owner and closes it on drop.
+#[cfg(unix)]
+#[must_use]
+pub fn own_socket_from_raw(handle: i64) -> socket2::Socket {
+    // A unix fd is a non-negative int: the bridge widened it losslessly to i64, so the
+    // narrowing back to i32 cannot truncate for any legitimate handle. Enforce that (rejecting
+    // -1/garbage) here at THE conversion point rather than inheriting `OwnedFd`'s niche UB.
+    assert!(
+        (0..=i64::from(i32::MAX)).contains(&handle),
+        "invalid socket fd crossed the FFI bridge: {handle}"
+    );
+    #[expect(clippy::cast_possible_truncation)]
+    let fd = handle as i32;
+    socket2::Socket::from(own_fd_from_raw(fd))
+}
+
+/// The `cfg(windows)` twin of [`own_socket_from_raw`]: the raw handle is a winsock `SOCKET`
+/// (`u64`-shaped `RawSocket`; a live SOCKET fits in an `i64` without colliding with the -1
+/// sentinel, which is `INVALID_SOCKET` and never crosses the bridge as an owned handle).
+// Validated by Windows CI; mirrors the unix arm.
+#[cfg(windows)]
+#[must_use]
+pub fn own_socket_from_raw(handle: i64) -> socket2::Socket {
+    use std::os::windows::io::FromRawSocket;
+    use std::os::windows::io::OwnedSocket;
+    use std::os::windows::io::RawSocket;
+    // Live SOCKET values are non-negative in i64 (the -1 sentinel is INVALID_SOCKET, which
+    // `OwnedSocket` forbids as its niche and which must never cross the bridge as an owned
+    // handle) — enforce at THE conversion point rather than inheriting the niche UB.
+    assert!(
+        handle >= 0,
+        "invalid SOCKET crossed the FFI bridge: {handle}"
+    );
+    // The bridge carries the SOCKET's bits verbatim.
+    #[allow(clippy::cast_sign_loss)]
+    let raw = handle as RawSocket;
+    // Safety: per the bridge contract `handle` is an open SOCKET owned by us from this point on.
+    let owned = unsafe { OwnedSocket::from_raw_socket(raw) };
+    socket2::Socket::from(owned)
+}
+
+/// Duplicates a *borrowed* raw fd into an independently-owned fd (`F_DUPFD_CLOEXEC`), for the
+/// handle tier of [`take_kj_socket`]: the kj stream keeps its own fd, we get a fresh dup.
+///
+/// Unix only, deliberately: no windows twin is needed. The handle tier only fires for *foreign*
+/// handle-backed kj streams, and under the all-rust mode on Windows every socket-backed stream
+/// originates in kj-rs-io (tier-1 unwrap); the other in-process dup users don't dup on windows
+/// either (`when_write_disconnected` is unix-only — never-resolving on windows, KJ parity — and
+/// windows `shutdown_write` borrows via `SockRef` instead of dup'ing). If a windows twin is
+/// ever needed, `std::os::windows::io::BorrowedSocket::try_clone_to_owned`
+/// (`WSADuplicateSocketW`) is the same-process equivalent.
+///
+/// # Errors
+///
+/// Returns the `dup()` `io::Error` (mapped to a `kj::Exception`) if the syscall fails.
+#[cfg(unix)]
+pub fn dup_raw_fd(fd: i32) -> Result<std::os::fd::OwnedFd> {
+    // Safety: the caller owns whatever `fd` belongs to (take_kj_socket holds the kj stream;
+    // new_fd_watcher is called from FileWatcher::Impl's constructor, which owns the fd) and so
+    // keeps it open for the duration of the call; we immediately dup it into an
+    // independently-owned fd and never touch `fd` again.
+    unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) }
+        .try_clone_to_owned()
+        .map_err(op("dup()"))
+}
+
+// ======================================================================================
+// `struct sockaddr` <-> bytes.
+
+/// Copies a `socket2::SockAddr`'s initialized `struct sockaddr` bytes into an owned `Vec`, to
+/// hand across the bridge for the C++ side's `kj::_::NetworkFilter` (restrictPeers) checks.
+#[must_use]
+pub fn sockaddr_to_bytes(sockaddr: &socket2::SockAddr) -> Vec<u8> {
+    // Safety: as_ptr()/len() delimit an initialized sockaddr owned by `sockaddr`.
+    let bytes = unsafe {
+        std::slice::from_raw_parts(sockaddr.as_ptr().cast::<u8>(), sockaddr.len() as usize)
+    };
+    bytes.to_vec()
+}
+
+/// Decodes raw `struct sockaddr` bytes (arriving from C++) into a `socket2::SockAddr`.
+///
+/// # Errors
+///
+/// Errors if the byte length is too short to hold a family, exceeds `sockaddr_storage`, or (on
+/// unix) is shorter than the family's own address struct -- an `AF_INET` in four bytes is
+/// garbage, not an address.
+#[cfg(any(unix, windows))]
+pub fn sockaddr_from_bytes(bytes: &[u8]) -> Result<socket2::SockAddr> {
+    use crate::error::KjIoError;
+
+    let mut storage = socket2::SockAddrStorage::zeroed();
+    let storage_size = std::mem::size_of::<socket2::SockAddrStorage>();
+    // Every sockaddr starts with its family (on BSDs preceded by a length byte); anything
+    // shorter than that header cannot even be classified.
+    #[cfg(unix)]
+    let header_size = std::mem::offset_of!(libc::sockaddr, sa_data);
+    #[cfg(not(unix))]
+    let header_size = std::mem::size_of::<socket2::sa_family_t>();
+    if bytes.len() < header_size || bytes.len() > storage_size {
+        return Err(KjIoError::other("sockaddr", "invalid sockaddr length"));
+    }
+    // Safety: SockAddrStorage is plain-old-data large enough for any sockaddr; we copy
+    // `bytes.len() <= size_of::<SockAddrStorage>()` bytes into it.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            std::ptr::from_mut(&mut storage).cast::<u8>(),
+            bytes.len(),
+        );
+    }
+    #[expect(clippy::cast_possible_truncation)]
+    let len = bytes.len() as socket2::socklen_t;
+    // Safety: `storage` is a zeroed sockaddr_storage with the caller's `len` bytes copied in,
+    // satisfying SockAddr::new's layout/length requirements. Reading a known family's struct
+    // out of it below is always in bounds (storage is full-size and zero-filled), so a
+    // length/family mismatch is a wrong address, never an out-of-bounds read; it is rejected
+    // as an error just after. Families socket2 does not understand (e.g. AF_NETLINK) make the
+    // accessors `as_socket()`/`as_pathname()` return `None`, and callers surface that as an
+    // "unsupported sockaddr family" error (see `net.rs::network_get_sockaddr`).
+    let addr = unsafe { socket2::SockAddr::new(storage, len) };
+    #[cfg(unix)]
+    {
+        let min_len = match i32::from(addr.family()) {
+            libc::AF_INET => std::mem::size_of::<libc::sockaddr_in>(),
+            libc::AF_INET6 => std::mem::size_of::<libc::sockaddr_in6>(),
+            libc::AF_UNIX => std::mem::offset_of!(libc::sockaddr_un, sun_path),
+            _ => 0,
+        };
+        if bytes.len() < min_len {
+            return Err(KjIoError::other(
+                "sockaddr",
+                format!(
+                    "sockaddr too short for its family: {} bytes, family {} needs at least {min_len}",
+                    bytes.len(),
+                    addr.family()
+                ),
+            ));
+        }
+    }
+    Ok(addr)
+}
+
+// ======================================================================================
+// Raw `getsockopt(2)` / `setsockopt(2)`.
+//
+// The socket-option passthrough behind `kj::AsyncIoStream::get/setsockopt` and
+// `kj::ConnectionReceiver::get/setsockopt`. The option buffer is caller-owned opaque bytes with
+// raw socklen in/out semantics (the caller's buffer may be smaller than the option value, and the
+// syscall's reported length must be surfaced verbatim), which no safe std/socket2 API expresses —
+// so the raw syscalls are declared and called here, in the unsafe island.
+
+/// Raw `getsockopt(2)` on a borrowed socket fd. `value.len()` is passed as the in `optlen` (the
+/// kernel truncates the option value to it); the syscall's reported out `optlen` is returned so
+/// the C++ caller can mirror `*length = socklen` exactly as `KJ_SYSCALL(::getsockopt(...))` did.
+#[cfg(unix)]
+fn getsockopt_raw(
+    fd: std::os::fd::BorrowedFd<'_>,
+    level: i32,
+    option: i32,
+    value: &mut [u8],
+) -> Result<usize> {
+    use core::ffi::c_int;
+    use core::ffi::c_void;
+    use std::os::fd::AsRawFd;
+    unsafe extern "C" {
+        fn getsockopt(
+            sockfd: c_int,
+            level: c_int,
+            optname: c_int,
+            optval: *mut c_void,
+            optlen: *mut socket2::socklen_t,
+        ) -> c_int;
+    }
+    #[expect(clippy::cast_possible_truncation)]
+    let mut optlen = value.len() as socket2::socklen_t;
+    // Safety: simple syscall wrapper. `fd` is a live socket fd (borrowed from the tokio object
+    // for the duration of the call); `value.as_mut_ptr()` with in-`optlen == value.len()`
+    // delimits writable caller memory the kernel fills (never past `optlen`); `&raw mut optlen`
+    // is a valid in/out pointer for the call.
+    let rc = unsafe {
+        getsockopt(
+            fd.as_raw_fd(),
+            level,
+            option,
+            value.as_mut_ptr().cast::<c_void>(),
+            &raw mut optlen,
+        )
+    };
+    if rc != 0 {
+        return Err(op("getsockopt()")(std::io::Error::last_os_error()));
+    }
+    Ok(optlen as usize)
+}
+
+/// Raw `setsockopt(2)` on a borrowed socket fd.
+#[cfg(unix)]
+fn setsockopt_raw(
+    fd: std::os::fd::BorrowedFd<'_>,
+    level: i32,
+    option: i32,
+    value: &[u8],
+) -> Result<()> {
+    use core::ffi::c_int;
+    use core::ffi::c_void;
+    use std::os::fd::AsRawFd;
+    unsafe extern "C" {
+        fn setsockopt(
+            sockfd: c_int,
+            level: c_int,
+            optname: c_int,
+            optval: *const c_void,
+            optlen: socket2::socklen_t,
+        ) -> c_int;
+    }
+    #[expect(clippy::cast_possible_truncation)]
+    let optlen = value.len() as socket2::socklen_t;
+    // Safety: simple syscall wrapper. `fd` is a live socket fd (borrowed from the tokio object
+    // for the duration of the call); `value.as_ptr()` with `optlen == value.len()` delimits
+    // readable caller memory the kernel only reads.
+    let rc = unsafe {
+        setsockopt(
+            fd.as_raw_fd(),
+            level,
+            option,
+            value.as_ptr().cast::<c_void>(),
+            optlen,
+        )
+    };
+    if rc != 0 {
+        return Err(op("setsockopt()")(std::io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Raw ws2_32 `getsockopt` on a borrowed `SOCKET`. Same socklen in/out semantics as the unix
+/// arm above: `value.len()` is passed as the in `optlen`, and the reported out `optlen` is
+/// returned verbatim.
+// Validated by Windows CI; mirrors the unix arm.
+#[cfg(windows)]
+fn getsockopt_raw(
+    sock: std::os::windows::io::BorrowedSocket<'_>,
+    level: i32,
+    option: i32,
+    value: &mut [u8],
+) -> Result<usize> {
+    use core::ffi::c_char;
+    use core::ffi::c_int;
+    use std::os::windows::io::AsRawSocket;
+    use std::os::windows::io::RawSocket;
+    #[link(name = "ws2_32")]
+    unsafe extern "system" {
+        fn getsockopt(
+            s: RawSocket,
+            level: c_int,
+            optname: c_int,
+            optval: *mut c_char,
+            optlen: *mut c_int,
+        ) -> c_int;
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let mut optlen = value.len() as c_int;
+    // Safety: simple syscall wrapper. `sock` is a live `SOCKET` (borrowed from the tokio object
+    // for the duration of the call); `value.as_mut_ptr()` with in-`optlen == value.len()`
+    // delimits writable caller memory winsock fills (never past `optlen`); `&raw mut optlen` is
+    // a valid in/out pointer for the call.
+    let rc = unsafe {
+        getsockopt(
+            sock.as_raw_socket(),
+            level,
+            option,
+            value.as_mut_ptr().cast::<c_char>(),
+            &raw mut optlen,
+        )
+    };
+    if rc != 0 {
+        // rc is SOCKET_ERROR (-1); `last_os_error()` reads `WSAGetLastError()` on Windows.
+        return Err(op("getsockopt()")(std::io::Error::last_os_error()));
+    }
+    // The out-length winsock reports is non-negative (and bounded by the in-length).
+    #[allow(clippy::cast_sign_loss)]
+    let reported = optlen as usize;
+    Ok(reported)
+}
+
+/// Raw ws2_32 `setsockopt` on a borrowed `SOCKET`.
+// Validated by Windows CI; mirrors the unix arm.
+#[cfg(windows)]
+fn setsockopt_raw(
+    sock: std::os::windows::io::BorrowedSocket<'_>,
+    level: i32,
+    option: i32,
+    value: &[u8],
+) -> Result<()> {
+    use core::ffi::c_char;
+    use core::ffi::c_int;
+    use std::os::windows::io::AsRawSocket;
+    use std::os::windows::io::RawSocket;
+    #[link(name = "ws2_32")]
+    unsafe extern "system" {
+        fn setsockopt(
+            s: RawSocket,
+            level: c_int,
+            optname: c_int,
+            optval: *const c_char,
+            optlen: c_int,
+        ) -> c_int;
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let optlen = value.len() as c_int;
+    // Safety: simple syscall wrapper. `sock` is a live `SOCKET` (borrowed from the tokio object
+    // for the duration of the call); `value.as_ptr()` with `optlen == value.len()` delimits
+    // readable caller memory winsock only reads.
+    let rc = unsafe {
+        setsockopt(
+            sock.as_raw_socket(),
+            level,
+            option,
+            value.as_ptr().cast::<c_char>(),
+            optlen,
+        )
+    };
+    if rc != 0 {
+        // rc is SOCKET_ERROR (-1); `last_os_error()` reads `WSAGetLastError()` on Windows.
+        return Err(op("setsockopt()")(std::io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+pub fn stream_getsockopt(
+    stream: &TokioStream,
+    level: i32,
+    option: i32,
+    value: &mut [u8],
+) -> Result<usize> {
+    #[cfg(unix)]
+    {
+        stream.with_borrowed_fd(|fd| getsockopt_raw(fd, level, option, value))?
+    }
+    // Validated by Windows CI; mirrors the unix arm.
+    #[cfg(windows)]
+    {
+        stream.with_borrowed_socket(|sock| getsockopt_raw(sock, level, option, value))?
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (stream, level, option, value);
+        Err(crate::error::KjIoError::other(
+            "getsockopt",
+            "not implemented by kj-rs-io on this platform",
+        ))
+    }
+}
+
+pub fn stream_setsockopt(
+    stream: &TokioStream,
+    level: i32,
+    option: i32,
+    value: &[u8],
+) -> Result<()> {
+    #[cfg(unix)]
+    {
+        stream.with_borrowed_fd(|fd| setsockopt_raw(fd, level, option, value))?
+    }
+    // Validated by Windows CI; mirrors the unix arm.
+    #[cfg(windows)]
+    {
+        stream.with_borrowed_socket(|sock| setsockopt_raw(sock, level, option, value))?
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (stream, level, option, value);
+        Err(crate::error::KjIoError::other(
+            "setsockopt",
+            "not implemented by kj-rs-io on this platform",
+        ))
+    }
+}
+
+pub fn listener_getsockopt(
+    listener: &TokioListener,
+    level: i32,
+    option: i32,
+    value: &mut [u8],
+) -> Result<usize> {
+    #[cfg(unix)]
+    {
+        getsockopt_raw(listener.as_borrowed_fd(), level, option, value)
+    }
+    // Validated by Windows CI; mirrors the unix arm.
+    #[cfg(windows)]
+    {
+        getsockopt_raw(listener.as_borrowed_socket(), level, option, value)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (listener, level, option, value);
+        Err(crate::error::KjIoError::other(
+            "getsockopt",
+            "not implemented by kj-rs-io on this platform",
+        ))
+    }
+}
+
+pub fn listener_setsockopt(
+    listener: &TokioListener,
+    level: i32,
+    option: i32,
+    value: &[u8],
+) -> Result<()> {
+    #[cfg(unix)]
+    {
+        setsockopt_raw(listener.as_borrowed_fd(), level, option, value)
+    }
+    // Validated by Windows CI; mirrors the unix arm.
+    #[cfg(windows)]
+    {
+        setsockopt_raw(listener.as_borrowed_socket(), level, option, value)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (listener, level, option, value);
+        Err(crate::error::KjIoError::other(
+            "setsockopt",
+            "not implemented by kj-rs-io on this platform",
+        ))
+    }
+}
+
+// ======================================================================================
+// Typed read/write halves of a pumped `kj::AsyncIoStream`.
+//
+// kj's stream contract — at most one read and one write may be in flight at once — is prose in
+// kj; these halves make the borrow checker enforce it. Each half's operations take `&mut self`,
+// so an in-flight operation's future exclusively borrows its half (a second overlapping read is
+// a compile error), and `split_kj_stream` takes the owner's `&mut`, so while the halves live
+// nothing else (an unwrap, another split) can touch the stream. The bridged operations behind
+// them are not re-exported: the halves are the only way to drive a foreign stream.
+
+/// The read direction of a pumped stream. See the module comment above.
+pub struct KjStreamReadHalf<'a>(&'a KjAsyncIoStream);
+
+/// The write direction of a pumped stream (writes and the write-side shutdown). See the module
+/// comment above.
+pub struct KjStreamWriteHalf<'a>(&'a KjAsyncIoStream);
+
+/// Splits the owned stream into its two directions. Holding the owner's `&mut` for the halves'
+/// lifetime proves exactly one pair exists and reserves the stream for them.
+// The unused `&mut` is the point (see the doc comment): it reserves the stream for the halves.
+#[expect(clippy::needless_pass_by_ref_mut)]
+pub fn split_kj_stream(
+    stream: &mut KjOwn<KjAsyncIoStream>,
+) -> (KjStreamReadHalf<'_>, KjStreamWriteHalf<'_>) {
+    let stream = &**stream;
+    (KjStreamReadHalf(stream), KjStreamWriteHalf(stream))
+}
+
+impl KjStreamReadHalf<'_> {
+    /// `kj::AsyncIoStream::tryRead(buffer, min_bytes, buffer.len())`.
+    // The unused `&mut self` is the point: an in-flight read's future exclusively borrows the
+    // read half (kj's one-read-in-flight contract), see the section comment above.
+    #[expect(clippy::needless_pass_by_ref_mut)]
+    pub(crate) async fn try_read(
+        &mut self,
+        buf: &mut [u8],
+        min_bytes: usize,
+    ) -> std::result::Result<usize, KjException> {
+        bridge::kj_stream_try_read(self.0, buf, min_bytes).await
+    }
+}
+
+impl KjStreamWriteHalf<'_> {
+    /// `kj::AsyncIoStream::write(buffer)` (write-all semantics).
+    // The unused `&mut self` is the point: an in-flight write's future exclusively borrows the
+    // write half (kj's one-write-in-flight contract), see the section comment above.
+    #[expect(clippy::needless_pass_by_ref_mut)]
+    pub(crate) async fn write(&mut self, buf: &[u8]) -> std::result::Result<(), KjException> {
+        bridge::kj_stream_write(self.0, buf).await
+    }
+
+    /// `kj::AsyncIoStream::shutdownWrite()`.
+    // The unused `&mut self` is the point: an exclusive borrow of the write half serializes
+    // write-side operations (kj's one-write-in-flight contract), see the section comment above.
+    #[expect(clippy::needless_pass_by_ref_mut)]
+    pub(crate) fn shutdown_write(&mut self) -> std::result::Result<(), KjException> {
+        bridge::kj_stream_shutdown_write(self.0)
+    }
+}
+
+// ======================================================================================
+// Borrow-based unwrap entry point (`Pin<&mut kj::AsyncIoStream>`). Safe: the in-flight-I/O
+// conflict it must avoid is detected by TokioStream's RefCell guard (see stream.rs).
+//
+// The owning native-serve entry points (`take_kj_socket`, `serve_kj_stream`) are safe fns in
+// [`crate::serve`] — ownership arrives as a `KjOwn` and no raw pointer crosses the crate's
+// public surface. Only the borrow-based unwrap remains here: C++ keeps the (hollow) wrapper,
+// so its "no I/O in flight" precondition cannot be expressed structurally.
+
+/// Recovers the native [`TokioStream`] out of a `kj::AsyncIoStream` that was created by
+/// kj-rs-io, leaving the C++ wrapper hollow (any further I/O through it fails).
+///
+/// # Errors
+///
+/// Returns an error if the stream is not a kj-rs-io tokio-backed stream, was already unwrapped,
+/// or has I/O operations (reads, writes, `whenWriteDisconnected`) in flight -- their futures
+/// borrow the native object this function moves out, and `TokioStream` tracks those borrows,
+/// so the conflict is detected rather than being a caller contract.
+pub fn unwrap_kj_stream(
+    stream: Pin<&mut KjAsyncIoStream>,
+) -> std::result::Result<Box<TokioStream>, KjException> {
+    bridge::unwrap_tokio_stream(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use cxx::KjError;
+
+    use super::*;
+
+    #[test]
+    fn sockaddr_round_trips_v4_and_v6() {
+        for text in ["1.2.3.4:80", "[::1]:443", "[fe80::1]:0"] {
+            let addr: std::net::SocketAddr = text.parse().unwrap();
+            let original = socket2::SockAddr::from(addr);
+            let bytes = sockaddr_to_bytes(&original);
+            assert_eq!(bytes.len(), original.len() as usize);
+            let decoded = sockaddr_from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.as_socket(), Some(addr), "{text}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sockaddr_round_trips_unix_paths() {
+        let original = socket2::SockAddr::unix("/tmp/kj-rs-io-test.sock").unwrap();
+        let bytes = sockaddr_to_bytes(&original);
+        let decoded = sockaddr_from_bytes(&bytes).unwrap();
+        assert!(decoded.is_unix());
+        assert_eq!(
+            decoded.as_pathname(),
+            Some(std::path::Path::new("/tmp/kj-rs-io-test.sock"))
+        );
+    }
+
+    #[test]
+    fn sockaddr_from_bytes_rejects_bad_lengths() {
+        assert!(sockaddr_from_bytes(&[]).is_err());
+        assert!(
+            sockaddr_from_bytes(&[0u8]).is_err(),
+            "shorter than a family"
+        );
+        let too_long = vec![0u8; std::mem::size_of::<socket2::SockAddrStorage>() + 1];
+        assert!(sockaddr_from_bytes(&too_long).is_err());
+    }
+
+    /// A family whose struct does not fit in the given length is garbage, not an address: a
+    /// truncated `sockaddr_in`, or an `AF_INET6` claimed in `sockaddr_in`'s size, must be rejected
+    /// rather than decoded out of the zero-filled tail of the storage.
+    #[cfg(unix)]
+    #[test]
+    fn sockaddr_from_bytes_rejects_family_length_mismatch() {
+        let v4: std::net::SocketAddr = "1.2.3.4:80".parse().unwrap();
+        let v4_bytes = sockaddr_to_bytes(&socket2::SockAddr::from(v4));
+        // Truncated sockaddr_in (family present, address cut off).
+        let truncated = &v4_bytes[..std::mem::size_of::<libc::sockaddr_in>() - 1];
+        let err = KjError::from(sockaddr_from_bytes(truncated).unwrap_err());
+        assert!(
+            err.description().contains("too short for its family"),
+            "{}",
+            err.description()
+        );
+
+        // An AF_INET6 family in only sockaddr_in's worth of bytes.
+        let v6: std::net::SocketAddr = "[::1]:443".parse().unwrap();
+        let v6_bytes = sockaddr_to_bytes(&socket2::SockAddr::from(v6));
+        let short_v6 = &v6_bytes[..std::mem::size_of::<libc::sockaddr_in>()];
+        assert!(sockaddr_from_bytes(short_v6).is_err());
+
+        // The exact struct sizes are accepted.
+        assert!(sockaddr_from_bytes(&v4_bytes[..std::mem::size_of::<libc::sockaddr_in>()]).is_ok());
+        assert!(
+            sockaddr_from_bytes(&v6_bytes[..std::mem::size_of::<libc::sockaddr_in6>()]).is_ok()
+        );
+
+        // A unix sockaddr needs at least its header (family + sun_path offset).
+        let un = sockaddr_to_bytes(&socket2::SockAddr::unix("/tmp/x").unwrap());
+        assert!(
+            sockaddr_from_bytes(&un[..std::mem::offset_of!(libc::sockaddr_un, sun_path) - 1])
+                .is_err()
+        );
+    }
+
+    /// Randomized: `sockaddr_from_bytes` must never panic on arbitrary input, and whatever it
+    /// accepts must be self-consistent (family and length agree; accessors do not read past
+    /// the given length's worth of meaning). Seeded xorshift, so a failure is reproducible.
+    #[cfg(unix)]
+    #[test]
+    fn sockaddr_from_bytes_never_panics_on_random_input() {
+        let mut state: u64 = 0x9e37_79b9_7f4a_7c15;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        let max = std::mem::size_of::<socket2::SockAddrStorage>() + 4;
+        for _ in 0..20_000 {
+            #[expect(clippy::cast_possible_truncation)]
+            let len = (next() % (max as u64 + 1)) as usize;
+            let mut bytes: Vec<u8> = (0..len).map(|_| (next() & 0xff) as u8).collect();
+            // Bias the family field toward the interesting ones half of the time.
+            if len >= 2 && next() % 2 == 0 {
+                let fam = [
+                    libc::AF_INET,
+                    libc::AF_INET6,
+                    libc::AF_UNIX,
+                    libc::AF_UNSPEC,
+                ][(next() % 4) as usize];
+                #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let fam = fam as socket2::sa_family_t;
+                let off = std::mem::offset_of!(libc::sockaddr, sa_family);
+                let fam_bytes = fam.to_ne_bytes();
+                bytes[off..off + fam_bytes.len().min(len - off)]
+                    .copy_from_slice(&fam_bytes[..fam_bytes.len().min(len - off)]);
+            }
+            if let Ok(addr) = sockaddr_from_bytes(&bytes) {
+                let min_len = match i32::from(addr.family()) {
+                    libc::AF_INET => std::mem::size_of::<libc::sockaddr_in>(),
+                    libc::AF_INET6 => std::mem::size_of::<libc::sockaddr_in6>(),
+                    libc::AF_UNIX => std::mem::offset_of!(libc::sockaddr_un, sun_path),
+                    _ => 0,
+                };
+                assert!(
+                    len >= min_len,
+                    "accepted {len} bytes for family {}",
+                    addr.family()
+                );
+                // Accessors must be safe to call on anything accepted.
+                let _ = addr.as_socket();
+                let _ = addr.as_pathname();
+                let _ = sockaddr_to_bytes(&addr);
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid fd crossed the FFI bridge")]
+    fn own_fd_from_raw_rejects_negative_fds() {
+        // -1 is OwnedFd's niche: turning it into an OwnedFd would be library UB, so the single
+        // conversion point must refuse it loudly (a panic here becomes a kj::Exception).
+        let _ = own_fd_from_raw(-1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[should_panic(expected = "invalid socket fd crossed the FFI bridge")]
+    fn own_socket_from_raw_rejects_negative_handles() {
+        let _ = own_socket_from_raw(-1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[should_panic(expected = "invalid socket fd crossed the FFI bridge")]
+    fn own_socket_from_raw_rejects_handles_that_do_not_fit_an_fd() {
+        let _ = own_socket_from_raw(i64::from(i32::MAX) + 1);
+    }
+
+    /// The happy path of THE conversion point: an fd released by std becomes a socket2 socket
+    /// that owns it (closes it on drop) and is fully usable.
+    #[cfg(unix)]
+    #[test]
+    fn own_socket_from_raw_takes_ownership_of_a_live_socket() {
+        use std::os::fd::AsRawFd;
+        use std::os::fd::IntoRawFd;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let raw = listener.into_raw_fd();
+        let socket = own_socket_from_raw(i64::from(raw));
+        assert_eq!(socket.as_raw_fd(), raw);
+        assert_eq!(
+            socket.local_addr().unwrap().as_socket().unwrap().port(),
+            port
+        );
+        // `socket` is the sole owner: dropping it closes the fd (socket2::Socket's drop glue).
+    }
+}

--- a/src/rust/cxx/kj-rs-io/ffi.rs
+++ b/src/rust/cxx/kj-rs-io/ffi.rs
@@ -911,6 +911,7 @@ pub fn unwrap_kj_stream(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use cxx::KjError;
 
     use super::*;

--- a/src/rust/cxx/kj-rs-io/ffi.rs
+++ b/src/rust/cxx/kj-rs-io/ffi.rs
@@ -44,6 +44,7 @@ use kj_rs::KjOwn;
 
 use crate::error::Result;
 use crate::error::op;
+use crate::net::OwnedConnectingSocket;
 use crate::net::TokioAddress;
 use crate::net::TokioListener;
 use crate::net::address_clone;
@@ -57,6 +58,7 @@ use crate::net::listener_local_addr;
 use crate::net::listener_port;
 use crate::net::network_get_sockaddr;
 use crate::net::network_parse_address;
+use crate::net::own_connecting_socket;
 use crate::net::wrap_connecting_socket_fd;
 use crate::net::wrap_listen_fd;
 use crate::net::wrap_socket_fd;
@@ -97,6 +99,7 @@ mod bridge {
         type TokioAddress;
         type TokioInputFd;
         type TokioOutputFd;
+        type OwnedConnectingSocket;
 
         // ==================================================================================
         // Streams (TCP or Unix domain, behind kj::AsyncIoStream)
@@ -248,11 +251,15 @@ mod bridge {
         /// Wraps a bound+listening socket handle (TCP or Unix domain, detected automatically).
         fn wrap_listen_fd(handle: i64) -> Result<Box<TokioListener>>;
 
-        /// Wraps an unconnected TCP socket handle and connects it to `sockaddr` (a raw
-        /// `struct sockaddr`, AF_INET/AF_INET6 only; owned copy, since the caller's pointer
-        /// need not outlive the call).
+        /// Takes ownership of an unconnected TCP socket handle synchronously, before the async
+        /// connect operation exists.
+        fn own_connecting_socket(handle: i64) -> Box<OwnedConnectingSocket>;
+
+        /// Connects an owned TCP socket to `sockaddr` (a raw `struct sockaddr`,
+        /// AF_INET/AF_INET6 only; owned copy, since the caller's pointer need not outlive the
+        /// call).
         async fn wrap_connecting_socket_fd(
-            handle: i64,
+            socket: Box<OwnedConnectingSocket>,
             sockaddr: Vec<u8>,
         ) -> Result<Box<TokioStream>>;
 
@@ -1074,5 +1081,31 @@ mod tests {
             port
         );
         // `socket` is the sole owner: dropping it closes the fd (socket2::Socket's drop glue).
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dropping_an_unpolled_connect_closes_the_transferred_socket() {
+        use std::os::fd::IntoRawFd;
+
+        let socket = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::STREAM,
+            Some(socket2::Protocol::TCP),
+        )
+        .unwrap();
+        let fd = socket.into_raw_fd();
+
+        let socket = crate::net::own_connecting_socket(i64::from(fd));
+        let connect = crate::net::wrap_connecting_socket_fd(socket, Vec::new());
+        drop(connect);
+
+        // SAFETY: F_GETFD only inspects the numeric descriptor; EBADF is the expected result
+        // after ownership passed into and was dropped with the unpolled future.
+        assert_eq!(unsafe { libc::fcntl(fd, libc::F_GETFD) }, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::EBADF)
+        );
     }
 }

--- a/src/rust/cxx/kj-rs-io/ffi.rs
+++ b/src/rust/cxx/kj-rs-io/ffi.rs
@@ -34,6 +34,7 @@ use core::pin::Pin;
 /// crate-root re-exports) keep using `ffi::`.
 pub use bridge::KjAsyncIoStream;
 pub use bridge::KjPieces;
+pub use bridge::is_tokio_stream;
 pub use bridge::kj_piece;
 pub use bridge::kj_pieces_count;
 pub use bridge::kj_stream_get_handle;
@@ -312,6 +313,10 @@ mod bridge {
         #[namespace = "kj"]
         #[cxx_name = "AsyncIoStream"]
         type KjAsyncIoStream;
+
+        /// Whether the stream is the kj-rs-io wrapper accepted by `unwrap_tokio_stream`.
+        #[cxx_name = "isTokioStream"]
+        fn is_tokio_stream(stream: &KjAsyncIoStream) -> bool;
 
         /// Implemented in `async-io.c++`: downcasts to the kj-rs-io wrapper and moves the native
         /// stream out. Throws (surfaced as `Err`) for foreign streams.

--- a/src/rust/cxx/kj-rs-io/ffi.rs
+++ b/src/rust/cxx/kj-rs-io/ffi.rs
@@ -342,16 +342,17 @@ mod bridge {
         async fn kj_stream_write(stream: &KjAsyncIoStream, buffer: &[u8]) -> Result<()>;
 
         /// Corresponds to `kj::AsyncIoStream::shutdownWrite()`. `Result`: the C++ side can
-        /// throw (e.g. `shutdown(2)` on an already-reset socket), and a C++ exception crossing a
-        /// non-`Result` shim would abort the process.
+        /// throw (e.g. `shutdown(2)` on an already-reset socket), and an infallible CXX
+        /// declaration would convert that exception to a Rust panic.
         #[cxx_name = "kjStreamShutdownWrite"]
         fn kj_stream_shutdown_write(stream: &KjAsyncIoStream) -> Result<()>;
 
         /// The stream's underlying raw OS socket handle (fd on unix, `SOCKET` on windows;
         /// `kj::AsyncIoStream::getFd()` / `getWin32Handle()`) as an `i64`, or -1 if it exposes
-        /// none. Backs the handle tier of [`take_kj_socket`].
+        /// none. Backs the handle tier of [`take_kj_socket`]. This is fallible because foreign
+        /// stream implementations may throw while retrieving their handle.
         #[cxx_name = "kjStreamGetHandle"]
-        fn kj_stream_get_handle(stream: &KjAsyncIoStream) -> i64;
+        fn kj_stream_get_handle(stream: &KjAsyncIoStream) -> Result<i64>;
     }
 }
 

--- a/src/rust/cxx/kj-rs-io/ffi.rs
+++ b/src/rust/cxx/kj-rs-io/ffi.rs
@@ -1028,6 +1028,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     #[should_panic(expected = "invalid fd crossed the FFI bridge")]
     fn own_fd_from_raw_rejects_negative_fds() {

--- a/src/rust/cxx/kj-rs-io/file-watcher.c++
+++ b/src/rust/cxx/kj-rs-io/file-watcher.c++
@@ -1,0 +1,228 @@
+// kj_rs_io::FileWatcher implementation. Each platform backend is a line-for-line port of
+// workerd's kj-mode FileWatcher (workerd.c++), with the one difference that waiting for the
+// notification fd to become readable goes through tokio's AsyncFd (TokioFdWatcher, see
+// readiness.rs) instead of kj::UnixEventPort::FdObserver::whenBecomesReadable(). Everything
+// else -- which fds get created, which watch masks are used, how events are drained and
+// filtered -- is kept identical so that --watch behaves the same on either event loop.
+
+#include "kj-rs-io/file-watcher.h"
+
+#include "kj-rs-io/ffi.rs.h"
+
+#include <kj/debug.h>
+#include <kj/io.h>
+#include <kj/map.h>
+#include <kj/refcount.h>
+#include <kj/vector.h>
+
+#include <cstring>
+
+#if __linux__
+#include <fcntl.h>
+#include <sys/inotify.h>
+#include <unistd.h>
+#elif __APPLE__ || __FreeBSD__ || __OpenBSD__ || __NetBSD__ || __DragonFly__
+#define KJ_RS_IO_USE_KQUEUE_FOR_FILE_WATCHER 1
+#include <fcntl.h>
+#include <sys/event.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+namespace kj_rs_io {
+
+#if __linux__
+
+// inotify backend. Watches each file's parent directory (IN_DELETE | IN_MODIFY | IN_MOVE |
+// IN_CREATE) and filters events by basename, so files replaced by rename (editors' atomic
+// saves) or deleted-and-recreated keep firing, and the watched file itself need not exist yet.
+struct FileWatcher::Impl: public kj::Refcounted {
+  kj::OwnFd inotifyFd;
+  // Owns a dup of `inotifyFd` and its one registration with the tokio I/O driver (see
+  // readiness.rs): declared after the fd it was created from, destroyed before it.
+  ::rust::Box<TokioFdWatcher> watcher;
+
+  kj::HashMap<kj::String, int> watches;
+  kj::HashMap<int, kj::HashSet<kj::String>> filesWatched;
+
+  Impl()
+      : inotifyFd(KJ_SYSCALL_FD(inotify_init1(IN_NONBLOCK | IN_CLOEXEC))),
+        watcher(new_fd_watcher(inotifyFd.get())) {}
+
+  bool isSupported() {
+    return true;
+  }
+
+  void watch(kj::PathPtr path, kj::Maybe<const kj::ReadableFile &> file) {
+    // The inotify backend doesn't use `file`; it watches the parent directory.
+
+    auto pathStr = path.parent().toNativeString(true);
+
+    int wd = watches.findOrCreate(pathStr, [&]() {
+      int wd;
+      uint32_t mask = IN_DELETE | IN_MODIFY | IN_MOVE | IN_CREATE;
+      KJ_SYSCALL(wd = inotify_add_watch(inotifyFd, pathStr.cStr(), mask));
+      return decltype(watches)::Entry{kj::mv(pathStr), wd};
+    });
+
+    auto &files =
+        filesWatched.findOrCreate(wd, [&]() { return decltype(filesWatched)::Entry{wd, {}}; });
+
+    files.upsert(kj::str(path.basename()[0]), [](auto &&...) {});
+  }
+
+  // `self` is this Impl's own refcount, held by the coroutine frame: the frame reads `this`
+  // across every co_await, so it keeps its referent alive itself rather than relying on the
+  // FileWatcher outliving the promise.
+  kj::Promise<void> onChange(kj::Own<Impl> self) {
+    kj::byte buffer[4096]{};
+
+    for (;;) {
+      ssize_t n;
+      KJ_NONBLOCKING_SYSCALL(n = read(inotifyFd, buffer, sizeof(buffer)));
+
+      if (n < 0) {
+        // No more data to read: wait for the inotify fd to become readable again.
+        co_await watcher->readable();
+        continue;
+      }
+
+      kj::byte *ptr = buffer;
+      while (n > 0) {
+        KJ_ASSERT(n >= sizeof(struct inotify_event));
+
+        auto &event = *reinterpret_cast<struct inotify_event *>(ptr);
+        size_t eventSize = sizeof(struct inotify_event) + event.len;
+        KJ_ASSERT(n >= eventSize);
+        KJ_ASSERT(eventSize % sizeof(void *) == 0);
+        ptr += eventSize;
+        n -= eventSize;
+
+        if (event.len > 0 && event.name[0] != '\0') {
+          auto &watched = KJ_ASSERT_NONNULL(filesWatched.find(event.wd));
+          if (watched.find(kj::StringPtr(event.name)) != kj::none) {
+            // HIT! We saw a change.
+            co_return;
+          }
+        }
+      }
+    }
+  }
+};
+
+#elif KJ_RS_IO_USE_KQUEUE_FOR_FILE_WATCHER
+
+// kqueue backend. One EVFILT_VNODE registration per watched file (dup of the already-open
+// config fd when available, else opened by path -- so the path must exist). NOTE_DELETE /
+// NOTE_RENAME on the old inode cover atomic-rename saves. kqueue doesn't scale to whole
+// directory trees, but we only watch the specific files opened while parsing the config.
+struct FileWatcher::Impl: public kj::Refcounted {
+  kj::OwnFd kqueueFd;
+  // Owns a dup of `kqueueFd` and its one registration with the tokio I/O driver (see
+  // readiness.rs): declared after the fd it was created from, destroyed before it.
+  ::rust::Box<TokioFdWatcher> watcher;
+  kj::Vector<kj::OwnFd> filesWatched;
+
+  Impl(): kqueueFd(makeKqueue()), watcher(new_fd_watcher(kqueueFd.get())) {}
+
+  bool isSupported() {
+    return true;
+  }
+
+  void watch(kj::PathPtr path, kj::Maybe<const kj::ReadableFile &> file) {
+    KJ_IF_SOME(f, file) {
+      KJ_IF_SOME(fd, f.getFd()) {
+        // We need to duplicate the fd because the original will probably be closed later, and
+        // closing the fd unregisters it from kqueue.
+        watchFd(KJ_SYSCALL_FD(dup(fd)));
+        return;
+      }
+    }
+
+    // No existing file, open from disk.
+    watchFd(KJ_SYSCALL_FD(open(path.toNativeString(true).cStr(), O_RDONLY)));
+  }
+
+  // `self` is this Impl's own refcount, held by the coroutine frame (see the inotify backend).
+  kj::Promise<void> onChange(kj::Own<Impl> self) {
+    for (;;) {
+      struct kevent event;
+      struct timespec timeout;
+      memset(&event, 0, sizeof(event));
+      memset(&timeout, 0, sizeof(timeout));
+
+      int n;
+      KJ_SYSCALL(n = kevent(kqueueFd, nullptr, 0, &event, 1, &timeout));
+
+      if (n == 0) {
+        // No events: wait for the kqueue fd to become readable, indicating an event has been
+        // delivered.
+        co_await watcher->readable();
+        continue;
+      } else {
+        // We only registered for events that indicate changes in the first place, so there's
+        // no need to examine the event: it definitely means something changed.
+        co_return;
+      }
+    }
+  }
+
+  static kj::OwnFd makeKqueue() {
+    auto fd = KJ_SYSCALL_FD(kqueue());
+    KJ_SYSCALL(fcntl(fd, F_SETFD, FD_CLOEXEC));
+    return kj::mv(fd);
+  }
+
+  void watchFd(kj::OwnFd fd) {
+    KJ_SYSCALL(fcntl(fd, F_SETFD, FD_CLOEXEC));
+
+    struct kevent change;
+    memset(&change, 0, sizeof(change));
+    change.ident = fd.get();
+    change.filter = EVFILT_VNODE;
+    change.flags = EV_ADD | EV_CLEAR;
+    change.fflags = NOTE_WRITE | NOTE_EXTEND | NOTE_DELETE | NOTE_RENAME;
+    KJ_SYSCALL(kevent(kqueueFd, &change, 1, nullptr, 0, nullptr));
+    filesWatched.add(kj::mv(fd));
+  }
+};
+
+#else
+
+// Dummy backend for platforms without an implementation (Windows, ...), mirroring workerd's:
+// isSupported() returns false, which workerd surfaces as a clean CLI error for --watch
+// ("File watching is not yet implemented on your OS") rather than a crash. A real Windows
+// backend (e.g. ReadDirectoryChangesW, perhaps via the notify crate) is a potential follow-up.
+struct FileWatcher::Impl: public kj::Refcounted {
+  bool isSupported() {
+    return false;
+  }
+
+  void watch(kj::PathPtr path, kj::Maybe<const kj::ReadableFile &> file) {}
+
+  kj::Promise<void> onChange(kj::Own<Impl>) {
+    return kj::NEVER_DONE;
+  }
+};
+
+#endif
+
+FileWatcher::FileWatcher(): impl(kj::refcounted<Impl>()) {}
+FileWatcher::~FileWatcher() noexcept(false) = default;
+
+bool FileWatcher::isSupported() {
+  return impl->isSupported();
+}
+
+void FileWatcher::watch(kj::PathPtr path, kj::Maybe<const kj::ReadableFile &> file) {
+  impl->watch(path, file);
+}
+
+kj::Promise<void> FileWatcher::onChange() {
+  // The coroutine frame co-owns the Impl (see Impl::onChange), so the returned promise stays
+  // valid even if this FileWatcher is destroyed first: no outlive-the-watcher contract.
+  return impl->onChange(kj::addRef(*impl));
+}
+
+}  // namespace kj_rs_io

--- a/src/rust/cxx/kj-rs-io/file-watcher.h
+++ b/src/rust/cxx/kj-rs-io/file-watcher.h
@@ -1,0 +1,57 @@
+#pragma once
+// kj_rs_io::FileWatcher: the tokio-loop replacement for workerd's `--watch` file watcher.
+//
+// Watches a set of individual files and resolves onChange() when any of them changes. The
+// platform backends mirror workerd's kj FileWatcher exactly — inotify on the parent directory
+// on Linux, kqueue EVFILT_VNODE per open file on macOS/BSD — but the notification fd's
+// readiness is awaited through tokio's AsyncFd (kj_rs_io::wait_fd_readable) instead of
+// kj::UnixEventPort::FdObserver, so it works on the tokio-backed event loop where no
+// UnixEventPort exists.
+//
+// Behavior notes (all matching the kj version):
+//  - Multiple rapid changes coalesce: onChange() resolves once for whatever is queued; calling
+//    it again drains the queue before waiting, so changes are never lost between calls.
+//  - Linux: the watched file itself need not exist (only its parent directory must), and a
+//    file deleted and re-created is picked up again. macOS/BSD: watch() opens the file (or
+//    dups the provided already-open fd), so watching a nonexistent file throws; a
+//    replaced-by-rename file still fires on the old inode.
+//  - All internal fds are CLOEXEC: --watch reloads via execve(), which must not leak them.
+//  - Unsupported platforms (Windows, ...): isSupported() returns false, watch() is a no-op and
+//    onChange() never resolves, mirroring workerd's dummy watcher.
+//
+// onChange() must be awaited on the thread owning the kj_rs_tokio::TokioEventPort, and at most
+// one onChange() promise may be outstanding at a time (workerd awaits it sequentially). The
+// promise co-owns the watcher's state, so it may outlive the FileWatcher object itself.
+
+#include <kj/async.h>
+#include <kj/filesystem.h>
+
+namespace kj_rs_io {
+
+class FileWatcher {
+ public:
+  FileWatcher();
+  ~FileWatcher() noexcept(false);
+  KJ_DISALLOW_COPY_AND_MOVE(FileWatcher);
+
+  // False on platforms with no watcher implementation (callers should report an error).
+  bool isSupported();
+
+  // Adds `path` to the watched set. `file`, if provided, is an already-open handle for the
+  // same path (the kqueue backend watches it directly via a dup'd fd; the inotify backend
+  // ignores it and watches the parent directory by name).
+  void watch(kj::PathPtr path, kj::Maybe<const kj::ReadableFile &> file);
+
+  // Resolves the next time any watched file changes (immediately, if a change is already
+  // queued). Eagerly evaluated, per kj-rs-io convention for I/O promises. The promise co-owns
+  // the watcher's state (the notification fd, its I/O-driver registration, the watched set), so
+  // destroying the FileWatcher while it is pending is safe: the state lives until the promise
+  // settles or is dropped.
+  kj::Promise<void> onChange();
+
+ private:
+  struct Impl;
+  kj::Own<Impl> impl;
+};
+
+}  // namespace kj_rs_io

--- a/src/rust/cxx/kj-rs-io/lib.rs
+++ b/src/rust/cxx/kj-rs-io/lib.rs
@@ -1,0 +1,111 @@
+//! Rust half of kj-rs-io: tokio-backed implementations of KJ's async I/O interfaces.
+//!
+//! The C++ side (`async-io.h`) implements `kj::AsyncIoStream`, `kj::ConnectionReceiver`,
+//! `kj::NetworkAddress`, `kj::Network`, `kj::AsyncIoProvider` and `kj::LowLevelAsyncIoProvider`
+//! as thin wrappers over the opaque Rust types in this crate. All async operations are plain
+//! `async fn`s bridged to `kj::Promise<T>` by workerd-cxx; dropping the promise drops the Rust
+//! future, which releases any tokio readiness interest (cancellation is implicit).
+//!
+//! Every future returned from this crate must be polled on the thread that owns the
+//! `kj_rs_tokio::TokioEventPort` runtime: tokio I/O objects register with that runtime's I/O
+//! driver, which is only driven while the KJ event loop sleeps inside the port's
+//! `wait()`/`poll()`.
+//!
+//! A Rust-originated stream wrapped as `kj::AsyncIoStream` can be recovered as its native
+//! tokio object so Rust servers can drive the connection without crossing the
+//! FFI per read: [`unwrap_kj_stream`] from Rust, `kj_rs_io::unwrapTokioStream()` from C++.
+//! Foreign streams fail to unwrap with a `kj::Exception`. The native-serve entry points
+//! ([`serve_kj_stream`], [`take_kj_socket`]) build on the [`serve`] module's `ServeIo` / pump
+//! machinery.
+//!
+//! # Object relationships
+//!
+//! C++ owns the KJ-facing objects; each holds an opaque Rust object by `rust::Box`:
+//!
+//! ```text
+//! TokioAsyncIoContext (C++)            -- kj::setupAsyncIo() analogue: composes
+//!     │                                   kj_rs_tokio::TokioAsyncIoContext (port -> loop,
+//!     │                                   runtime, timer; WaitScope) with the providers below;
+//!     │                                   teardown is member order (providers, then the base)
+//!     ├── kj_rs_tokio::TokioAsyncIoContext -- the loop's tokio runtime (see kj-rs-tokio)
+//!     ├── TokioLowLevelAsyncIoProvider  -- wrap*Fd(): owned fd/SOCKET as i64 -> Rust owns it
+//!     └── TokioAsyncIoProvider
+//!             └── TokioNetwork          -- Rc<PeerFilter> (restrictPeers chain; children
+//!                     │                    share ownership, nothing outlives anything by
+//!                     │                    convention)
+//!                     ├── TokioNetworkAddress  -- Box<TokioAddress> + Rc<PeerFilter> share
+//!                     │       └── TokioConnectionReceiver -- Box<TokioListener> + filter
+//!                     └── TokioAsyncIoStream   -- Box<TokioStream>
+//!
+//! TokioStream (this crate)             -- RefCell<Option<Inner>>: every I/O op holds a
+//!     │                                   shared borrow across its await; take() needs the
+//!     │                                   exclusive borrow, so unwrapping with I/O in flight
+//!     │                                   is an Err, not aliasing. None = hollow wrapper.
+//!     └── Inner::Tcp / Inner::Unix     -- the native tokio socket
+//!
+//! serve_kj_stream(KjOwn<AsyncIoStream>) -> ServedKjStream
+//!     ├── native path: unwrap -> ServeIo::Tcp/Unix, hollow wrapper destroyed
+//!     └── pump path:   ServeIo::Duplex (consumer end) + StreamPump (!Send) owning the KjOwn
+//!                      and the other duplex end, polled on the KJ thread
+//!
+//! FileWatcher::Impl (C++)              -- owns the inotify/kqueue fd, parses events
+//!     └── Box<TokioFdWatcher>          -- owns a dup of that fd + one I/O-driver registration
+//! ```
+
+// Safety & panic enforcement walls. Test code exempted.
+//
+// `unsafe` is quarantined into a single named FFI island: the crate root denies `unsafe_code`, so
+// the serve / net / stream / error / runtime / readiness / signal business logic is
+// *compiler-proven* free of hand-written unsafe. The one island that opts back in via
+// `#![allow(unsafe_code)]` is `ffi.rs`: it holds the `#[cxx::bridge] mod bridge` (re-exported as
+// `crate::ffi::*`) plus all the fd / sockaddr laundering. The public surface has no `unsafe fn`
+// at all: `unwrap_kj_stream` is a safe fn (the in-flight-I/O conflict it used to leave to the
+// caller is detected on the Rust side), and the owning entry points (`take_kj_socket`,
+// `serve_kj_stream`) are safe fns in `serve.rs`: ownership arrives as a `KjOwn`, the pump drives
+// it through compiler-checked shared borrows (shared-receiver shims, see unwrap.h), and no raw
+// pointer crosses the public surface.
+#![deny(unsafe_op_in_unsafe_fn)]
+#![deny(unsafe_code)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::todo,
+    clippy::unimplemented
+)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
+
+pub use net::TokioAddress;
+pub use stream::TokioStream;
+
+mod error;
+mod ffi;
+mod net;
+mod readiness;
+mod runtime;
+pub mod serve;
+mod signal;
+mod stream;
+
+/// Opaque binding of `kj::AsyncIoStream` (see [`unwrap_kj_stream`]).
+pub use ffi::KjAsyncIoStream;
+pub use ffi::unwrap_kj_stream;
+pub use serve::ServeIo;
+pub use serve::ServePath;
+pub use serve::ServedKjStream;
+pub use serve::StreamPump;
+pub use serve::TakeSocketError;
+pub use serve::serve_kj_stream;
+pub use serve::take_kj_socket;

--- a/src/rust/cxx/kj-rs-io/lib.rs
+++ b/src/rust/cxx/kj-rs-io/lib.rs
@@ -43,7 +43,7 @@
 //!     │                                   is an Err, not aliasing. None = hollow wrapper.
 //!     └── Inner::Tcp / Inner::Unix     -- the native tokio socket
 //!
-//! serve_kj_stream(KjOwn<AsyncIoStream>) -> ServedKjStream
+//! serve_kj_stream(KjOwn<AsyncIoStream>) -> Result<ServedKjStream, TakeSocketError>
 //!     ├── native path: unwrap -> ServeIo::Tcp/Unix, hollow wrapper destroyed
 //!     └── pump path:   ServeIo::Duplex (consumer end) + StreamPump (!Send) owning the KjOwn
 //!                      and the other duplex end, polled on the KJ thread

--- a/src/rust/cxx/kj-rs-io/net.rs
+++ b/src/rust/cxx/kj-rs-io/net.rs
@@ -1,0 +1,840 @@
+//! Tokio-backed `kj::Network` / `kj::NetworkAddress` / `kj::ConnectionReceiver` backends.
+//!
+//! Address-string grammar follows KJ's `SocketAddress::parse` (kj/async-io-unix.c++) for the
+//! subset workerd feeds it:
+//!
+//! - IPv4: `"1.2.3.4"`, `"1.2.3.4:80"`
+//! - IPv6: `"1234:5678::abcd"`, `"[1234:5678::abcd]:80"`
+//! - Wildcard (dual-stack): `"*"`, `"*:80"`
+//! - Hostnames (DNS via blocking `getaddrinfo` on tokio's blocking pool, its completion delivered
+//!   same-thread through a tokio runtime task — see [`resolve_host`]): `"example.com"`,
+//!   `"example.com:80"`
+//! - Unix domain: `"unix:/path/to/socket"` (Unix only)
+//!
+//! Known deviations from KJ, all erroring loudly rather than misbehaving: named services
+//! (`"host:http"`), `unix-abstract:` addresses, and IPv6 scope IDs (`"fe80::1%eth0"`) are not
+//! supported.
+
+use std::net::IpAddr;
+use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
+
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::UnixListener;
+#[cfg(unix)]
+use tokio::net::UnixStream;
+
+use crate::error::KjIoError;
+use crate::error::Result;
+use crate::error::op;
+use crate::runtime::on_loop_runtime;
+use crate::runtime::require_loop_runtime;
+use crate::stream::TokioStream;
+
+const LISTEN_BACKLOG: i32 = 1024;
+
+/// A parsed network address: one or more socket addresses to try in order.
+pub struct TokioAddress {
+    spec: Spec,
+}
+
+#[derive(Clone)]
+enum Spec {
+    Ip {
+        /// Resolved addresses, tried in order by `connect()`; `listen()` binds the first one
+        /// (mirroring KJ, which also only listens on the first result).
+        addrs: Vec<SocketAddr>,
+        /// `"*"`: listen on `[::]` with `IPV6_V6ONLY` disabled (dual-stack), reject `connect()`.
+        wildcard: bool,
+    },
+    #[cfg(unix)]
+    Unix { path: std::path::PathBuf },
+}
+
+impl TokioAddress {
+    /// An address that resolves to exactly `addrs`, tried in that order by `connect()`. The
+    /// programmatic counterpart of what DNS resolution produces; `listen()` binds the first.
+    #[must_use]
+    pub fn from_socket_addrs(addrs: Vec<SocketAddr>) -> Self {
+        Self {
+            spec: Spec::Ip {
+                addrs,
+                wildcard: false,
+            },
+        }
+    }
+
+    async fn parse(text: &str, port_hint: u16) -> Result<Self> {
+        if let Some(path) = text.strip_prefix("unix:") {
+            #[cfg(unix)]
+            {
+                return Ok(Self {
+                    spec: Spec::Unix { path: path.into() },
+                });
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = path;
+                return Err(KjIoError::other(
+                    "parseAddress",
+                    "Unix domain sockets are not supported on this platform",
+                ));
+            }
+        }
+        if text.starts_with("unix-abstract:") {
+            return Err(KjIoError::other(
+                "parseAddress",
+                "abstract Unix domain sockets are not implemented by kj-rs-io",
+            ));
+        }
+
+        // Split into address and port parts, exactly like KJ's SocketAddress::parse.
+        let (addr_part, port_part) = if let Some(rest) = text.strip_prefix('[') {
+            // Bracketed IPv6, optionally "[..]:port".
+            let close = rest.rfind(']').ok_or_else(|| {
+                KjIoError::other("parseAddress", format!("Unclosed '[' in address: {text}"))
+            })?;
+            let addr = &rest[..close];
+            let tail = &rest[close + 1..];
+            if tail.is_empty() {
+                (addr, None)
+            } else if let Some(port) = tail.strip_prefix(':') {
+                (addr, Some(port))
+            } else {
+                return Err(KjIoError::other(
+                    "parseAddress",
+                    format!("Expected port suffix after ']': {text}"),
+                ));
+            }
+        } else if let Some(colon) = text.find(':') {
+            if text[colon + 1..].contains(':') {
+                // Two or more colons, no brackets: a bare IPv6 address with no port.
+                (text, None)
+            } else {
+                // Exactly one colon: ip4/hostname with port.
+                (&text[..colon], Some(&text[colon + 1..]))
+            }
+        } else {
+            (text, None)
+        };
+
+        let port = match port_part {
+            Some(port_text) => port_text.parse::<u16>().map_err(|_| {
+                // KJ falls back to getaddrinfo service-name resolution here; tokio's resolver
+                // only accepts numeric ports.
+                KjIoError::other(
+                    "parseAddress",
+                    format!("invalid port (named services are not supported): {port_text}"),
+                )
+            })?,
+            None => port_hint,
+        };
+
+        if addr_part == "*" {
+            return Ok(Self {
+                spec: Spec::Ip {
+                    addrs: vec![SocketAddr::new(
+                        IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+                        port,
+                    )],
+                    wildcard: true,
+                },
+            });
+        }
+
+        if let Ok(ip) = addr_part.parse::<IpAddr>() {
+            return Ok(Self {
+                spec: Spec::Ip {
+                    addrs: vec![SocketAddr::new(ip, port)],
+                    wildcard: false,
+                },
+            });
+        }
+
+        // Not a literal: resolve the hostname via getaddrinfo on tokio's blocking pool. The
+        // completion is absorbed by a runtime task and forwarded to the loop thread so this
+        // await resumes same-thread -- an optimization (a cross-thread wake would go through
+        // the waker bridge's cross-thread fulfiller, which is legal but slower); see
+        // `resolve_host` for the full rationale.
+        let addrs: Vec<SocketAddr> = resolve_host(addr_part, port).await?;
+        if addrs.is_empty() {
+            return Err(KjIoError::other(
+                "getaddrinfo()",
+                format!("no addresses found for host: {addr_part}"),
+            ));
+        }
+        Ok(Self {
+            spec: Spec::Ip {
+                addrs,
+                wildcard: false,
+            },
+        })
+    }
+
+    async fn connect_index(&self, index: usize) -> Result<Box<TokioStream>> {
+        match &self.spec {
+            Spec::Ip { addrs, wildcard } => {
+                if *wildcard {
+                    return Err(KjIoError::other(
+                        "connect()",
+                        "cannot connect() to a wildcard address",
+                    ));
+                }
+                let addr = addrs
+                    .get(index)
+                    .ok_or_else(|| KjIoError::other("connect()", "address index out of range"))?;
+                let stream = TcpStream::connect(addr).await.map_err(op("connect()"))?;
+                Ok(Box::new(TokioStream::from_tcp(stream)))
+            }
+            #[cfg(unix)]
+            Spec::Unix { path } => {
+                if index != 0 {
+                    return Err(KjIoError::other("connect()", "address index out of range"));
+                }
+                let stream = UnixStream::connect(path).await.map_err(op("connect()"))?;
+                Ok(Box::new(TokioStream::from_unix(stream)))
+            }
+        }
+    }
+
+    fn count(&self) -> usize {
+        match &self.spec {
+            Spec::Ip { addrs, .. } => addrs.len(),
+            #[cfg(unix)]
+            Spec::Unix { .. } => 1,
+        }
+    }
+
+    fn raw_sockaddr(&self, index: usize) -> Result<Vec<u8>> {
+        let sockaddr: socket2::SockAddr = match &self.spec {
+            Spec::Ip { addrs, .. } => (*addrs
+                .get(index)
+                .ok_or_else(|| KjIoError::other("sockaddr", "address index out of range"))?)
+            .into(),
+            #[cfg(unix)]
+            Spec::Unix { path } => {
+                if index != 0 {
+                    return Err(KjIoError::other("sockaddr", "address index out of range"));
+                }
+                socket2::SockAddr::unix(path).map_err(op("sockaddr"))?
+            }
+        };
+        Ok(crate::ffi::sockaddr_to_bytes(&sockaddr))
+    }
+
+    fn listen(&self) -> Result<Box<TokioListener>> {
+        require_loop_runtime()?;
+        match &self.spec {
+            Spec::Ip { addrs, wildcard } => {
+                let addr = *addrs
+                    .first()
+                    .ok_or_else(|| KjIoError::other("listen()", "no addresses to bind"))?;
+                let domain = socket2::Domain::for_address(addr);
+                let socket = socket2::Socket::new(domain, socket2::Type::STREAM, None)
+                    .map_err(op("socket()"))?;
+                // KJ parity: SO_REUSEADDR on listeners; wildcard sockets accept both address
+                // families (IPV6_V6ONLY off).
+                socket.set_reuse_address(true).map_err(op("setsockopt()"))?;
+                if *wildcard {
+                    socket.set_only_v6(false).map_err(op("setsockopt()"))?;
+                }
+                socket.bind(&addr.into()).map_err(op("bind()"))?;
+                socket.listen(LISTEN_BACKLOG).map_err(op("listen()"))?;
+                socket.set_nonblocking(true).map_err(op("fcntl()"))?;
+                let listener = TcpListener::from_std(socket.into()).map_err(op("wrap listener"))?;
+                Ok(Box::new(TokioListener {
+                    inner: ListenerInner::Tcp(listener),
+                }))
+            }
+            #[cfg(unix)]
+            Spec::Unix { path } => {
+                // Like KJ, no unlink(): binding an existing path fails.
+                let listener =
+                    std::os::unix::net::UnixListener::bind(path).map_err(op("bind()"))?;
+                listener.set_nonblocking(true).map_err(op("fcntl()"))?;
+                let listener = UnixListener::from_std(listener).map_err(op("wrap listener"))?;
+                Ok(Box::new(TokioListener {
+                    inner: ListenerInner::Unix(listener),
+                }))
+            }
+        }
+    }
+
+    fn to_display_string(&self) -> String {
+        match &self.spec {
+            Spec::Ip { addrs, wildcard } => {
+                if *wildcard {
+                    format!("*:{}", addrs[0].port())
+                } else {
+                    let parts: Vec<String> = addrs.iter().map(ToString::to_string).collect();
+                    parts.join(",")
+                }
+            }
+            #[cfg(unix)]
+            Spec::Unix { path } => format!("unix:{}", path.display()),
+        }
+    }
+}
+
+/// A listening socket (`kj::ConnectionReceiver` backend).
+pub struct TokioListener {
+    inner: ListenerInner,
+}
+
+enum ListenerInner {
+    Tcp(TcpListener),
+    #[cfg(unix)]
+    Unix(UnixListener),
+}
+
+impl TokioListener {
+    async fn accept(&self) -> Result<Box<TokioStream>> {
+        match &self.inner {
+            ListenerInner::Tcp(listener) => {
+                let (stream, _peer) = listener.accept().await.map_err(op("accept()"))?;
+                let _ = stream.set_nodelay(true);
+                Ok(Box::new(TokioStream::from_tcp(stream)))
+            }
+            #[cfg(unix)]
+            ListenerInner::Unix(listener) => {
+                let (stream, _peer) = listener.accept().await.map_err(op("accept()"))?;
+                Ok(Box::new(TokioStream::from_unix(stream)))
+            }
+        }
+    }
+
+    fn port(&self) -> Result<u16> {
+        match &self.inner {
+            ListenerInner::Tcp(listener) => {
+                Ok(listener.local_addr().map_err(op("getsockname()"))?.port())
+            }
+            // KJ returns 0 for non-IP listeners.
+            #[cfg(unix)]
+            ListenerInner::Unix(_) => Ok(0),
+        }
+    }
+
+    /// Borrows the live listener socket's fd (tokio listeners implement `AsFd`), for the
+    /// sockopt/sockname passthrough behind `kj::ConnectionReceiver`.
+    #[cfg(unix)]
+    pub(crate) fn as_borrowed_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        use std::os::fd::AsFd;
+        match &self.inner {
+            ListenerInner::Tcp(listener) => listener.as_fd(),
+            ListenerInner::Unix(listener) => listener.as_fd(),
+        }
+    }
+
+    /// Borrows the live listener socket's `SOCKET` (tokio's `TcpListener` implements
+    /// `AsSocket`): the Windows counterpart of [`TokioListener::as_borrowed_fd`]. On Windows
+    /// only the Tcp variant of `ListenerInner` exists.
+    // Validated by Windows CI; mirrors the unix arm.
+    #[cfg(windows)]
+    pub(crate) fn as_borrowed_socket(&self) -> std::os::windows::io::BorrowedSocket<'_> {
+        use std::os::windows::io::AsSocket;
+        match &self.inner {
+            ListenerInner::Tcp(listener) => listener.as_socket(),
+        }
+    }
+
+    /// Raw `struct sockaddr` bytes of the listener's bound address (the `getsockname()`
+    /// passthrough behind `kj::ConnectionReceiver::getsockname`).
+    #[cfg(any(unix, windows))]
+    fn local_addr_bytes(&self) -> Result<Vec<u8>> {
+        #[cfg(unix)]
+        let sock = self.as_borrowed_fd();
+        // Validated by Windows CI; mirrors the unix arm.
+        #[cfg(windows)]
+        let sock = self.as_borrowed_socket();
+        let addr = socket2::SockRef::from(&sock)
+            .local_addr()
+            .map_err(op("getsockname()"))?;
+        Ok(crate::ffi::sockaddr_to_bytes(&addr))
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn local_addr_bytes(&self) -> Result<Vec<u8>> {
+        Err(KjIoError::other(
+            "getsockname",
+            "not implemented by kj-rs-io on this platform",
+        ))
+    }
+}
+
+// ======================================================================================
+// Bridge entry points (see lib.rs).
+
+/// Resolves a hostname via blocking `getaddrinfo` on tokio's blocking pool. A task on the loop's
+/// `LocalSet` owns the blocking `JoinHandle`, so the blocking-pool completion wakes tokio's own
+/// scheduler waker and the result comes back over a oneshot, waking the awaiting future
+/// same-thread. The kj-rs waker bridge is thread-safe, so `tokio::net::lookup_host` (whose
+/// `JoinHandle` wake lands on the caller's waker cross-thread) would also be *correct*; this
+/// shape is kept as an optimization — it keeps every bridged-waker wake on the loop thread's
+/// fast path instead of a cross-thread fulfiller hop per lookup. Same blocking `getaddrinfo`
+/// call and NSS/`/etc/hosts` parity as `lookup_host`.
+async fn resolve_host(host: &str, port: u16) -> Result<Vec<SocketAddr>> {
+    let host = host.to_owned();
+    let (tx, rx) = tokio::sync::oneshot::channel::<std::io::Result<Vec<SocketAddr>>>();
+
+    // The forwarding task's waker is tokio's own scheduler waker (Send + Sync), so the
+    // cross-thread completion from the blocking pool terminates inside tokio's scheduler
+    // (unparking this loop), never at a rust cross-thread waker. The task forwards the result on
+    // the loop thread, waking the awaiting future same-thread. Spawned onto the loop's LocalSet
+    // (kj_rs_tokio::spawn) so it is cancelled with the loop rather than with the runtime.
+    let task = kj_rs_tokio::spawn(async move {
+        let resolved = match tokio::task::spawn_blocking(move || {
+            (host.as_str(), port)
+                .to_socket_addrs()
+                .map(std::iter::Iterator::collect::<Vec<SocketAddr>>)
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(std::io::Error::other("getaddrinfo task failed")),
+        };
+        let _ = tx.send(resolved);
+    });
+    // If this future is dropped (KJ promise cancelled), abort the forwarding task rather than
+    // leaving it to run to completion for nobody. The blocking getaddrinfo call itself cannot be
+    // interrupted once started (an OS limitation shared with KJ's own resolver and tokio's
+    // `lookup_host`), so its blocking-pool slot is reclaimed only when the syscall returns.
+    let _abort_guard = crate::runtime::AbortOnDrop(task);
+
+    match rx.await {
+        Ok(result) => result.map_err(op("getaddrinfo()")),
+        Err(_) => Err(KjIoError::other(
+            "getaddrinfo()",
+            "DNS resolver task dropped",
+        )),
+    }
+}
+
+pub async fn network_parse_address(addr: String, port_hint: u16) -> Result<Box<TokioAddress>> {
+    on_loop_runtime(async move { Ok(Box::new(TokioAddress::parse(&addr, port_hint).await?)) }).await
+}
+
+pub fn network_get_sockaddr(sockaddr: &[u8]) -> Result<Box<TokioAddress>> {
+    #[cfg(any(unix, windows))]
+    {
+        let addr = sockaddr_from_bytes(sockaddr)?;
+        if let Some(socket_addr) = addr.as_socket() {
+            return Ok(Box::new(TokioAddress {
+                spec: Spec::Ip {
+                    addrs: vec![socket_addr],
+                    wildcard: false,
+                },
+            }));
+        }
+        #[cfg(unix)]
+        if let Some(path) = addr.as_pathname() {
+            return Ok(Box::new(TokioAddress {
+                spec: Spec::Unix { path: path.into() },
+            }));
+        }
+        Err(KjIoError::other(
+            "getSockaddr",
+            "unsupported sockaddr family",
+        ))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = sockaddr;
+        Err(KjIoError::other(
+            "getSockaddr",
+            "not implemented on this platform",
+        ))
+    }
+}
+
+/// Connects to exactly the `index`th resolved address (no fallback). The C++ side drives the
+/// try-each-address loop itself so it can apply `restrictPeers()` filtering per address before
+/// initiating each connection attempt (KJ parity: a blocked address contributes a
+/// "`connect()` blocked by `restrictPeers()`" failure; only the last address's error propagates).
+pub async fn address_connect_index(addr: &TokioAddress, index: usize) -> Result<Box<TokioStream>> {
+    on_loop_runtime(addr.connect_index(index)).await
+}
+
+/// Number of resolved socket addresses behind this address (>= 1).
+pub fn address_count(addr: &TokioAddress) -> usize {
+    addr.count()
+}
+
+/// Raw `struct sockaddr` bytes of the `index`th resolved address, for the C++ side's
+/// `kj::_::NetworkFilter` (restrictPeers) checks.
+pub fn address_raw_sockaddr(addr: &TokioAddress, index: usize) -> Result<Vec<u8>> {
+    addr.raw_sockaddr(index)
+}
+
+pub fn address_listen(addr: &TokioAddress) -> Result<Box<TokioListener>> {
+    addr.listen()
+}
+
+#[expect(clippy::unnecessary_box_returns)] // Opaque cxx types must cross the bridge boxed.
+pub fn address_clone(addr: &TokioAddress) -> Box<TokioAddress> {
+    Box::new(TokioAddress {
+        spec: addr.spec.clone(),
+    })
+}
+
+pub fn address_to_string(addr: &TokioAddress) -> String {
+    addr.to_display_string()
+}
+
+pub async fn listener_accept(listener: &TokioListener) -> Result<Box<TokioStream>> {
+    on_loop_runtime(listener.accept()).await
+}
+
+pub fn listener_port(listener: &TokioListener) -> Result<u16> {
+    listener.port()
+}
+
+pub fn listener_local_addr(listener: &TokioListener) -> Result<Vec<u8>> {
+    listener.local_addr_bytes()
+}
+
+// ======================================================================================
+// Socket-handle wrapping. All handles arrive owned and non-blocking as an `i64` "raw socket
+// handle" — a Unix fd or a win32 SOCKET (the C++ side normalizes KJ's TAKE_OWNERSHIP /
+// ALREADY_CLOEXEC / ALREADY_NONBLOCK flags, dup'ing when not taking ownership). The platform
+// split lives entirely in `ffi::own_socket_from_raw` (the one conversion point); everything
+// here operates on the uniform `socket2::Socket` / std / tokio types.
+
+#[cfg(any(unix, windows))]
+fn socket_from_raw(handle: i64) -> socket2::Socket {
+    crate::ffi::own_socket_from_raw(handle)
+}
+
+#[cfg(any(unix, windows))]
+fn sockaddr_from_bytes(bytes: &[u8]) -> Result<socket2::SockAddr> {
+    crate::ffi::sockaddr_from_bytes(bytes)
+}
+
+/// The handle tier of [`crate::take_kj_socket`] (unix only; see that function's docs): wraps
+/// an *owned*, connected stream-socket fd (TCP or Unix domain, detected automatically) as a
+/// [`crate::serve::ServeIo`]. Unlike [`wrap_socket_fd`] the fd is a fresh dup of a kj stream's
+/// socket, so non-blocking mode is forced rather than assumed (the original may have come from
+/// anywhere).
+#[cfg(unix)]
+pub fn serve_io_from_owned_fd(fd: std::os::fd::OwnedFd) -> Result<crate::serve::ServeIo> {
+    let socket = socket2::Socket::from(fd);
+    socket.set_nonblocking(true).map_err(op("fcntl()"))?;
+    let local = socket.local_addr().map_err(op("getsockname()"))?;
+    require_loop_runtime()?;
+    match local.domain() {
+        socket2::Domain::IPV4 | socket2::Domain::IPV6 => {
+            let stream = TcpStream::from_std(socket.into()).map_err(op("takeKjSocket"))?;
+            Ok(crate::serve::ServeIo::Tcp(stream))
+        }
+        socket2::Domain::UNIX => {
+            let stream = UnixStream::from_std(socket.into()).map_err(op("takeKjSocket"))?;
+            Ok(crate::serve::ServeIo::Unix(stream))
+        }
+        _ => Err(KjIoError::other(
+            "takeKjSocket",
+            "unsupported socket family",
+        )),
+    }
+}
+
+pub fn wrap_socket_fd(handle: i64) -> Result<Box<TokioStream>> {
+    #[cfg(any(unix, windows))]
+    {
+        let socket = socket_from_raw(handle);
+        let local = socket.local_addr().map_err(op("getsockname()"))?;
+        require_loop_runtime()?;
+        match local.domain() {
+            socket2::Domain::IPV4 | socket2::Domain::IPV6 => {
+                let stream = TcpStream::from_std(socket.into()).map_err(op("wrapSocketFd"))?;
+                Ok(Box::new(TokioStream::from_tcp(stream)))
+            }
+            #[cfg(unix)]
+            socket2::Domain::UNIX => {
+                let stream = UnixStream::from_std(socket.into()).map_err(op("wrapSocketFd"))?;
+                Ok(Box::new(TokioStream::from_unix(stream)))
+            }
+            _ => Err(KjIoError::other(
+                "wrapSocketFd",
+                "unsupported socket family",
+            )),
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = handle;
+        Err(KjIoError::other(
+            "wrapSocketFd",
+            "not implemented on this platform",
+        ))
+    }
+}
+
+pub fn wrap_listen_fd(handle: i64) -> Result<Box<TokioListener>> {
+    #[cfg(any(unix, windows))]
+    {
+        let socket = socket_from_raw(handle);
+        let local = socket.local_addr().map_err(op("getsockname()"))?;
+        require_loop_runtime()?;
+        match local.domain() {
+            socket2::Domain::IPV4 | socket2::Domain::IPV6 => {
+                let listener =
+                    TcpListener::from_std(socket.into()).map_err(op("wrapListenSocketFd"))?;
+                Ok(Box::new(TokioListener {
+                    inner: ListenerInner::Tcp(listener),
+                }))
+            }
+            #[cfg(unix)]
+            socket2::Domain::UNIX => {
+                let listener =
+                    UnixListener::from_std(socket.into()).map_err(op("wrapListenSocketFd"))?;
+                Ok(Box::new(TokioListener {
+                    inner: ListenerInner::Unix(listener),
+                }))
+            }
+            _ => Err(KjIoError::other(
+                "wrapListenSocketFd",
+                "unsupported socket family",
+            )),
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = handle;
+        Err(KjIoError::other(
+            "wrapListenSocketFd",
+            "not implemented on this platform",
+        ))
+    }
+}
+
+pub async fn wrap_connecting_socket_fd(handle: i64, sockaddr: Vec<u8>) -> Result<Box<TokioStream>> {
+    #[cfg(any(unix, windows))]
+    {
+        on_loop_runtime(async move {
+            let addr = sockaddr_from_bytes(&sockaddr)?;
+            let socket_addr = addr.as_socket().ok_or_else(|| {
+                KjIoError::other(
+                    "wrapConnectingSocketFd",
+                    "only AF_INET/AF_INET6 sockaddrs are supported",
+                )
+            })?;
+            let socket = socket_from_raw(handle);
+            // TcpSocket::connect handles the nonblocking connect dance (EINPROGRESS, wait for
+            // writability, check SO_ERROR) and registers with the I/O driver.
+            let tcp_socket = tokio::net::TcpSocket::from_std_stream(socket.into());
+            let stream = tcp_socket
+                .connect(socket_addr)
+                .await
+                .map_err(op("connect()"))?;
+            Ok(Box::new(TokioStream::from_tcp(stream)))
+        })
+        .await
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (handle, sockaddr);
+        Err(KjIoError::other(
+            "wrapConnectingSocketFd",
+            "not implemented on this platform",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+    use std::net::Ipv6Addr;
+    use std::net::SocketAddr;
+
+    use cxx::KjError;
+
+    use super::*;
+
+    /// `TokioAddress::parse` is `async` only because hostnames go through DNS; every literal
+    /// form below resolves without ever awaiting, so a single poll with a no-op waker suffices.
+    fn parse_literal(text: &str, port_hint: u16) -> Result<TokioAddress> {
+        let mut fut = std::pin::pin!(TokioAddress::parse(text, port_hint));
+        let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+        match fut.as_mut().poll(&mut cx) {
+            std::task::Poll::Ready(result) => result,
+            std::task::Poll::Pending => panic!("literal address {text:?} should not await"),
+        }
+    }
+
+    fn parse_ok(text: &str, port_hint: u16) -> TokioAddress {
+        match parse_literal(text, port_hint) {
+            Ok(addr) => addr,
+            Err(e) => panic!(
+                "{text:?} failed to parse: {}",
+                KjError::from(e).description()
+            ),
+        }
+    }
+
+    fn parse_err(text: &str, port_hint: u16) -> KjError {
+        match parse_literal(text, port_hint) {
+            Ok(_) => panic!("{text:?} unexpectedly parsed"),
+            Err(e) => KjError::from(e),
+        }
+    }
+
+    fn ip_addrs(addr: &TokioAddress) -> (&[SocketAddr], bool) {
+        match &addr.spec {
+            Spec::Ip { addrs, wildcard } => (addrs, *wildcard),
+            #[cfg(unix)]
+            Spec::Unix { .. } => panic!("expected an IP address"),
+        }
+    }
+
+    #[test]
+    fn ipv4_literal_with_and_without_port() {
+        let addr = parse_ok("1.2.3.4:80", 0);
+        let (addrs, wildcard) = ip_addrs(&addr);
+        assert_eq!(
+            addrs,
+            &[SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 80)]
+        );
+        assert!(!wildcard);
+
+        // No port: the port hint fills in.
+        let addr = parse_ok("1.2.3.4", 8080);
+        assert_eq!(ip_addrs(&addr).0[0].port(), 8080);
+    }
+
+    #[test]
+    fn ipv6_literal_forms() {
+        // Bracketed with port.
+        let addr = parse_ok("[::1]:443", 0);
+        assert_eq!(
+            ip_addrs(&addr).0,
+            &[SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 443)]
+        );
+        // Bracketed without port: hint applies.
+        let addr = parse_ok("[::1]", 7);
+        assert_eq!(ip_addrs(&addr).0[0].port(), 7);
+        // Bare IPv6 (two or more colons, no brackets) means "no port" -- never "host:port".
+        let addr = parse_ok("fe80::1", 9);
+        assert_eq!(
+            ip_addrs(&addr).0[0],
+            SocketAddr::new("fe80::1".parse::<IpAddr>().unwrap(), 9)
+        );
+    }
+
+    #[test]
+    fn wildcard_forms() {
+        let addr = parse_ok("*", 1234);
+        let (addrs, wildcard) = ip_addrs(&addr);
+        assert!(wildcard);
+        assert_eq!(
+            addrs,
+            &[SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 1234)]
+        );
+        let addr = parse_ok("*:80", 0);
+        let (addrs, wildcard) = ip_addrs(&addr);
+        assert!(wildcard);
+        assert_eq!(addrs[0].port(), 80);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_forms() {
+        match &parse_ok("unix:/tmp/sock", 0).spec {
+            Spec::Unix { path } => assert_eq!(path, std::path::Path::new("/tmp/sock")),
+            Spec::Ip { .. } => panic!("expected a unix address"),
+        }
+        // Abstract sockets are a documented gap.
+        assert!(
+            parse_err("unix-abstract:foo", 0)
+                .description()
+                .contains("abstract")
+        );
+    }
+
+    #[test]
+    fn get_sockaddr_rejects_unsupported_family() {
+        // A zeroed sockaddr (family AF_UNSPEC) is neither AF_INET/6 nor AF_UNIX, so
+        // network_get_sockaddr must reject it rather than fabricate an address. Length is a
+        // valid sockaddr_in size so it passes the length check and reaches the family branch.
+        let bogus = vec![0u8; core::mem::size_of::<libc::sockaddr_in>()];
+        let err = match network_get_sockaddr(&bogus) {
+            Ok(_) => panic!("a zeroed (AF_UNSPEC) sockaddr must be rejected"),
+            Err(e) => KjError::from(e),
+        };
+        assert!(
+            err.description().contains("unsupported sockaddr family"),
+            "{}",
+            err.description()
+        );
+    }
+
+    /// Randomized: the address grammar must never panic on arbitrary strings, and every literal
+    /// it accepts must survive a display round trip. Hostname-shaped inputs are allowed to go
+    /// Pending (they start a DNS lookup on the loop's runtime, which needs a port; dropping the
+    /// future aborts it). Seeded xorshift, so a failure is reproducible.
+    #[test]
+    fn parse_never_panics_on_random_input_and_literals_round_trip() {
+        const ALPHABET: &[u8] = b"0123456789abcdef:.[]*%-/xu";
+        let _port = kj_rs_tokio::TokioPort::new();
+        let mut state: u64 = 0x2545_f491_4f6c_dd1d;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        let cx_waker = std::task::Waker::noop();
+        for _ in 0..20_000 {
+            let len = usize::try_from(next() % 24).unwrap();
+            let text: String = (0..len)
+                .map(|_| ALPHABET[usize::try_from(next() % ALPHABET.len() as u64).unwrap()] as char)
+                .collect();
+            let hint = u16::try_from(next() & 0xffff).unwrap();
+            let mut fut = std::pin::pin!(TokioAddress::parse(&text, hint));
+            let mut cx = std::task::Context::from_waker(cx_waker);
+            let std::task::Poll::Ready(Ok(addr)) = fut.as_mut().poll(&mut cx) else {
+                continue; // rejected, or a hostname now resolving: both fine
+            };
+            // Round trip: what it prints must parse back to the same addresses.
+            let shown = addr.to_display_string();
+            let Spec::Ip { addrs, wildcard } = &addr.spec else {
+                continue;
+            };
+            if *wildcard {
+                assert!(shown.starts_with("*:"), "{text:?} -> {shown:?}");
+                continue;
+            }
+            let expected = addrs[0];
+            let reparsed = parse_ok(&shown, 0);
+            assert_eq!(ip_addrs(&reparsed).0[0], expected, "{text:?} -> {shown:?}");
+        }
+    }
+
+    #[test]
+    fn documented_rejections() {
+        // Named services: tokio's resolver only takes numeric ports.
+        let err = parse_err("1.2.3.4:http", 0);
+        assert!(
+            err.description().contains("named services"),
+            "{}",
+            err.description()
+        );
+        // Unclosed bracket.
+        let err = parse_err("[::1", 0);
+        assert!(
+            err.description().contains("Unclosed"),
+            "{}",
+            err.description()
+        );
+        // Junk after the closing bracket.
+        let err = parse_err("[::1]x", 0);
+        assert!(
+            err.description().contains("Expected port suffix"),
+            "{}",
+            err.description()
+        );
+        // Out-of-range port.
+        let _ = parse_err("1.2.3.4:70000", 0);
+    }
+}

--- a/src/rust/cxx/kj-rs-io/net.rs
+++ b/src/rust/cxx/kj-rs-io/net.rs
@@ -516,6 +516,29 @@ fn sockaddr_from_bytes(bytes: &[u8]) -> Result<socket2::SockAddr> {
     crate::ffi::sockaddr_from_bytes(bytes)
 }
 
+/// Owns an unconnected socket from the instant C++ transfers its raw handle. C++ constructs
+/// this synchronously before asking cxx to create the connect future, so dropping that future
+/// without polling it still closes the socket.
+pub struct OwnedConnectingSocket {
+    #[cfg(any(unix, windows))]
+    socket: socket2::Socket,
+}
+
+#[expect(clippy::unnecessary_box_returns)] // Opaque cxx types must cross the bridge boxed.
+pub fn own_connecting_socket(handle: i64) -> Box<OwnedConnectingSocket> {
+    #[cfg(any(unix, windows))]
+    {
+        Box::new(OwnedConnectingSocket {
+            socket: socket_from_raw(handle),
+        })
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = handle;
+        Box::new(OwnedConnectingSocket {})
+    }
+}
+
 /// The handle tier of [`crate::take_kj_socket`] (unix only; see that function's docs): wraps
 /// an *owned*, connected stream-socket fd (TCP or Unix domain, detected automatically) as a
 /// [`crate::serve::ServeIo`]. Unlike [`wrap_socket_fd`] the fd is a fresh dup of a kj stream's
@@ -613,7 +636,10 @@ pub fn wrap_listen_fd(handle: i64) -> Result<Box<TokioListener>> {
     }
 }
 
-pub async fn wrap_connecting_socket_fd(handle: i64, sockaddr: Vec<u8>) -> Result<Box<TokioStream>> {
+pub async fn wrap_connecting_socket_fd(
+    socket: Box<OwnedConnectingSocket>,
+    sockaddr: Vec<u8>,
+) -> Result<Box<TokioStream>> {
     #[cfg(any(unix, windows))]
     {
         on_loop_runtime(async move {
@@ -624,7 +650,7 @@ pub async fn wrap_connecting_socket_fd(handle: i64, sockaddr: Vec<u8>) -> Result
                     "only AF_INET/AF_INET6 sockaddrs are supported",
                 )
             })?;
-            let socket = socket_from_raw(handle);
+            let OwnedConnectingSocket { socket } = *socket;
             // TcpSocket::connect handles the nonblocking connect dance (EINPROGRESS, wait for
             // writability, check SO_ERROR) and registers with the I/O driver.
             let tcp_socket = tokio::net::TcpSocket::from_std_stream(socket.into());
@@ -638,7 +664,7 @@ pub async fn wrap_connecting_socket_fd(handle: i64, sockaddr: Vec<u8>) -> Result
     }
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = (handle, sockaddr);
+        let _ = (socket, sockaddr);
         Err(KjIoError::other(
             "wrapConnectingSocketFd",
             "not implemented on this platform",

--- a/src/rust/cxx/kj-rs-io/net.rs
+++ b/src/rust/cxx/kj-rs-io/net.rs
@@ -779,6 +779,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn get_sockaddr_rejects_unsupported_family() {
         // A zeroed sockaddr (family AF_UNSPEC) is neither AF_INET/6 nor AF_UNIX, so

--- a/src/rust/cxx/kj-rs-io/net.rs
+++ b/src/rust/cxx/kj-rs-io/net.rs
@@ -186,6 +186,9 @@ impl TokioAddress {
                     .get(index)
                     .ok_or_else(|| KjIoError::other("connect()", "address index out of range"))?;
                 let stream = TcpStream::connect(addr).await.map_err(op("connect()"))?;
+                stream
+                    .set_nodelay(true)
+                    .map_err(op("setsockopt(TCP_NODELAY)"))?;
                 Ok(Box::new(TokioStream::from_tcp(stream)))
             }
             #[cfg(unix)]
@@ -294,7 +297,9 @@ impl TokioListener {
         match &self.inner {
             ListenerInner::Tcp(listener) => {
                 let (stream, _peer) = listener.accept().await.map_err(op("accept()"))?;
-                let _ = stream.set_nodelay(true);
+                stream
+                    .set_nodelay(true)
+                    .map_err(op("setsockopt(TCP_NODELAY)"))?;
                 Ok(Box::new(TokioStream::from_tcp(stream)))
             }
             #[cfg(unix)]

--- a/src/rust/cxx/kj-rs-io/net.rs
+++ b/src/rust/cxx/kj-rs-io/net.rs
@@ -371,23 +371,19 @@ impl TokioListener {
 // ======================================================================================
 // Bridge entry points (see lib.rs).
 
-/// Resolves a hostname via blocking `getaddrinfo` on tokio's blocking pool. A task on the loop's
-/// `LocalSet` owns the blocking `JoinHandle`, so the blocking-pool completion wakes tokio's own
-/// scheduler waker and the result comes back over a oneshot, waking the awaiting future
-/// same-thread. The kj-rs waker bridge is thread-safe, so `tokio::net::lookup_host` (whose
-/// `JoinHandle` wake lands on the caller's waker cross-thread) would also be *correct*; this
-/// shape is kept as an optimization — it keeps every bridged-waker wake on the loop thread's
-/// fast path instead of a cross-thread fulfiller hop per lookup. Same blocking `getaddrinfo`
-/// call and NSS/`/etc/hosts` parity as `lookup_host`.
+/// Resolves a hostname via blocking `getaddrinfo` on tokio's blocking pool. A task on the
+/// loop's `LocalSet` owns the blocking `JoinHandle` and forwards its result through a oneshot.
+/// Dropping the awaiting future aborts the forwarding task, and loop teardown cancels it.
+/// The blocking syscall itself cannot be interrupted. Resolution uses the same system
+/// resolver, including NSS and `/etc/hosts`, as tokio's `lookup_host`.
 async fn resolve_host(host: &str, port: u16) -> Result<Vec<SocketAddr>> {
     let host = host.to_owned();
     let (tx, rx) = tokio::sync::oneshot::channel::<std::io::Result<Vec<SocketAddr>>>();
 
-    // The forwarding task's waker is tokio's own scheduler waker (Send + Sync), so the
-    // cross-thread completion from the blocking pool terminates inside tokio's scheduler
-    // (unparking this loop), never at a rust cross-thread waker. The task forwards the result on
-    // the loop thread, waking the awaiting future same-thread. Spawned onto the loop's LocalSet
-    // (kj_rs_tokio::spawn) so it is cancelled with the loop rather than with the runtime.
+    // The blocking-pool completion wakes the LocalSet task through tokio's scheduler.
+    // That task sends the result on the loop thread; the receiver's cloned ArcWaker then
+    // fulfills its promise to schedule the bridged future. LocalSet ownership ties the
+    // forwarding task to the KJ loop's lifetime.
     let task = kj_rs_tokio::spawn(async move {
         let resolved = match tokio::task::spawn_blocking(move || {
             (host.as_str(), port)

--- a/src/rust/cxx/kj-rs-io/peer-filter.c++
+++ b/src/rust/cxx/kj-rs-io/peer-filter.c++
@@ -1,0 +1,203 @@
+// Port of KJ's kj::_::NetworkFilter (kj/async-io.c++, MIT-licensed, Sandstorm Development
+// Group and contributors) — see peer-filter.h for why this is a port rather than a reuse.
+// Behavior must be kept in lockstep with upstream KJ.
+
+#include "kj-rs-io/peer-filter.h"
+
+#include <kj/debug.h>
+
+#if _WIN32
+#include <winsock2.h>
+// windows.h (pulled in by winsock2.h) defines ERROR as a macro, which breaks KJ_LOG(ERROR).
+#include <kj/windows-sanity.h>
+#else
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+
+namespace kj_rs_io {
+namespace {
+
+using kj::CidrRange;
+
+kj::ArrayPtr<const CidrRange> localCidrs() {
+  static const CidrRange result[] = {
+    // localhost
+    "127.0.0.0/8"_kj,
+    "::1/128"_kj,
+
+    // Trying to *connect* to 0.0.0.0 on many systems is equivalent to connecting to
+    // localhost. (wat)
+    "0.0.0.0/32"_kj,
+    "::/128"_kj,
+  };
+  return kj::arrayPtr(result, kj::size(result));
+}
+
+kj::ArrayPtr<const CidrRange> privateCidrs() {
+  static const CidrRange result[] = {
+    "10.0.0.0/8"_kj,      // RFC1918 reserved for internal network
+    "100.64.0.0/10"_kj,   // RFC6598 "shared address space" for carrier-grade NAT
+    "169.254.0.0/16"_kj,  // RFC3927 "link local" (auto-configured LAN in absence of DHCP)
+    "172.16.0.0/12"_kj,   // RFC1918 reserved for internal network
+    "192.168.0.0/16"_kj,  // RFC1918 reserved for internal network
+
+    "fc00::/7"_kj,   // RFC4193 unique private network
+    "fe80::/10"_kj,  // RFC4291 "link local" (auto-configured LAN in absence of DHCP)
+  };
+  return kj::arrayPtr(result, kj::size(result));
+}
+
+kj::ArrayPtr<const CidrRange> reservedCidrs() {
+  // Address ranges reserved by RFCs for specific alternative protocols. These are not
+  // considered part of "public", "private", "network", nor "local". But, we will allow apps to
+  // explicitly allowlist CIDRs in this range if they really want, because some people actually
+  // use these ranges as if they were private ranges.
+  static const CidrRange result[] = {
+    "192.0.0.0/24"_kj,        // RFC6890 reserved for special protocols
+    "224.0.0.0/4"_kj,         // RFC1112 multicast
+    "240.0.0.0/4"_kj,         // RFC1112 multicast / reserved for future use
+    "255.255.255.255/32"_kj,  // RFC0919 broadcast address
+
+    "2001::/23"_kj,  // RFC2928 reserved for special protocols
+    "ff00::/8"_kj,   // RFC4291 multicast
+  };
+  return kj::arrayPtr(result, kj::size(result));
+}
+
+bool matchesAny(kj::ArrayPtr<const CidrRange> cidrs, const struct sockaddr *addr) {
+  for (auto &cidr: cidrs) {
+    if (cidr.matches(addr)) return true;
+  }
+  return false;
+}
+
+#if !_WIN32
+// sockaddr_un::sun_path is not required to have a NUL terminator, so it must be read carefully.
+kj::ArrayPtr<const char> safeUnixPath(const struct sockaddr_un *addr, kj::uint addrlen) {
+  KJ_REQUIRE(addr->sun_family == AF_UNIX, "not a unix address");
+  KJ_REQUIRE(addrlen >= offsetof(sockaddr_un, sun_path), "invalid unix address");
+
+  size_t maxPathlen = addrlen - offsetof(sockaddr_un, sun_path);
+
+  size_t pathlen;
+  if (maxPathlen > 0 && addr->sun_path[0] == '\0') {
+    // Linux "abstract" unix address
+    pathlen = strnlen(addr->sun_path + 1, maxPathlen - 1) + 1;
+  } else {
+    pathlen = strnlen(addr->sun_path, maxPathlen);
+  }
+  return kj::arrayPtr(addr->sun_path, pathlen);
+}
+#endif  // !_WIN32
+
+}  // namespace
+
+PeerFilter::PeerFilter(): allowUnix(true), allowAbstractUnix(true) {
+  allowCidrs.add(CidrRange::inet4({0, 0, 0, 0}, 0));
+  allowCidrs.add(CidrRange::inet6({}, {}, 0));
+}
+
+PeerFilter::PeerFilter(kj::ArrayPtr<const kj::StringPtr> allow,
+    kj::ArrayPtr<const kj::StringPtr> deny,
+    kj::Rc<PeerFilter> next)
+    : allowUnix(false),
+      allowAbstractUnix(false),
+      next(kj::mv(next)) {
+  for (auto rule: allow) {
+    if (rule == "local") {
+      allowCidrs.addAll(localCidrs());
+    } else if (rule == "network") {
+      // Can't be represented as a simple union of CIDRs, so we handle in shouldAllow().
+      allowNetwork = true;
+    } else if (rule == "private") {
+      allowCidrs.addAll(privateCidrs());
+      allowCidrs.addAll(localCidrs());
+    } else if (rule == "public") {
+      // Can't be represented as a simple union of CIDRs, so we handle in shouldAllow().
+      allowPublic = true;
+    } else if (rule == "unix") {
+      allowUnix = true;
+    } else if (rule == "unix-abstract") {
+      allowAbstractUnix = true;
+    } else {
+      allowCidrs.add(CidrRange(rule));
+    }
+  }
+
+  for (auto rule: deny) {
+    if (rule == "local") {
+      denyCidrs.addAll(localCidrs());
+    } else if (rule == "network") {
+      KJ_FAIL_REQUIRE("don't deny 'network', allow 'local' instead");
+    } else if (rule == "private") {
+      denyCidrs.addAll(privateCidrs());
+    } else if (rule == "public") {
+      // Tricky: What if we allow 'network' and deny 'public'?
+      KJ_FAIL_REQUIRE("don't deny 'public', allow 'private' instead");
+    } else if (rule == "unix") {
+      allowUnix = false;
+    } else if (rule == "unix-abstract") {
+      allowAbstractUnix = false;
+    } else {
+      denyCidrs.add(CidrRange(rule));
+    }
+  }
+}
+
+bool PeerFilter::shouldAllow(const struct sockaddr *addr, kj::uint addrlen) {
+  KJ_REQUIRE(addrlen >= sizeof(addr->sa_family));
+
+#if !_WIN32
+  if (addr->sa_family == AF_UNIX) {
+    auto path = safeUnixPath(reinterpret_cast<const struct sockaddr_un *>(addr), addrlen);
+    if (path.size() > 0 && path[0] == '\0') {
+      return allowAbstractUnix;
+    } else {
+      return allowUnix;
+    }
+  }
+#endif
+
+  bool allowed = false;
+  kj::uint allowSpecificity = 0;
+
+  if (allowPublic) {
+    if ((addr->sa_family == AF_INET || addr->sa_family == AF_INET6) &&
+        !matchesAny(privateCidrs(), addr) && !matchesAny(localCidrs(), addr) &&
+        !matchesAny(reservedCidrs(), addr)) {
+      allowed = true;
+      // Don't adjust allowSpecificity as this match has an effective specificity of zero.
+    }
+  }
+
+  if (allowNetwork) {
+    if ((addr->sa_family == AF_INET || addr->sa_family == AF_INET6) &&
+        !matchesAny(localCidrs(), addr) && !matchesAny(reservedCidrs(), addr)) {
+      allowed = true;
+      // Don't adjust allowSpecificity as this match has an effective specificity of zero.
+    }
+  }
+
+  for (auto &cidr: allowCidrs) {
+    if (cidr.matches(addr)) {
+      allowSpecificity = kj::max(allowSpecificity, cidr.getSpecificity());
+      allowed = true;
+    }
+  }
+  if (!allowed) return false;
+  for (auto &cidr: denyCidrs) {
+    if (cidr.matches(addr)) {
+      if (cidr.getSpecificity() >= allowSpecificity) return false;
+    }
+  }
+
+  KJ_IF_SOME(n, next) {
+    return n->shouldAllow(addr, addrlen);
+  } else {
+    return true;
+  }
+}
+
+}  // namespace kj_rs_io

--- a/src/rust/cxx/kj-rs-io/peer-filter.c++
+++ b/src/rust/cxx/kj-rs-io/peer-filter.c++
@@ -132,6 +132,8 @@ PeerFilter::PeerFilter(kj::ArrayPtr<const kj::StringPtr> allow,
     } else if (rule == "network") {
       KJ_FAIL_REQUIRE("don't deny 'network', allow 'local' instead");
     } else if (rule == "private") {
+      // KJ treats local addresses as a separate deny category even though its "private" allow
+      // category includes them. Keep that distinction so this port remains policy-compatible.
       denyCidrs.addAll(privateCidrs());
     } else if (rule == "public") {
       // Tricky: What if we allow 'network' and deny 'public'?

--- a/src/rust/cxx/kj-rs-io/peer-filter.c++
+++ b/src/rust/cxx/kj-rs-io/peer-filter.c++
@@ -152,11 +152,12 @@ bool PeerFilter::shouldAllow(const struct sockaddr *addr, kj::uint addrlen) {
 #if !_WIN32
   if (addr->sa_family == AF_UNIX) {
     auto path = safeUnixPath(reinterpret_cast<const struct sockaddr_un *>(addr), addrlen);
-    if (path.size() > 0 && path[0] == '\0') {
-      return allowAbstractUnix;
-    } else {
-      return allowUnix;
+    bool allowed = path.size() > 0 && path[0] == '\0' ? allowAbstractUnix : allowUnix;
+    if (!allowed) return false;
+    KJ_IF_SOME(n, next) {
+      return n->shouldAllow(addr, addrlen);
     }
+    return true;
   }
 #endif
 

--- a/src/rust/cxx/kj-rs-io/peer-filter.h
+++ b/src/rust/cxx/kj-rs-io/peer-filter.h
@@ -1,0 +1,55 @@
+#pragma once
+// PeerFilter: a faithful port of KJ's kj::_::NetworkFilter (kj/async-io.c++), backing
+// kj-rs-io's Network::restrictPeers() support.
+//
+// Ported rather than reused because kj::_::NetworkFilter lives in KJ's internal header
+// (kj/async-io-internal.h), whose quoted includes ("vector.h") only resolve inside the KJ
+// source tree — it is not includable through Bazel's virtual include dirs. The allow/deny
+// grammar ("public"/"private"/"local"/"network"/"unix"/"unix-abstract"/CIDRs), the RFC CIDR
+// tables, the specificity tie-breaking between allow and deny rules, and the filter-chaining
+// semantics are kept identical so restrictPeers() behaves exactly like kj::setupAsyncIo()'s
+// networks. kj::CidrRange itself IS reused (kj/cidr.h is a clean public header).
+
+#include <kj/async-io.h>
+#include <kj/cidr.h>
+#include <kj/refcount.h>
+#include <kj/vector.h>
+
+namespace kj_rs_io {
+
+class PeerFilter final: public kj::LowLevelAsyncIoProvider::NetworkFilter, public kj::Refcounted {
+ public:
+  // Allow-everything filter (matches KJ's root networks).
+  PeerFilter();
+
+  // Restriction layered on `next`, which the new filter OWNS: a restrictPeers() chain keeps its
+  // parent filters alive, so there is no outlive-me contract between networks. Grammar identical
+  // to kj::Network::restrictPeers().
+  PeerFilter(kj::ArrayPtr<const kj::StringPtr> allow,
+      kj::ArrayPtr<const kj::StringPtr> deny,
+      kj::Rc<PeerFilter> next);
+
+  // Read-only despite the non-const signature: this override matches
+  // kj::LowLevelAsyncIoProvider::NetworkFilter::shouldAllow (declared non-const upstream), but the
+  // implementation only *reads* the CIDR tables / flags and recurses into `next` — it mutates no
+  // member and has no interior mutability, so concurrent callers sharing a filter are safe. Keep
+  // it read-only.
+  bool shouldAllow(const struct sockaddr *addr, kj::uint addrlen) override;
+
+  // Refcounted (always created via kj::rc<PeerFilter>()) and immobile: every holder — networks,
+  // addresses, receivers, derived filters' `next` — shares ownership via kj::Rc, so a filter can
+  // never be destroyed or moved out from under its chain.
+  KJ_DISALLOW_COPY_AND_MOVE(PeerFilter);
+
+ private:
+  kj::Vector<kj::CidrRange> allowCidrs;
+  kj::Vector<kj::CidrRange> denyCidrs;
+  bool allowUnix;
+  bool allowAbstractUnix;
+  bool allowPublic = false;
+  bool allowNetwork = false;
+
+  kj::Maybe<kj::Rc<PeerFilter>> next;
+};
+
+}  // namespace kj_rs_io

--- a/src/rust/cxx/kj-rs-io/readiness.rs
+++ b/src/rust/cxx/kj-rs-io/readiness.rs
@@ -1,0 +1,94 @@
+//! tokio-backed fd readiness watching.
+//!
+//! This backs `kj_rs_io::FileWatcher` (file-watcher.h), the tokio-loop replacement for
+//! workerd's `--watch` file watcher. The C++ side owns the platform notification fd (inotify on
+//! Linux, kqueue on macOS/BSD) and does all the event parsing; the Rust side only supplies
+//! "resolve when this fd becomes readable", replacing
+//! `kj::UnixEventPort::FdObserver::whenBecomesReadable()`.
+//!
+//! Ownership: a [`TokioFdWatcher`] owns its own `dup(2)` of the notification fd and ONE
+//! registration of it with the tokio I/O driver, created when the C++ `FileWatcher::Impl` is
+//! constructed and released when it is destroyed. Nothing about the original fd is borrowed past
+//! the constructor call, and C++ never has to keep an fd open for a pending promise or avoid
+//! registering it twice -- the two contracts the previous borrowed-raw-fd design left to
+//! comments.
+//!
+//! Semantics of [`TokioFdWatcher::readable`]:
+//!
+//! - Readiness that already exists when it is called is reported immediately (both epoll and
+//!   kqueue report existing readiness at registration; tokio remembers it thereafter).
+//! - The wake consumes tokio's cached readiness (`clear_ready`) BEFORE resolving, so after C++
+//!   drains the fd (via the original) the next call sleeps until a genuinely new event. An
+//!   event that lands between the clear and the drain is drained, and costs at most one
+//!   spurious wake later (C++'s read then sees EAGAIN and calls again) -- never a lost wake
+//!   and never a busy loop.
+//! - Dropping a pending future just removes its waker; the registration stays.
+
+use crate::error::Result;
+
+/// See the module docs. Unix only; on other platforms construction fails.
+pub struct TokioFdWatcher {
+    #[cfg(unix)]
+    afd: tokio::io::unix::AsyncFd<std::os::fd::OwnedFd>,
+}
+
+/// Creates a watcher for `fd`, which is borrowed only for the duration of this call.
+///
+/// # Errors
+///
+/// Fails if the fd cannot be duplicated or registered with the loop runtime's I/O driver, or on
+/// non-Unix platforms.
+pub fn new_fd_watcher(fd: i32) -> Result<Box<TokioFdWatcher>> {
+    #[cfg(unix)]
+    {
+        use tokio::io::Interest;
+        use tokio::io::unix::AsyncFd;
+
+        use crate::error::op;
+        // The caller (C++ FileWatcher::Impl) owns `fd` and it is open for this call; we keep
+        // only the dup (see `dup_raw_fd`).
+        let owned = crate::ffi::dup_raw_fd(fd)?;
+        crate::runtime::require_loop_runtime()?;
+        let afd = AsyncFd::with_interest(owned, Interest::READABLE).map_err(op("AsyncFd"))?;
+        Ok(Box::new(TokioFdWatcher { afd }))
+    }
+    #[cfg(not(unix))]
+    {
+        use crate::error::KjIoError;
+        let _ = fd;
+        Err(KjIoError::other(
+            "new_fd_watcher",
+            "kj-rs-io fd readiness watching is only implemented on Unix",
+        ))
+    }
+}
+
+impl TokioFdWatcher {
+    /// Resolves when the watched fd becomes readable. See the module docs for the exact
+    /// semantics.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the I/O driver reports an error for the fd, or on non-Unix platforms.
+    pub async fn readable(&self) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use crate::error::op;
+            use crate::runtime::on_loop_runtime;
+            on_loop_runtime(async {
+                let mut guard = self.afd.readable().await.map_err(op("readable"))?;
+                guard.clear_ready();
+                Ok(())
+            })
+            .await
+        }
+        #[cfg(not(unix))]
+        {
+            use crate::error::KjIoError;
+            Err(KjIoError::other(
+                "readable",
+                "kj-rs-io fd readiness watching is only implemented on Unix",
+            ))
+        }
+    }
+}

--- a/src/rust/cxx/kj-rs-io/runtime.rs
+++ b/src/rust/cxx/kj-rs-io/runtime.rs
@@ -1,0 +1,61 @@
+//! Loop-runtime precondition: every kj-rs-io operation runs on a thread owning a
+//! `kj_rs_tokio::TokioEventPort`, whose tokio runtime context that thread is permanently inside
+//! (see `kj_rs_tokio`'s `EnteredRuntime`). tokio resources therefore register with the loop's
+//! I/O driver and timers without any per-call `Handle::enter()`; the only thing left to do here
+//! is turn "no port on this thread" into a `kj::Exception` with a useful message instead of the
+//! panic tokio would raise.
+
+use std::future::Future;
+
+use crate::error::KjIoError;
+use crate::error::Result;
+
+/// Errors (`kj::Exception`-convertible) unless this thread owns a `TokioEventPort`.
+pub fn require_loop_runtime() -> Result<()> {
+    if kj_rs_tokio::current_handle().is_some() {
+        Ok(())
+    } else {
+        Err(KjIoError::other(
+            "kj_rs_io",
+            "no kj-rs-tokio runtime on this thread; kj-rs-io requires a TokioEventPort \
+             (see kj_rs_io::setupTokioAsyncIo())",
+        ))
+    }
+}
+
+/// Aborts the wrapped tokio task when dropped. Used by the "task forwards a result over a
+/// oneshot" pattern (see `net.rs::resolve_host`): if the awaiting bridged future is dropped (KJ
+/// promise cancelled), the forwarding task is aborted instead of lingering until its underlying
+/// operation completes on its own.
+pub struct AbortOnDrop(pub tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Runs `fut` after checking the loop-runtime precondition (the check happens once, when the
+/// future is first polled -- not per poll).
+pub async fn on_loop_runtime<T>(fut: impl Future<Output = Result<T>>) -> Result<T> {
+    require_loop_runtime()?;
+    fut.await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_loop_runtime_errors_without_a_port() {
+        // A thread with no TokioEventPort has no loop runtime; the precondition must be a
+        // kj::Exception-convertible error naming it, not a tokio panic.
+        let err = cxx::KjError::from(require_loop_runtime().unwrap_err());
+        assert!(
+            err.description()
+                .contains("no kj-rs-tokio runtime on this thread"),
+            "{}",
+            err.description()
+        );
+    }
+}

--- a/src/rust/cxx/kj-rs-io/serve.rs
+++ b/src/rust/cxx/kj-rs-io/serve.rs
@@ -1,0 +1,459 @@
+//! The native-serve entry points: give a Rust server (any tokio consumer) the
+//! best-available tokio-side byte stream for an owned `kj::AsyncIoStream`.
+//!
+//! Three tiers, two entry points:
+//! (1) kj-rs-io-originated streams give up their native tokio socket (the hollow
+//! wrapper is destroyed); (2) [`take_kj_socket`] only — a foreign fd-backed stream's fd is
+//! duplicated into a fresh tokio socket; (3) [`serve_kj_stream`] only — any other foreign
+//! stream is bridged through an in-memory duplex plus a pump future that owns it. Ownership
+//! arrives as a [`KjOwn`], so both entry points are safe functions: there is no
+//! keep-it-alive caller contract, and the stream is destroyed by the tier that consumed it.
+//! See the two entry points' docs for the remaining semantics, in particular why the fd tier
+//! is caller-asserted and never automatic.
+//!
+//! # Pump semantics (matching the hand-built pumps this subsumes)
+//!
+//! - Bidirectional; each direction ends independently.
+//! - Half-close propagates both ways: kj-side EOF shuts down the duplex write half (the tokio
+//!   consumer reads EOF); the consumer shutting down (or dropping) its duplex end results in
+//!   `shutdownWrite()` on the kj stream.
+//! - Peer-teardown-shaped kj failures (DISCONNECTED reads/writes) are treated as normal EOF,
+//!   not errors — abrupt client disconnects are normal server load.
+//! - Dropping the pump future cancels the in-flight bridged kj promises synchronously, drops
+//!   the kj-side duplex end (the tokio consumer observes EOF), and destroys the owned kj
+//!   stream — the peer observes teardown, not a zombie half-open connection (abort-on-drop).
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+use cxx::KjError;
+use cxx::KjException;
+use cxx::KjExceptionType;
+use kj_rs::KjOwn;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+use tokio::io::DuplexStream;
+use tokio::io::ReadBuf;
+use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::UnixStream;
+
+use crate::ffi::KjAsyncIoStream;
+#[cfg(unix)]
+use crate::ffi::dup_raw_fd;
+#[cfg(unix)]
+use crate::ffi::kj_stream_get_handle;
+use crate::ffi::split_kj_stream;
+use crate::ffi::unwrap_tokio_stream;
+
+/// Read chunk size for the pump fallback.
+const PUMP_BUF: usize = 8192;
+
+/// In-memory buffer per direction of the pump's duplex (how far the two sides may run ahead
+/// of each other before backpressure).
+pub(crate) const DUPLEX_CAPACITY: usize = 4 * PUMP_BUF;
+
+/// Which transport path [`serve_kj_stream`] produced (perf observability: `Pumped` costs FFI
+/// promise round-trips per buffer, `Native` costs none).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServePath {
+    /// A native tokio socket (unwrap fast path).
+    Native,
+    /// An in-memory duplex fed by the FFI stream pump.
+    Pumped,
+}
+
+impl std::fmt::Display for ServePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Native => "native",
+            Self::Pumped => "pumped",
+        })
+    }
+}
+
+/// The tokio-side byte stream for a served kj stream: a native socket or the consumer end of
+/// the pump's duplex.
+///
+/// Implements `AsyncRead + AsyncWrite`, so it drops into any tokio consumer, on any runtime
+/// thread -- see [`ServedKjStream::io`] for the (performance, not soundness) note on driving
+/// `Duplex` off the KJ event-loop thread.
+pub enum ServeIo {
+    Tcp(TcpStream),
+    #[cfg(unix)]
+    Unix(UnixStream),
+    Duplex(DuplexStream),
+}
+
+impl ServeIo {
+    /// Which transport path this stream is on (see [`ServePath`]).
+    #[must_use]
+    pub fn path(&self) -> ServePath {
+        match self {
+            Self::Tcp(_) => ServePath::Native,
+            #[cfg(unix)]
+            Self::Unix(_) => ServePath::Native,
+            Self::Duplex(_) => ServePath::Pumped,
+        }
+    }
+
+    /// Sets `TCP_NODELAY` on the underlying socket where applicable (a no-op for Unix-domain
+    /// and duplex transports, which have no Nagle to disable).
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying `std::io::Error` if setting the socket option fails.
+    pub fn set_nodelay(&self, nodelay: bool) -> std::io::Result<()> {
+        match self {
+            Self::Tcp(s) => s.set_nodelay(nodelay),
+            #[cfg(unix)]
+            Self::Unix(_) => Ok(()),
+            Self::Duplex(_) => Ok(()),
+        }
+    }
+}
+
+impl AsyncRead for ServeIo {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Self::Tcp(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(unix)]
+            Self::Unix(s) => Pin::new(s).poll_read(cx, buf),
+            Self::Duplex(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for ServeIo {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            Self::Tcp(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(unix)]
+            Self::Unix(s) => Pin::new(s).poll_write(cx, buf),
+            Self::Duplex(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Self::Tcp(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(unix)]
+            Self::Unix(s) => Pin::new(s).poll_flush(cx),
+            Self::Duplex(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Self::Tcp(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(unix)]
+            Self::Unix(s) => Pin::new(s).poll_shutdown(cx),
+            Self::Duplex(s) => Pin::new(s).poll_shutdown(cx),
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            Self::Tcp(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            #[cfg(unix)]
+            Self::Unix(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            Self::Duplex(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        match self {
+            Self::Tcp(s) => s.is_write_vectored(),
+            #[cfg(unix)]
+            Self::Unix(s) => s.is_write_vectored(),
+            Self::Duplex(s) => s.is_write_vectored(),
+        }
+    }
+}
+
+/// The KJ-side pump future of the fallback path.
+///
+/// Not `Send`: it awaits bridged `kj::Promise`s and must be polled on the KJ event-loop thread
+/// owning the stream. Resolves when both directions are done; dropping it aborts the
+/// connection bridge (see the module docs).
+pub type StreamPump = Pin<Box<dyn Future<Output = Result<(), KjError>>>>;
+
+/// The result of [`serve_kj_stream`].
+pub struct ServedKjStream {
+    /// The tokio-side stream.
+    ///
+    /// Thread affinity: every variant may be handed to a connection task on any runtime thread.
+    /// The NATIVE variants (`Tcp`/`Unix`) stay registered with the I/O driver that created them
+    /// (for kj-rs-io streams, this thread's KJ-loop runtime) and wake their consumer via
+    /// tokio's own task waker. The [`ServeIo::Duplex`] variant's peer end lives inside `pump`,
+    /// which is polled as a bridged future, so the waker parked in the duplex's internal waker
+    /// slots is a `kj_rs` `FutureWakerCell` clone -- atomically refcounted and honoring the full
+    /// `Waker: Send + Sync` contract: a read/write/drop of the duplex from another thread wakes
+    /// the pump through the cell's cross-thread fulfiller. That hop is a bit more expensive
+    /// than a same-thread wake, so co-locating a `Duplex` consumer with the KJ event-loop
+    /// thread is a performance recommendation (check [`ServedKjStream::path`]), not a
+    /// soundness requirement.
+    pub io: ServeIo,
+    /// Present iff `io` is [`ServeIo::Duplex`]: the pump that actually moves the bytes, owning
+    /// the kj stream it bridges. The caller must poll it on the KJ event-loop thread until it
+    /// settles or is dropped; dropping it destroys the stream (see the module docs).
+    pub pump: Option<StreamPump>,
+}
+
+impl ServedKjStream {
+    /// Which transport path was taken (see [`ServePath`]).
+    #[must_use]
+    pub fn path(&self) -> ServePath {
+        self.io.path()
+    }
+}
+
+// =======================================================================================
+// Entry points
+
+/// [`take_kj_socket`]'s error: the failure, plus the untouched stream handed back so the
+/// caller can fall back to [`serve_kj_stream`]'s pump tier (or destroy it).
+pub struct TakeSocketError {
+    /// The stream `take_kj_socket` consumed, returned untouched.
+    pub stream: KjOwn<KjAsyncIoStream>,
+    /// Why the socket could not be taken natively.
+    pub error: KjError,
+}
+
+impl std::fmt::Debug for TakeSocketError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TakeSocketError")
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for TakeSocketError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.error)
+    }
+}
+
+/// Drops the handed-back stream (on the current — KJ event-loop — thread) and keeps the error.
+impl From<TakeSocketError> for KjError {
+    fn from(e: TakeSocketError) -> Self {
+        e.error
+    }
+}
+
+/// Tier-1 unwrap: if the owned stream is kj-rs-io-originated, moves its native tokio socket
+/// out (leaving the C++ wrapper hollow) and returns it. `None` for a foreign stream.
+fn unwrap_native(stream: &mut KjOwn<KjAsyncIoStream>) -> Option<ServeIo> {
+    unwrap_tokio_stream(stream.as_mut())
+        .ok()
+        .and_then(|native| native.into_serve_io())
+}
+
+/// Takes the stream's socket natively (tiers 1 + 2).
+///
+/// Tier 1 moves the native tokio object out of a kj-rs-io stream; tier 2 — unix only —
+/// duplicates the stream's OS fd (`F_DUPFD_CLOEXEC`, forced non-blocking) into a fresh tokio
+/// socket. Either way the result is an owned, KJ-independent [`ServeIo`] (never
+/// [`ServeIo::Duplex`]) and the consumed kj stream is destroyed before returning.
+///
+/// The handle tier (tier 2) is `cfg(unix)`: under the all-rust mode on Windows every
+/// socket-backed stream originates in kj-rs-io, so tier 1 always applies and a windows dup arm
+/// would be dead code (see `dup_raw_fd`'s docs for the analysis and the
+/// `BorrowedSocket::try_clone_to_owned` escape hatch should that ever change).
+///
+/// The caller asserts the stream is a **plain stream socket**: if it exposes an fd, that fd
+/// carries the stream's own bytes. Byte-transforming wrappers (TLS — `kj::TlsConnection`
+/// forwards `getFd()` to the ciphertext transport socket) violate this and must go through
+/// [`serve_kj_stream`] instead. As with destroying any kj stream, no I/O promises may be
+/// outstanding on it when ownership is handed over (for kj-rs-io streams the unwrap detects
+/// and rejects that; for foreign streams it remains KJ's own contract).
+///
+/// # Errors
+///
+/// Errors when the stream is neither kj-rs-io native nor fd-backed (in-memory pipes, promised
+/// streams, non-Unix platforms' foreign streams): such transports can only be served through
+/// [`serve_kj_stream`]'s pump tier — the error hands the stream back for exactly that
+/// fallback. Also errors if the dup or tokio registration fails.
+pub fn take_kj_socket(
+    stream: KjOwn<KjAsyncIoStream>,
+) -> std::result::Result<ServeIo, TakeSocketError> {
+    let mut stream = stream;
+    if let Some(io) = unwrap_native(&mut stream) {
+        // Tier 1: the wrapper is hollow; destroy it now.
+        drop(stream);
+        return Ok(io);
+    }
+    #[cfg(unix)]
+    {
+        let handle = kj_stream_get_handle(&stream);
+        if handle >= 0 {
+            // A unix fd is a non-negative int, widened losslessly to i64 by the bridge.
+            #[expect(clippy::cast_possible_truncation)]
+            let fd = handle as i32;
+            let result = dup_raw_fd(fd)
+                .map_err(KjError::from)
+                .and_then(|owned| crate::net::serve_io_from_owned_fd(owned).map_err(KjError::from));
+            return match result {
+                Ok(io) => {
+                    // Tier 2: the dup is independent; the original stream (and its fd) can go.
+                    drop(stream);
+                    Ok(io)
+                }
+                Err(error) => Err(TakeSocketError { stream, error }),
+            };
+        }
+    }
+    Err(TakeSocketError {
+        stream,
+        error: KjError::new(
+            KjExceptionType::Failed,
+            "cannot take the stream's socket natively: not a kj-rs-io stream and no underlying \
+             OS fd (foreign non-socket transport; serve it through serve_kj_stream's pump instead)"
+                .to_owned(),
+        ),
+    })
+}
+
+/// Yields the best-available tokio-side stream for the owned `stream`.
+///
+/// That is the native tokio object when `stream` originated in kj-rs-io, else an in-memory
+/// duplex bridged by a pump future that owns the stream. Never extracts a foreign stream's fd
+/// — kj wrappers forward `getFd()` to their transport socket, so a byte-transforming wrapper's
+/// fd carries the wrong bytes (TLS ciphertext); callers that can assert a plain socket should
+/// prefer [`take_kj_socket`].
+///
+/// On the native path the hollow wrapper is destroyed before returning; on the pump path the
+/// stream lives inside the pump and is destroyed when the pump settles or is dropped. The pump
+/// must only be polled from the KJ event-loop thread owning the stream. As with destroying any
+/// kj stream, no I/O promises may be outstanding on it when ownership is handed over (for
+/// kj-rs-io streams the unwrap detects and rejects that; for foreign streams it remains KJ's
+/// own contract).
+#[must_use]
+pub fn serve_kj_stream(stream: KjOwn<KjAsyncIoStream>) -> ServedKjStream {
+    let mut stream = stream;
+    if let Some(io) = unwrap_native(&mut stream) {
+        // Native path: the wrapper is hollow; destroy it now.
+        drop(stream);
+        return ServedKjStream { io, pump: None };
+    }
+
+    // Foreign stream (or, pathologically, an already-hollow wrapper, whose pump reads will
+    // surface the "already unwrapped" error): bridge through a duplex pump owning the stream.
+    let (consumer_end, kj_end) = tokio::io::duplex(DUPLEX_CAPACITY);
+    let pump = Box::pin(pump_kj_stream(stream, kj_end));
+    ServedKjStream {
+        io: ServeIo::Duplex(consumer_end),
+        pump: Some(pump),
+    }
+}
+
+/// Whether a bridged kj exception is peer-teardown-shaped (treated as EOF by the pump).
+fn is_disconnected(exception: &KjException) -> bool {
+    exception.r#type() == KjExceptionType::Disconnected
+}
+
+/// The duplex pump: bridges the owned `stream` (via bridged `kj::io` promises, on the calling
+/// KJ thread) to `kj_end`, the pump-side end of the consumer's duplex. Owns the stream: it is
+/// destroyed when this future settles or is dropped.
+///
+/// Unsafe-free and compiler-checked end to end: the stream is split into typed read/write
+/// halves ([`split_kj_stream`]), so the borrow checker enforces kj's stream contract — at most
+/// one read and one write in flight, nothing else touching the stream while the halves live —
+/// and proves the owner outlives every in-flight bridged promise.
+pub(crate) async fn pump_kj_stream(
+    mut stream: KjOwn<KjAsyncIoStream>,
+    kj_end: DuplexStream,
+) -> Result<(), KjError> {
+    let (mut rd, mut wr) = split_kj_stream(&mut stream);
+    let (mut from_consumer, mut to_consumer) = tokio::io::split(kj_end);
+
+    // kj stream -> consumer. Ends (shutting down the duplex write half, i.e. EOF to the
+    // consumer) at kj-side EOF — or when the peer disconnects abruptly (DISCONNECTED read
+    // failures are normal client behavior, treated as EOF).
+    let kj_to_consumer = async {
+        let mut buf = vec![0u8; PUMP_BUF];
+        loop {
+            let n = match rd.try_read(&mut buf, 1).await {
+                Ok(n) => n,
+                Err(e) if is_disconnected(&e) => 0,
+                Err(e) => return Err(KjError::from(e)),
+            };
+            if n == 0 {
+                let _ = to_consumer.shutdown().await;
+                return Ok::<(), KjError>(());
+            }
+            if to_consumer.write_all(&buf[..n]).await.is_err() {
+                // The consumer dropped its duplex end: the connection was abandoned
+                // deliberately; nothing more to deliver in this direction.
+                return Ok(());
+            }
+        }
+    };
+
+    // consumer -> kj stream. Ends (with a kj-side shutdownWrite) when the consumer shuts
+    // down or drops its end — or, without an error, when the kj peer already went away (a
+    // DISCONNECTED write failure: the consumer's remaining output has nowhere to go).
+    let consumer_to_kj = async {
+        let mut buf = vec![0u8; PUMP_BUF];
+        loop {
+            let n = match from_consumer.read(&mut buf).await {
+                // Duplex reads only fail if the consumer end vanished ungracefully; either
+                // way this direction is over.
+                Ok(0) | Err(_) => 0,
+                Ok(n) => n,
+            };
+            if n == 0 {
+                // The consumer is done writing: half-close the kj side. A peer that already
+                // vanished (DISCONNECTED) is the same outcome for this direction.
+                match wr.shutdown_write() {
+                    Ok(()) => {}
+                    Err(e) if is_disconnected(&e) => {}
+                    Err(e) => return Err(KjError::from(e)),
+                }
+                return Ok::<(), KjError>(());
+            }
+            match wr.write(&buf[..n]).await {
+                Ok(()) => {}
+                Err(e) if is_disconnected(&e) => return Ok(()),
+                Err(e) => return Err(KjError::from(e)),
+            }
+        }
+    };
+
+    tokio::try_join!(kj_to_consumer, consumer_to_kj).map(|((), ())| ())
+}
+
+#[cfg(test)]
+mod send_guards {
+    use static_assertions::assert_impl_all;
+    use static_assertions::assert_not_impl_any;
+
+    use super::*;
+
+    // The pump awaits bridged kj::Promises and owns a KjOwn: it must be polled on the KJ
+    // event-loop thread, which the type system enforces only while this stays true.
+    assert_not_impl_any!(StreamPump: Send, Sync);
+
+    // The consumer-side stream may be handed to a connection task on any runtime thread
+    // (native variants: tokio's own wakers; Duplex: the thread-safe kj-rs waker cell).
+    assert_impl_all!(ServeIo: Send);
+
+    // Hands a KjOwn back to the caller: a KJ object, single-loop, never Send.
+    assert_not_impl_any!(TakeSocketError: Send, Sync);
+}

--- a/src/rust/cxx/kj-rs-io/serve.rs
+++ b/src/rust/cxx/kj-rs-io/serve.rs
@@ -321,7 +321,15 @@ pub fn take_kj_socket(
     }
     #[cfg(unix)]
     {
-        let handle = kj_stream_get_handle(&stream);
+        let handle = match kj_stream_get_handle(&stream) {
+            Ok(handle) => handle,
+            Err(error) => {
+                return Err(TakeSocketError {
+                    stream,
+                    error: KjError::from(error),
+                });
+            }
+        };
         if handle >= 0 {
             // A unix fd is a non-negative int, widened losslessly to i64 by the bridge.
             #[expect(clippy::cast_possible_truncation)]

--- a/src/rust/cxx/kj-rs-io/serve.rs
+++ b/src/rust/cxx/kj-rs-io/serve.rs
@@ -200,16 +200,12 @@ pub struct ServedKjStream {
     /// The tokio-side stream.
     ///
     /// Thread affinity: every variant may be handed to a connection task on any runtime thread.
-    /// The NATIVE variants (`Tcp`/`Unix`) stay registered with the I/O driver that created them
-    /// (for kj-rs-io streams, this thread's KJ-loop runtime) and wake their consumer via
-    /// tokio's own task waker. The [`ServeIo::Duplex`] variant's peer end lives inside `pump`,
-    /// which is polled as a bridged future, so the waker parked in the duplex's internal waker
-    /// slots is a `kj_rs` `FutureWakerCell` clone -- atomically refcounted and honoring the full
-    /// `Waker: Send + Sync` contract: a read/write/drop of the duplex from another thread wakes
-    /// the pump through the cell's cross-thread fulfiller. That hop is a bit more expensive
-    /// than a same-thread wake, so co-locating a `Duplex` consumer with the KJ event-loop
-    /// thread is a performance recommendation (check [`ServedKjStream::path`]), not a
-    /// soundness requirement.
+    /// The native variants (`Tcp`/`Unix`) stay registered with the I/O driver that created them
+    /// and wake their consumer through tokio's task waker. The [`ServeIo::Duplex`] variant's
+    /// peer end lives inside `pump`, which is polled as a bridged future on the KJ event loop.
+    /// Its stored waker owns an atomically refcounted kj-rs `ArcWaker`; waking it fulfills a
+    /// cross-thread promise that schedules the pump on its owning KJ loop. The consumer may
+    /// therefore run on another thread while the pump and its KJ stream remain on their owner.
     pub io: ServeIo,
     /// Present iff `io` is [`ServeIo::Duplex`]: the pump that actually moves the bytes, owning
     /// the kj stream it bridges. The caller must poll it on the KJ event-loop thread until it

--- a/src/rust/cxx/kj-rs-io/serve.rs
+++ b/src/rust/cxx/kj-rs-io/serve.rs
@@ -45,6 +45,7 @@ use tokio::net::UnixStream;
 use crate::ffi::KjAsyncIoStream;
 #[cfg(unix)]
 use crate::ffi::dup_raw_fd;
+use crate::ffi::is_tokio_stream;
 #[cfg(unix)]
 use crate::ffi::kj_stream_get_handle;
 use crate::ffi::split_kj_stream;
@@ -227,10 +228,13 @@ impl ServedKjStream {
 // =======================================================================================
 // Entry points
 
-/// [`take_kj_socket`]'s error: the failure, plus the untouched stream handed back so the
-/// caller can fall back to [`serve_kj_stream`]'s pump tier (or destroy it).
+/// A native-serving error, plus the untouched stream handed back to the caller.
+///
+/// A foreign-stream error from [`take_kj_socket`] can fall back to [`serve_kj_stream`]'s pump
+/// tier. A native extraction error must not: an operation still borrows the wrapper, so the
+/// caller must cancel that operation before retrying or destroying the returned stream.
 pub struct TakeSocketError {
-    /// The stream `take_kj_socket` consumed, returned untouched.
+    /// The stream consumed by the native-serving entry point, returned untouched.
     pub stream: KjOwn<KjAsyncIoStream>,
     /// Why the socket could not be taken natively.
     pub error: KjError,
@@ -258,11 +262,23 @@ impl From<TakeSocketError> for KjError {
 }
 
 /// Tier-1 unwrap: if the owned stream is kj-rs-io-originated, moves its native tokio socket
-/// out (leaving the C++ wrapper hollow) and returns it. `None` for a foreign stream.
-fn unwrap_native(stream: &mut KjOwn<KjAsyncIoStream>) -> Option<ServeIo> {
-    unwrap_tokio_stream(stream.as_mut())
-        .ok()
-        .and_then(|native| native.into_serve_io())
+/// out (leaving the C++ wrapper hollow) and returns it. `Ok(None)` for a foreign stream. A
+/// checked extraction failure remains distinct so callers do not reuse or destroy the native
+/// wrapper while an operation still borrows it.
+fn unwrap_native(
+    stream: &mut KjOwn<KjAsyncIoStream>,
+) -> std::result::Result<Option<ServeIo>, KjError> {
+    if !is_tokio_stream(stream.as_ref()) {
+        return Ok(None);
+    }
+
+    let native = unwrap_tokio_stream(stream.as_mut()).map_err(KjError::from)?;
+    native.into_serve_io().map(Some).ok_or_else(|| {
+        KjError::new(
+            KjExceptionType::Failed,
+            "native unwrap returned a hollow stream".to_owned(),
+        )
+    })
 }
 
 /// Takes the stream's socket natively (tiers 1 + 2).
@@ -294,10 +310,14 @@ pub fn take_kj_socket(
     stream: KjOwn<KjAsyncIoStream>,
 ) -> std::result::Result<ServeIo, TakeSocketError> {
     let mut stream = stream;
-    if let Some(io) = unwrap_native(&mut stream) {
-        // Tier 1: the wrapper is hollow; destroy it now.
-        drop(stream);
-        return Ok(io);
+    match unwrap_native(&mut stream) {
+        Ok(Some(io)) => {
+            // Tier 1: the wrapper is hollow; destroy it now.
+            drop(stream);
+            return Ok(io);
+        }
+        Ok(None) => {}
+        Err(error) => return Err(TakeSocketError { stream, error }),
     }
     #[cfg(unix)]
     {
@@ -344,23 +364,33 @@ pub fn take_kj_socket(
 /// kj stream, no I/O promises may be outstanding on it when ownership is handed over (for
 /// kj-rs-io streams the unwrap detects and rejects that; for foreign streams it remains KJ's
 /// own contract).
-#[must_use]
-pub fn serve_kj_stream(stream: KjOwn<KjAsyncIoStream>) -> ServedKjStream {
+///
+/// # Errors
+///
+/// Returns the untouched stream when it is a kj-rs-io wrapper whose native socket cannot be
+/// extracted, such as while an I/O operation still borrows it.
+pub fn serve_kj_stream(
+    stream: KjOwn<KjAsyncIoStream>,
+) -> std::result::Result<ServedKjStream, TakeSocketError> {
     let mut stream = stream;
-    if let Some(io) = unwrap_native(&mut stream) {
-        // Native path: the wrapper is hollow; destroy it now.
-        drop(stream);
-        return ServedKjStream { io, pump: None };
+    match unwrap_native(&mut stream) {
+        Ok(Some(io)) => {
+            // Native path: the wrapper is hollow; destroy it now.
+            drop(stream);
+            return Ok(ServedKjStream { io, pump: None });
+        }
+        Ok(None) => {}
+        Err(error) => return Err(TakeSocketError { stream, error }),
     }
 
     // Foreign stream (or, pathologically, an already-hollow wrapper, whose pump reads will
     // surface the "already unwrapped" error): bridge through a duplex pump owning the stream.
     let (consumer_end, kj_end) = tokio::io::duplex(DUPLEX_CAPACITY);
     let pump = Box::pin(pump_kj_stream(stream, kj_end));
-    ServedKjStream {
+    Ok(ServedKjStream {
         io: ServeIo::Duplex(consumer_end),
         pump: Some(pump),
-    }
+    })
 }
 
 /// Whether a bridged kj exception is peer-teardown-shaped (treated as EOF by the pump).

--- a/src/rust/cxx/kj-rs-io/signal.rs
+++ b/src/rust/cxx/kj-rs-io/signal.rs
@@ -1,0 +1,94 @@
+//! tokio-backed signal watching: POSIX signals on Unix, the corresponding console control
+//! events on Windows.
+//!
+//! This backs `kj_rs_io::onSignal()` (async-io.h), the tokio-loop replacement for
+//! `kj::UnixEventPort::onSignal()` -- workerd uses it for SIGTERM graceful drain.
+//!
+//! Semantics differences vs `UnixEventPort::onSignal()` (acceptable for the drain use case):
+//!
+//! - No `siginfo_t` is reported; the promise just resolves.
+//! - The handler is registered when the returned future is first polled (tokio registers with
+//!   the process-global signal registry at `signal()` time), not at call time, and KJ does not
+//!   block the signal beforehand the way `UnixEventPort::captureSignal()` does. A signal
+//!   delivered before the first poll takes its default disposition.
+//! - tokio's signal registration is process-wide and persists for the life of the process
+//!   (dropping the future stops *watching*, but does not restore `SIG_DFL`).
+//!
+//! Cross-thread delivery note: tokio's signal registry is process-global, and its broadcast can
+//! run on a different thread — another runtime's loop thread on unix (whichever runtime's driver
+//! consumes the signal's wake byte, e.g. workerd's inspector thread), or the OS-spawned
+//! console-ctrl thread on Windows. That is fine: the kj-rs waker bridge is thread-safe (a
+//! cross-thread wake is delivered through the `FutureWakerCell`'s cross-thread fulfiller; see
+//! kj-rs/waker.h), so the streams are awaited directly from the bridged future here. The
+//! multi-runtime case is covered by the "onSignal is delivered even when another runtime's
+//! thread consumes the signal" test in tests/async-io-test.c++ — the scenario that, before the
+//! bridge was thread-safe, made workerd ignore SIGTERM whenever the inspector thread's runtime
+//! won the race.
+//!
+//! On Windows the signums workerd actually passes are mapped to their conventional console
+//! control events: SIGTERM -> `ctrl_shutdown`, SIGINT -> `ctrl_c`. Anything else errors.
+
+use crate::error::KjIoError;
+use crate::error::Result;
+use crate::runtime::on_loop_runtime;
+
+/// Resolves when the process receives signal `signum` (on Windows: the console control event
+/// conventionally mapped to it). Errors immediately for unmapped signums / other platforms.
+pub async fn wait_for_signal(signum: i32) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use crate::error::op;
+        on_loop_runtime(async move {
+            let kind = tokio::signal::unix::SignalKind::from_raw(signum);
+            let mut sig = tokio::signal::unix::signal(kind).map_err(op("signal"))?;
+            sig.recv()
+                .await
+                .ok_or_else(|| KjIoError::other("signal", "signal stream closed unexpectedly"))?;
+            Ok(())
+        })
+        .await
+    }
+    // Validated by Windows CI. tokio's `SetConsoleCtrlHandler` handler broadcasts from an
+    // OS-spawned console-ctrl thread; the thread-safe waker bridge absorbs that (see the module
+    // doc), so this arm awaits directly too.
+    #[cfg(windows)]
+    {
+        use crate::error::op;
+        // `<csignal>` values as the C++ callers pass them (MSVC defines SIGINT=2, SIGTERM=15).
+        // workerd's only caller passes SIGTERM (graceful drain; server/cli-io-backend.c++);
+        // SIGINT is mapped for completeness.
+        const SIGINT: i32 = 2;
+        const SIGTERM: i32 = 15;
+        on_loop_runtime(async move {
+            // SIGTERM -> ctrl_shutdown, SIGINT -> ctrl_c (the conventional mappings).
+            let received = match signum {
+                SIGTERM => {
+                    let mut sig = tokio::signal::windows::ctrl_shutdown().map_err(op("signal"))?;
+                    sig.recv().await
+                }
+                SIGINT => {
+                    let mut sig = tokio::signal::windows::ctrl_c().map_err(op("signal"))?;
+                    sig.recv().await
+                }
+                _ => {
+                    return Err(KjIoError::other(
+                        "signal",
+                        "kj-rs-io only watches SIGTERM/SIGINT on Windows",
+                    ));
+                }
+            };
+            received
+                .ok_or_else(|| KjIoError::other("signal", "signal stream closed unexpectedly"))?;
+            Ok(())
+        })
+        .await
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = signum;
+        Err(KjIoError::other(
+            "signal",
+            "kj-rs-io signal watching is not implemented on this platform",
+        ))
+    }
+}

--- a/src/rust/cxx/kj-rs-io/signal.rs
+++ b/src/rust/cxx/kj-rs-io/signal.rs
@@ -14,16 +14,13 @@
 //! - tokio's signal registration is process-wide and persists for the life of the process
 //!   (dropping the future stops *watching*, but does not restore `SIG_DFL`).
 //!
-//! Cross-thread delivery note: tokio's signal registry is process-global, and its broadcast can
-//! run on a different thread — another runtime's loop thread on unix (whichever runtime's driver
-//! consumes the signal's wake byte, e.g. workerd's inspector thread), or the OS-spawned
-//! console-ctrl thread on Windows. That is fine: the kj-rs waker bridge is thread-safe (a
-//! cross-thread wake is delivered through the `FutureWakerCell`'s cross-thread fulfiller; see
-//! kj-rs/waker.h), so the streams are awaited directly from the bridged future here. The
-//! multi-runtime case is covered by the "onSignal is delivered even when another runtime's
-//! thread consumes the signal" test in tests/async-io-test.c++ — the scenario that, before the
-//! bridge was thread-safe, made workerd ignore SIGTERM whenever the inspector thread's runtime
-//! won the race.
+//! Tokio's signal registry is process-global. Its broadcast may run on another runtime's
+//! thread on Unix, or on the OS-created console-control thread on Windows. The bridged
+//! future's cloned waker owns a kj-rs `ArcWaker`, whose cross-thread fulfiller schedules the
+//! next poll on the owning KJ loop. Signal streams can therefore be awaited directly here.
+//! The test "onSignal is delivered even when another runtime's thread consumes the signal"
+//! in tests/async-io-test.c++ exercises delivery with another runtime parked on a different
+//! thread, as can happen with workerd's inspector runtime.
 //!
 //! On Windows the signums workerd actually passes are mapped to their conventional console
 //! control events: SIGTERM -> `ctrl_shutdown`, SIGINT -> `ctrl_c`. Anything else errors.

--- a/src/rust/cxx/kj-rs-io/stream.rs
+++ b/src/rust/cxx/kj-rs-io/stream.rs
@@ -1,0 +1,848 @@
+//! Tokio-backed byte streams behind KJ's stream interfaces.
+//!
+//! `TokioStream` (TCP or Unix domain) implements the `kj::AsyncIoStream` operations; all I/O
+//! uses tokio's `&self` readiness API (`ready()` + `try_read`/`try_write`), which supports
+//! concurrent reads and writes on one stream and is cancel-safe: dropping a pending future
+//! (i.e. dropping the wrapping `kj::Promise`) merely deregisters the waker, releasing the
+//! readiness interest so the stream can be reused or dropped sanely.
+
+use std::cell::Ref;
+use std::cell::RefCell;
+use std::io::IoSlice;
+use std::io::Read;
+use std::io::Write;
+
+use tokio::io::Interest;
+use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::UnixStream;
+
+use crate::error::KjIoError;
+use crate::error::Result;
+use crate::error::op;
+use crate::runtime::on_loop_runtime;
+
+/// A native tokio stream (the "unwrap fast path" object).
+///
+/// C++ holds one of these inside every kj-rs-io `kj::AsyncIoStream`; Rust code can take it
+/// back out via [`crate::unwrap_kj_stream`] and drive the connection natively.
+///
+/// # Ownership of the native stream while I/O is in flight
+///
+/// Every I/O operation borrows the native stream for its whole duration (across its awaits),
+/// and [`TokioStream::take`] moves it out. Those two must never overlap -- the moved-out object
+/// is exactly what the pending operation is using. Rather than making that a caller contract
+/// ("no I/O promises may be in flight when unwrapping"), the `RefCell` makes it checked: each
+/// operation holds a shared borrow (`Ref`) of the slot for as long as it runs, and `take()`
+/// needs the exclusive borrow, so unwrapping with I/O in flight fails with an error instead of
+/// aliasing live borrows. This is why `TokioStream` is `!Sync`: it is a KJ-loop-thread object
+/// (its owner, the C++ `kj::AsyncIoStream` wrapper, is), never shared across threads.
+pub struct TokioStream {
+    /// `None` after the native stream has been moved out by [`TokioStream::take`] (the C++
+    /// wrapper is then "hollow" and every operation fails).
+    inner: RefCell<Option<Inner>>,
+}
+
+enum Inner {
+    Tcp(TcpStream),
+    #[cfg(unix)]
+    Unix(UnixStream),
+}
+
+impl Inner {
+    async fn ready(&self, interest: Interest) -> Result<()> {
+        match self {
+            Self::Tcp(s) => s.ready(interest).await,
+            #[cfg(unix)]
+            Self::Unix(s) => s.ready(interest).await,
+        }
+        .map_err(op("poll()"))?;
+        Ok(())
+    }
+
+    fn try_read(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Tcp(s) => s.try_read(buf),
+            #[cfg(unix)]
+            Self::Unix(s) => s.try_read(buf),
+        }
+    }
+
+    fn try_write(&self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Tcp(s) => s.try_write(buf),
+            #[cfg(unix)]
+            Self::Unix(s) => s.try_write(buf),
+        }
+    }
+
+    fn try_write_vectored(&self, bufs: &[IoSlice<'_>]) -> std::io::Result<usize> {
+        match self {
+            Self::Tcp(s) => s.try_write_vectored(bufs),
+            #[cfg(unix)]
+            Self::Unix(s) => s.try_write_vectored(bufs),
+        }
+    }
+
+    /// Borrows the live tokio socket's fd (tokio streams implement `AsFd`), for dup-based
+    /// operations that must not conjure a raw fd out of an integer.
+    #[cfg(unix)]
+    fn as_borrowed_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        use std::os::fd::AsFd;
+        match self {
+            Self::Tcp(s) => s.as_fd(),
+            Self::Unix(s) => s.as_fd(),
+        }
+    }
+
+    /// Borrows the live tokio socket's `SOCKET` (tokio's `TcpStream` implements `AsSocket`):
+    /// the Windows counterpart of [`Inner::as_borrowed_fd`]. On Windows only the Tcp variant
+    /// exists. Validated by Windows CI.
+    #[cfg(windows)]
+    fn as_borrowed_socket(&self) -> std::os::windows::io::BorrowedSocket<'_> {
+        use std::os::windows::io::AsSocket;
+        match self {
+            Self::Tcp(s) => s.as_socket(),
+        }
+    }
+}
+
+fn hollow() -> KjIoError {
+    KjIoError::other("kj_rs_io", "stream was unwrapped (hollow wrapper)")
+}
+
+impl TokioStream {
+    fn new(inner: Inner) -> Self {
+        Self {
+            inner: RefCell::new(Some(inner)),
+        }
+    }
+
+    #[must_use]
+    pub fn from_tcp(stream: TcpStream) -> Self {
+        Self::new(Inner::Tcp(stream))
+    }
+
+    #[cfg(unix)]
+    #[must_use]
+    pub fn from_unix(stream: UnixStream) -> Self {
+        Self::new(Inner::Unix(stream))
+    }
+
+    /// Recovers the native tokio TCP stream, if this is a (non-hollow) TCP stream.
+    #[must_use]
+    pub fn into_tcp_stream(self) -> Option<TcpStream> {
+        match self.inner.into_inner() {
+            Some(Inner::Tcp(stream)) => Some(stream),
+            _ => None,
+        }
+    }
+
+    /// Recovers the native tokio Unix-domain stream, if this is one.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn into_unix_stream(self) -> Option<UnixStream> {
+        match self.inner.into_inner() {
+            Some(Inner::Unix(stream)) => Some(stream),
+            _ => None,
+        }
+    }
+
+    /// Borrows the live native stream for the duration of an operation. The returned `Ref` is
+    /// what makes a concurrent [`TokioStream::take`] fail (see the type docs). Errors if the
+    /// wrapper is hollow.
+    fn live(&self) -> Result<Ref<'_, Inner>> {
+        // `take()` is synchronous and never yields while holding the exclusive borrow, so a
+        // failed shared borrow here cannot happen in practice; report it rather than panic.
+        let slot = self
+            .inner
+            .try_borrow()
+            .map_err(|_| KjIoError::other("kj_rs_io", "stream is being unwrapped concurrently"))?;
+        Ref::filter_map(slot, Option::as_ref).map_err(|_| hollow())
+    }
+
+    /// Runs `f` on the live socket's borrowed fd. Errors if the wrapper is hollow.
+    #[cfg(unix)]
+    pub(crate) fn with_borrowed_fd<T>(
+        &self,
+        f: impl FnOnce(std::os::fd::BorrowedFd<'_>) -> T,
+    ) -> Result<T> {
+        let inner = self.live()?;
+        Ok(f(inner.as_borrowed_fd()))
+    }
+
+    /// Runs `f` on the live socket's borrowed `SOCKET`. Errors if the wrapper is hollow.
+    /// Validated by Windows CI; mirrors the unix arm.
+    #[cfg(windows)]
+    pub(crate) fn with_borrowed_socket<T>(
+        &self,
+        f: impl FnOnce(std::os::windows::io::BorrowedSocket<'_>) -> T,
+    ) -> Result<T> {
+        let inner = self.live()?;
+        Ok(f(inner.as_borrowed_socket()))
+    }
+
+    /// KJ `tryRead` semantics: loop until at least `min_bytes` (or EOF), up to `buf.len()`.
+    // Holding the `Ref` across awaits is the whole point (see the type docs): it reserves the
+    // native stream for this operation so a concurrent `take()`/unwrap fails cleanly. Sound
+    // here: the only conflicting accessor is `take()`, which uses `try_borrow_mut` and returns
+    // an error rather than panicking, and concurrent read+write just stack shared `Ref`s.
+    #[expect(
+        clippy::await_holding_refcell_ref,
+        reason = "intentional in-flight guard; see above"
+    )]
+    async fn try_read_min(&self, buf: &mut [u8], min_bytes: usize) -> Result<usize> {
+        let inner = self.live()?;
+        let min_bytes = min_bytes.min(buf.len());
+        let mut total = 0;
+        while total < min_bytes {
+            match inner.try_read(&mut buf[total..]) {
+                Ok(0) => break, // EOF: return what we have (< min_bytes signals EOF to KJ).
+                Ok(n) => total += n,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    inner.ready(Interest::READABLE).await?;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(op("read()")(e)),
+            }
+        }
+        Ok(total)
+    }
+
+    /// Write-all semantics.
+    // Holding the `Ref` across awaits is the whole point (see the type docs): it reserves the
+    // native stream for this operation so a concurrent `take()`/unwrap fails cleanly. Sound
+    // here: the only conflicting accessor is `take()`, which uses `try_borrow_mut` and returns
+    // an error rather than panicking, and concurrent read+write just stack shared `Ref`s.
+    #[expect(
+        clippy::await_holding_refcell_ref,
+        reason = "intentional in-flight guard; see above"
+    )]
+    async fn write_all(&self, buf: &[u8]) -> Result<()> {
+        let inner = self.live()?;
+        let mut written = 0;
+        while written < buf.len() {
+            match inner.try_write(&buf[written..]) {
+                Ok(0) => {
+                    // try_write on a socket signals "would block" via Err(WouldBlock), so a
+                    // zero-byte result for a non-empty buffer means the connection is gone.
+                    return Err(KjIoError::other(
+                        "write()",
+                        "wrote zero bytes (connection closed)",
+                    ));
+                }
+                Ok(n) => written += n,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    inner.ready(Interest::WRITABLE).await?;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(op("write()")(e)),
+            }
+        }
+        Ok(())
+    }
+
+    /// Write-all semantics over several pieces, as one operation: `writev` until every piece is
+    /// fully written. `IoSlice::advance_slices` drops fully-written leading pieces and trims a
+    /// partially-written one, so a short write resumes exactly where the kernel stopped.
+    // Holding the `Ref` across awaits is the whole point (see the type docs): it reserves the
+    // native stream for this operation so a concurrent `take()`/unwrap fails cleanly. Sound
+    // here: the only conflicting accessor is `take()`, which uses `try_borrow_mut` and returns
+    // an error rather than panicking, and concurrent read+write just stack shared `Ref`s.
+    #[expect(
+        clippy::await_holding_refcell_ref,
+        reason = "intentional in-flight guard; see above"
+    )]
+    async fn write_all_pieces(&self, pieces: &crate::ffi::KjPieces) -> Result<()> {
+        let inner = self.live()?;
+        let count = crate::ffi::kj_pieces_count(pieces);
+        let mut slices: Vec<IoSlice<'_>> = (0..count)
+            .map(|index| IoSlice::new(crate::ffi::kj_piece(pieces, index)))
+            .collect();
+        let mut bufs: &mut [IoSlice<'_>] = &mut slices;
+        loop {
+            // All-empty remainder (including all-empty input): nothing left to write. Checked
+            // before the syscall because writev of zero bytes returns 0, which below means
+            // "connection closed".
+            if bufs.iter().all(|piece| piece.is_empty()) {
+                return Ok(());
+            }
+            match inner.try_write_vectored(bufs) {
+                Ok(0) => {
+                    return Err(KjIoError::other(
+                        "writev()",
+                        "wrote zero bytes (connection closed)",
+                    ));
+                }
+                Ok(n) => IoSlice::advance_slices(&mut bufs, n),
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    inner.ready(Interest::WRITABLE).await?;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(op("writev()")(e)),
+            }
+        }
+    }
+
+    /// Resolves once new writes are doomed to fail (peer reset / hangup observed).
+    ///
+    /// tokio has no direct primitive for this, so we register a *duplicate* of the socket fd
+    /// with the I/O driver for WRITABLE interest and wait — explicitly clearing plain-writable
+    /// readiness — until the OS reports write-closed (kqueue: `EV_EOF` on the write filter;
+    /// epoll: `EPOLLHUP`/`EPOLLERR`) or an error. Like KJ's own implementation this does *not*
+    /// fire on a mere half-close (peer FIN / `EPOLLRDHUP`): reads hitting EOF must not count as
+    /// write-disconnect.
+    ///
+    /// Why a second fd rather than the socket's own registration: tokio caches readiness per
+    /// registration, and `try_write` consults that cache before making the syscall -- if the
+    /// cached WRITABLE bit is clear it returns `WouldBlock` and the writer parks in
+    /// `ready(WRITABLE)` until the *next* epoll/kqueue edge. This waiter must clear WRITABLE to
+    /// avoid spinning on an always-writable socket, so sharing the registration with concurrent
+    /// writers would park them on an edge that never comes (the socket stays writable): a hang,
+    /// not a slowdown. A `dup(2)` is its own registration, so clearing its readiness disturbs no
+    /// one. The cost is one extra fd and one extra driver registration for as long as the wait
+    /// is pending; kj-http holds one per server connection.
+    ///
+    /// Windows behavior (see the arm below): a never-resolving future, which IS KJ
+    /// parity — KJ's *current* Windows behavior (`whenWriteDisconnected` returns `NEVER_DONE`).
+    /// Win32 has no documented primitive for detecting disconnect without a read/write; KJ's own
+    /// TODO points at the undocumented-but-stable `IOCTL_AFD_POLL` ioctl (capnproto
+    /// `async-io-win32.c++:289` — the mechanism `select()` itself is built on). An AFD-poll
+    /// implementation remains an optional upgrade over this documented parity behavior.
+    #[cfg(unix)]
+    // Holding the `Ref` across awaits is the whole point (see the type docs): it reserves the
+    // native stream for this operation so a concurrent `take()`/unwrap fails cleanly. Sound
+    // here: the only conflicting accessor is `take()`, which uses `try_borrow_mut` and returns
+    // an error rather than panicking, and concurrent read+write just stack shared `Ref`s.
+    #[expect(
+        clippy::await_holding_refcell_ref,
+        reason = "intentional in-flight guard; see above"
+    )]
+    async fn when_write_disconnected(&self) -> Result<()> {
+        use std::os::fd::AsRawFd;
+
+        // Borrow the live socket's fd directly (tokio streams implement `AsFd`) and dup it, so
+        // no raw fd is ever materialized without an owner. The `Ref` is held for the whole wait:
+        // this IS an in-flight operation as far as `take()` is concerned.
+        let inner = self.live()?;
+        let borrowed = inner.as_borrowed_fd();
+        let owned = borrowed.try_clone_to_owned().map_err(op("dup()"))?;
+        debug_assert_ne!(owned.as_raw_fd(), borrowed.as_raw_fd());
+        // The dup shares the underlying open socket (and its O_NONBLOCK status), but has its own
+        // registration with the I/O driver, so clearing readiness here never disturbs reads or
+        // writes on the primary registration.
+        let async_fd = tokio::io::unix::AsyncFd::with_interest(owned, Interest::WRITABLE)
+            .map_err(op("whenWriteDisconnected"))?;
+        loop {
+            let mut guard = async_fd
+                .ready(Interest::WRITABLE)
+                .await
+                .map_err(op("whenWriteDisconnected"))?;
+            let ready = guard.ready();
+            if ready.is_write_closed() || ready.is_error() {
+                return Ok(());
+            }
+            // Plain "writable": clear it so the next wait sleeps until an actual state-change
+            // event (edge-triggered), rather than spinning on an always-writable socket.
+            guard.clear_ready();
+        }
+    }
+
+    /// Never resolves: KJ parity, not a gap — capnproto's win32 `whenWriteDisconnected` returns
+    /// `NEVER_DONE` today (its `IOCTL_AFD_POLL` idea is only a TODO; see the Windows-behavior note
+    /// on the unix arm above). Validated by Windows CI.
+    #[cfg(windows)]
+    #[expect(
+        clippy::await_holding_refcell_ref,
+        reason = "intentional in-flight guard; see above"
+    )]
+    async fn when_write_disconnected(&self) -> Result<()> {
+        // Holds the in-flight guard (like the unix arm) and never resolves. `pending()` infers
+        // the Result<()> return type, so there is no unreachable tail (crate-level
+        // deny(clippy::unreachable)).
+        let _inner = self.live()?;
+        std::future::pending().await
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    async fn when_write_disconnected(&self) -> Result<()> {
+        self.live()?;
+        Err(KjIoError::other(
+            "whenWriteDisconnected",
+            "not implemented by kj-rs-io on this platform",
+        ))
+    }
+
+    fn shutdown_write(&self) -> Result<()> {
+        // `shutdown(2)` acts on the socket, not on a descriptor, so a `SockRef` borrow of the
+        // live socket is all it needs: no dup, no owning std type, identical on unix and windows.
+        #[cfg(any(unix, windows))]
+        {
+            self.with_sock_ref("shutdown(SHUT_WR)", |sock| {
+                sock.shutdown(std::net::Shutdown::Write)
+            })
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            Err(KjIoError::other(
+                "shutdownWrite",
+                "not implemented on this platform",
+            ))
+        }
+    }
+
+    /// Runs `f` on a `socket2::SockRef` borrowing the live socket — the shared body of the
+    /// `getsockname()`/`getpeername()` passthroughs; only the socket borrow is per-platform.
+    fn with_sock_ref<T>(
+        &self,
+        op_name: &'static str,
+        f: impl FnOnce(&socket2::SockRef<'_>) -> std::io::Result<T>,
+    ) -> Result<T> {
+        #[cfg(unix)]
+        {
+            self.with_borrowed_fd(|fd| f(&socket2::SockRef::from(&fd)))?
+                .map_err(op(op_name))
+        }
+        // Validated by Windows CI; mirrors the unix arm.
+        #[cfg(windows)]
+        {
+            self.with_borrowed_socket(|sock| f(&socket2::SockRef::from(&sock)))?
+                .map_err(op(op_name))
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = f;
+            self.live()?;
+            Err(KjIoError::other(
+                op_name,
+                "not implemented by kj-rs-io on this platform",
+            ))
+        }
+    }
+
+    /// Raw `struct sockaddr` bytes of the socket's locally-bound address (the `getsockname()`
+    /// passthrough behind `kj::AsyncIoStream::getsockname`).
+    fn local_addr_bytes(&self) -> Result<Vec<u8>> {
+        let addr = self.with_sock_ref("getsockname()", |sock| sock.local_addr())?;
+        Ok(crate::ffi::sockaddr_to_bytes(&addr))
+    }
+
+    /// Raw `struct sockaddr` bytes of the connected peer's address (the `getpeername()`
+    /// passthrough behind `kj::AsyncIoStream::getpeername` and the accept-loop peer-filter
+    /// check).
+    fn peer_addr_bytes(&self) -> Result<Vec<u8>> {
+        let addr = self.with_sock_ref("getpeername()", |sock| sock.peer_addr())?;
+        Ok(crate::ffi::sockaddr_to_bytes(&addr))
+    }
+
+    /// The underlying raw OS socket handle, widened to `i64`: a Unix fd
+    /// (`kj::AsyncIoStream::getFd()`) or a win32 `SOCKET` (`getWin32Handle()`).
+    fn raw_handle(&self) -> Result<i64> {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            self.with_borrowed_fd(|fd| i64::from(fd.as_raw_fd()))
+        }
+        // Validated by Windows CI; mirrors the unix arm.
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawSocket;
+            // A live SOCKET fits in i64 (Windows handles fit in 32 bits); the bridge carries
+            // its bits verbatim.
+            #[allow(clippy::cast_possible_wrap)]
+            self.with_borrowed_socket(|sock| sock.as_raw_socket() as i64)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            self.live()?;
+            Err(KjIoError::other(
+                "getFd",
+                "file descriptors are not available on this platform",
+            ))
+        }
+    }
+
+    /// Recovers whichever native tokio object this is, as a [`crate::serve::ServeIo`]
+    /// (the unwrap fast path of [`crate::serve_kj_stream`]). `None` if hollow.
+    pub(crate) fn into_serve_io(self) -> Option<crate::serve::ServeIo> {
+        match self.inner.into_inner()? {
+            Inner::Tcp(stream) => Some(crate::serve::ServeIo::Tcp(stream)),
+            #[cfg(unix)]
+            Inner::Unix(stream) => Some(crate::serve::ServeIo::Unix(stream)),
+        }
+    }
+
+    /// Moves the native stream out into a fresh wrapper, leaving this one hollow. Fails if the
+    /// wrapper is already hollow, or if any I/O operation is in flight (see the type docs):
+    /// that is the checked replacement for the old "no I/O promises may be outstanding" caller
+    /// contract.
+    fn take(&self) -> Result<Box<Self>> {
+        let mut slot = self.inner.try_borrow_mut().map_err(|_| {
+            KjIoError::other(
+                "kj_rs_io",
+                "cannot unwrap a stream while I/O operations are in flight on it",
+            )
+        })?;
+        let inner = slot.take().ok_or_else(|| {
+            KjIoError::other("kj_rs_io", "stream was already unwrapped (hollow wrapper)")
+        })?;
+        Ok(Box::new(Self::new(inner)))
+    }
+}
+
+// ======================================================================================
+// Bridge entry points (see lib.rs). Every async fn checks the loop-runtime precondition once
+// (`on_loop_runtime`); the loop thread is permanently inside the runtime's context, so resources
+// created while polling on the KJ thread reach the loop runtime's I/O driver on their own.
+
+pub async fn stream_try_read(
+    stream: &TokioStream,
+    buf: &mut [u8],
+    min_bytes: usize,
+) -> Result<usize> {
+    on_loop_runtime(stream.try_read_min(buf, min_bytes)).await
+}
+
+pub async fn stream_write(stream: &TokioStream, buf: &[u8]) -> Result<()> {
+    on_loop_runtime(stream.write_all(buf)).await
+}
+
+pub async fn stream_write_pieces(
+    stream: &TokioStream,
+    pieces: &crate::ffi::KjPieces,
+) -> Result<()> {
+    on_loop_runtime(stream.write_all_pieces(pieces)).await
+}
+
+pub async fn stream_when_write_disconnected(stream: &TokioStream) -> Result<()> {
+    on_loop_runtime(stream.when_write_disconnected()).await
+}
+
+pub fn stream_shutdown_write(stream: &TokioStream) -> Result<()> {
+    stream.shutdown_write()
+}
+
+pub fn stream_raw_handle(stream: &TokioStream) -> Result<i64> {
+    stream.raw_handle()
+}
+
+/// Non-throwing variant for `kj::AsyncIoStream::getFd()`/`getWin32Handle()`, which return a
+/// `kj::Maybe`: -1 when the wrapper is hollow (or the platform has no handle), so C++ does not
+/// have to use exception catching as control flow.
+pub fn stream_try_raw_handle(stream: &TokioStream) -> i64 {
+    stream.raw_handle().unwrap_or(-1)
+}
+
+pub fn stream_local_addr(stream: &TokioStream) -> Result<Vec<u8>> {
+    stream.local_addr_bytes()
+}
+
+pub fn stream_peer_addr(stream: &TokioStream) -> Result<Vec<u8>> {
+    stream.peer_addr_bytes()
+}
+
+pub fn stream_take(stream: &TokioStream) -> Result<Box<TokioStream>> {
+    stream.take()
+}
+
+// ======================================================================================
+// Arbitrary readable/writable fds (kj::LowLevelAsyncIoProvider::wrapInputFd/wrapOutputFd).
+// Unix only: implemented over AsyncFd, which supports pipes, character devices and sockets
+// (regular files are rejected by epoll/kqueue, matching KJ's fd-observer-based provider).
+// Deliberately no windows arm: kj's win32 LowLevelAsyncIoProvider has no pipe-fd tier — its
+// `Fd` is documented as a SOCKET (capnproto async-io.h) and its wrapInputFd/wrapOutputFd are
+// implemented identically to wrapSocketFd (async-io-win32.c++) — so the C++ side
+// (async-io.c++) routes win32 wrapInputFd/wrapOutputFd through the tested socket path
+// (`wrap_socket_fd`) and never calls these entry points there; the `not(unix)` arms below are
+// totality backstops only.
+
+#[cfg(unix)]
+type FdIo = tokio::io::unix::AsyncFd<std::fs::File>;
+
+pub struct TokioInputFd {
+    #[cfg(unix)]
+    inner: FdIo,
+}
+
+pub struct TokioOutputFd {
+    #[cfg(unix)]
+    inner: FdIo,
+}
+
+#[cfg(unix)]
+fn fd_io_from_raw(fd: i32, interest: Interest) -> Result<FdIo> {
+    let owned = crate::ffi::own_fd_from_raw(fd);
+    crate::runtime::require_loop_runtime()?;
+    tokio::io::unix::AsyncFd::with_interest(std::fs::File::from(owned), interest)
+        .map_err(op("wrapFd"))
+}
+
+pub fn wrap_input_fd(fd: i32) -> Result<Box<TokioInputFd>> {
+    #[cfg(unix)]
+    {
+        Ok(Box::new(TokioInputFd {
+            inner: fd_io_from_raw(fd, Interest::READABLE)?,
+        }))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = fd;
+        Err(KjIoError::other(
+            "wrapInputFd",
+            "not implemented on this platform",
+        ))
+    }
+}
+
+pub fn wrap_output_fd(fd: i32) -> Result<Box<TokioOutputFd>> {
+    #[cfg(unix)]
+    {
+        Ok(Box::new(TokioOutputFd {
+            inner: fd_io_from_raw(fd, Interest::WRITABLE)?,
+        }))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = fd;
+        Err(KjIoError::other(
+            "wrapOutputFd",
+            "not implemented on this platform",
+        ))
+    }
+}
+
+pub async fn input_fd_try_read(
+    stream: &TokioInputFd,
+    buf: &mut [u8],
+    min_bytes: usize,
+) -> Result<usize> {
+    #[cfg(unix)]
+    {
+        on_loop_runtime(async move {
+            let min_bytes = min_bytes.min(buf.len());
+            let mut total = 0;
+            while total < min_bytes {
+                let mut guard = stream
+                    .inner
+                    .ready(Interest::READABLE)
+                    .await
+                    .map_err(op("poll()"))?;
+                match guard.try_io(|inner| {
+                    let mut file: &std::fs::File = inner.get_ref();
+                    file.read(&mut buf[total..])
+                }) {
+                    Ok(Ok(0)) => break, // EOF
+                    Ok(Ok(n)) => total += n,
+                    Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                    Ok(Err(e)) => return Err(op("read()")(e)),
+                    Err(_would_block) => {}
+                }
+            }
+            Ok(total)
+        })
+        .await
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (stream, buf, min_bytes);
+        Err(KjIoError::other(
+            "read()",
+            "not implemented on this platform",
+        ))
+    }
+}
+
+pub async fn output_fd_write(stream: &TokioOutputFd, buf: &[u8]) -> Result<()> {
+    #[cfg(unix)]
+    {
+        on_loop_runtime(async move {
+            let mut written = 0;
+            while written < buf.len() {
+                let mut guard = stream
+                    .inner
+                    .ready(Interest::WRITABLE)
+                    .await
+                    .map_err(op("poll()"))?;
+                match guard.try_io(|inner| {
+                    let mut file: &std::fs::File = inner.get_ref();
+                    file.write(&buf[written..])
+                }) {
+                    Ok(Ok(0)) => {
+                        return Err(KjIoError::other("write()", "wrote zero bytes"));
+                    }
+                    Ok(Ok(n)) => written += n,
+                    Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                    Ok(Err(e)) => return Err(op("write()")(e)),
+                    Err(_would_block) => {}
+                }
+            }
+            Ok(())
+        })
+        .await
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (stream, buf);
+        Err(KjIoError::other(
+            "write()",
+            "not implemented on this platform",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::task::Context;
+    use std::task::Waker;
+
+    use cxx::KjError;
+    use static_assertions::assert_impl_all;
+    use static_assertions::assert_not_impl_any;
+
+    use super::*;
+
+    // `TokioStream` is a KJ-loop-thread object whose in-flight-operation tracking lives in a
+    // `RefCell` (see the type docs): it must never become `Sync` by accident. It stays `Send`,
+    // like the native tokio sockets inside it, so `unwrap_kj_stream`'s `Box<TokioStream>` can be
+    // handed to a connection task.
+    assert_not_impl_any!(TokioStream: Sync);
+    assert_impl_all!(TokioStream: Send);
+
+    /// A connected localhost TCP pair as tokio streams registered with `port`'s runtime.
+    // Takes the port only to make the caller prove one exists: the thread must be inside the
+    // port's runtime context for `TcpStream::from_std` to find the I/O driver.
+    fn connected_pair(_port: &kj_rs_tokio::TokioPort) -> (TokioStream, std::net::TcpStream) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let client = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        server.set_nonblocking(true).unwrap();
+        // No `enter()`: the thread is inside the port's runtime context for the port's life.
+        (
+            TokioStream::from_tcp(TcpStream::from_std(server).unwrap()),
+            client,
+        )
+    }
+
+    #[test]
+    fn hollow_wrapper_rejects_every_operation_and_second_take() {
+        let port = kj_rs_tokio::TokioPort::new();
+        let (stream, _client) = connected_pair(&port);
+
+        let taken = match stream.take() {
+            Ok(taken) => taken,
+            Err(e) => panic!("first take: {}", KjError::from(e).description()),
+        };
+        assert!(
+            taken.live().is_ok(),
+            "the taken wrapper holds the live stream"
+        );
+
+        // The original is hollow now.
+        let err = |r: Result<()>| match r {
+            Ok(()) => panic!("expected an error from a hollow wrapper"),
+            Err(e) => KjError::from(e).description().to_owned(),
+        };
+        assert!(stream.live().is_err());
+        assert!(err(stream.shutdown_write()).contains("hollow"));
+        assert!(stream.raw_handle().is_err());
+        assert_eq!(stream_try_raw_handle(&stream), -1);
+        assert!(stream.local_addr_bytes().is_err());
+        assert!(err(stream.take().map(drop)).contains("already unwrapped"));
+        assert!(stream.into_tcp_stream().is_none());
+    }
+
+    #[test]
+    fn take_while_an_operation_is_in_flight_is_an_error_not_aliasing() {
+        let port = kj_rs_tokio::TokioPort::new();
+        let (stream, _client) = connected_pair(&port);
+
+        // Start a read and park it: nothing has been written, so it registers readiness
+        // interest and returns Pending while holding its borrow of the native stream. The
+        // runtime guard is held across the poll so the tokio reactor is reachable.
+        let mut buf = [0u8; 8];
+        let mut read = Box::pin(stream.try_read_min(&mut buf, 1));
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(read.as_mut().poll(&mut cx).is_pending());
+
+        // Unwrapping now would alias that live borrow; it is refused instead.
+        let err = match stream.take() {
+            Ok(_) => panic!("take() must fail while a read is in flight"),
+            Err(e) => KjError::from(e),
+        };
+        assert!(
+            err.description().contains("in flight"),
+            "{}",
+            err.description()
+        );
+
+        // Once the operation is gone the unwrap goes through, and the native stream is intact.
+        drop(read);
+        let taken = match stream.take() {
+            Ok(taken) => taken,
+            Err(e) => panic!(
+                "take after the read was dropped: {}",
+                KjError::from(e).description()
+            ),
+        };
+        assert!(taken.into_tcp_stream().is_some());
+    }
+
+    #[test]
+    fn concurrent_read_and_write_both_in_flight_share_the_borrow() {
+        // The load-bearing invariant of the RefCell design: shared borrows stack, so a read and
+        // a write can be in flight at once (kj's one-read + one-write contract), and `take()`
+        // fails while EITHER is alive, succeeding only once BOTH are dropped.
+        let port = kj_rs_tokio::TokioPort::new();
+        let (stream, _client) = connected_pair(&port);
+
+        let mut buf = [0u8; 8];
+        let mut read = Box::pin(stream.try_read_min(&mut buf, 1));
+        // 1 MiB: larger than the socket buffer, so the write cannot drain in one go and the
+        // future stays pending, holding its borrow.
+        let payload = vec![0u8; 1024 * 1024];
+        let mut write = Box::pin(stream.write_all(&payload));
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(read.as_mut().poll(&mut cx).is_pending());
+        assert!(write.as_mut().poll(&mut cx).is_pending());
+        // Both borrows are live and coexist; take() is refused.
+        assert!(
+            stream.take().is_err(),
+            "take() must fail while read+write are both in flight"
+        );
+        drop(read);
+        assert!(
+            stream.take().is_err(),
+            "take() must still fail while the write is in flight"
+        );
+        drop(write);
+        assert!(
+            stream.take().is_ok(),
+            "take() succeeds once both operations are gone"
+        );
+    }
+
+    #[test]
+    fn hollow_into_serve_io_is_none() {
+        let port = kj_rs_tokio::TokioPort::new();
+        let (stream, _client) = connected_pair(&port);
+        let _taken = stream.take().expect("first take");
+        // The original is hollow; recovering a ServeIo yields None (the into_inner()? == None arm).
+        assert!(stream.into_serve_io().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_disconnected_wait_counts_as_in_flight() {
+        let port = kj_rs_tokio::TokioPort::new();
+        let (stream, _client) = connected_pair(&port);
+        let mut wait = Box::pin(stream.when_write_disconnected());
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(wait.as_mut().poll(&mut cx).is_pending());
+        assert!(
+            stream.take().is_err(),
+            "whenWriteDisconnected holds the stream too"
+        );
+        drop(wait);
+        assert!(stream.take().is_ok());
+    }
+}

--- a/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
@@ -58,3 +58,25 @@ cc_test(
         "@capnp-cpp//src/kj:kj-test",
     ],
 )
+
+cc_test(
+    name = "file-watcher-test",
+    # medium: real I/O plus timer-bounded waits; small's 3 s budget is exceeded under parallel
+    # build load even though the suite runs in ~2 s alone.
+    size = "medium",
+    srcs = ["file-watcher-test.c++"],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":tests",
+        "//src/rust/cxx/kj-rs-io:kj-rs-io-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
@@ -103,3 +103,27 @@ cc_test(
         "@capnp-cpp//src/kj/compat:kj-http",
     ],
 )
+
+cc_test(
+    name = "serve-test",
+    size = "small",
+    srcs = [
+        "io-test-helpers.h",
+        "serve-test.c++",
+    ],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":bridge",
+        ":tests",
+        "//src/rust/cxx/kj-rs-io:kj-rs-io-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
@@ -127,3 +127,26 @@ cc_test(
         "@capnp-cpp//src/kj:kj-test",
     ],
 )
+
+cc_test(
+    name = "capnp-rpc-test",
+    # medium: real I/O plus timer-bounded waits; small's 3 s budget is exceeded under parallel
+    # build load even though the suite runs in ~2 s alone.
+    size = "medium",
+    srcs = ["capnp-rpc-test.c++"],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":tests",
+        "//src/rust/cxx/kj-rs-io:kj-rs-io-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/capnp:capnp-rpc",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
@@ -32,3 +32,29 @@ rust_cxx_bridge(
         "//src/rust/cxx/kj-rs-io:bridge",
     ],
 )
+
+cc_test(
+    name = "async-io-test",
+    # medium: several tests do real socket I/O plus timer-bounded waits (backpressure, signals,
+    # DNS), which can exceed small's 60 s budget under load / sanitizers.
+    size = "medium",
+    srcs = [
+        "async-io-test.c++",
+        "io-test-helpers.h",
+    ],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":bridge",
+        ":tests",
+        "//src/rust/cxx/kj-rs-io:kj-rs-io-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
@@ -80,3 +80,26 @@ cc_test(
         "@capnp-cpp//src/kj:kj-test",
     ],
 )
+
+cc_test(
+    name = "http-test",
+    # medium: real I/O plus timer-bounded waits; small's 3 s budget is exceeded under parallel
+    # build load even though the suite runs in ~2 s alone.
+    size = "medium",
+    srcs = ["http-test.c++"],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":tests",
+        "//src/rust/cxx/kj-rs-io:kj-rs-io-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+        "@capnp-cpp//src/kj/compat:kj-http",
+    ],
+)

--- a/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
@@ -150,3 +150,22 @@ cc_test(
         "@capnp-cpp//src/kj:kj-test",
     ],
 )
+
+cc_test(
+    name = "peer-filter-test",
+    size = "small",
+    srcs = ["peer-filter-test.c++"],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//src/rust/cxx/kj-rs-io:peer-filter-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//src/rust/cxx/tools/bazel:rust_cxx_bridge.bzl", "rust_cxx_bridge")
+
+rust_library(
+    name = "tests",
+    srcs = glob(["*.rs"]),
+    edition = "2024",
+    link_deps = [
+        ":bridge",
+    ],
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//src/rust/cxx",
+        "//src/rust/cxx/kj-rs",
+        "//src/rust/cxx/kj-rs-io",
+        "//src/rust/cxx/kj-rs-tokio",
+        "@crates_vendor//:bytes",
+        "@crates_vendor//:tokio",
+    ],
+)
+
+rust_cxx_bridge(
+    name = "bridge",
+    src = "lib.rs",
+    include_prefix = "kj-rs-io-test",
+    deps = [
+        "//src/rust/cxx/kj-rs",
+        "//src/rust/cxx/kj-rs-io:bridge",
+    ],
+)

--- a/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-io/tests/BUILD.bazel
@@ -129,6 +129,25 @@ cc_test(
 )
 
 cc_test(
+    name = "peer-filter-test",
+    size = "small",
+    srcs = ["peer-filter-test.c++"],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//src/rust/cxx/kj-rs-io:peer-filter-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)
+
+cc_test(
     name = "capnp-rpc-test",
     # medium: real I/O plus timer-bounded waits; small's 3 s budget is exceeded under parallel
     # build load even though the suite runs in ~2 s alone.
@@ -147,25 +166,6 @@ cc_test(
         "//src/rust/cxx/kj-rs-io:kj-rs-io-lib",
         "//src/rust/cxx/third-party:runtime",
         "@capnp-cpp//src/capnp:capnp-rpc",
-        "@capnp-cpp//src/kj:kj-test",
-    ],
-)
-
-cc_test(
-    name = "peer-filter-test",
-    size = "small",
-    srcs = ["peer-filter-test.c++"],
-    linkstatic = select({
-        "@platforms//os:windows": True,
-        "//conditions:default": False,
-    }),
-    target_compatible_with = select({
-        "@//build/config:no_build": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
-    deps = [
-        "//src/rust/cxx/kj-rs-io:peer-filter-lib",
-        "//src/rust/cxx/third-party:runtime",
         "@capnp-cpp//src/kj:kj-test",
     ],
 )

--- a/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
@@ -741,12 +741,10 @@ KJ_TEST("restrictPeers filters accepted peers (disallowed peers are dropped, "
 }
 
 KJ_TEST("onSignal is delivered even when another runtime's thread consumes the signal") {
-  // Regression test for a SIGTERM hang observed in workerd: tokio's signal registry is
-  // process-global, and whichever runtime's driver consumes the signal's wake byte performs the
-  // broadcast. With a second tokio runtime parked on another thread (workerd's inspector thread,
-  // in the wild), the broadcast often runs on THAT thread — a cross-thread wake of this loop's
-  // waker. Before the kj-rs waker bridge was thread-safe, that wake was lost and workerd ignored
-  // SIGTERM until killed; now it must always be delivered (kj-rs/waker.h's cross-thread path).
+  // Tokio's process-global signal registry broadcasts from whichever runtime consumes the
+  // signal's wake byte. A second parked runtime can therefore wake this loop's signal future
+  // from another thread, as workerd's inspector runtime can. ArcWaker must deliver that wake
+  // through its cross-thread fulfiller so this loop observes the signal.
   auto io = setupTokioAsyncIo();
   auto &ws = io.getWaitScope();
 

--- a/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
@@ -544,7 +544,8 @@ KJ_TEST("unwrap fast path: recover the native tokio stream and write from Rust")
 
   // ...and Rust can drive the connection natively: it writes via the tokio readiness API and
   // closes; C++ reads the bytes plus EOF through the (still wrapped) client end.
-  auto writeDone = native_write_via_unwrap(kj::mv(native), toRustVec("native write"_kjb));
+  auto writeDone = native_write_via_unwrap(kj::mv(native), toRustVec("native write"_kjb))
+                       .eagerlyEvaluate(nullptr);
   KJ_EXPECT(pair.client->tryRead(buffer, 12, sizeof(buffer)).wait(ws) == 12);
   KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 12) == "native write"_kjb);
   writeDone.wait(ws);
@@ -558,7 +559,8 @@ KJ_TEST("unwrap fast path: Rust-side unwrap_kj_stream() from a "
   auto pair = makeTcpPair(io);
 
   // Rust receives only a kj::AsyncIoStream& and performs the unwrap + native write itself.
-  auto writeDone = native_write_via_kj_unwrap(*pair.server, toRust("rust unwrap"_kjb));
+  auto writeDone =
+      native_write_via_kj_unwrap(*pair.server, toRust("rust unwrap"_kjb)).eagerlyEvaluate(nullptr);
   kj::byte buffer[32];
   KJ_EXPECT(pair.client->tryRead(buffer, 11, sizeof(buffer)).wait(ws) == 11);
   KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 11) == "rust unwrap"_kjb);
@@ -674,7 +676,7 @@ KJ_TEST("wrapInputFd/wrapOutputFd move bytes through an OS pipe and observe EOF"
   kj::byte buffer[16];
   auto readPromise = input->tryRead(buffer, 9, 9);
   KJ_EXPECT(!readPromise.poll(ws));
-  auto writePromise = output->write("pipe fd io"_kjb);
+  auto writePromise = output->write("pipe fd io"_kjb).eagerlyEvaluate(nullptr);
   KJ_EXPECT(readPromise.wait(ws) == 9);
   writePromise.wait(ws);
   KJ_EXPECT(input->tryRead(buffer, 1, sizeof(buffer)).wait(ws) == 1);  // "o"

--- a/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
@@ -268,13 +268,15 @@ KJ_TEST("sockname/peername/sockopt/getFd passthrough") {
   KJ_EXPECT(peer.sin_port == local.sin_port);
   KJ_EXPECT(peer.sin_addr.s_addr == local.sin_addr.s_addr);
 
-  // setsockopt/getsockopt round-trip (this is also how setNoDelay-style options are applied).
-  int on = 1;
-  pair.client->setsockopt(IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on));
-  int result = 0;
-  kj::uint resultLen = sizeof(result);
-  pair.client->getsockopt(IPPROTO_TCP, TCP_NODELAY, &result, &resultLen);
-  KJ_EXPECT(result != 0);
+  int clientNoDelay = 0;
+  kj::uint clientNoDelayLen = sizeof(clientNoDelay);
+  pair.client->getsockopt(IPPROTO_TCP, TCP_NODELAY, &clientNoDelay, &clientNoDelayLen);
+  KJ_EXPECT(clientNoDelay != 0);
+
+  int serverNoDelay = 0;
+  kj::uint serverNoDelayLen = sizeof(serverNoDelay);
+  pair.server->getsockopt(IPPROTO_TCP, TCP_NODELAY, &serverNoDelay, &serverNoDelayLen);
+  KJ_EXPECT(serverNoDelay != 0);
 #endif
 }
 

--- a/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
@@ -9,6 +9,7 @@
 #include <kj/array.h>
 #include <kj/async.h>
 #include <kj/debug.h>
+#include <kj/io.h>
 #include <kj/test.h>
 #include <kj/thread.h>
 
@@ -609,6 +610,26 @@ KJ_TEST("wrapSocketFd wraps both ends of a socketpair") {
   kj::byte buffer[16];
   KJ_EXPECT(end1->tryRead(buffer, 10, sizeof(buffer)).wait(ws) == 10);
   KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 10) == "socketpair"_kjb);
+}
+
+KJ_TEST("wrapSocketFd normalizes a borrowed descriptor without consuming it") {
+  auto io = setupTokioAsyncIo();
+
+  int fds[2];
+  KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+  kj::OwnFd borrowed(fds[0]);
+  kj::OwnFd peer(fds[1]);
+
+  auto wrapped = io.getLowLevelProvider().wrapSocketFd(borrowed, 0);
+  auto wrappedFd = KJ_ASSERT_NONNULL(wrapped->getFd());
+  KJ_EXPECT(wrappedFd != borrowed.get());
+  int descriptorFlags;
+  KJ_SYSCALL(descriptorFlags = fcntl(wrappedFd, F_GETFD));
+  KJ_EXPECT((descriptorFlags & FD_CLOEXEC) != 0);
+  int statusFlags;
+  KJ_SYSCALL(statusFlags = fcntl(wrappedFd, F_GETFL));
+  KJ_EXPECT((statusFlags & O_NONBLOCK) != 0);
+  KJ_SYSCALL(fcntl(borrowed, F_GETFD));
 }
 
 KJ_TEST("wrapConnectingSocketFd completes a nonblocking connect") {

--- a/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
@@ -1,0 +1,1111 @@
+// Tests for kj-rs-io: tokio-backed implementations of KJ's async I/O interfaces, driven by a
+// kj::EventLoop on a TokioEventPort. Following kj-rs conventions, C++ KJ_TESTs drive; Rust
+// helpers (tests/lib.rs) provide the native-side behaviors (unwrap fast path, pre-bound fds).
+
+#include "io-test-helpers.h"
+#include "kj-rs-io-test/lib.rs.h"
+#include "kj-rs-io/async-io.h"
+
+#include <kj/array.h>
+#include <kj/async.h>
+#include <kj/debug.h>
+#include <kj/test.h>
+#include <kj/thread.h>
+
+#include <cstring>
+#include <type_traits>
+
+#if _WIN32
+#include <windows.h>  // Win32 APIs used by the Windows-only test arms below.
+
+// After windows.h: un-breaks macros it leaks over KJ's, notably ERROR (which otherwise breaks
+// the KJ_LOG(ERROR, ...) inside KJ_FAIL_* expansions).
+#include <kj/windows-sanity.h>
+#else
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace kj_rs_io_test {
+namespace {
+
+using kj_rs_io::setupTokioAsyncIo;
+using kj_rs_io::TokioAsyncIoContext;
+
+static_assert(!std::is_move_constructible_v<TokioAsyncIoContext>);
+
+// =======================================================================================
+// Helpers (shared ones: io-test-helpers.h)
+
+::rust::Slice<const uint8_t> toRust(kj::ArrayPtr<const kj::byte> data) {
+  return ::rust::Slice<const uint8_t>(data.begin(), data.size());
+}
+
+::rust::Vec<uint8_t> toRustVec(kj::ArrayPtr<const kj::byte> data) {
+  ::rust::Vec<uint8_t> vec;
+  vec.reserve(data.size());
+  for (auto b: data) {
+    vec.push_back(b);
+  }
+  return vec;
+}
+
+// Waits for `connectPromise` (a connect to a certainly-closed port) to fail and returns the
+// exception, bounded by a KJ timer so a never-settling connect fails the test with a message
+// instead of eating the binary's bazel timeout. (An earlier version of this helper carried a
+// watchdog thread and CPU accounting to diagnose a Windows CI wedge: a lost connect-readiness
+// wake caused by the then single-threaded waker bridge. That bridge is thread-safe now and the
+// wedge is gone with it; the timer bound is kept as a plain test hygiene measure.)
+kj::Exception expectConnectFailure(
+    TokioAsyncIoContext &io, kj::Promise<kj::Own<kj::AsyncIoStream>> connectPromise) {
+  auto timeout =
+      io.getTimer().afterDelay(30 * kj::SECONDS).then([]() -> kj::Own<kj::AsyncIoStream> {
+    KJ_FAIL_ASSERT("connect() to a closed port neither succeeded nor failed within 30s");
+  });
+  return KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
+    connectPromise.exclusiveJoin(kj::mv(timeout)).wait(io.getWaitScope());
+  }),
+      "connect() to a closed port unexpectedly succeeded");
+}
+
+// =======================================================================================
+// Stream contract
+
+KJ_TEST("tryRead waits for minBytes, then returns what is available up to "
+        "maxBytes") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  kj::byte buffer[16];
+
+  // Exactly-min: 3 bytes written, min 3 -> resolves with 3.
+  pair.client->write("abc"_kjb).wait(ws);
+  KJ_EXPECT(pair.server->tryRead(buffer, 3, sizeof(buffer)).wait(ws) == 3);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 3) == "abc"_kjb);
+
+  // Blocks until minBytes: 2 available < min 5 -> pending; 3 more arrive -> resolves with 5.
+  pair.client->write("de"_kjb).wait(ws);
+  auto readPromise = pair.server->tryRead(buffer, 5, sizeof(buffer));
+  KJ_EXPECT(!readPromise.poll(ws));
+  pair.client->write("fgh"_kjb).wait(ws);
+  KJ_EXPECT(readPromise.wait(ws) == 5);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 5) == "defgh"_kjb);
+}
+
+KJ_TEST("EOF before minBytes returns a short count; half-close keeps the other "
+        "direction usable") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  pair.client->write("ab"_kjb).wait(ws);
+  pair.client->shutdownWrite();
+
+  // EOF-before-min: only 2 bytes then FIN -> tryRead(min 5) resolves with 2.
+  kj::byte buffer[16];
+  KJ_EXPECT(pair.server->tryRead(buffer, 5, sizeof(buffer)).wait(ws) == 2);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 2) == "ab"_kjb);
+  // Subsequent reads keep reporting EOF.
+  KJ_EXPECT(pair.server->tryRead(buffer, 1, sizeof(buffer)).wait(ws) == 0);
+
+  // Half-close: server -> client direction still works after client's shutdownWrite.
+  pair.server->write("reply"_kjb).wait(ws);
+  KJ_EXPECT(pair.client->tryRead(buffer, 5, sizeof(buffer)).wait(ws) == 5);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 5) == "reply"_kjb);
+}
+
+KJ_TEST("multi-megabyte transfers in both directions with concurrent read+write "
+        "per stream") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  constexpr size_t SIZE = 8 * 1024 * 1024;
+  auto dataA = makePatternedData(SIZE, 1);
+  auto dataB = makePatternedData(SIZE, 2);
+
+  // All four directions at once: each stream is simultaneously reading and writing, and each
+  // transfer is far larger than the socket buffers (forcing many readiness round-trips).
+  auto builder = kj::heapArrayBuilder<kj::Promise<void>>(4);
+  builder.add(writeChunked(*pair.client, dataA));
+  builder.add(readExact(*pair.server, dataA));
+  builder.add(writeChunked(*pair.server, dataB));
+  builder.add(readExact(*pair.client, dataB));
+  kj::joinPromisesFailFast(builder.finish()).wait(ws);
+}
+
+KJ_TEST("multi-piece write() writes all pieces in order") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  const kj::ArrayPtr<const kj::byte> pieces[] = {"one,"_kjb, "two,"_kjb, "three"_kjb};
+  pair.client->write(kj::arrayPtr(pieces, 3)).wait(ws);
+
+  kj::byte buffer[32];
+  KJ_EXPECT(pair.server->tryRead(buffer, 13, sizeof(buffer)).wait(ws) == 13);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 13) == "one,two,three"_kjb);
+}
+
+KJ_TEST("canceling a blocked read releases the socket for reuse") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  kj::byte buffer[16];
+  {
+    // A read blocked in tokio (registered with the I/O driver, no data available)...
+    auto blocked = pair.server->tryRead(buffer, 1, sizeof(buffer));
+    KJ_EXPECT(!blocked.poll(ws));
+    // ...is canceled by dropping the promise, which must drop the Rust future and release the
+    // read interest.
+  }
+
+  // The stream remains fully usable: a fresh read gets the next bytes.
+  pair.client->write("later"_kjb).wait(ws);
+  KJ_EXPECT(pair.server->tryRead(buffer, 5, sizeof(buffer)).wait(ws) == 5);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 5) == "later"_kjb);
+
+  // Canceling mid-large-write also leaves the process sane (bytes may be lost, like KJ).
+  {
+    auto data = makePatternedData(16 * 1024 * 1024, 7);
+    auto bigWrite = pair.client->write(data);
+    if (bigWrite.poll(ws)) {
+      bigWrite.wait(ws);
+    }
+  }
+}
+
+#if !_WIN32
+KJ_TEST("whenWriteDisconnected resolves on peer reset, not on half-close") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  auto disconnected = pair.client->whenWriteDisconnected();
+  KJ_EXPECT(!disconnected.poll(ws));
+
+  // A peer half-close (FIN) must NOT count as write-disconnect: the client can still write.
+  pair.server->shutdownWrite();
+  kj::byte buffer[16];
+  KJ_EXPECT(pair.client->tryRead(buffer, 1, sizeof(buffer)).wait(ws) == 0);  // observe EOF
+  KJ_EXPECT(!disconnected.poll(ws));
+
+  // Destroying the server end with SO_LINGER=0 sends an RST; now writes are doomed.
+  struct linger lin;
+  lin.l_onoff = 1;
+  lin.l_linger = 0;
+  pair.server->setsockopt(SOL_SOCKET, SO_LINGER, &lin, sizeof(lin));
+  pair.server = nullptr;
+
+  disconnected.wait(ws);
+}
+#endif
+
+KJ_TEST("acceptAuthenticated reports the TCP peer's NetworkPeerIdentity") {
+  // workerd's HTTP listener builds the cf blob's clientIp (-> the CF-Connecting-IP header) from
+  // this identity; UnknownPeerIdentity (kj's base-class default) silently yields an empty
+  // client IP.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto listener = parseNow(io, "127.0.0.1")->listen();
+  auto acceptPromise = listener->acceptAuthenticated();
+  auto client = parseNow(io, kj::str("127.0.0.1:", listener->getPort()))->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+
+  auto &identity =
+      KJ_ASSERT_NONNULL(kj::tryDowncast<kj::NetworkPeerIdentity>(*server.peerIdentity));
+  // KJ's "ip:port" format, byte-identical to the native backend.
+  auto text = identity.toString();
+  KJ_EXPECT(text.startsWith("127.0.0.1:"), text);
+}
+
+#if !_WIN32
+KJ_TEST("acceptAuthenticated reports LocalPeerIdentity credentials on unix sockets") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // /tmp rather than TEST_TMPDIR: sun_path is limited to ~104 bytes.
+  auto path = kj::str("/tmp/kj-rs-io-auth-test-", getpid(), ".sock");
+  auto addr = parseNow(io, kj::str("unix:", path));
+
+  auto listener = addr->listen();
+  auto acceptPromise = listener->acceptAuthenticated();
+  auto client = addr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+
+  auto &identity = KJ_ASSERT_NONNULL(kj::tryDowncast<kj::LocalPeerIdentity>(*server.peerIdentity));
+  auto creds = identity.getCredentials();
+  // The peer is this very process.
+  KJ_EXPECT(KJ_ASSERT_NONNULL(creds.pid) == getpid());
+  KJ_EXPECT(KJ_ASSERT_NONNULL(creds.uid) == getuid());
+
+  unlink(path.cStr());
+}
+#endif
+
+KJ_TEST("sockname/peername/sockopt/getFd passthrough") {
+#if _WIN32
+  return;
+#else
+  auto io = setupTokioAsyncIo();
+  auto pair = makeTcpPair(io);
+
+  // getFd is populated.
+  KJ_EXPECT(KJ_ASSERT_NONNULL(pair.client->getFd()) >= 0);
+
+  // The client's peer is the server's local socket.
+  struct sockaddr_in peer, local;
+  kj::uint peerLen = sizeof(peer), localLen = sizeof(local);
+  pair.client->getpeername(reinterpret_cast<struct sockaddr *>(&peer), &peerLen);
+  pair.server->getsockname(reinterpret_cast<struct sockaddr *>(&local), &localLen);
+  KJ_EXPECT(peer.sin_port == local.sin_port);
+  KJ_EXPECT(peer.sin_addr.s_addr == local.sin_addr.s_addr);
+
+  // setsockopt/getsockopt round-trip (this is also how setNoDelay-style options are applied).
+  int on = 1;
+  pair.client->setsockopt(IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on));
+  int result = 0;
+  kj::uint resultLen = sizeof(result);
+  pair.client->getsockopt(IPPROTO_TCP, TCP_NODELAY, &result, &resultLen);
+  KJ_EXPECT(result != 0);
+#endif
+}
+
+// =======================================================================================
+// Network / addresses
+
+KJ_TEST("parseAddress handles IP literals, port hints, and toString round-trips") {
+  auto io = setupTokioAsyncIo();
+
+  KJ_EXPECT(parseNow(io, "1.2.3.4:80")->toString() == "1.2.3.4:80");
+  KJ_EXPECT(parseNow(io, "1.2.3.4", 99)->toString() == "1.2.3.4:99");
+  KJ_EXPECT(parseNow(io, "[1234:5678::abcd]:80")->toString() == "[1234:5678::abcd]:80");
+  KJ_EXPECT(parseNow(io, "1234:5678::abcd", 80)->toString() == "[1234:5678::abcd]:80");
+  KJ_EXPECT(parseNow(io, "*:80")->toString() == "*:80");
+  KJ_EXPECT(parseNow(io, "*")->toString() == "*:0");
+
+  // clone() produces an equivalent address.
+  auto addr = parseNow(io, "127.0.0.1:1234");
+  KJ_EXPECT(addr->clone()->toString() == addr->toString());
+}
+
+KJ_TEST("wildcard listen binds dual-stack and reports its port; port 0 picks a "
+        "free port") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto listener = parseNow(io, "*:0")->listen();
+  kj::uint port = listener->getPort();
+  KJ_EXPECT(port != 0);
+
+  // Reachable over both IPv4 and IPv6 loopback (IPV6_V6ONLY off, like KJ).
+  kj::String addrTexts[] = {kj::str("127.0.0.1:", port), kj::str("[::1]:", port)};
+  for (auto &addrText: addrTexts) {
+    auto acceptPromise = listener->accept();
+    auto client = parseNow(io, addrText)->connect().wait(ws);
+    auto server = acceptPromise.wait(ws);
+    client->write("ping"_kjb).wait(ws);
+    kj::byte buffer[4];
+    KJ_EXPECT(server->tryRead(buffer, 4, sizeof(buffer)).wait(ws) == 4);
+  }
+}
+
+KJ_TEST("parseAddress resolves hostnames via DNS") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // Listen on IPv4 loopback only. "localhost" resolves to 127.0.0.1 (and, on most systems, ::1
+  // as well, which connect()'s per-address fallback -- tested deterministically below -- skips).
+  auto listener = parseNow(io, "127.0.0.1")->listen();
+  auto addr = parseNow(io, kj::str("localhost:", listener->getPort()));
+
+  auto acceptPromise = listener->accept();
+  auto client = addr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+  client->write("dns!"_kjb).wait(ws);
+  kj::byte buffer[4];
+  KJ_EXPECT(server->tryRead(buffer, 4, sizeof(buffer)).wait(ws) == 4);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 4) == "dns!"_kjb);
+}
+
+KJ_TEST("connect() tries each resolved address in order, falling through refused ones") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // A port that is certainly closed: bind, note the port, close.
+  kj::uint closedPort = parseNow(io, "127.0.0.1")->listen()->getPort();
+  auto listener = parseNow(io, "127.0.0.1")->listen();
+
+  // Two addresses, the first refused: a deterministic multi-result "DNS" answer.
+  uint16_t ports[] = {
+    static_cast<uint16_t>(closedPort), static_cast<uint16_t>(listener->getPort())};
+  auto addr = kj::heap<kj_rs_io::TokioNetworkAddress>(
+      address_from_loopback_ports(::rust::Slice<const uint16_t>(ports, kj::size(ports))),
+      kj::rc<kj_rs_io::PeerFilter>());
+  auto acceptPromise = listener->accept();
+  auto client = addr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+  client->write("2nd"_kjb).wait(ws);
+  kj::byte buffer[3];
+  KJ_EXPECT(server->tryRead(buffer, 3, 3).wait(ws) == 3);
+
+  // All refused: the LAST address's exception propagates (KJ parity).
+  kj::uint closedPort2 = parseNow(io, "127.0.0.1")->listen()->getPort();
+  uint16_t closedPorts[] = {static_cast<uint16_t>(closedPort), static_cast<uint16_t>(closedPort2)};
+  auto allClosed = kj::heap<kj_rs_io::TokioNetworkAddress>(
+      address_from_loopback_ports(
+          ::rust::Slice<const uint16_t>(closedPorts, kj::size(closedPorts))),
+      kj::rc<kj_rs_io::PeerFilter>());
+  auto exception = expectConnectFailure(io, allClosed->connect());
+  KJ_EXPECT(exception.getType() == kj::Exception::Type::DISCONNECTED, exception);
+  KJ_EXPECT(exception.getDescription().contains("connect()"), exception.getDescription());
+}
+
+KJ_TEST("connect to a closed port surfaces a DISCONNECTED kj::Exception "
+        "mentioning the refusal") {
+  auto io = setupTokioAsyncIo();
+
+  // Find a port that is certainly closed: bind one, note it, close it.
+  kj::uint port;
+  {
+    auto listener = parseNow(io, "127.0.0.1")->listen();
+    port = listener->getPort();
+  }
+
+  auto addr = parseNow(io, kj::str("127.0.0.1:", port));
+  auto exception = expectConnectFailure(io, addr->connect());
+  // Exact text (recorded): "connect(): Connection refused (os error 61)" on macOS /
+  // "... (os error 111)" on Linux. KJ's native text would be "connect(): Connection refused".
+  KJ_EXPECT(
+      strstr(exception.getDescription().cStr(), "refused") != nullptr, exception.getDescription());
+  KJ_EXPECT(exception.getType() == kj::Exception::Type::DISCONNECTED);
+}
+
+KJ_TEST("the address may be dropped while connect() is pending (KJ lifetime "
+        "contract)") {
+  // Upstream KJ heap-copies the resolved address list into the connect promise
+  // (NetworkAddressImpl::connect() in kj/async-io-unix.c++), so callers may legally drop
+  // the kj::NetworkAddress right after calling connect(). Verify this port honors the same
+  // contract, on both the success path and the error/retry path.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // Success path: drop the address immediately, then complete the connect.
+  {
+    auto listener = parseNow(io, "127.0.0.1")->listen();
+    auto acceptPromise = listener->accept();
+
+    kj::Promise<kj::Own<kj::AsyncIoStream>> connectPromise = nullptr;
+    {
+      auto addr = parseNow(io, kj::str("127.0.0.1:", listener->getPort()));
+      connectPromise = addr->connect();
+      // `addr` is destroyed here, while the connect is still in flight.
+    }
+
+    auto client = connectPromise.wait(ws);
+    auto server = acceptPromise.wait(ws);
+    client->write("hello"_kjb).wait(ws);
+    kj::byte buffer[5] = {};
+    KJ_EXPECT(server->tryRead(buffer, 5, 5).wait(ws) == 5);
+    KJ_EXPECT(kj::arrayPtr(buffer, 5) == "hello"_kjb);
+  }
+
+  // Error path: connect to a certainly-closed port with the address already dropped; the
+  // failure continuation (which re-reads the address list) must still be safe and surface
+  // the normal exception.
+  {
+    kj::uint port;
+    {
+      auto listener = parseNow(io, "127.0.0.1")->listen();
+      port = listener->getPort();
+    }
+
+    kj::Promise<kj::Own<kj::AsyncIoStream>> connectPromise = nullptr;
+    {
+      auto addr = parseNow(io, kj::str("127.0.0.1:", port));
+      connectPromise = addr->connect();
+    }
+
+    auto exception = expectConnectFailure(io, kj::mv(connectPromise));
+    KJ_EXPECT(strstr(exception.getDescription().cStr(), "refused") != nullptr,
+        exception.getDescription());
+    KJ_EXPECT(exception.getType() == kj::Exception::Type::DISCONNECTED);
+  }
+}
+
+KJ_TEST("connecting to a wildcard address is an error") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto addr = parseNow(io, "*:1234");
+  KJ_EXPECT_THROW_MESSAGE("wildcard", addr->connect().wait(ws));
+}
+
+#if !_WIN32
+KJ_TEST("unix domain sockets: parse, listen, connect, toString") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // Note: /tmp rather than TEST_TMPDIR because sun_path is limited to ~104 bytes.
+  auto path = kj::str("/tmp/kj-rs-io-test-", getpid(), ".sock");
+  auto addrText = kj::str("unix:", path);
+
+  auto addr = parseNow(io, addrText);
+  KJ_EXPECT(addr->toString() == addrText);
+
+  auto listener = addr->listen();
+  KJ_EXPECT(listener->getPort() == 0);  // KJ reports 0 for non-IP listeners.
+  auto acceptPromise = listener->accept();
+  auto client = addr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+
+  client->write("via unix"_kjb).wait(ws);
+  client->shutdownWrite();
+  kj::byte buffer[16];
+  KJ_EXPECT(server->tryRead(buffer, 16, sizeof(buffer)).wait(ws) == 8);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 8) == "via unix"_kjb);
+
+  unlink(path.cStr());
+}
+
+KJ_TEST("getSockaddr builds a connectable address from a raw struct sockaddr") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto listener = parseNow(io, "127.0.0.1")->listen();
+
+  struct sockaddr_in sin;
+  memset(&sin, 0, sizeof(sin));
+  sin.sin_family = AF_INET;
+  sin.sin_port = htons(static_cast<uint16_t>(listener->getPort()));
+  sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  auto addr = io.getNetwork().getSockaddr(&sin, sizeof(sin));
+  KJ_EXPECT(addr->toString() == kj::str("127.0.0.1:", listener->getPort()));
+
+  auto acceptPromise = listener->accept();
+  auto client = addr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+  client->write("hi"_kjb).wait(ws);
+  kj::byte buffer[2];
+  KJ_EXPECT(server->tryRead(buffer, 2, sizeof(buffer)).wait(ws) == 2);
+}
+#endif
+
+KJ_TEST("newPipeThread is a documented stub") {
+  auto io = setupTokioAsyncIo();
+  KJ_EXPECT_THROW_MESSAGE("newPipeThread",
+      io.getProvider().newPipeThread(
+          [](kj::AsyncIoProvider &, kj::AsyncIoStream &, kj::WaitScope &) {}));
+}
+
+// =======================================================================================
+// Provider odds and ends
+
+KJ_TEST("provider pipes (in-memory) and timer work under the tokio loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto pipe = io.getProvider().newTwoWayPipe();
+  auto writePromise = pipe.ends[0]->write("pipe data"_kjb).eagerlyEvaluate(nullptr);
+  kj::byte buffer[16];
+  KJ_EXPECT(pipe.ends[1]->tryRead(buffer, 9, sizeof(buffer)).wait(ws) == 9);
+  writePromise.wait(ws);
+
+  auto &timer = io.getProvider().getTimer();
+  auto before = timer.now();
+  timer.afterDelay(5 * kj::MILLISECONDS).wait(ws);
+  KJ_EXPECT(timer.now() - before >= 5 * kj::MILLISECONDS);
+}
+
+// =======================================================================================
+// Unwrap fast path
+
+KJ_TEST("unwrap fast path: recover the native tokio stream and write from Rust") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // Recover the native tokio TcpStream out of the kj wrapper (free-function form, as a Rust
+  // server would after being handed a kj::AsyncIoStream&)...
+  auto native = kj_rs_io::unwrapTokioStream(*pair.server);
+
+  // ...the hollow wrapper now refuses I/O...
+  kj::byte buffer[32];
+  KJ_EXPECT_THROW_MESSAGE("unwrapped", pair.server->tryRead(buffer, 1, sizeof(buffer)).wait(ws));
+
+  // ...and Rust can drive the connection natively: it writes via the tokio readiness API and
+  // closes; C++ reads the bytes plus EOF through the (still wrapped) client end.
+  auto writeDone = native_write_via_unwrap(kj::mv(native), toRustVec("native write"_kjb));
+  KJ_EXPECT(pair.client->tryRead(buffer, 12, sizeof(buffer)).wait(ws) == 12);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 12) == "native write"_kjb);
+  writeDone.wait(ws);
+  KJ_EXPECT(pair.client->tryRead(buffer, 1, sizeof(buffer)).wait(ws) == 0);  // EOF
+}
+
+KJ_TEST("unwrap fast path: Rust-side unwrap_kj_stream() from a "
+        "kj::AsyncIoStream&") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // Rust receives only a kj::AsyncIoStream& and performs the unwrap + native write itself.
+  auto writeDone = native_write_via_kj_unwrap(*pair.server, toRust("rust unwrap"_kjb));
+  kj::byte buffer[32];
+  KJ_EXPECT(pair.client->tryRead(buffer, 11, sizeof(buffer)).wait(ws) == 11);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 11) == "rust unwrap"_kjb);
+  writeDone.wait(ws);
+
+  // Unwrapping a foreign (non-kj-rs-io) stream fails cleanly.
+  auto pipe = io.getProvider().newTwoWayPipe();
+  KJ_EXPECT_THROW_MESSAGE("cannot unwrap", kj_rs_io::unwrapTokioStream(*pipe.ends[0]));
+}
+
+// =======================================================================================
+// Fd wrapping (kj::LowLevelAsyncIoProvider)
+
+#if !_WIN32
+KJ_TEST("wrapListenSocketFd accepts connections on a pre-bound listener (the "
+        "--socket-fd case)") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // Rust binds a *blocking* std listener (like an fd inherited from a supervisor) and hands us
+  // the raw fd; wrapListenSocketFd must take ownership and make it usable.
+  auto prebound = create_prebound_listener_fd();
+  auto receiver = io.getLowLevelProvider().wrapListenSocketFd(
+      prebound.fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP);
+  KJ_EXPECT(receiver->getPort() == prebound.port);
+
+  auto acceptPromise = receiver->accept();
+  auto client = parseNow(io, kj::str("127.0.0.1:", prebound.port))->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+
+  client->write("fd listen"_kjb).wait(ws);
+  kj::byte buffer[16];
+  KJ_EXPECT(server->tryRead(buffer, 9, sizeof(buffer)).wait(ws) == 9);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 9) == "fd listen"_kjb);
+}
+
+KJ_TEST("wrapSocketFd wraps both ends of a socketpair") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  int fds[2];
+  KJ_SYSCALL(socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+  auto end0 =
+      io.getLowLevelProvider().wrapSocketFd(fds[0], kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP);
+  auto end1 =
+      io.getLowLevelProvider().wrapSocketFd(fds[1], kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP);
+
+  end0->write("socketpair"_kjb).wait(ws);
+  kj::byte buffer[16];
+  KJ_EXPECT(end1->tryRead(buffer, 10, sizeof(buffer)).wait(ws) == 10);
+  KJ_EXPECT(kj::ArrayPtr<kj::byte>(buffer, 10) == "socketpair"_kjb);
+}
+
+KJ_TEST("wrapConnectingSocketFd completes a nonblocking connect") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto listener = parseNow(io, "127.0.0.1")->listen();
+
+  int fd;
+  KJ_SYSCALL(fd = socket(AF_INET, SOCK_STREAM, 0));
+  struct sockaddr_in sin;
+  memset(&sin, 0, sizeof(sin));
+  sin.sin_family = AF_INET;
+  sin.sin_port = htons(static_cast<uint16_t>(listener->getPort()));
+  sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+  auto acceptPromise = listener->accept();
+  auto client = io.getLowLevelProvider()
+                    .wrapConnectingSocketFd(fd, reinterpret_cast<struct sockaddr *>(&sin),
+                        sizeof(sin), kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP)
+                    .wait(ws);
+  auto server = acceptPromise.wait(ws);
+
+  client->write("connected"_kjb).wait(ws);
+  kj::byte buffer[16];
+  KJ_EXPECT(server->tryRead(buffer, 9, sizeof(buffer)).wait(ws) == 9);
+}
+
+KJ_TEST("wrapInputFd/wrapOutputFd move bytes through an OS pipe and observe EOF") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  int fds[2];
+  KJ_SYSCALL(pipe(fds));
+  auto input =
+      io.getLowLevelProvider().wrapInputFd(fds[0], kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP);
+  auto output =
+      io.getLowLevelProvider().wrapOutputFd(fds[1], kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP);
+
+  // Blocked read completes once data is written ("pipe fd io" is 10 bytes; cap the first read
+  // at 9 so one byte remains).
+  kj::byte buffer[16];
+  auto readPromise = input->tryRead(buffer, 9, 9);
+  KJ_EXPECT(!readPromise.poll(ws));
+  auto writePromise = output->write("pipe fd io"_kjb);
+  KJ_EXPECT(readPromise.wait(ws) == 9);
+  writePromise.wait(ws);
+  KJ_EXPECT(input->tryRead(buffer, 1, sizeof(buffer)).wait(ws) == 1);  // "o"
+
+  // Dropping the output stream closes the write end -> EOF.
+  output = nullptr;
+  KJ_EXPECT(input->tryRead(buffer, 1, sizeof(buffer)).wait(ws) == 0);
+}
+
+KJ_TEST("restrictPeers blocks disallowed connect() with KJ's error text") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  kj_rs_io::TokioNetwork network;
+  auto restricted = network.restrictPeers({"public"_kj}, {});
+
+  // Loopback is not "public": blocked before any connection attempt.
+  auto blockedAddr = restricted->parseAddress("127.0.0.1:1").wait(ws);
+  KJ_EXPECT_THROW_MESSAGE("connect() blocked by restrictPeers()", blockedAddr->connect().wait(ws));
+
+  // getSockaddr is rejected eagerly, like KJ.
+  struct sockaddr_in sin;
+  memset(&sin, 0, sizeof(sin));
+  sin.sin_family = AF_INET;
+  sin.sin_port = htons(1);
+  sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  KJ_EXPECT_THROW_MESSAGE(
+      "address blocked by restrictPeers()", restricted->getSockaddr(&sin, sizeof(sin)));
+
+  // An allowing restriction still connects.
+  auto allowed = network.restrictPeers({"private"_kj}, {});
+  auto listener = network.parseAddress("127.0.0.1", 0).wait(ws)->listen();
+  auto acceptPromise = listener->accept();
+  auto client = allowed->parseAddress(kj::str("127.0.0.1:", listener->getPort()))
+                    .wait(ws)
+                    ->connect()
+                    .wait(ws);
+  auto server = acceptPromise.wait(ws);
+  client->write("ok"_kjb).wait(ws);
+  kj::byte buffer[2];
+  KJ_EXPECT(server->tryRead(buffer, 2, 2).wait(ws) == 2);
+}
+
+KJ_TEST("restrictPeers filters accepted peers (disallowed peers are dropped, "
+        "accept keeps waiting)") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  kj_rs_io::TokioNetwork network;
+  auto restricted = network.restrictPeers({"public"_kj}, {});
+
+  auto listener = restricted->parseAddress("127.0.0.1", 0).wait(ws)->listen();
+  auto acceptPromise = listener->accept();
+
+  // Connect via the unrestricted network; the loopback peer is not "public", so the listener
+  // silently drops it: accept() stays pending and the client observes EOF.
+  auto client = network.parseAddress(kj::str("127.0.0.1:", listener->getPort()), 0)
+                    .wait(ws)
+                    ->connect()
+                    .wait(ws);
+  KJ_EXPECT(!acceptPromise.poll(ws));
+  kj::byte buffer[1];
+  KJ_EXPECT(client->tryRead(buffer, 1, 1).wait(ws) == 0);
+}
+
+KJ_TEST("onSignal is delivered even when another runtime's thread consumes the signal") {
+  // Regression test for a SIGTERM hang observed in workerd: tokio's signal registry is
+  // process-global, and whichever runtime's driver consumes the signal's wake byte performs the
+  // broadcast. With a second tokio runtime parked on another thread (workerd's inspector thread,
+  // in the wild), the broadcast often runs on THAT thread — a cross-thread wake of this loop's
+  // waker. Before the kj-rs waker bridge was thread-safe, that wake was lost and workerd ignored
+  // SIGTERM until killed; now it must always be delivered (kj-rs/waker.h's cross-thread path).
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // A second, idle tokio-ported KJ loop parked on another thread for the duration of the test.
+  // The shutdown promise must be created ON that thread's loop (kj promises are single-loop
+  // objects); only its CrossThreadPromiseFulfiller half comes back to this thread.
+  kj::MutexGuarded<kj::Maybe<kj::Own<const kj::CrossThreadPromiseFulfiller<void>>>> shutdown;
+  kj::Thread otherLoop([&shutdown]() {
+    auto io2 = setupTokioAsyncIo();
+    auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
+    *shutdown.lockExclusive() = kj::mv(paf.fulfiller);
+    paf.promise.wait(io2.getWaitScope());
+  });
+  KJ_DEFER({
+    KJ_IF_SOME(fulfiller, *shutdown.lockExclusive()) {
+      fulfiller->fulfill();
+    }
+  });
+  // Wait until the other loop is up and parked (and the shutdown fulfiller exists) before
+  // raising any signals, so its runtime genuinely participates in the wake-byte race.
+  shutdown.when([](auto &maybe) { return maybe != kj::none; }, [](auto &) {});
+
+  // Several rounds, giving each runtime chances to win the wake-byte race. Bounded so a lost
+  // wake fails with a diagnosis instead of eating the binary's bazel timeout.
+  for (int i = 0; i < 5; i++) {
+    auto promise = kj_rs_io::onSignal(SIGUSR2);
+    // Pump the loop so the handler is installed before we raise (see the test below).
+    KJ_EXPECT(!promise.poll(ws));
+    KJ_SYSCALL(kill(getpid(), SIGUSR2));
+    promise
+        .exclusiveJoin(io.getTimer().afterDelay(20 * kj::SECONDS).then([]() {
+      KJ_FAIL_ASSERT("onSignal wake was lost (cross-thread waker regression)");
+    })).wait(ws);
+  }
+}
+
+KJ_TEST("onSignal resolves when the process receives the signal") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto promise = kj_rs_io::onSignal(SIGUSR2);
+  // Pump the loop so the (cold, first-poll-registered) tokio signal handler is installed
+  // before we raise; raising first would take SIGUSR2's default disposition (terminate).
+  KJ_EXPECT(!promise.poll(ws));
+
+  KJ_SYSCALL(kill(getpid(), SIGUSR2));
+  promise.wait(ws);
+
+  // A second watcher works too (the process-global registration is reusable).
+  auto again = kj_rs_io::onSignal(SIGUSR2);
+  KJ_EXPECT(!again.poll(ws));
+  KJ_SYSCALL(kill(getpid(), SIGUSR2));
+  again.wait(ws);
+}
+#endif
+
+// =======================================================================================
+// Review-driven hardening tests (re-review of Part2 against the prep-review lens).
+
+KJ_TEST("concurrent acceptAuthenticated on two tokio-ported loops does not race the filter") {
+  // Regression guard for the per-identity allow-all filter: it must NOT be a process-wide
+  // static kj::Rc (non-atomic refcount) shared across accept loops on different threads. Two
+  // loops, each accepting a TCP connection and building a NetworkPeerIdentity (which creates
+  // that filter), running concurrently. TSAN target; also ASAN-visible as a double-free if the
+  // refcount ever races.
+  constexpr kj::uint N = 40;
+  auto runOne = []() noexcept {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    for (kj::uint i = 0; i < N; i++) {
+      auto listener = parseNow(io, "127.0.0.1")->listen();
+      auto connectAddr = parseNow(io, kj::str("127.0.0.1:", listener->getPort()));
+      auto acceptPromise = listener->acceptAuthenticated();
+      auto client = connectAddr->connect().wait(ws);
+      auto authed = acceptPromise.wait(ws);
+      // Touch the identity so the allow-all filter is actually built and addRef'd.
+      KJ_EXPECT(authed.peerIdentity->toString() != nullptr);
+    }
+  };
+  kj::Thread other(runOne);
+  runOne();
+}
+
+KJ_TEST("restrictPeers: a child network (and its addresses) outlive the parent network") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // Build a restricted child, then DROP the parent network while keeping the child and an
+  // address parsed from it. The refcounted PeerFilter chain must keep the parent's filter alive
+  // through the child's Rc, so the child stays usable.
+  kj::Own<kj::NetworkAddress> addr;
+  kj::Own<kj::Network> child;
+  {
+    auto parent = io.getNetwork().restrictPeers({"public"_kj}, {});
+    child = parent->restrictPeers({"private"_kj}, {});
+    addr = child->parseAddress("127.0.0.1:1").wait(ws);
+    // `parent` drops here.
+  }
+  // The child still works (its filter chain is intact): a private address connect is blocked
+  // with KJ's error text, proving the (grand)parent rules still apply.
+  auto blocked = kj::runCatchingExceptions([&]() { addr->connect().wait(ws); });
+  KJ_EXPECT(blocked != kj::none);
+  KJ_EXPECT(KJ_ASSERT_NONNULL(blocked).getDescription().contains("restrictPeers"));
+}
+
+KJ_TEST("dropping a just-started connect() then tearing down the context is clean") {
+  // Start a connect(), kick the machinery with one poll, then drop the promise and destroy the
+  // whole context -- exercising cancellation of the connect's readiness registration and the
+  // teardown that follows (ASAN target). Whether the connect has settled by the poll is
+  // environment-dependent and irrelevant: either way the drop + teardown must be clean.
+  // 198.51.100.1 is TEST-NET-2 (RFC 5737), non-routable, so it usually stays pending.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto addr = parseNow(io, "198.51.100.1:80");
+  auto connectPromise = addr->connect();
+  connectPromise.poll(ws);
+  { auto dropped = kj::mv(connectPromise); }
+  KJ_EXPECT(kj::evalLater([]() { return 1; }).wait(ws) == 1);
+}
+
+KJ_TEST("canceling a pending accept() then accepting again works") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto listener = parseNow(io, "127.0.0.1")->listen();
+  auto connectAddr = parseNow(io, kj::str("127.0.0.1:", listener->getPort()));
+
+  // Start an accept with no client, then drop it.
+  {
+    auto pending = listener->accept();
+    KJ_EXPECT(!pending.poll(ws));
+  }
+
+  // The listener is still usable: a fresh accept completes against a new client.
+  auto acceptPromise = listener->accept();
+  auto client = connectAddr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+  KJ_EXPECT(server->write("x"_kjb).then([]() { return true; }).wait(ws));
+}
+
+KJ_TEST("context teardown while a DNS parseAddress() is in flight is clean") {
+  // parseAddress() of a hostname spawns a runtime task (getaddrinfo on the blocking pool). Drop
+  // the promise mid-lookup and tear the context down: the spawned task must be cancelled without
+  // touching freed KJ state (ASAN target; the kj-rs-tokio teardown-order fix covers this).
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto parsePromise = io.getNetwork().parseAddress("example.invalid:80");
+  // `.invalid` never resolves to success, but the lookup is in flight after one poll.
+  parsePromise.poll(ws);
+  { auto dropped = kj::mv(parsePromise); }
+  KJ_EXPECT(kj::evalLater([]() { return 2; }).wait(ws) == 2);
+}
+
+KJ_TEST("zero-length write() is a no-op that succeeds") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+  pair.client->write(kj::ArrayPtr<const kj::byte>()).wait(ws);
+  // The stream is still fully usable afterwards.
+  pair.client->write("hi"_kjb).wait(ws);
+  kj::byte buf[2];
+  KJ_EXPECT(pair.server->tryRead(buf, 2, 2).wait(ws) == 2);
+}
+
+KJ_TEST("write() to a reset peer surfaces a DISCONNECTED exception") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // RST the server end (SO_LINGER=0 close), then write from the client until the RST is
+  // observed. The first write may still succeed into the local send buffer, so loop; the
+  // failure, when it comes, must be DISCONNECTED (EPIPE/ECONNRESET), not FAILED.
+  struct linger lin;
+  lin.l_onoff = 1;
+  lin.l_linger = 0;
+  pair.server->setsockopt(SOL_SOCKET, SO_LINGER, &lin, sizeof(lin));
+  pair.server = nullptr;
+
+  auto chunk = kj::heapArray<kj::byte>(64 * 1024);
+  memset(chunk.begin(), 0, chunk.size());
+  kj::Maybe<kj::Exception> maybeException;
+  for (int i = 0; i < 100 && maybeException == kj::none; i++) {
+    maybeException = kj::runCatchingExceptions([&]() { pair.client->write(chunk).wait(ws); });
+  }
+  auto &exception = KJ_ASSERT_NONNULL(maybeException, "write to a reset peer should fail");
+  KJ_EXPECT(exception.getType() == kj::Exception::Type::DISCONNECTED, exception.getDescription());
+}
+
+KJ_TEST("write_all applies backpressure: it stays pending against a peer that never reads") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // Write far more than the combined send+recv socket buffers to a peer that never reads: the
+  // write must NOT complete (write_all's try_write hits WouldBlock and awaits WRITABLE).
+  auto payload = kj::heapArray<kj::byte>(16 * 1024 * 1024);
+  memset(payload.begin(), 0x5a, payload.size());
+  auto write = pair.client->write(payload);
+  // Give the loop real turns; a correct write stays pending under backpressure.
+  for (int i = 0; i < 5; i++) {
+    io.getTimer().afterDelay(5 * kj::MILLISECONDS).wait(ws);
+  }
+  KJ_EXPECT(!write.poll(ws), "write_all must not complete while the peer never reads");
+
+  // Now drain on the peer; the write completes.
+  auto drain = [](kj::AsyncIoStream &s, size_t total) -> kj::Promise<void> {
+    auto buf = kj::heapArray<kj::byte>(256 * 1024);
+    size_t got = 0;
+    while (got < total) {
+      size_t n = co_await s.tryRead(buf.begin(), 1, buf.size());
+      if (n == 0) break;
+      got += n;
+    }
+  }(*pair.server, payload.size());
+  write.exclusiveJoin(kj::mv(drain)).wait(ws);
+}
+
+KJ_TEST("getSockaddr builds a connectable IPv6 address from a raw sockaddr_in6") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto listener = parseNow(io, "[::1]")->listen();
+
+  struct sockaddr_in6 sin6;
+  memset(&sin6, 0, sizeof(sin6));
+  sin6.sin6_family = AF_INET6;
+  sin6.sin6_port = htons(static_cast<uint16_t>(listener->getPort()));
+  sin6.sin6_addr = in6addr_loopback;
+  auto addr = io.getNetwork().getSockaddr(&sin6, sizeof(sin6));
+  KJ_EXPECT(addr->toString() == kj::str("[::1]:", listener->getPort()));
+
+  auto acceptPromise = listener->accept();
+  auto client = addr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+  client->write("v6"_kjb).wait(ws);
+  kj::byte buf[2];
+  KJ_EXPECT(server->tryRead(buf, 2, 2).wait(ws) == 2);
+}
+
+#if !_WIN32
+KJ_TEST("multiple concurrent onSignal for the same signum all fire") {
+  // tokio broadcasts a signal to every live stream for that signum, so two concurrent
+  // onSignal(SIGUSR2) must both resolve on a single delivery.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto a = kj_rs_io::onSignal(SIGUSR2);
+  auto b = kj_rs_io::onSignal(SIGUSR2);
+  KJ_EXPECT(!a.poll(ws));  // both handlers installed before we raise
+  KJ_EXPECT(!b.poll(ws));
+  KJ_SYSCALL(kill(getpid(), SIGUSR2));
+  a.wait(ws);
+  b.wait(ws);
+}
+
+KJ_TEST("onSignal isolates different signums") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto usr1 = kj_rs_io::onSignal(SIGUSR1);
+  auto usr2 = kj_rs_io::onSignal(SIGUSR2);
+  KJ_EXPECT(!usr1.poll(ws));
+  KJ_EXPECT(!usr2.poll(ws));
+  KJ_SYSCALL(kill(getpid(), SIGUSR2));
+  usr2.wait(ws);
+  // Only SIGUSR2 was raised; the SIGUSR1 watcher stays pending.
+  KJ_EXPECT(!usr1.poll(ws));
+}
+
+KJ_TEST("dropping a pending onSignal does not break later watches") {
+  // Cancel a registered-but-unfired signal watch, then confirm a fresh watch still delivers --
+  // the dropped tokio signal stream must not disturb the process-global registration. ASAN-
+  // relevant (the drop cancels the stream).
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  {
+    auto dropped = kj_rs_io::onSignal(SIGUSR2);
+    KJ_EXPECT(!dropped.poll(ws));
+  }
+  auto again = kj_rs_io::onSignal(SIGUSR2);
+  KJ_EXPECT(!again.poll(ws));
+  KJ_SYSCALL(kill(getpid(), SIGUSR2));
+  again.wait(ws);
+}
+
+KJ_TEST("onSignal for an unwatchable signum errors instead of aborting") {
+  // SIGKILL/SIGSTOP cannot have handlers; tokio's signal() rejects them, which must surface as a
+  // catchable kj::Exception (a rejected promise), never a crash. No signal is raised.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  KJ_EXPECT_THROW_MESSAGE("signal", kj_rs_io::onSignal(SIGKILL).wait(ws));
+}
+#endif  // !_WIN32
+
+// =======================================================================================
+// Added coverage: vectored writes under backpressure, DNS failure, unix bind collisions,
+// acceptAuthenticated through a restricted listener.
+
+KJ_TEST("multi-piece write() larger than the socket buffer arrives intact and in order "
+        "(partial writev + backpressure)") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // Several MiB across pieces of very different sizes, with empty pieces mixed in: the kernel
+  // will accept only part of the iovec array per writev, so the Rust side must resume from the
+  // exact byte the previous writev stopped at, across pieces.
+  auto a = makePatternedData(3 * 1024 * 1024, 1);
+  auto b = makePatternedData(7, 2);
+  auto c = makePatternedData(2 * 1024 * 1024, 3);
+  kj::ArrayPtr<const kj::byte> empty;
+  kj::ArrayPtr<const kj::byte> pieces[] = {empty, a, b, empty, c, empty};
+
+  auto expected = kj::heapArray<kj::byte>(a.size() + b.size() + c.size());
+  memcpy(expected.begin(), a.begin(), a.size());
+  memcpy(expected.begin() + a.size(), b.begin(), b.size());
+  memcpy(expected.begin() + a.size() + b.size(), c.begin(), c.size());
+
+  auto write = pair.client->write(kj::arrayPtr(pieces, kj::size(pieces)));
+  // The reader runs concurrently: nothing drains the socket otherwise, so the write must hit
+  // WouldBlock partway through the array and pick up where it left off.
+  kj::joinPromisesFailFast(kj::arr(kj::mv(write), readExact(*pair.server, expected))).wait(ws);
+}
+
+KJ_TEST("multi-piece write() of only empty pieces succeeds without touching the socket") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+  kj::ArrayPtr<const kj::byte> pieces[] = {{}, {}};
+  pair.client->write(kj::arrayPtr(pieces, 2)).wait(ws);
+  // Nothing was written: a short read times out rather than returning bytes.
+  kj::byte buffer[1];
+  auto read = pair.server->tryRead(buffer, 1, 1);
+  KJ_EXPECT(!read.poll(ws));
+}
+
+KJ_TEST("parseAddress of an unresolvable host fails with a getaddrinfo exception") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // RFC 6761 reserves .invalid: resolvers must answer NXDOMAIN without asking upstream.
+  auto exception = KJ_ASSERT_NONNULL(kj::runCatchingExceptions([&]() {
+    boundedBy(io, io.getNetwork().parseAddress("nonexistent.invalid:80"), 30 * kj::SECONDS,
+        "DNS failure to be reported")
+        .wait(ws);
+  }),
+      "nonexistent.invalid unexpectedly resolved");
+  KJ_EXPECT(exception.getDescription().contains("getaddrinfo"), exception.getDescription());
+}
+
+#if !_WIN32
+KJ_TEST("listen() on a unix socket path that already exists fails (no unlink, like KJ)") {
+  auto io = setupTokioAsyncIo();
+  auto path = freshUnixSocketPath("bind-twice");
+  KJ_DEFER(::unlink(path.cStr()));
+  auto addr = parseNow(io, kj::str("unix:", path));
+  auto first = addr->listen();
+  KJ_EXPECT_THROW_MESSAGE("bind()", addr->listen());
+  // The first listener still works.
+  KJ_EXPECT(first->getPort() == 0);
+}
+#endif  // !_WIN32
+
+KJ_TEST("acceptAuthenticated() through a restricted listener drops disallowed peers too") {
+  // Mirrors the accept() test above through the other entry point: both share acceptImpl, and
+  // the filter must run before any peer identity is minted.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  kj_rs_io::TokioNetwork network;
+  auto restricted = network.restrictPeers({"public"_kj}, {});
+
+  auto listener = restricted->parseAddress("127.0.0.1", 0).wait(ws)->listen();
+  auto acceptPromise = listener->acceptAuthenticated();
+
+  auto client = network.parseAddress(kj::str("127.0.0.1:", listener->getPort()), 0)
+                    .wait(ws)
+                    ->connect()
+                    .wait(ws);
+  kj::byte buffer[1];
+  // The listener drops the loopback (non-"public") peer: the client sees EOF, and the accept is
+  // still pending afterwards (the EOF proves the drop happened, so this poll is meaningful).
+  KJ_EXPECT(client->tryRead(buffer, 1, 1).wait(ws) == 0);
+  KJ_EXPECT(!acceptPromise.poll(ws));
+}
+
+}  // namespace
+}  // namespace kj_rs_io_test

--- a/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
@@ -909,6 +909,7 @@ KJ_TEST("zero-length write() is a no-op that succeeds") {
   KJ_EXPECT(pair.server->tryRead(buf, 2, 2).wait(ws) == 2);
 }
 
+#if !_WIN32
 KJ_TEST("write() to a reset peer surfaces a DISCONNECTED exception") {
   auto io = setupTokioAsyncIo();
   auto &ws = io.getWaitScope();
@@ -984,7 +985,6 @@ KJ_TEST("getSockaddr builds a connectable IPv6 address from a raw sockaddr_in6")
   KJ_EXPECT(server->tryRead(buf, 2, 2).wait(ws) == 2);
 }
 
-#if !_WIN32
 KJ_TEST("multiple concurrent onSignal for the same signum all fire") {
   // tokio broadcasts a signal to every live stream for that signum, so two concurrent
   // onSignal(SIGUSR2) must both resolve on a single delivery.

--- a/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/async-io-test.c++
@@ -737,11 +737,12 @@ KJ_TEST("onSignal is delivered even when another runtime's thread consumes the s
     *shutdown.lockExclusive() = kj::mv(paf.fulfiller);
     paf.promise.wait(io2.getWaitScope());
   });
-  KJ_DEFER({
+  auto fulfillShutdown = [&]() {
     KJ_IF_SOME(fulfiller, *shutdown.lockExclusive()) {
       fulfiller->fulfill();
     }
-  });
+  };
+  KJ_DEFER(fulfillShutdown());
   // Wait until the other loop is up and parked (and the shutdown fulfiller exists) before
   // raising any signals, so its runtime genuinely participates in the wake-byte race.
   shutdown.when([](auto &maybe) { return maybe != kj::none; }, [](auto &) {});

--- a/src/rust/cxx/kj-rs-io/tests/capnp-rpc-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/capnp-rpc-test.c++
@@ -1,0 +1,79 @@
+// capnp RPC integration: capnp::TwoPartyServer / capnp::TwoPartyClient running over kj-rs-io
+// (tokio-backed) streams on the tokio event loop — bootstrap plus call round-trips. Uses a
+// schema-less capability (raw dispatchCall / typelessRequest with Text payloads) to avoid
+// needing capnp codegen in this repo.
+
+#include "kj-rs-io/async-io.h"
+
+#include <capnp/capability.h>
+#include <capnp/message.h>
+#include <capnp/rpc-twoparty.h>
+#include <kj/async.h>
+#include <kj/debug.h>
+#include <kj/test.h>
+
+namespace kj_rs_io_test {
+namespace {
+
+using kj_rs_io::setupTokioAsyncIo;
+
+constexpr uint64_t ECHO_INTERFACE_ID = 0xabcd1234abcd1234ull;
+constexpr uint16_t ECHO_METHOD_ID = 0;
+
+// A schema-less capability: method 0 takes a Text param and returns "echo:" + text.
+class EchoCapability final: public capnp::Capability::Server {
+ public:
+  DispatchCallResult dispatchCall(uint64_t interfaceId,
+      uint16_t methodId,
+      capnp::CallContext<capnp::AnyPointer, capnp::AnyPointer> context) override {
+    KJ_ASSERT(interfaceId == ECHO_INTERFACE_ID);
+    KJ_ASSERT(methodId == ECHO_METHOD_ID);
+    auto params = kj::str(context.getParams().getAs<capnp::Text>());
+    context.releaseParams();
+    context.getResults(capnp::MessageSize{16, 0}).setAs<capnp::Text>(kj::str("echo:", params));
+    return DispatchCallResult{kj::READY_NOW, false, true};
+  }
+};
+
+KJ_TEST("capnp two-party RPC bootstrap and call round-trips over kj-rs-io "
+        "streams on the tokio loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // Server: TwoPartyServer accepting from a kj-rs-io ConnectionReceiver.
+  capnp::TwoPartyServer server(kj::heap<EchoCapability>());
+  auto listener = io.getNetwork().parseAddress("127.0.0.1", 0).wait(ws)->listen();
+  auto listenTask = server.listen(*listener).eagerlyEvaluate(
+      [](kj::Exception &&e) { KJ_FAIL_EXPECT("RPC server failed", e); });
+
+  // Client: TwoPartyClient over a kj-rs-io connection.
+  auto addr = io.getNetwork().parseAddress(kj::str("127.0.0.1:", listener->getPort())).wait(ws);
+  auto connection = addr->connect().wait(ws);
+  capnp::TwoPartyClient client(*connection);
+  auto cap = client.bootstrap();
+
+  // Single call round trip.
+  {
+    auto request = cap.typelessRequest(ECHO_INTERFACE_ID, ECHO_METHOD_ID, kj::none, {});
+    request.setAs<capnp::Text>("hello tokio");
+    auto response = request.send().wait(ws);
+    KJ_EXPECT(response.getAs<capnp::Text>() == "echo:hello tokio");
+  }
+
+  // A pile of pipelined calls in flight at once.
+  {
+    constexpr int COUNT = 64;
+    auto builder = kj::heapArrayBuilder<kj::Promise<void>>(COUNT);
+    for (int i = 0; i < COUNT; i++) {
+      auto request = cap.typelessRequest(ECHO_INTERFACE_ID, ECHO_METHOD_ID, kj::none, {});
+      request.setAs<capnp::Text>(kj::str("msg", i));
+      builder.add(request.send().then([i](capnp::Response<capnp::AnyPointer> response) {
+        KJ_EXPECT(response.getAs<capnp::Text>() == kj::str("echo:msg", i));
+      }));
+    }
+    kj::joinPromisesFailFast(builder.finish()).wait(ws);
+  }
+}
+
+}  // namespace
+}  // namespace kj_rs_io_test

--- a/src/rust/cxx/kj-rs-io/tests/file-watcher-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/file-watcher-test.c++
@@ -1,0 +1,368 @@
+// Tests for kj_rs_io::FileWatcher (file-watcher.h), the tokio-loop replacement for workerd's
+// --watch FileWatcher. Exercises the behaviors workerd depends on: plain modification, atomic
+// replace-by-rename (editor saves), event queueing/coalescing across onChange() calls, the
+// already-open-fd watch path (kqueue backends), missing-file handling, and teardown/cancel
+// while a watch promise is armed.
+
+#include "kj-rs-io/async-io.h"
+#include "kj-rs-io/file-watcher.h"
+
+#include <kj/async.h>
+#include <kj/debug.h>
+#include <kj/filesystem.h>
+#include <kj/test.h>
+
+#include <cstdlib>
+#include <cstring>
+
+#if !_WIN32
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+#endif
+
+namespace kj_rs_io_test {
+namespace {
+
+using kj_rs_io::FileWatcher;
+using kj_rs_io::setupTokioAsyncIo;
+using kj_rs_io::TokioAsyncIoContext;
+
+#if !_WIN32
+
+// =======================================================================================
+// Helpers
+
+// Waits for `promise` to resolve, returning true, or false after `timeout`.
+bool resolvesWithin(kj::Promise<void> promise, TokioAsyncIoContext &io, kj::Duration timeout) {
+  auto timedOut = io.getTimer().afterDelay(timeout).then([]() { return false; });
+  return promise.then([]() { return true; })
+      .exclusiveJoin(kj::mv(timedOut))
+      .wait(io.getWaitScope());
+}
+
+// Generous bound for "the change fires"; file events are near-immediate on both backends.
+constexpr kj::Duration FIRE_TIMEOUT = 5 * kj::SECONDS;
+// Short bound for "nothing fires" checks.
+constexpr kj::Duration QUIET_TIMEOUT = 200 * kj::MILLISECONDS;
+
+struct TempDir {
+  kj::String path;
+
+  TempDir() {
+    const char *base = getenv("TEST_TMPDIR");
+    if (base == nullptr) base = "/tmp";
+    auto tmpl = kj::str(base, "/kj-rs-io-file-watcher-test.XXXXXX");
+    KJ_ASSERT(mkdtemp(tmpl.begin()) != nullptr, strerror(errno));
+    path = kj::mv(tmpl);
+  }
+
+  ~TempDir() noexcept(false) {
+    // Best-effort cleanup; TEST_TMPDIR is wiped by bazel anyway.
+    auto cmd = kj::str("rm -rf ", path);
+    (void)system(cmd.cStr());
+  }
+
+  kj::String fileName(kj::StringPtr name) {
+    return kj::str(path, "/", name);
+  }
+
+  kj::Path filePath(kj::StringPtr name) {
+    auto full = fileName(name);
+    KJ_ASSERT(full.startsWith("/"));
+    return kj::Path::parse(full.slice(1));
+  }
+};
+
+void writeFile(kj::StringPtr path, kj::StringPtr content) {
+  kj::OwnFd fd = KJ_SYSCALL_FD(open(path.cStr(), O_WRONLY | O_CREAT | O_TRUNC, 0644));
+  KJ_SYSCALL(write(fd, content.begin(), content.size()));
+}
+
+void appendFile(kj::StringPtr path, kj::StringPtr content) {
+  kj::OwnFd fd = KJ_SYSCALL_FD(open(path.cStr(), O_WRONLY | O_APPEND));
+  KJ_SYSCALL(write(fd, content.begin(), content.size()));
+}
+
+// After a change fired, drains any further already-queued events so the next onChange() call
+// starts from a quiet state (mirrors what workerd's waitForChanges() settle loop achieves).
+void drain(FileWatcher &watcher, TokioAsyncIoContext &io) {
+  while (resolvesWithin(watcher.onChange(), io, QUIET_TIMEOUT)) {}
+}
+
+// =======================================================================================
+// Tests
+
+KJ_TEST("FileWatcher: supported on this platform") {
+  auto io = setupTokioAsyncIo();
+  FileWatcher watcher;
+  KJ_EXPECT(watcher.isSupported());
+}
+
+KJ_TEST("FileWatcher: modification fires onChange") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), kj::none);
+
+  auto change = watcher.onChange();
+  appendFile(dir.fileName("a.txt"), " two");
+  KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+}
+
+KJ_TEST("FileWatcher: change before onChange() is called is not lost") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), kj::none);
+
+  // Modify before anyone is waiting: the event queues in the kernel.
+  appendFile(dir.fileName("a.txt"), " two");
+  KJ_EXPECT(resolvesWithin(watcher.onChange(), io, FIRE_TIMEOUT));
+}
+
+KJ_TEST("FileWatcher: atomic replace-by-rename fires onChange") {
+  // Editors typically save by writing a temporary file and rename(2)ing it over the target.
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), kj::none);
+
+  auto change = watcher.onChange();
+  writeFile(dir.fileName("a.txt.tmp"), "two");
+  KJ_SYSCALL(rename(dir.fileName("a.txt.tmp").cStr(), dir.fileName("a.txt").cStr()));
+  KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+}
+
+KJ_TEST("FileWatcher: watching via an already-open file handle") {
+  // workerd passes the config files' already-open kj::ReadableFile to watch(); the kqueue
+  // backend watches a dup of that fd (the inotify backend ignores it and uses the path).
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  auto file = kj::newDiskReadableFile(KJ_SYSCALL_FD(open(dir.fileName("a.txt").cStr(), O_RDONLY)));
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), *file);
+  file = nullptr;  // The original handle may be closed; the watch must survive.
+
+  auto change = watcher.onChange();
+  appendFile(dir.fileName("a.txt"), " two");
+  KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+}
+
+KJ_TEST("FileWatcher: rapid changes coalesce; watcher stays armed for later "
+        "changes") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), kj::none);
+
+  // A burst of changes produces one resolution per onChange() call (not one per event), ...
+  auto change = watcher.onChange();
+  appendFile(dir.fileName("a.txt"), " two");
+  appendFile(dir.fileName("a.txt"), " three");
+  appendFile(dir.fileName("a.txt"), " four");
+  KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+
+  // ... and once the queue is drained, the watcher is quiet ...
+  drain(watcher, io);
+
+  // ... but still armed: a fresh change fires a fresh onChange().
+  auto later = watcher.onChange();
+  appendFile(dir.fileName("a.txt"), " five");
+  KJ_EXPECT(resolvesWithin(kj::mv(later), io, FIRE_TIMEOUT));
+}
+
+KJ_TEST("FileWatcher: deleting the watched file fires; a recreated file is tracked where the "
+        "backend can") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), kj::none);
+
+  // Delete: both backends report it (inotify IN_DELETE on the directory; kqueue NOTE_DELETE on
+  // the open fd).
+  auto change = watcher.onChange();
+  KJ_SYSCALL(unlink(dir.fileName("a.txt").cStr()));
+  KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+  drain(watcher, io);
+
+  // Recreate and modify. The inotify backend watches the directory by name, so the new file is
+  // picked up; the kqueue backend watches the deleted inode's fd and cannot see the new file
+  // (workerd's --watch re-execs on the first change anyway, so this only matters for coverage
+  // of the two backends' documented difference).
+  auto later = watcher.onChange();
+  writeFile(dir.fileName("a.txt"), "two");
+  appendFile(dir.fileName("a.txt"), " three");
+#if __linux__
+  KJ_EXPECT(resolvesWithin(kj::mv(later), io, FIRE_TIMEOUT));
+#else
+  KJ_EXPECT(!resolvesWithin(kj::mv(later), io, QUIET_TIMEOUT));
+#endif
+}
+
+KJ_TEST("FileWatcher: the onChange() promise outlives the FileWatcher object") {
+  // The promise co-owns the watcher state, so destroying the FileWatcher first must neither
+  // crash nor invalidate the pending promise: a change made afterwards still resolves it.
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  kj::Promise<void> change = nullptr;
+  {
+    FileWatcher watcher;
+    watcher.watch(dir.filePath("a.txt"), kj::none);
+    change = watcher.onChange();
+    KJ_EXPECT(!change.poll(io.getWaitScope()));
+  }
+  appendFile(dir.fileName("a.txt"), " two");
+  KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+}
+
+KJ_TEST("FileWatcher: unrelated files in the same directory do not fire "
+        "(inotify filtering)") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+  writeFile(dir.fileName("other.txt"), "other");
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), kj::none);
+
+  appendFile(dir.fileName("other.txt"), " more");
+  KJ_EXPECT(!resolvesWithin(watcher.onChange(), io, QUIET_TIMEOUT));
+}
+
+#if __linux__
+KJ_TEST("FileWatcher: watching a not-yet-existing file fires when it is created") {
+  // The inotify backend watches the parent directory, so the file itself need not exist yet.
+  // (The kqueue backend opens the file and so requires it to exist; see the test below.)
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("missing.txt"), kj::none);
+
+  auto change = watcher.onChange();
+  writeFile(dir.fileName("missing.txt"), "now it exists");
+  KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+}
+#else
+KJ_TEST("FileWatcher: watching a nonexistent file throws (kqueue backend)") {
+  // Same behavior as workerd's kj-mode kqueue watcher: watch() opens the path with
+  // KJ_SYSCALL, which throws if it doesn't exist.
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+
+  FileWatcher watcher;
+  auto exception =
+      kj::runCatchingExceptions([&]() { watcher.watch(dir.filePath("missing.txt"), kj::none); });
+  KJ_EXPECT(exception != kj::none);
+}
+#endif
+
+KJ_TEST("FileWatcher: canceling an armed onChange() and re-arming works") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), kj::none);
+
+  {
+    auto armed = watcher.onChange();
+    KJ_EXPECT(!armed.poll(io.getWaitScope()));
+    // Dropped here while armed (fd registered with the tokio I/O driver).
+  }
+
+  auto change = watcher.onChange();
+  appendFile(dir.fileName("a.txt"), " two");
+  KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+}
+
+KJ_TEST("FileWatcher: multiple files in one watcher each fire on change") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "a");
+  writeFile(dir.fileName("b.txt"), "b");
+
+  FileWatcher watcher;
+  watcher.watch(dir.filePath("a.txt"), kj::none);
+  watcher.watch(dir.filePath("b.txt"), kj::none);
+
+  {
+    auto change = watcher.onChange();
+    appendFile(dir.fileName("a.txt"), "1");
+    KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+  }
+  // Drain any residual events from the first change before testing the second file.
+  while (resolvesWithin(watcher.onChange(), io, QUIET_TIMEOUT)) {}
+  {
+    auto change = watcher.onChange();
+    appendFile(dir.fileName("b.txt"), "2");
+    KJ_EXPECT(resolvesWithin(kj::mv(change), io, FIRE_TIMEOUT));
+  }
+}
+
+KJ_TEST("FileWatcher: two independent watchers do not cross-fire") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "a");
+  writeFile(dir.fileName("b.txt"), "b");
+
+  FileWatcher w1;
+  w1.watch(dir.filePath("a.txt"), kj::none);
+  FileWatcher w2;
+  w2.watch(dir.filePath("b.txt"), kj::none);
+
+  // Changing a.txt fires w1 but must NOT fire w2 (inotify filters by basename; kqueue watches
+  // only b.txt's own fd).
+  auto c2 = w2.onChange();
+  {
+    auto c1 = w1.onChange();
+    appendFile(dir.fileName("a.txt"), "1");
+    KJ_EXPECT(resolvesWithin(kj::mv(c1), io, FIRE_TIMEOUT));
+  }
+  KJ_EXPECT(!resolvesWithin(kj::mv(c2), io, QUIET_TIMEOUT));
+}
+
+KJ_TEST("FileWatcher: teardown while a watch promise is armed") {
+  auto io = setupTokioAsyncIo();
+  TempDir dir;
+  writeFile(dir.fileName("a.txt"), "one");
+
+  auto watcher = kj::heap<FileWatcher>();
+  watcher->watch(dir.filePath("a.txt"), kj::none);
+
+  auto armed = watcher->onChange();
+  KJ_EXPECT(!armed.poll(io.getWaitScope()));
+
+  // Promise first (it borrows the watcher's fd), then the watcher itself.
+  armed = nullptr;
+  watcher = nullptr;
+}
+
+#else  // _WIN32
+
+KJ_TEST("FileWatcher: reports unsupported on this platform") {
+  auto io = setupTokioAsyncIo();
+  FileWatcher watcher;
+  KJ_EXPECT(!watcher.isSupported());
+}
+
+#endif
+
+}  // namespace
+}  // namespace kj_rs_io_test

--- a/src/rust/cxx/kj-rs-io/tests/http-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/http-test.c++
@@ -1,0 +1,147 @@
+// kj-http integration ("the acid test"): a real kj::HttpServer serving on a kj-rs-io listener
+// and a kj::HttpClient over a kj-rs-io connection, all driven by the tokio event loop. Proves
+// that kj-http works unchanged over tokio-backed streams.
+
+#include "kj-rs-io/async-io.h"
+
+#include <kj/async.h>
+#include <kj/compat/http.h>
+#include <kj/debug.h>
+#include <kj/test.h>
+
+#include <cstring>
+
+namespace kj_rs_io_test {
+namespace {
+
+using kj_rs_io::setupTokioAsyncIo;
+
+// Echoes the request body back as the response body, streaming (pumpTo), preserving the
+// content length when known.
+class EchoService final: public kj::HttpService {
+ public:
+  explicit EchoService(kj::HttpHeaderTable &table): table(table) {}
+
+  kj::Promise<void> request(kj::HttpMethod method,
+      kj::StringPtr url,
+      const kj::HttpHeaders &headers,
+      kj::AsyncInputStream &requestBody,
+      Response &response) override {
+    kj::HttpHeaders responseHeaders(table);
+    auto body = response.send(200, "OK", responseHeaders, requestBody.tryGetLength());
+    co_await requestBody.pumpTo(*body);
+  }
+
+ private:
+  kj::HttpHeaderTable &table;
+};
+
+kj::Array<kj::byte> makeBody(size_t size) {
+  auto data = kj::heapArray<kj::byte>(size);
+  for (size_t i = 0; i < size; i++) {
+    data[i] = static_cast<kj::byte>(('A' + i / 8192 + i * 13) & 0xff);
+  }
+  return data;
+}
+
+// Writes `data` in chunks to the request body stream, then closes it.
+kj::Promise<void> writeBody(
+    kj::Own<kj::AsyncOutputStream> body, kj::ArrayPtr<const kj::byte> data) {
+  constexpr size_t CHUNK = 128 * 1024;
+  size_t offset = 0;
+  while (offset < data.size()) {
+    size_t n = kj::min(CHUNK, data.size() - offset);
+    co_await body->write(data.slice(offset, offset + n));
+    offset += n;
+  }
+  // Dropping `body` (coroutine frame teardown) finishes the request body.
+}
+
+KJ_TEST("bodyless GET works (regression: kj-http never awaits its header-write "
+        "queue for bodyless requests, relying on KJ hot-promise write semantics)") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  kj::HttpHeaderTable table;
+  EchoService service(table);
+  kj::HttpServer server(io.getTimer(), table, service);
+  auto listener = io.getNetwork().parseAddress("127.0.0.1", 0).wait(ws)->listen();
+  auto listenTask = server.listenHttp(*listener).eagerlyEvaluate(nullptr);
+  auto addr = io.getNetwork().parseAddress(kj::str("127.0.0.1:", listener->getPort())).wait(ws);
+  auto connection = addr->connect().wait(ws);
+  auto client = kj::newHttpClient(table, *connection);
+  kj::HttpHeaders headers(table);
+  auto request = client->request(kj::HttpMethod::GET, "/x", headers, static_cast<uint64_t>(0));
+  auto response = request.response.wait(ws);
+  KJ_EXPECT(response.statusCode == 200);
+  auto body = response.body->readAllBytes().wait(ws);
+  KJ_EXPECT(body.size() == 0);
+}
+
+KJ_TEST("kj-http round trip with streaming bodies over kj-rs-io streams on the "
+        "tokio loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  kj::HttpHeaderTable table;
+  EchoService service(table);
+  kj::HttpServer server(io.getTimer(), table, service);
+
+  // Server side: kj::HttpServer accepting from a kj-rs-io ConnectionReceiver.
+  auto listener = io.getNetwork().parseAddress("127.0.0.1", 0).wait(ws)->listen();
+  auto listenTask = server.listenHttp(*listener).eagerlyEvaluate(
+      [](kj::Exception &&e) { KJ_FAIL_EXPECT("HTTP server failed", e); });
+
+  // Client side: kj::HttpClient over a kj-rs-io connection.
+  auto addr = io.getNetwork().parseAddress(kj::str("127.0.0.1:", listener->getPort())).wait(ws);
+  auto connection = addr->connect().wait(ws);
+  auto client = kj::newHttpClient(table, *connection);
+
+  // Round trip 1: 4 MB POST with a streamed request body, echoed back and read while the
+  // request body is still being written (full-duplex streaming through the tokio loop).
+  {
+    constexpr size_t SIZE = 4 * 1024 * 1024;
+    auto data = makeBody(SIZE);
+
+    kj::HttpHeaders headers(table);
+    auto request =
+        client->request(kj::HttpMethod::POST, "/echo", headers, static_cast<uint64_t>(SIZE));
+
+    auto writeTask = writeBody(kj::mv(request.body), data).eagerlyEvaluate(nullptr);
+    auto response = request.response.wait(ws);
+    KJ_EXPECT(response.statusCode == 200);
+    KJ_EXPECT(KJ_ASSERT_NONNULL(response.body->tryGetLength()) == SIZE);
+
+    auto echoed = response.body->readAllBytes(SIZE + 1).wait(ws);
+    KJ_ASSERT(echoed.size() == SIZE);
+    KJ_ASSERT(memcmp(echoed.begin(), data.begin(), SIZE) == 0);
+    writeTask.wait(ws);
+  }
+
+  // Round trip 2 on the same connection (keep-alive): small GET, empty echoed body.
+  {
+    kj::HttpHeaders headers(table);
+    auto request =
+        client->request(kj::HttpMethod::GET, "/again", headers, static_cast<uint64_t>(0));
+    auto response = request.response.wait(ws);
+    KJ_EXPECT(response.statusCode == 200);
+    auto body = response.body->readAllBytes().wait(ws);
+    KJ_EXPECT(body.size() == 0);
+  }
+
+  // Round trip 3: chunked request body (no expected size -> Transfer-Encoding: chunked).
+  {
+    kj::HttpHeaders headers(table);
+    auto request = client->request(kj::HttpMethod::POST, "/chunked", headers);
+    auto data = makeBody(64 * 1024);
+    auto writeTask = writeBody(kj::mv(request.body), data).eagerlyEvaluate(nullptr);
+    auto response = request.response.wait(ws);
+    KJ_EXPECT(response.statusCode == 200);
+    auto echoed = response.body->readAllBytes().wait(ws);
+    KJ_ASSERT(echoed.size() == data.size());
+    KJ_ASSERT(memcmp(echoed.begin(), data.begin(), data.size()) == 0);
+    writeTask.wait(ws);
+  }
+}
+
+}  // namespace
+}  // namespace kj_rs_io_test

--- a/src/rust/cxx/kj-rs-io/tests/http-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/http-test.c++
@@ -57,8 +57,7 @@ kj::Promise<void> writeBody(
   // Dropping `body` (coroutine frame teardown) finishes the request body.
 }
 
-KJ_TEST("bodyless GET works (regression: kj-http never awaits its header-write "
-        "queue for bodyless requests, relying on KJ hot-promise write semantics)") {
+KJ_TEST("bodyless GET sends headers without a subsequent body write") {
   auto io = setupTokioAsyncIo();
   auto &ws = io.getWaitScope();
   kj::HttpHeaderTable table;

--- a/src/rust/cxx/kj-rs-io/tests/io-test-helpers.h
+++ b/src/rust/cxx/kj-rs-io/tests/io-test-helpers.h
@@ -1,0 +1,108 @@
+#pragma once
+// Shared helpers for the kj-rs-io C++ tests (async-io-test, serve-test): connected stream pairs
+// over the tokio-backed network, patterned payloads, and chunked write / verify pumps.
+
+#include "kj-rs-io/async-io.h"
+
+#include <kj/array.h>
+#include <kj/async-io.h>
+#include <kj/async.h>
+#include <kj/debug.h>
+
+#include <cstring>
+
+#if !_WIN32
+#include <unistd.h>  // getpid()/unlink() for the unix-socket pair helper
+#endif
+
+namespace kj_rs_io_test {
+
+struct ConnectedPair {
+  kj::Own<kj::ConnectionReceiver> listener;
+  kj::Own<kj::AsyncIoStream> client;
+  kj::Own<kj::AsyncIoStream> server;
+};
+
+inline kj::Own<kj::NetworkAddress> parseNow(
+    kj_rs_io::TokioAsyncIoContext &io, kj::StringPtr addr, kj::uint portHint = 0) {
+  return io.getNetwork().parseAddress(addr, portHint).wait(io.getWaitScope());
+}
+
+// A connected loopback TCP pair from the kj-rs-io network.
+inline ConnectedPair makeTcpPair(kj_rs_io::TokioAsyncIoContext &io) {
+  auto &ws = io.getWaitScope();
+  auto listener = parseNow(io, "127.0.0.1")->listen();
+  auto connectAddr = parseNow(io, kj::str("127.0.0.1:", listener->getPort()));
+  auto acceptPromise = listener->accept();
+  auto client = connectAddr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+  return ConnectedPair{kj::mv(listener), kj::mv(client), kj::mv(server)};
+}
+
+#if !_WIN32
+// A short /tmp unix-socket path unique per process + call, so parallel/repeated runs never
+// collide. Stale files are unlinked first.
+inline kj::String freshUnixSocketPath(kj::StringPtr tag) {
+  static uint counter = 0;
+  auto path = kj::str("/tmp/kj-rs-io-", tag, "-", ::getpid(), "-", counter++, ".sock");
+  ::unlink(path.cStr());
+  return path;
+}
+
+// A connected AF_UNIX stream-socket pair from the kj-rs-io network's `unix:` support. The bound
+// path is unlinked once both ends are connected.
+inline ConnectedPair makeUnixPair(kj_rs_io::TokioAsyncIoContext &io) {
+  auto &ws = io.getWaitScope();
+  auto path = freshUnixSocketPath("pair");
+  auto addr = kj::str("unix:", path);
+  auto listener = parseNow(io, addr)->listen();
+  auto connectAddr = parseNow(io, addr);
+  auto acceptPromise = listener->accept();
+  auto client = connectAddr->connect().wait(ws);
+  auto server = acceptPromise.wait(ws);
+  ::unlink(path.cStr());
+  return ConnectedPair{kj::mv(listener), kj::mv(client), kj::mv(server)};
+}
+#endif  // !_WIN32
+
+inline kj::Array<kj::byte> makePatternedData(size_t size, kj::byte seed) {
+  auto data = kj::heapArray<kj::byte>(size);
+  for (size_t i = 0; i < size; i++) {
+    data[i] = static_cast<kj::byte>((i * 31 + seed) & 0xff);
+  }
+  return data;
+}
+
+// Writes `data` to `out` in 64 KiB chunks (exercising write-all + backpressure).
+inline kj::Promise<void> writeChunked(
+    kj::AsyncOutputStream &out, kj::ArrayPtr<const kj::byte> data) {
+  constexpr size_t CHUNK = 64 * 1024;
+  size_t offset = 0;
+  while (offset < data.size()) {
+    size_t n = kj::min(CHUNK, data.size() - offset);
+    co_await out.write(data.slice(offset, offset + n));
+    offset += n;
+  }
+}
+
+// Reads exactly `expected.size()` bytes from `in` and verifies they match `expected`.
+inline kj::Promise<void> readExact(
+    kj::AsyncInputStream &in, kj::ArrayPtr<const kj::byte> expected) {
+  auto buffer = kj::heapArray<kj::byte>(expected.size());
+  size_t total = co_await in.tryRead(buffer.begin(), buffer.size(), buffer.size());
+  KJ_ASSERT(total == expected.size(), total, expected.size());
+  KJ_ASSERT(memcmp(buffer.begin(), expected.begin(), expected.size()) == 0);
+}
+
+// `promise`, failing loudly (rather than hanging until bazel's timeout) if it is still pending
+// after `timeout` on the context's KJ timer.
+template <typename T>
+kj::Promise<T> boundedBy(kj_rs_io::TokioAsyncIoContext &io,
+    kj::Promise<T> promise,
+    kj::Duration timeout,
+    kj::StringPtr what) {
+  return promise.exclusiveJoin(io.getTimer().afterDelay(timeout).then(
+      [what]() -> T { KJ_FAIL_ASSERT("timed out waiting for", what); }));
+}
+
+}  // namespace kj_rs_io_test

--- a/src/rust/cxx/kj-rs-io/tests/lib.rs
+++ b/src/rust/cxx/kj-rs-io/tests/lib.rs
@@ -1,0 +1,105 @@
+#![allow(clippy::unused_async)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::unnecessary_box_returns)] // cxx bridge functions return Box<T> by contract
+
+mod serve_helpers;
+mod test_helpers;
+
+use serve_helpers::ServeEchoSession;
+use serve_helpers::start_serve_drop_consumer;
+use serve_helpers::start_serve_echo;
+use serve_helpers::start_serve_echo_foreign_thread;
+use serve_helpers::start_take_socket_echo;
+use test_helpers::address_from_loopback_ports;
+use test_helpers::create_prebound_listener_fd;
+use test_helpers::native_write_via_kj_unwrap;
+use test_helpers::native_write_via_unwrap;
+
+#[cxx::bridge(namespace = "kj_rs_io_test")]
+mod ffi {
+    /// A pre-bound, *blocking* std TCP listener handed to C++ as a raw fd (the `--socket-fd`
+    /// scenario for `wrapListenSocketFd`).
+    struct PreboundListener {
+        fd: i32,
+        port: u16,
+    }
+
+    extern "Rust" {
+        /// Recovers the native tokio TcpStream from an unwrapped kj-rs-io stream Box and writes
+        /// `data` natively (tokio readiness API, no FFI-per-byte), then closes the connection.
+        async fn native_write_via_unwrap(stream: Box<TokioStream>, data: Vec<u8>) -> Result<()>;
+
+        /// Same, but starts from a `kj::AsyncIoStream&`: unwraps it from the Rust side via
+        /// `kj_rs_io::unwrap_kj_stream` (the API a native Rust server's glue will use), then writes
+        /// natively. Leaves the C++ wrapper hollow.
+        async unsafe fn native_write_via_kj_unwrap<'a>(
+            stream: Pin<&'a mut KjAsyncIoStream>,
+            data: &'a [u8],
+        ) -> Result<()>;
+
+        /// Binds 127.0.0.1:0 with std (blocking mode, like an inherited `--socket-fd` listener)
+        /// and releases it as a raw fd owned by the caller.
+        fn create_prebound_listener_fd() -> Result<PreboundListener>;
+
+        /// A kj-rs-io address resolving to `127.0.0.1:<port>` for each of `ports`, in order:
+        /// a deterministic stand-in for a multi-result DNS lookup, for testing connect()'s
+        /// try-each-address fallback.
+        fn address_from_loopback_ports(ports: &[u16]) -> Box<TokioAddress>;
+
+        // --- serve_kj_stream (serve_helpers.rs)
+
+        /// One echo server over a served kj stream: `start_serve_echo` picks the transport
+        /// path (unwrap fast path or duplex pump) via `kj_rs_io::serve_kj_stream` — taking
+        /// ownership of the stream — and spawns the echo consumer on the loop runtime;
+        /// `drive()` runs the connection (the pump, on the pumped path) to completion —
+        /// dropping the `drive()` promise mid-connection is the abort-on-drop path, which
+        /// also destroys the owned stream.
+        type ServeEchoSession;
+
+        fn start_serve_echo(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession>;
+
+        /// Like `start_serve_echo`, but the consumer reads one message and then DROPS its
+        /// `ServeIo` without calling `shutdown()`: the pump must turn the dropped duplex end into
+        /// `shutdownWrite()` on the kj stream.
+        fn start_serve_drop_consumer(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession>;
+
+        /// Like `start_serve_echo`, but the echo consumer runs on a separate OS thread with its
+        /// own tokio runtime, driving a pumped stream's `ServeIo::Duplex` end off the KJ
+        /// event-loop thread (cross-thread waker path; TSAN target).
+        fn start_serve_echo_foreign_thread(stream: KjOwn<KjAsyncIoStream>)
+        -> Box<ServeEchoSession>;
+
+        /// Like `start_serve_echo`, but through the native-only `take_kj_socket` entry point
+        /// (unwrap tier, else fd-dup tier): errors — instead of pumping — for streams that
+        /// are neither. The consumed stream is destroyed before this returns.
+        fn start_take_socket_echo(stream: KjOwn<KjAsyncIoStream>) -> Result<Box<ServeEchoSession>>;
+
+        /// Whether the unwrap fast path was taken (perf observability surface).
+        fn is_native(self: &ServeEchoSession) -> bool;
+
+        /// Runs the connection to completion (see the type's docs). May only be called once.
+        async unsafe fn drive<'a>(self: &'a ServeEchoSession) -> Result<()>;
+
+        /// Resolves once the echo task has exited — observing that dropping `drive()` EOFs
+        /// the pumped consumer.
+        async unsafe fn wait_echo_done<'a>(self: &'a ServeEchoSession);
+    }
+
+    extern "Rust" {
+        #[namespace = "kj_rs_io"]
+        type TokioStream = kj_rs_io::TokioStream;
+        #[namespace = "kj_rs_io"]
+        type TokioAddress = kj_rs_io::TokioAddress;
+    }
+
+    unsafe extern "C++" {
+        include!("kj-rs-io/unwrap.h");
+
+        #[namespace = "kj"]
+        #[cxx_name = "AsyncIoStream"]
+        type KjAsyncIoStream = kj_rs_io::KjAsyncIoStream;
+    }
+}

--- a/src/rust/cxx/kj-rs-io/tests/lib.rs
+++ b/src/rust/cxx/kj-rs-io/tests/lib.rs
@@ -8,7 +8,10 @@
 mod serve_helpers;
 mod test_helpers;
 
+use serve_helpers::NativeServeFailure;
 use serve_helpers::ServeEchoSession;
+use serve_helpers::expect_serve_stream_failure;
+use serve_helpers::expect_take_socket_failure;
 use serve_helpers::start_serve_drop_consumer;
 use serve_helpers::start_serve_echo;
 use serve_helpers::start_serve_echo_foreign_thread;
@@ -59,23 +62,38 @@ mod ffi {
         /// also destroys the owned stream.
         type ServeEchoSession;
 
-        fn start_serve_echo(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession>;
+        fn start_serve_echo(stream: KjOwn<KjAsyncIoStream>) -> Result<Box<ServeEchoSession>>;
 
         /// Like `start_serve_echo`, but the consumer reads one message and then DROPS its
         /// `ServeIo` without calling `shutdown()`: the pump must turn the dropped duplex end into
         /// `shutdownWrite()` on the kj stream.
-        fn start_serve_drop_consumer(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession>;
+        fn start_serve_drop_consumer(
+            stream: KjOwn<KjAsyncIoStream>,
+        ) -> Result<Box<ServeEchoSession>>;
 
         /// Like `start_serve_echo`, but the echo consumer runs on a separate OS thread with its
         /// own tokio runtime, driving a pumped stream's `ServeIo::Duplex` end off the KJ
         /// event-loop thread (cross-thread waker path; TSAN target).
-        fn start_serve_echo_foreign_thread(stream: KjOwn<KjAsyncIoStream>)
-        -> Box<ServeEchoSession>;
+        fn start_serve_echo_foreign_thread(
+            stream: KjOwn<KjAsyncIoStream>,
+        ) -> Result<Box<ServeEchoSession>>;
 
         /// Like `start_serve_echo`, but through the native-only `take_kj_socket` entry point
         /// (unwrap tier, else fd-dup tier): errors — instead of pumping — for streams that
         /// are neither. The consumed stream is destroyed before this returns.
         fn start_take_socket_echo(stream: KjOwn<KjAsyncIoStream>) -> Result<Box<ServeEchoSession>>;
+
+        /// Requires native socket extraction to reject an in-flight operation while retaining
+        /// ownership of the untouched stream.
+        type NativeServeFailure;
+
+        fn expect_take_socket_failure(stream: KjOwn<KjAsyncIoStream>) -> Box<NativeServeFailure>;
+
+        fn expect_serve_stream_failure(stream: KjOwn<KjAsyncIoStream>) -> Box<NativeServeFailure>;
+
+        fn is_in_flight(self: &NativeServeFailure) -> bool;
+
+        fn take_stream(self: &NativeServeFailure) -> KjOwn<KjAsyncIoStream>;
 
         /// Whether the unwrap fast path was taken (perf observability surface).
         fn is_native(self: &ServeEchoSession) -> bool;

--- a/src/rust/cxx/kj-rs-io/tests/lib.rs
+++ b/src/rust/cxx/kj-rs-io/tests/lib.rs
@@ -93,6 +93,8 @@ mod ffi {
 
         fn is_in_flight(self: &NativeServeFailure) -> bool;
 
+        fn is_get_fd_failure(self: &NativeServeFailure) -> bool;
+
         fn take_stream(self: &NativeServeFailure) -> KjOwn<KjAsyncIoStream>;
 
         /// Whether the unwrap fast path was taken (perf observability surface).

--- a/src/rust/cxx/kj-rs-io/tests/peer-filter-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/peer-filter-test.c++
@@ -1,0 +1,193 @@
+// Direct unit tests for PeerFilter::shouldAllow — the faithful port of kj::_::NetworkFilter that
+// backs restrictPeers(). The network-level tests (async-io-test.c++) only exercise
+// {"public"}/{"private"} end to end; this file drives the grammar directly against hand-built
+// sockaddrs (no event loop, no sockets), covering every rule class, the allow/deny specificity
+// tie-break, IPv6, unix/unix-abstract, and filter chaining.
+
+#include "kj-rs-io/peer-filter.h"
+
+#include <kj/debug.h>
+#include <kj/test.h>
+
+#include <cstring>
+
+#if _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include <kj/windows-sanity.h>
+#else
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+
+namespace kj_rs_io {
+namespace {
+
+// A filter with `allow`/`deny` rules layered on an allow-everything parent, so the parent never
+// changes the verdict and the rules under test are what decides.
+kj::Rc<PeerFilter> filter(
+    kj::ArrayPtr<const kj::StringPtr> allow, kj::ArrayPtr<const kj::StringPtr> deny = nullptr) {
+  return kj::rc<PeerFilter>(allow, deny, kj::rc<PeerFilter>());
+}
+
+// Does `f` allow the given numeric IP (v4 if it has no ':', else v6), port 1?
+bool allowsIp(PeerFilter& f, kj::StringPtr ip) {
+  if (ip.findFirst(':') != kj::none) {
+    struct sockaddr_in6 sin6;
+    memset(&sin6, 0, sizeof(sin6));
+    sin6.sin6_family = AF_INET6;
+    sin6.sin6_port = htons(1);
+    KJ_ASSERT(inet_pton(AF_INET6, ip.cStr(), &sin6.sin6_addr) == 1, ip);
+    return f.shouldAllow(reinterpret_cast<struct sockaddr*>(&sin6), sizeof(sin6));
+  } else {
+    struct sockaddr_in sin;
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = htons(1);
+    KJ_ASSERT(inet_pton(AF_INET, ip.cStr(), &sin.sin_addr) == 1, ip);
+    return f.shouldAllow(reinterpret_cast<struct sockaddr*>(&sin), sizeof(sin));
+  }
+}
+
+KJ_TEST("PeerFilter: default filter allows everything") {
+  auto f = kj::rc<PeerFilter>();
+  KJ_EXPECT(allowsIp(*f, "8.8.8.8"));
+  KJ_EXPECT(allowsIp(*f, "127.0.0.1"));
+  KJ_EXPECT(allowsIp(*f, "10.0.0.1"));
+  KJ_EXPECT(allowsIp(*f, "::1"));
+}
+
+KJ_TEST("PeerFilter: 'public' allows public IPs, blocks private/local/reserved") {
+  auto f = filter({"public"_kj});
+  KJ_EXPECT(allowsIp(*f, "8.8.8.8"));       // public
+  KJ_EXPECT(allowsIp(*f, "1.1.1.1"));       // public
+  KJ_EXPECT(!allowsIp(*f, "10.0.0.1"));     // RFC1918 private
+  KJ_EXPECT(!allowsIp(*f, "192.168.1.1"));  // RFC1918 private
+  KJ_EXPECT(!allowsIp(*f, "172.16.5.5"));   // RFC1918 private
+  KJ_EXPECT(!allowsIp(*f, "127.0.0.1"));    // local
+  KJ_EXPECT(!allowsIp(*f, "224.0.0.1"));    // reserved (multicast)
+  KJ_EXPECT(!allowsIp(*f, "169.254.1.1"));  // link-local (private)
+}
+
+KJ_TEST("PeerFilter: 'network' allows public+private, blocks local/reserved") {
+  auto f = filter({"network"_kj});
+  KJ_EXPECT(allowsIp(*f, "8.8.8.8"));      // public
+  KJ_EXPECT(allowsIp(*f, "10.0.0.1"));     // private — the difference from 'public'
+  KJ_EXPECT(allowsIp(*f, "192.168.1.1"));  // private
+  KJ_EXPECT(!allowsIp(*f, "127.0.0.1"));   // local
+  KJ_EXPECT(!allowsIp(*f, "224.0.0.1"));   // reserved
+}
+
+KJ_TEST("PeerFilter: 'local' allows loopback only") {
+  auto f = filter({"local"_kj});
+  KJ_EXPECT(allowsIp(*f, "127.0.0.1"));
+  KJ_EXPECT(allowsIp(*f, "127.5.5.5"));  // 127/8
+  KJ_EXPECT(!allowsIp(*f, "8.8.8.8"));
+  KJ_EXPECT(!allowsIp(*f, "10.0.0.1"));
+}
+
+KJ_TEST("PeerFilter: 'private' allows RFC1918 + local, blocks public") {
+  auto f = filter({"private"_kj});
+  KJ_EXPECT(allowsIp(*f, "10.1.2.3"));
+  KJ_EXPECT(allowsIp(*f, "192.168.0.1"));
+  KJ_EXPECT(allowsIp(*f, "127.0.0.1"));  // 'private' includes local
+  KJ_EXPECT(!allowsIp(*f, "8.8.8.8"));
+}
+
+KJ_TEST("PeerFilter: explicit CIDR allow") {
+  auto f = filter({"10.0.0.0/8"_kj});
+  KJ_EXPECT(allowsIp(*f, "10.1.2.3"));
+  KJ_EXPECT(allowsIp(*f, "10.255.255.255"));
+  KJ_EXPECT(!allowsIp(*f, "11.0.0.1"));
+  KJ_EXPECT(!allowsIp(*f, "8.8.8.8"));
+}
+
+KJ_TEST("PeerFilter: allow + more-specific deny (specificity tie-break)") {
+  // allow 10/8 but deny the more-specific 10.1/16: 10.1.x blocked, other 10.x allowed.
+  auto f = filter({"10.0.0.0/8"_kj}, {"10.1.0.0/16"_kj});
+  KJ_EXPECT(allowsIp(*f, "10.2.3.4"));   // allowed by /8, no deny matches
+  KJ_EXPECT(!allowsIp(*f, "10.1.2.3"));  // deny /16 is more specific than allow /8
+  KJ_EXPECT(allowsIp(*f, "10.255.0.1"));
+}
+
+KJ_TEST("PeerFilter: equal-specificity deny wins over allow (>= tie-break)") {
+  // Same prefix length on both sides: deny's `>=` means the deny wins.
+  auto f = filter({"10.1.0.0/16"_kj}, {"10.1.0.0/16"_kj});
+  KJ_EXPECT(!allowsIp(*f, "10.1.2.3"));
+}
+
+KJ_TEST("PeerFilter: IPv6 public/private/explicit rules") {
+  auto pub = filter({"public"_kj});
+  KJ_EXPECT(allowsIp(*pub, "2606:4700:4700::1111"));  // public v6
+  KJ_EXPECT(!allowsIp(*pub, "::1"));                  // v6 loopback (local)
+  KJ_EXPECT(!allowsIp(*pub, "fc00::1"));              // v6 unique-local (private)
+
+  auto priv = filter({"private"_kj});
+  KJ_EXPECT(allowsIp(*priv, "fc00::1"));  // fc00::/7 private
+  KJ_EXPECT(allowsIp(*priv, "::1"));      // local included in private
+  KJ_EXPECT(!allowsIp(*priv, "2606:4700:4700::1111"));
+
+  auto cidr = filter({"fc00::/7"_kj});
+  KJ_EXPECT(allowsIp(*cidr, "fc00::1"));
+  KJ_EXPECT(!allowsIp(*cidr, "2606:4700:4700::1111"));
+}
+
+KJ_TEST("PeerFilter: nested filter chain enforces BOTH levels") {
+  // Child allows all private; parent (next) allows only local. An address the child allows but
+  // the parent denies must be blocked — the chain is an AND.
+  auto parent = kj::rc<PeerFilter>(kj::arr("local"_kj), nullptr, kj::rc<PeerFilter>());
+  auto child = kj::rc<PeerFilter>(kj::arr("private"_kj), nullptr, kj::mv(parent));
+  KJ_EXPECT(allowsIp(*child, "127.0.0.1"));  // allowed by both child (private⊇local) and parent
+  KJ_EXPECT(!allowsIp(*child, "10.0.0.1"));  // allowed by child, DENIED by parent → blocked
+}
+
+KJ_TEST("PeerFilter: denying 'network' or 'public' is rejected") {
+  KJ_EXPECT_THROW_MESSAGE("don't deny 'network'",
+      kj::rc<PeerFilter>(nullptr, kj::arr("network"_kj), kj::rc<PeerFilter>()));
+  KJ_EXPECT_THROW_MESSAGE("don't deny 'public'",
+      kj::rc<PeerFilter>(nullptr, kj::arr("public"_kj), kj::rc<PeerFilter>()));
+}
+
+#if !_WIN32
+// Builds a sockaddr_un for `path` (abstract if `abstractLeadingNul`) and returns the verdict.
+bool allowsUnix(PeerFilter& f, kj::StringPtr path, bool abstractLeadingNul = false) {
+  struct sockaddr_un su;
+  memset(&su, 0, sizeof(su));
+  su.sun_family = AF_UNIX;
+  size_t off = 0;
+  if (abstractLeadingNul) {
+    su.sun_path[0] = '\0';
+    off = 1;
+  }
+  memcpy(su.sun_path + off, path.begin(), path.size());
+  kj::uint addrlen =
+      static_cast<kj::uint>(offsetof(struct sockaddr_un, sun_path) + off + path.size());
+  return f.shouldAllow(reinterpret_cast<struct sockaddr*>(&su), addrlen);
+}
+
+KJ_TEST("PeerFilter: unix and unix-abstract allow/deny") {
+  // Default allows both.
+  auto def = kj::rc<PeerFilter>();
+  KJ_EXPECT(allowsUnix(*def, "/tmp/sock"));
+  KJ_EXPECT(allowsUnix(*def, "abstract-name", true));
+
+  // "unix" allows pathname sockets, not abstract; "unix-abstract" the reverse.
+  auto pathOnly = filter({"unix"_kj});
+  KJ_EXPECT(allowsUnix(*pathOnly, "/tmp/sock"));
+  KJ_EXPECT(!allowsUnix(*pathOnly, "abstract-name", true));
+
+  auto abstractOnly = filter({"unix-abstract"_kj});
+  KJ_EXPECT(!allowsUnix(*abstractOnly, "/tmp/sock"));
+  KJ_EXPECT(allowsUnix(*abstractOnly, "abstract-name", true));
+
+  // Deny turns them off even from the allow-everything default.
+  auto denyUnix = kj::rc<PeerFilter>(
+      kj::arr("private"_kj, "unix"_kj), kj::arr("unix"_kj), kj::rc<PeerFilter>());
+  KJ_EXPECT(!allowsUnix(*denyUnix, "/tmp/sock"));
+}
+#endif  // !_WIN32
+
+}  // namespace
+}  // namespace kj_rs_io

--- a/src/rust/cxx/kj-rs-io/tests/peer-filter-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/peer-filter-test.c++
@@ -96,6 +96,14 @@ KJ_TEST("PeerFilter: 'private' allows RFC1918 + local, blocks public") {
   KJ_EXPECT(!allowsIp(*f, "8.8.8.8"));
 }
 
+KJ_TEST("PeerFilter: denying 'private' retains KJ's separate local category") {
+  auto f = filter({"private"_kj}, {"private"_kj});
+  KJ_EXPECT(!allowsIp(*f, "10.1.2.3"));
+  KJ_EXPECT(!allowsIp(*f, "fc00::1"));
+  KJ_EXPECT(allowsIp(*f, "127.0.0.1"));
+  KJ_EXPECT(allowsIp(*f, "::1"));
+}
+
 KJ_TEST("PeerFilter: explicit CIDR allow") {
   auto f = filter({"10.0.0.0/8"_kj});
   KJ_EXPECT(allowsIp(*f, "10.1.2.3"));

--- a/src/rust/cxx/kj-rs-io/tests/peer-filter-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/peer-filter-test.c++
@@ -187,6 +187,14 @@ KJ_TEST("PeerFilter: unix and unix-abstract allow/deny") {
       kj::arr("private"_kj, "unix"_kj), kj::arr("unix"_kj), kj::rc<PeerFilter>());
   KJ_EXPECT(!allowsUnix(*denyUnix, "/tmp/sock"));
 }
+
+KJ_TEST("PeerFilter: nested filters intersect unix socket permissions") {
+  auto parent = kj::rc<PeerFilter>(kj::arr("public"_kj), nullptr, kj::rc<PeerFilter>());
+  auto child = kj::rc<PeerFilter>(kj::arr("unix"_kj, "unix-abstract"_kj), nullptr, kj::mv(parent));
+
+  KJ_EXPECT(!allowsUnix(*child, "/tmp/sock"));
+  KJ_EXPECT(!allowsUnix(*child, "abstract-name", true));
+}
 #endif  // !_WIN32
 
 }  // namespace

--- a/src/rust/cxx/kj-rs-io/tests/serve-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/serve-test.c++
@@ -1,0 +1,423 @@
+// Tests for kj_rs_io::serve_kj_stream (serve.rs): the native-serve entry
+// point Rust servers use to drive a kj::AsyncIoStream's connection natively. Following kj-rs
+// conventions, C++ KJ_TESTs drive; Rust helpers (tests/serve_helpers.rs) run the echo server
+// side over whichever transport path the entry point picks.
+
+#include "io-test-helpers.h"
+#include "kj-rs-io-test/lib.rs.h"
+#include "kj-rs-io/async-io.h"
+
+#include <kj/array.h>
+#include <kj/async-io.h>
+#include <kj/async.h>
+#include <kj/debug.h>
+#include <kj/test.h>
+
+#include <cstring>
+
+namespace kj_rs_io_test {
+namespace {
+
+using kj_rs_io::setupTokioAsyncIo;
+using kj_rs_io::TokioAsyncIoContext;
+
+// The client side of an echo round trip: write `data` (in chunks) and concurrently read the
+// echo back and verify it (concurrent, so bounded transports -- the pump duplex, socket
+// buffers -- never deadlock on payloads larger than their buffering); then half-close and
+// expect EOF.
+kj::Promise<void> echoRoundTrip(
+    kj::AsyncIoStream &clientStream, kj::ArrayPtr<const kj::byte> data) {
+  static auto constexpr readBack = [](kj::AsyncIoStream &s,
+                                       kj::ArrayPtr<const kj::byte> expected) -> kj::Promise<void> {
+    auto buffer = kj::heapArray<kj::byte>(expected.size());
+    size_t total = co_await s.tryRead(buffer.begin(), buffer.size(), buffer.size());
+    KJ_ASSERT(total == expected.size(), total, expected.size());
+    KJ_ASSERT(memcmp(buffer.begin(), expected.begin(), expected.size()) == 0);
+  };
+
+  static auto constexpr writeAll = [](kj::AsyncIoStream &s,
+                                       kj::ArrayPtr<const kj::byte> data) -> kj::Promise<void> {
+    constexpr size_t CHUNK = 64 * 1024;
+    size_t offset = 0;
+    while (offset < data.size()) {
+      size_t n = kj::min(CHUNK, data.size() - offset);
+      co_await s.write(data.slice(offset, offset + n));
+      offset += n;
+    }
+    s.shutdownWrite();  // half-close: the echo server sees EOF and finishes flushing
+  };
+
+  co_await kj::joinPromisesFailFast(
+      kj::arr(writeAll(clientStream, data), readBack(clientStream, data)));
+  kj::byte extra;
+  KJ_EXPECT(co_await clientStream.tryRead(&extra, 1, 1) == 0);  // EOF after echo completes
+}
+
+// =======================================================================================
+// Unwrap fast path
+
+KJ_TEST("serve_kj_stream takes the native path for kj-rs-io TCP streams and "
+        "echoes") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // Native path: the connection now belongs to the Rust side (the hollow wrapper was
+  // destroyed by serve_kj_stream).
+  auto session = start_serve_echo(kj::mv(pair.server));
+  KJ_EXPECT(session->is_native());
+
+  auto data = makePatternedData(256 * 1024, 7);
+  auto drive = session->drive();
+  auto client = echoRoundTrip(*pair.client, data);
+  kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(client))).wait(ws);
+}
+
+// =======================================================================================
+// Duplex pump fallback (foreign streams)
+
+KJ_TEST("serve_kj_stream pumps foreign streams: bidirectional echo + half-close") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // An in-memory kj pipe is the canonical foreign stream: not kj-rs-io-originated.
+  auto pipe = kj::newTwoWayPipe();
+
+  auto session = start_serve_echo(kj::mv(pipe.ends[0]));
+  KJ_EXPECT(!session->is_native());
+
+  auto data = makePatternedData(512 * 1024, 3);
+  auto drive = session->drive();
+  auto client = echoRoundTrip(*pipe.ends[1], data);
+  // The pump owns `pipe.ends[0]` now; only the client end stays with the test.
+  kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(client))).wait(ws);
+}
+
+KJ_TEST("serve_kj_stream pump: dropping the pump aborts the bridge (drop-abort)") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pipe = kj::newTwoWayPipe();
+
+  auto session = start_serve_echo(kj::mv(pipe.ends[0]));
+  KJ_EXPECT(!session->is_native());
+
+  {
+    // Prove the bridge is live: one small round trip, driving the pump only while the
+    // client operation runs, then *drop* the drive promise mid-connection.
+    auto drive = session->drive();
+    auto oneRoundTrip = [](kj::AsyncIoStream &s) -> kj::Promise<void> {
+      co_await s.write("ping"_kjb);
+      kj::byte buffer[4];
+      size_t n = co_await s.tryRead(buffer, 4, 4);
+      KJ_ASSERT(n == 4);
+      KJ_ASSERT(memcmp(buffer, "ping", 4) == 0);
+    }(*pipe.ends[1]);
+    // exclusiveJoin: when the round trip finishes, `drive` is cancelled (dropped).
+    oneRoundTrip.exclusiveJoin(kj::mv(drive)).wait(ws);
+  }
+
+  // Dropping the pump dropped the kj-side duplex end: the echo consumer reads EOF and
+  // finishes...
+  session->wait_echo_done().wait(ws);
+
+  // ...and the pump destroyed the kj stream it owned: the peer observes teardown (a rejected
+  // write), not a zombie half-open pipe.
+  auto orphanWrite = kj::evalNow([&]() { return pipe.ends[1]->write("anyone there?"_kjb); });
+  KJ_EXPECT(orphanWrite.poll(ws));
+  orphanWrite
+      .then([]() { KJ_FAIL_EXPECT("write to a torn-down pipe unexpectedly succeeded"); },
+          [](kj::Exception &&) {
+  }).wait(ws);
+}
+
+KJ_TEST("serve_kj_stream pump: the Duplex consumer may be driven from another thread") {
+  // ServedKjStream::io's docs promise the Duplex variant is safe to drive off the KJ event-loop
+  // thread since the waker bridge became thread-safe. Here the echo consumer runs on its own OS
+  // thread and runtime, so every read/write/drop on the Duplex wakes the pump (parked on this
+  // KJ loop) cross-thread through the FutureWakerCell. TSAN target.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pipe = kj::newTwoWayPipe();
+
+  auto session = start_serve_echo_foreign_thread(kj::mv(pipe.ends[0]));
+  KJ_EXPECT(!session->is_native());
+
+  auto data = makePatternedData(512 * 1024, 5);
+  auto drive = session->drive();  // drives the pump here; the consumer echoes on its own thread
+  auto client = echoRoundTrip(*pipe.ends[1], data);
+  kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(client))).wait(ws);
+}
+
+// A foreign stream over one end of a kj two-way pipe whose read side reports a DISCONNECTED
+// failure once the pipe's data is gone (instead of a clean EOF), and whose write side may be
+// made to fail DISCONNECTED as well: the shape of an abruptly-reset TCP peer, as seen through a
+// non-kj-rs-io kj stream.
+class DisconnectingStream final: public kj::AsyncIoStream {
+ public:
+  DisconnectingStream(kj::Own<kj::AsyncIoStream> inner, bool writesDisconnected)
+      : inner(kj::mv(inner)),
+        writesDisconnected(writesDisconnected) {}
+
+  kj::Promise<size_t> tryRead(void *buffer, size_t minBytes, size_t maxBytes) override {
+    size_t n = co_await inner->tryRead(buffer, minBytes, maxBytes);
+    if (n < minBytes) {
+      // Where a well-behaved peer would half-close, this one was reset.
+      kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "peer reset the connection"));
+    }
+    co_return n;
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
+    if (writesDisconnected) return KJ_EXCEPTION(DISCONNECTED, "peer reset the connection");
+    return inner->write(buffer);
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override {
+    if (writesDisconnected) return KJ_EXCEPTION(DISCONNECTED, "peer reset the connection");
+    return inner->write(pieces);
+  }
+  kj::Promise<void> whenWriteDisconnected() override {
+    return inner->whenWriteDisconnected();
+  }
+  void shutdownWrite() override {
+    if (writesDisconnected) {
+      kj::throwFatalException(KJ_EXCEPTION(DISCONNECTED, "peer reset the connection"));
+    }
+    inner->shutdownWrite();
+  }
+
+ private:
+  kj::Own<kj::AsyncIoStream> inner;
+  bool writesDisconnected;
+};
+
+KJ_TEST("serve_kj_stream pump: a DISCONNECTED read is treated as EOF, not as an error") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pipe = kj::newTwoWayPipe();
+
+  auto session = start_serve_echo(kj::heap<DisconnectingStream>(kj::mv(pipe.ends[0]), false));
+  KJ_EXPECT(!session->is_native());
+
+  auto drive = session->drive();
+  // One message goes through, then the client goes away abruptly: the pump's read fails
+  // DISCONNECTED. The echo consumer must see EOF (and echo back what it got), and the pump must
+  // settle Ok -- abrupt client disconnects are normal load, not failures.
+  pipe.ends[1]->write("ping"_kjb).wait(ws);
+  kj::byte buffer[4];
+  KJ_EXPECT(pipe.ends[1]->tryRead(buffer, 4, 4).wait(ws) == 4);
+  pipe.ends[1]->shutdownWrite();  // the wrapper turns this EOF into DISCONNECTED
+  KJ_EXPECT(pipe.ends[1]->tryRead(buffer, 1, 1).wait(ws) == 0);  // consumer shut down -> EOF back
+  boundedBy(io, kj::mv(drive), 10 * kj::SECONDS, "the pump to settle").wait(ws);
+  session->wait_echo_done().wait(ws);
+}
+
+KJ_TEST("serve_kj_stream pump: a DISCONNECTED write ends the direction without an error") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pipe = kj::newTwoWayPipe();
+
+  auto session = start_serve_echo(kj::heap<DisconnectingStream>(kj::mv(pipe.ends[0]), true));
+  auto drive = session->drive();
+  // The consumer's echo of "ping" is written to a peer that already reset: the pump must not
+  // fail. Half-close so the read direction finishes normally too.
+  pipe.ends[1]->write("ping"_kjb).wait(ws);
+  pipe.ends[1]->shutdownWrite();
+  boundedBy(io, kj::mv(drive), 10 * kj::SECONDS, "the pump to settle").wait(ws);
+  session->wait_echo_done().wait(ws);
+}
+
+KJ_TEST("serve_kj_stream pump: the consumer dropping its end (no shutdown) half-closes the kj "
+        "side") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pipe = kj::newTwoWayPipe();
+
+  // A consumer that reads one message and then simply drops its ServeIo: no shutdown() call.
+  auto session = start_serve_drop_consumer(kj::mv(pipe.ends[0]));
+  KJ_EXPECT(!session->is_native());
+  auto drive = session->drive();
+
+  pipe.ends[1]->write("ping"_kjb).wait(ws);
+  // The drop must surface as shutdownWrite() on the kj stream: the client reads EOF.
+  kj::byte buffer[1];
+  KJ_EXPECT(boundedBy(io, pipe.ends[1]->tryRead(buffer, 1, 1), 10 * kj::SECONDS,
+                "EOF from the pump's shutdownWrite")
+                .wait(ws) == 0);
+  // The kj->consumer direction is still waiting on the client; closing the client end lets the
+  // pump finish both directions.
+  pipe.ends[1] = nullptr;
+  boundedBy(io, kj::mv(drive), 10 * kj::SECONDS, "the pump to settle").wait(ws);
+}
+
+// A byte-transforming wrapper over a kj-rs-io TCP stream: XORs everything in both directions.
+// The shape of kj::TlsConnection as far as serve_kj_stream is concerned -- it forwards getFd()
+// to its transport socket, whose bytes are NOT the stream's bytes.
+class XorStream final: public kj::AsyncIoStream {
+ public:
+  explicit XorStream(kj::Own<kj::AsyncIoStream> inner): inner(kj::mv(inner)) {}
+
+  kj::Promise<size_t> tryRead(void *buffer, size_t minBytes, size_t maxBytes) override {
+    size_t n = co_await inner->tryRead(buffer, minBytes, maxBytes);
+    auto bytes = reinterpret_cast<kj::byte *>(buffer);
+    for (size_t i = 0; i < n; i++) bytes[i] ^= KEY;
+    co_return n;
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte> buffer) override {
+    auto copy = kj::heapArray<kj::byte>(buffer.size());
+    for (size_t i = 0; i < buffer.size(); i++) copy[i] = buffer[i] ^ KEY;
+    co_await inner->write(copy);
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces) override {
+    for (auto piece: pieces) co_await write(piece);
+  }
+  kj::Promise<void> whenWriteDisconnected() override {
+    return inner->whenWriteDisconnected();
+  }
+  void shutdownWrite() override {
+    inner->shutdownWrite();
+  }
+  kj::Maybe<int> getFd() const override {
+    return inner->getFd();  // the transport's fd: ciphertext, not this stream's bytes
+  }
+
+ private:
+  static constexpr kj::byte KEY = 0x5a;
+  kj::Own<kj::AsyncIoStream> inner;
+};
+
+KJ_TEST("serve_kj_stream pumps a byte-transforming wrapper (TLS-shaped) correctly, never its "
+        "fd") {
+  // The wrapper exposes its transport's fd, so an fd-tier shortcut would serve the transformed
+  // bytes. serve_kj_stream must take the pump path and echo the plaintext the client sees.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  auto session = start_serve_echo(kj::heap<XorStream>(kj::mv(pair.server)));
+  KJ_EXPECT(!session->is_native());
+
+  // The client speaks through its own XorStream, so plaintext round-trips only if the server
+  // side was pumped through the wrapper (and not read off the raw socket).
+  XorStream client(kj::mv(pair.client));
+  auto data = makePatternedData(128 * 1024, 13);
+  auto drive = session->drive();
+  auto echo = echoRoundTrip(client, data);
+  kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(echo))).wait(ws);
+}
+
+// =======================================================================================
+// take_kj_socket (native-only: unwrap tier, else fd-dup tier)
+
+KJ_TEST("take_kj_socket unwraps kj-rs-io TCP streams (tier 1) and echoes") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // Native socket taken; the (hollow) kj stream was destroyed inside take_kj_socket.
+  auto session = start_take_socket_echo(kj::mv(pair.server));
+  KJ_EXPECT(session->is_native());
+
+  auto data = makePatternedData(256 * 1024, 5);
+  auto drive = session->drive();
+  auto client = echoRoundTrip(*pair.client, data);
+  kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(client))).wait(ws);
+}
+
+#if !_WIN32
+// A foreign kj::AsyncIoStream that exposes only its OS fd: unwrap must fail (it is not a
+// kj-rs-io wrapper) and any per-read FFI would abort the test -- proving take_kj_socket's fd
+// tier does all its I/O on the dup'd socket, never through the kj stream.
+class FdOnlyStream final: public kj::AsyncIoStream {
+ public:
+  explicit FdOnlyStream(kj::Own<kj::AsyncIoStream> inner): inner(kj::mv(inner)) {}
+
+  kj::Maybe<int> getFd() const override {
+    return inner->getFd();
+  }
+
+  kj::Promise<size_t> tryRead(void *, size_t, size_t) override {
+    KJ_UNIMPLEMENTED("FdOnlyStream must not be read through the FFI");
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte>) override {
+    KJ_UNIMPLEMENTED("FdOnlyStream must not be written through the FFI");
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>>) override {
+    KJ_UNIMPLEMENTED("FdOnlyStream must not be written through the FFI");
+  }
+  kj::Promise<void> whenWriteDisconnected() override {
+    KJ_UNIMPLEMENTED("FdOnlyStream must not be observed through the FFI");
+  }
+  void shutdownWrite() override {
+    KJ_UNIMPLEMENTED("FdOnlyStream must not be shut down through the FFI");
+  }
+
+ private:
+  kj::Own<kj::AsyncIoStream> inner;
+};
+
+KJ_TEST("take_kj_socket dups the fd of foreign fd-backed streams (tier 2); the "
+        "original stream may be dropped") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // Hide the kj-rs-io origin behind a foreign wrapper: only getFd() is reachable.
+  auto foreign = kj::heap<FdOnlyStream>(kj::mv(pair.server));
+
+  // Fd tier: the dup is independent; take_kj_socket destroys the wrapper (and with it the
+  // original socket's owner) before returning, which must not tear the served connection down.
+  auto session = start_take_socket_echo(kj::mv(foreign));
+  KJ_EXPECT(session->is_native());
+
+  auto data = makePatternedData(256 * 1024, 9);
+  auto drive = session->drive();
+  auto client = echoRoundTrip(*pair.client, data);
+  kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(client))).wait(ws);
+}
+
+// A unix-domain (AF_UNIX) socket must be served natively too: take_kj_socket's fd tier dups the
+// fd and detects the family (getsockname), producing a tokio UnixStream (ServeIo::Unix).
+KJ_TEST("take_kj_socket serves a unix-domain (AF_UNIX) socket via its fd tier and echoes") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeUnixPair(io);
+
+  // Hide the kj-rs-io origin behind a foreign wrapper so take_kj_socket must use its fd tier
+  // (dup + family detection), not the unwrap fast path -- proving the AF_UNIX -> UnixStream
+  // branch of serve_io_from_owned_fd.
+  auto foreign = kj::heap<FdOnlyStream>(kj::mv(pair.server));
+
+  auto session = start_take_socket_echo(kj::mv(foreign));
+  KJ_EXPECT(session->is_native());  // ServeIo::Unix is a native path (no pump)
+
+  auto data = makePatternedData(256 * 1024, 11);
+  auto drive = session->drive();
+  auto client = echoRoundTrip(*pair.client, data);
+  kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(client))).wait(ws);
+}
+#endif  // !_WIN32
+
+KJ_TEST("take_kj_socket on an already-unwrapped (hollow) kj-rs-io stream is refused") {
+  // Unwrap the stream first (leaving the C++ wrapper hollow), then take_kj_socket it: tier 1
+  // (unwrap) fails because it is hollow, and tier 2 (fd dup) finds no fd (getFd -> none on a
+  // hollow wrapper), so it is refused rather than crashing.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  // Unwrap + drop the native stream; pair.server is now a hollow wrapper.
+  native_write_via_kj_unwrap(*pair.server, ::rust::Slice<const uint8_t>()).wait(ws);
+
+  KJ_EXPECT_THROW_MESSAGE(
+      "cannot take the stream's socket natively", start_take_socket_echo(kj::mv(pair.server)));
+}
+
+KJ_TEST("take_kj_socket refuses fd-less foreign streams (no pump tier)") {
+  auto io = setupTokioAsyncIo();
+  auto pipe = kj::newTwoWayPipe();
+
+  KJ_EXPECT_THROW_MESSAGE(
+      "cannot take the stream's socket natively", start_take_socket_echo(kj::mv(pipe.ends[0])));
+}
+
+}  // namespace
+}  // namespace kj_rs_io_test

--- a/src/rust/cxx/kj-rs-io/tests/serve-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/serve-test.c++
@@ -175,10 +175,9 @@ KJ_TEST("serve_kj_stream pump: dropping the pump aborts the bridge (drop-abort)"
 }
 
 KJ_TEST("serve_kj_stream pump: the Duplex consumer may be driven from another thread") {
-  // ServedKjStream::io's docs promise the Duplex variant is safe to drive off the KJ event-loop
-  // thread since the waker bridge became thread-safe. Here the echo consumer runs on its own OS
-  // thread and runtime, so every read/write/drop on the Duplex wakes the pump (parked on this
-  // KJ loop) cross-thread through the FutureWakerCell. TSAN target.
+  // ServedKjStream::io permits a Duplex consumer on a different thread from its KJ pump.
+  // Here the echo consumer runs on its own thread and runtime. Notifications from its Duplex
+  // endpoint wake the pump through ArcWaker's cross-thread fulfiller.
   auto io = setupTokioAsyncIo();
   auto &ws = io.getWaitScope();
   auto pipe = kj::newTwoWayPipe();

--- a/src/rust/cxx/kj-rs-io/tests/serve-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/serve-test.c++
@@ -185,7 +185,7 @@ KJ_TEST("serve_kj_stream pump: the Duplex consumer may be driven from another th
   KJ_EXPECT(!session->is_native());
 
   auto data = makePatternedData(512 * 1024, 5);
-  auto drive = session->drive();  // drives the pump here; the consumer echoes on its own thread
+  auto drive = session->drive();  // the join below drives the pump alongside the client
   auto client = echoRoundTrip(*pipe.ends[1], data);
   kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(client))).wait(ws);
 }
@@ -239,7 +239,7 @@ KJ_TEST("serve_kj_stream pump: a DISCONNECTED read is treated as EOF, not as an 
   auto session = start_serve_echo(kj::heap<DisconnectingStream>(kj::mv(pipe.ends[0]), false));
   KJ_EXPECT(!session->is_native());
 
-  auto drive = session->drive();
+  auto drive = session->drive().eagerlyEvaluate(nullptr);
   // One message goes through, then the client goes away abruptly: the pump's read fails
   // DISCONNECTED. The echo consumer must see EOF (and echo back what it got), and the pump must
   // settle Ok -- abrupt client disconnects are normal load, not failures.
@@ -258,7 +258,7 @@ KJ_TEST("serve_kj_stream pump: a DISCONNECTED write ends the direction without a
   auto pipe = kj::newTwoWayPipe();
 
   auto session = start_serve_echo(kj::heap<DisconnectingStream>(kj::mv(pipe.ends[0]), true));
-  auto drive = session->drive();
+  auto drive = session->drive().eagerlyEvaluate(nullptr);
   // The consumer's echo of "ping" is written to a peer that already reset: the pump must not
   // fail. Half-close so the read direction finishes normally too.
   pipe.ends[1]->write("ping"_kjb).wait(ws);
@@ -276,7 +276,7 @@ KJ_TEST("serve_kj_stream pump: the consumer dropping its end (no shutdown) half-
   // A consumer that reads one message and then simply drops its ServeIo: no shutdown() call.
   auto session = start_serve_drop_consumer(kj::mv(pipe.ends[0]));
   KJ_EXPECT(!session->is_native());
-  auto drive = session->drive();
+  auto drive = session->drive().eagerlyEvaluate(nullptr);
 
   pipe.ends[1]->write("ping"_kjb).wait(ws);
   // The drop must surface as shutdownWrite() on the kj stream: the client reads EOF.

--- a/src/rust/cxx/kj-rs-io/tests/serve-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/serve-test.c++
@@ -19,7 +19,6 @@ namespace kj_rs_io_test {
 namespace {
 
 using kj_rs_io::setupTokioAsyncIo;
-using kj_rs_io::TokioAsyncIoContext;
 
 // The client side of an echo round trip: write `data` (in chunks) and concurrently read the
 // echo back and verify it (concurrent, so bounded transports -- the pump duplex, socket

--- a/src/rust/cxx/kj-rs-io/tests/serve-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/serve-test.c++
@@ -398,6 +398,38 @@ class FdOnlyStream final: public kj::AsyncIoStream {
   kj::Own<kj::AsyncIoStream> inner;
 };
 
+class ThrowingGetFdStream final: public kj::AsyncIoStream {
+ public:
+  kj::Maybe<int> getFd() const override {
+    KJ_FAIL_REQUIRE("getFd failure for test");
+  }
+
+  kj::Promise<size_t> tryRead(void *, size_t, size_t) override {
+    KJ_UNREACHABLE;
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::byte>) override {
+    KJ_UNREACHABLE;
+  }
+  kj::Promise<void> write(kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>>) override {
+    KJ_UNREACHABLE;
+  }
+  kj::Promise<void> whenWriteDisconnected() override {
+    KJ_UNREACHABLE;
+  }
+  void shutdownWrite() override {
+    KJ_UNREACHABLE;
+  }
+};
+
+KJ_TEST("take_kj_socket preserves exceptions from a foreign stream's getFd") {
+  auto io = setupTokioAsyncIo();
+
+  auto failure = expect_take_socket_failure(kj::heap<ThrowingGetFdStream>());
+  KJ_EXPECT(failure->is_get_fd_failure());
+  auto recovered = failure->take_stream();
+  KJ_EXPECT_THROW_MESSAGE("getFd failure for test", recovered->getFd());
+}
+
 KJ_TEST("take_kj_socket dups the fd of foreign fd-backed streams (tier 2); the "
         "original stream may be dropped") {
   auto io = setupTokioAsyncIo();

--- a/src/rust/cxx/kj-rs-io/tests/serve-test.c++
+++ b/src/rust/cxx/kj-rs-io/tests/serve-test.c++
@@ -73,6 +73,50 @@ KJ_TEST("serve_kj_stream takes the native path for kj-rs-io TCP streams and "
   kj::joinPromisesFailFast(kj::arr(kj::mv(drive), kj::mv(client))).wait(ws);
 }
 
+KJ_TEST("take_kj_socket preserves a native stream when extraction is blocked by in-flight I/O") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  kj::Own<kj::AsyncIoStream> recovered;
+  {
+    kj::byte pendingByte;
+    auto pendingRead = pair.server->tryRead(&pendingByte, 1, 1);
+    KJ_EXPECT(!pendingRead.poll(ws));
+
+    auto failure = expect_take_socket_failure(kj::mv(pair.server));
+    KJ_EXPECT(failure->is_in_flight());
+    recovered = failure->take_stream();
+  }
+
+  pair.client->write("ok"_kjb).wait(ws);
+  kj::byte buffer[2];
+  KJ_EXPECT(recovered->tryRead(buffer, 2, 2).wait(ws) == 2);
+  KJ_EXPECT(kj::arrayPtr(buffer) == "ok"_kjb);
+}
+
+KJ_TEST("serve_kj_stream preserves a native stream when extraction is blocked by in-flight I/O") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto pair = makeTcpPair(io);
+
+  kj::Own<kj::AsyncIoStream> recovered;
+  {
+    kj::byte pendingByte;
+    auto pendingRead = pair.server->tryRead(&pendingByte, 1, 1);
+    KJ_EXPECT(!pendingRead.poll(ws));
+
+    auto failure = expect_serve_stream_failure(kj::mv(pair.server));
+    KJ_EXPECT(failure->is_in_flight());
+    recovered = failure->take_stream();
+  }
+
+  pair.client->write("ok"_kjb).wait(ws);
+  kj::byte buffer[2];
+  KJ_EXPECT(recovered->tryRead(buffer, 2, 2).wait(ws) == 2);
+  KJ_EXPECT(kj::arrayPtr(buffer) == "ok"_kjb);
+}
+
 // =======================================================================================
 // Duplex pump fallback (foreign streams)
 
@@ -397,9 +441,9 @@ KJ_TEST("take_kj_socket serves a unix-domain (AF_UNIX) socket via its fd tier an
 #endif  // !_WIN32
 
 KJ_TEST("take_kj_socket on an already-unwrapped (hollow) kj-rs-io stream is refused") {
-  // Unwrap the stream first (leaving the C++ wrapper hollow), then take_kj_socket it: tier 1
-  // (unwrap) fails because it is hollow, and tier 2 (fd dup) finds no fd (getFd -> none on a
-  // hollow wrapper), so it is refused rather than crashing.
+  // Unwrap the stream first (leaving the C++ wrapper hollow), then take_kj_socket it. It is still
+  // recognizably a native wrapper, so the specific extraction failure must be preserved rather
+  // than falling through to the foreign-fd tier.
   auto io = setupTokioAsyncIo();
   auto &ws = io.getWaitScope();
   auto pair = makeTcpPair(io);
@@ -407,8 +451,7 @@ KJ_TEST("take_kj_socket on an already-unwrapped (hollow) kj-rs-io stream is refu
   // Unwrap + drop the native stream; pair.server is now a hollow wrapper.
   native_write_via_kj_unwrap(*pair.server, ::rust::Slice<const uint8_t>()).wait(ws);
 
-  KJ_EXPECT_THROW_MESSAGE(
-      "cannot take the stream's socket natively", start_take_socket_echo(kj::mv(pair.server)));
+  KJ_EXPECT_THROW_MESSAGE("already unwrapped", start_take_socket_echo(kj::mv(pair.server)));
 }
 
 KJ_TEST("take_kj_socket refuses fd-less foreign streams (no pump tier)") {

--- a/src/rust/cxx/kj-rs-io/tests/serve_helpers.rs
+++ b/src/rust/cxx/kj-rs-io/tests/serve_helpers.rs
@@ -1,0 +1,185 @@
+//! Rust helpers for the `serve_kj_stream` `KJ_TEST`s (`serve-test.c++`):
+//! echo sessions over each transport path, driven by the C++ tests.
+
+use std::cell::RefCell;
+
+use cxx::KjError;
+use kj_rs::KjOwn;
+use kj_rs_io::serve::ServeIo;
+use kj_rs_io::serve::ServePath;
+use kj_rs_io::serve::StreamPump;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::watch;
+
+use crate::ffi::KjAsyncIoStream;
+
+type Result<T> = std::result::Result<T, KjError>;
+
+fn kj_err(message: impl std::fmt::Display) -> KjError {
+    KjError::new(cxx::KjExceptionType::Failed, message.to_string())
+}
+
+/// The echo task shared by every path: copy everything read back to the writer, then
+/// propagate the half-close. Reports completion through `done_tx`.
+async fn echo(io: ServeIo, done_tx: watch::Sender<bool>) -> std::io::Result<u64> {
+    let result = async {
+        let (mut rd, mut wr) = tokio::io::split(io);
+        let n = tokio::io::copy(&mut rd, &mut wr).await?;
+        wr.shutdown().await?;
+        Ok(n)
+    }
+    .await;
+    let _ = done_tx.send(true);
+    result
+}
+
+/// A consumer that reads one message and then drops the stream WITHOUT `shutdown()` (see
+/// `start_serve_drop_consumer` in lib.rs). Reports completion through `done_tx`.
+async fn read_then_drop(mut io: ServeIo, done_tx: watch::Sender<bool>) -> std::io::Result<u64> {
+    use tokio::io::AsyncReadExt;
+    let result = async {
+        let mut buf = [0u8; 64];
+        let n = io.read(&mut buf).await?;
+        drop(io);
+        Ok(n as u64)
+    }
+    .await;
+    let _ = done_tx.send(true);
+    result
+}
+
+/// One echo server over a served kj stream; see `start_serve_echo` in lib.rs.
+pub struct ServeEchoSession {
+    native: bool,
+    /// Present for the pumped path; taken by `drive()`.
+    pump: RefCell<Option<StreamPump>>,
+    /// The echo task's completion signal (fires even if the task failed).
+    done_rx: watch::Receiver<bool>,
+    /// Taken by `drive()`.
+    echo: RefCell<Option<tokio::task::JoinHandle<std::io::Result<u64>>>>,
+    /// For the foreign-thread variant: the OS thread running the echo consumer, joined by
+    /// `drive()`. `None` for the loop-runtime variant.
+    foreign: RefCell<Option<std::thread::JoinHandle<std::io::Result<u64>>>>,
+}
+
+pub fn start_serve_echo(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession> {
+    let served = kj_rs_io::serve_kj_stream(stream);
+    Box::new(ServeEchoSession::new(served.io, served.pump))
+}
+
+pub fn start_serve_drop_consumer(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession> {
+    let served = kj_rs_io::serve_kj_stream(stream);
+    let native = served.io.path() == ServePath::Native;
+    let (done_tx, done_rx) = watch::channel(false);
+    let consumer = kj_rs_tokio::spawn(read_then_drop(served.io, done_tx));
+    Box::new(ServeEchoSession {
+        native,
+        pump: RefCell::new(served.pump),
+        done_rx,
+        echo: RefCell::new(Some(consumer)),
+        foreign: RefCell::new(None),
+    })
+}
+
+/// Like `start_serve_echo`, but the echo consumer runs on a SEPARATE OS thread with its own
+/// plain tokio runtime instead of this thread's KJ-loop runtime. For a pumped (Duplex) stream
+/// this drives the `ServeIo::Duplex` end entirely off the KJ event-loop thread: every read /
+/// write / drop on it wakes the pump (parked on the KJ loop) cross-thread through the kj-rs
+/// `FutureWakerCell`. That is the scenario `ServedKjStream::io`'s docs describe as legal since
+/// the waker bridge became thread-safe; this proves it (and is a TSAN target).
+pub fn start_serve_echo_foreign_thread(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession> {
+    let served = kj_rs_io::serve_kj_stream(stream);
+    Box::new(ServeEchoSession::new_foreign_thread(served.io, served.pump))
+}
+
+/// Like `start_serve_echo`, but through the native-only entry point (`take_kj_socket`,
+/// tiers 1 + 2): errors for streams that are neither kj-rs-io native nor fd-backed (the
+/// handed-back stream is dropped with the error).
+pub fn start_take_socket_echo(stream: KjOwn<KjAsyncIoStream>) -> Result<Box<ServeEchoSession>> {
+    let io = kj_rs_io::take_kj_socket(stream).map_err(KjError::from)?;
+    Ok(Box::new(ServeEchoSession::new(io, None)))
+}
+
+impl ServeEchoSession {
+    fn new(io: ServeIo, pump: Option<StreamPump>) -> Self {
+        let native = io.path() == ServePath::Native;
+        let (done_tx, done_rx) = watch::channel(false);
+        // The echo consumer runs on this thread's KJ-loop runtime: the one-runtime shape
+        // (native sockets are registered with this runtime's I/O driver anyway).
+        let echo = kj_rs_tokio::spawn(echo(io, done_tx));
+        Self {
+            native,
+            pump: RefCell::new(pump),
+            done_rx,
+            echo: RefCell::new(Some(echo)),
+            foreign: RefCell::new(None),
+        }
+    }
+
+    fn new_foreign_thread(io: ServeIo, pump: Option<StreamPump>) -> Self {
+        let native = io.path() == ServePath::Native;
+        let (done_tx, done_rx) = watch::channel(false);
+        // Run the echo consumer on its own OS thread with a private current-thread runtime, so
+        // the Duplex end is driven entirely off the KJ event-loop thread.
+        let foreign = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build echo-consumer runtime");
+            rt.block_on(echo(io, done_tx))
+        });
+        Self {
+            native,
+            pump: RefCell::new(pump),
+            done_rx,
+            echo: RefCell::new(None),
+            foreign: RefCell::new(Some(foreign)),
+        }
+    }
+
+    pub fn is_native(&self) -> bool {
+        self.native
+    }
+
+    /// Runs the connection to completion: drives the pump (if any) and waits for the echo
+    /// task to finish. Dropping the returned promise mid-connection drops the pump —
+    /// the abort-on-drop path.
+    pub async fn drive(&self) -> Result<()> {
+        let pump = self.pump.borrow_mut().take();
+        let echo = self.echo.borrow_mut().take();
+        // Await the pump but do NOT `?` yet: on the foreign-thread variant we must still join
+        // the consumer OS thread even if the pump errored, or we leak an unjoined thread.
+        let pump_result = match pump {
+            Some(pump) => pump.await,
+            None => Ok(()),
+        };
+        if let Some(handle) = echo {
+            handle
+                .await
+                .map_err(|e| kj_err(format!("echo task panicked: {e}")))?
+                .map_err(|e| kj_err(format!("echo failed: {e}")))?;
+        }
+        // Foreign-thread variant: wait for the consumer to finish (dropping the pump above
+        // EOFs it), then join. Waiting on the done signal first keeps the join near-instant.
+        let foreign = self.foreign.borrow_mut().take();
+        if let Some(handle) = foreign {
+            self.wait_echo_done().await;
+            handle
+                .join()
+                .map_err(|_| kj_err("echo consumer thread panicked"))?
+                .map_err(|e| kj_err(format!("echo failed: {e}")))?;
+        }
+        pump_result?;
+        Ok(())
+    }
+
+    /// Resolves once the echo task has finished (however `drive()` fared) — used by the
+    /// drop-abort test to observe that dropping the pump EOFs the consumer.
+    pub async fn wait_echo_done(&self) {
+        let mut rx = self.done_rx.clone();
+        // Cannot fail: the sender is owned by the echo task, which always sends before exit;
+        // even if it panicked, the closed channel resolves wait_for with an error we ignore
+        // after checking the flag.
+        let _ = rx.wait_for(|done| *done).await;
+    }
+}

--- a/src/rust/cxx/kj-rs-io/tests/serve_helpers.rs
+++ b/src/rust/cxx/kj-rs-io/tests/serve_helpers.rs
@@ -24,14 +24,17 @@ fn kj_err(message: impl std::fmt::Display) -> KjError {
 pub struct NativeServeFailure {
     stream: RefCell<Option<KjOwn<KjAsyncIoStream>>>,
     in_flight: bool,
+    get_fd_failure: bool,
 }
 
 impl NativeServeFailure {
     fn from_error(error: kj_rs_io::TakeSocketError) -> Box<Self> {
         let in_flight = error.error.description().contains("in flight");
+        let get_fd_failure = error.error.description().contains("getFd failure for test");
         Box::new(Self {
             stream: RefCell::new(Some(error.stream)),
             in_flight,
+            get_fd_failure,
         })
     }
 }
@@ -53,6 +56,10 @@ pub fn expect_serve_stream_failure(stream: KjOwn<KjAsyncIoStream>) -> Box<Native
 impl NativeServeFailure {
     pub fn is_in_flight(&self) -> bool {
         self.in_flight
+    }
+
+    pub fn is_get_fd_failure(&self) -> bool {
+        self.get_fd_failure
     }
 
     pub fn take_stream(&self) -> KjOwn<KjAsyncIoStream> {

--- a/src/rust/cxx/kj-rs-io/tests/serve_helpers.rs
+++ b/src/rust/cxx/kj-rs-io/tests/serve_helpers.rs
@@ -132,12 +132,10 @@ pub fn start_serve_drop_consumer(stream: KjOwn<KjAsyncIoStream>) -> Result<Box<S
     }))
 }
 
-/// Like `start_serve_echo`, but the echo consumer runs on a SEPARATE OS thread with its own
-/// plain tokio runtime instead of this thread's KJ-loop runtime. For a pumped (Duplex) stream
-/// this drives the `ServeIo::Duplex` end entirely off the KJ event-loop thread: every read /
-/// write / drop on it wakes the pump (parked on the KJ loop) cross-thread through the kj-rs
-/// `FutureWakerCell`. That is the scenario `ServedKjStream::io`'s docs describe as legal since
-/// the waker bridge became thread-safe; this proves it (and is a TSAN target).
+/// Like `start_serve_echo`, but the echo consumer runs on another OS thread with its own
+/// tokio runtime. For a pumped stream, this drives `ServeIo::Duplex` off the KJ loop thread;
+/// its notifications wake the pump through kj-rs's `ArcWaker` and cross-thread fulfiller.
+/// The pump and its owned KJ stream remain on the KJ loop thread.
 pub fn start_serve_echo_foreign_thread(
     stream: KjOwn<KjAsyncIoStream>,
 ) -> Result<Box<ServeEchoSession>> {

--- a/src/rust/cxx/kj-rs-io/tests/serve_helpers.rs
+++ b/src/rust/cxx/kj-rs-io/tests/serve_helpers.rs
@@ -19,6 +19,50 @@ fn kj_err(message: impl std::fmt::Display) -> KjError {
     KjError::new(cxx::KjExceptionType::Failed, message.to_string())
 }
 
+/// A native-serving failure whose stream remains owned until the C++ test has cancelled the
+/// operation that prevented extraction.
+pub struct NativeServeFailure {
+    stream: RefCell<Option<KjOwn<KjAsyncIoStream>>>,
+    in_flight: bool,
+}
+
+impl NativeServeFailure {
+    fn from_error(error: kj_rs_io::TakeSocketError) -> Box<Self> {
+        let in_flight = error.error.description().contains("in flight");
+        Box::new(Self {
+            stream: RefCell::new(Some(error.stream)),
+            in_flight,
+        })
+    }
+}
+
+pub fn expect_take_socket_failure(stream: KjOwn<KjAsyncIoStream>) -> Box<NativeServeFailure> {
+    match kj_rs_io::take_kj_socket(stream) {
+        Ok(_) => panic!("taking a native socket with I/O in flight unexpectedly succeeded"),
+        Err(error) => NativeServeFailure::from_error(error),
+    }
+}
+
+pub fn expect_serve_stream_failure(stream: KjOwn<KjAsyncIoStream>) -> Box<NativeServeFailure> {
+    match kj_rs_io::serve_kj_stream(stream) {
+        Ok(_) => panic!("serving a native stream with I/O in flight unexpectedly succeeded"),
+        Err(error) => NativeServeFailure::from_error(error),
+    }
+}
+
+impl NativeServeFailure {
+    pub fn is_in_flight(&self) -> bool {
+        self.in_flight
+    }
+
+    pub fn take_stream(&self) -> KjOwn<KjAsyncIoStream> {
+        self.stream
+            .borrow_mut()
+            .take()
+            .expect("failed native-serving stream already taken")
+    }
+}
+
 /// The echo task shared by every path: copy everything read back to the writer, then
 /// propagate the half-close. Reports completion through `done_tx`.
 async fn echo(io: ServeIo, done_tx: watch::Sender<bool>) -> std::io::Result<u64> {
@@ -62,23 +106,23 @@ pub struct ServeEchoSession {
     foreign: RefCell<Option<std::thread::JoinHandle<std::io::Result<u64>>>>,
 }
 
-pub fn start_serve_echo(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession> {
-    let served = kj_rs_io::serve_kj_stream(stream);
-    Box::new(ServeEchoSession::new(served.io, served.pump))
+pub fn start_serve_echo(stream: KjOwn<KjAsyncIoStream>) -> Result<Box<ServeEchoSession>> {
+    let served = kj_rs_io::serve_kj_stream(stream).map_err(KjError::from)?;
+    Ok(Box::new(ServeEchoSession::new(served.io, served.pump)))
 }
 
-pub fn start_serve_drop_consumer(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession> {
-    let served = kj_rs_io::serve_kj_stream(stream);
+pub fn start_serve_drop_consumer(stream: KjOwn<KjAsyncIoStream>) -> Result<Box<ServeEchoSession>> {
+    let served = kj_rs_io::serve_kj_stream(stream).map_err(KjError::from)?;
     let native = served.io.path() == ServePath::Native;
     let (done_tx, done_rx) = watch::channel(false);
     let consumer = kj_rs_tokio::spawn(read_then_drop(served.io, done_tx));
-    Box::new(ServeEchoSession {
+    Ok(Box::new(ServeEchoSession {
         native,
         pump: RefCell::new(served.pump),
         done_rx,
         echo: RefCell::new(Some(consumer)),
         foreign: RefCell::new(None),
-    })
+    }))
 }
 
 /// Like `start_serve_echo`, but the echo consumer runs on a SEPARATE OS thread with its own
@@ -87,9 +131,14 @@ pub fn start_serve_drop_consumer(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEch
 /// write / drop on it wakes the pump (parked on the KJ loop) cross-thread through the kj-rs
 /// `FutureWakerCell`. That is the scenario `ServedKjStream::io`'s docs describe as legal since
 /// the waker bridge became thread-safe; this proves it (and is a TSAN target).
-pub fn start_serve_echo_foreign_thread(stream: KjOwn<KjAsyncIoStream>) -> Box<ServeEchoSession> {
-    let served = kj_rs_io::serve_kj_stream(stream);
-    Box::new(ServeEchoSession::new_foreign_thread(served.io, served.pump))
+pub fn start_serve_echo_foreign_thread(
+    stream: KjOwn<KjAsyncIoStream>,
+) -> Result<Box<ServeEchoSession>> {
+    let served = kj_rs_io::serve_kj_stream(stream).map_err(KjError::from)?;
+    Ok(Box::new(ServeEchoSession::new_foreign_thread(
+        served.io,
+        served.pump,
+    )))
 }
 
 /// Like `start_serve_echo`, but through the native-only entry point (`take_kj_socket`,

--- a/src/rust/cxx/kj-rs-io/tests/test_helpers.rs
+++ b/src/rust/cxx/kj-rs-io/tests/test_helpers.rs
@@ -1,0 +1,80 @@
+use std::io;
+use std::pin::Pin;
+
+use cxx::KjError;
+use kj_rs_io::TokioStream;
+use tokio::io::Interest;
+use tokio::net::TcpStream;
+
+use crate::ffi::KjAsyncIoStream;
+use crate::ffi::PreboundListener;
+
+type Result<T> = std::result::Result<T, KjError>;
+
+fn kj_err(message: impl std::fmt::Display) -> KjError {
+    KjError::new(cxx::KjExceptionType::Failed, message.to_string())
+}
+
+/// Write-all over the native tokio readiness API.
+async fn native_write_all(stream: &TcpStream, data: &[u8]) -> io::Result<()> {
+    let mut written = 0;
+    while written < data.len() {
+        match stream.try_write(&data[written..]) {
+            Ok(n) => written += n,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                stream.ready(Interest::WRITABLE).await?;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+pub async fn native_write_via_unwrap(stream: Box<TokioStream>, data: Vec<u8>) -> Result<()> {
+    let tcp = stream
+        .into_tcp_stream()
+        .ok_or_else(|| kj_err("expected a TCP stream"))?;
+    native_write_all(&tcp, &data).await.map_err(kj_err)?;
+    // Dropping `tcp` closes the connection; the C++ side observes data followed by EOF.
+    Ok(())
+}
+
+pub async fn native_write_via_kj_unwrap(
+    stream: Pin<&mut KjAsyncIoStream>,
+    data: &[u8],
+) -> Result<()> {
+    // unwrap_kj_stream is safe now: it detects in-flight I/O and returns an error rather than
+    // aliasing (the C++ test also keeps no I/O in flight here).
+    let native = kj_rs_io::unwrap_kj_stream(stream).map_err(KjError::from)?;
+    let tcp = native
+        .into_tcp_stream()
+        .ok_or_else(|| kj_err("expected a TCP stream"))?;
+    native_write_all(&tcp, data).await.map_err(kj_err)?;
+    Ok(())
+}
+
+pub fn create_prebound_listener_fd() -> Result<PreboundListener> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").map_err(kj_err)?;
+    let port = listener.local_addr().map_err(kj_err)?.port();
+    #[cfg(unix)]
+    {
+        use std::os::fd::IntoRawFd;
+        Ok(PreboundListener {
+            fd: listener.into_raw_fd(),
+            port,
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        Err(kj_err("not supported on this platform"))
+    }
+}
+
+/// See the bridge doc on `address_from_loopback_ports` (lib.rs).
+pub fn address_from_loopback_ports(ports: &[u16]) -> Box<kj_rs_io::TokioAddress> {
+    let addrs = ports
+        .iter()
+        .map(|&port| std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port)))
+        .collect();
+    Box::new(kj_rs_io::TokioAddress::from_socket_addrs(addrs))
+}

--- a/src/rust/cxx/kj-rs-io/unwrap.h
+++ b/src/rust/cxx/kj-rs-io/unwrap.h
@@ -1,0 +1,95 @@
+#pragma once
+// Declarations needed by the kj-rs-io cxx bridge (lib.rs) itself. The full C++ API lives in
+// kj-rs-io/async-io.h; this header only exposes what the generated bridge code references:
+// kj::AsyncIoStream (as an opaque extern C++ type), the unwrap hook, and the bridged stream
+// operations backing serve_kj_stream()'s pump fallback (serve.rs).
+
+#include <rust/cxx.h>
+
+#include <kj/async-io.h>
+
+namespace kj_rs_io {
+
+struct TokioStream;  // Opaque Rust type, defined in the generated lib.rs.h.
+
+// Recovers the native Rust stream out of a kj::AsyncIoStream created by kj-rs-io (the "unwrap
+// fast path"), leaving the wrapper hollow: any further I/O through the wrapper throws. Throws if
+// `stream` is not a kj-rs-io stream, was already unwrapped, or has I/O promises in flight (the
+// Rust side tracks in-flight operations, so this is detected, not a caller contract).
+//
+// Implemented in async-io.c++. Rust code calls this through kj_rs_io::unwrap_kj_stream().
+::rust::Box<TokioStream> unwrapTokioStream(kj::AsyncIoStream &stream);
+
+// --- Bridged operations on a *foreign* kj::AsyncIoStream (one that did not originate in
+// kj-rs-io and therefore cannot be unwrapped). These back the duplex-pump fallback of
+// serve_kj_stream() (serve.rs): the pump owns the stream and reads and writes it through
+// concurrent Rust *shared* borrows — kj two-way streams support one read and one write in
+// flight at once.
+
+// A Rust shared borrow (&KjAsyncIoStream) arrives in C++ as a const&: the constness is cxx's
+// wire format for "shared", not a property of the object — the stream is uniquely owned by the
+// pump and never actually const. NOTE the meaning mismatch with KJ convention: KJ const means
+// *thread-safe* (Rust's Sync), but this shared-ness is the weaker property — reentrant use from
+// one thread's async tasks (the bridge types are !Send/!Sync, so Rust can never move these
+// borrows off the KJ event-loop thread that owns the stream). Recover the callable reference
+// here, once.
+inline kj::AsyncIoStream &pumpStream(const kj::AsyncIoStream &stream) {
+  return const_cast<kj::AsyncIoStream &>(stream);
+}
+
+// The pieces of a kj::AsyncOutputStream::write(pieces) call, handed to Rust for a vectored write
+// (stream_write_pieces, ffi.rs). Opaque to cxx; Rust reads it through the two accessors below.
+// Owned by the C++ coroutine frame that awaits the bridged future (TokioAsyncIoStream::
+// writePieces); the piece buffers are the caller's, valid until that promise settles.
+struct KjPieces {
+  kj::ArrayPtr<const kj::ArrayPtr<const kj::byte>> pieces;
+};
+
+inline size_t kjPiecesCount(const KjPieces &pieces) {
+  return pieces.pieces.size();
+}
+
+inline ::rust::Slice<const uint8_t> kjPiece(const KjPieces &pieces, size_t index) {
+  auto piece = pieces.pieces[index];
+  return ::rust::Slice<const uint8_t>(piece.begin(), piece.size());
+}
+
+// Corresponds to kj::AsyncIoStream::tryRead(buffer, minBytes, buffer.size()).
+inline kj::Promise<size_t> kjStreamTryRead(
+    const kj::AsyncIoStream &stream, ::rust::Slice<uint8_t> buffer, size_t minBytes) {
+  return pumpStream(stream).tryRead(buffer.data(), minBytes, buffer.size());
+}
+
+// Corresponds to kj::AsyncIoStream::write(buffer) (write-all semantics).
+inline kj::Promise<void> kjStreamWrite(
+    const kj::AsyncIoStream &stream, ::rust::Slice<const uint8_t> buffer) {
+  return pumpStream(stream).write(kj::arrayPtr(buffer.data(), buffer.size()));
+}
+
+// Corresponds to kj::AsyncIoStream::shutdownWrite().
+inline void kjStreamShutdownWrite(const kj::AsyncIoStream &stream) {
+  pumpStream(stream).shutdownWrite();
+}
+
+// The stream's underlying raw OS socket handle -- a Unix fd (kj::AsyncIoStream::getFd()) or a
+// win32 SOCKET (kj::AsyncIoStream::getWin32Handle()) -- widened to int64, or -1 if it exposes
+// none. int64 fits both losslessly with one sentinel: a Unix fd is a non-negative int, and
+// INVALID_SOCKET (~0 as UINT_PTR) is exactly -1 as int64 (live win64 SOCKET values fit in 32
+// bits per the Windows handle-interoperability guarantee, so they never collide with -1).
+// Backs the handle tier of take_kj_socket() (ffi.rs); see that function's docs for the
+// caller-asserted "the handle carries the stream's own bytes" contract (wrappers such as
+// kj::TlsConnection forward getFd() to their *transport* socket, which this tier must never be
+// used on).
+inline int64_t kjStreamGetHandle(const kj::AsyncIoStream &stream) {
+#if _WIN32
+  // Validated by Windows CI; mirrors the unix arm.
+  KJ_IF_SOME(handle, stream.getWin32Handle()) {
+    return static_cast<int64_t>(reinterpret_cast<uintptr_t>(handle));
+  }
+  return -1;
+#else
+  return stream.getFd().orDefault(-1);
+#endif
+}
+
+}  // namespace kj_rs_io

--- a/src/rust/cxx/kj-rs-io/unwrap.h
+++ b/src/rust/cxx/kj-rs-io/unwrap.h
@@ -12,6 +12,11 @@ namespace kj_rs_io {
 
 struct TokioStream;  // Opaque Rust type, defined in the generated lib.rs.h.
 
+// True if `stream` is the kj-rs-io wrapper accepted by unwrapTokioStream(). This lets Rust
+// distinguish a foreign stream, which may use a fallback transport, from a native wrapper whose
+// checked extraction failed and must be returned to the caller untouched.
+bool isTokioStream(const kj::AsyncIoStream &stream);
+
 // Recovers the native Rust stream out of a kj::AsyncIoStream created by kj-rs-io (the "unwrap
 // fast path"), leaving the wrapper hollow: any further I/O through the wrapper throws. Throws if
 // `stream` is not a kj-rs-io stream, was already unwrapped, or has I/O promises in flight (the

--- a/src/rust/cxx/kj-rs-tokio/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-tokio/BUILD.bazel
@@ -1,0 +1,65 @@
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//:build/wd_cc_library.bzl", "wd_cc_library")
+load("//:build/wd_rust_test.bzl", "wd_rust_test")
+load("//src/rust/cxx/tools/bazel:rust_cxx_bridge.bzl", "rust_cxx_bridge")
+
+wd_cc_library(
+    name = "kj-rs-tokio-lib",
+    srcs = glob(["*.c++"]),
+    hdrs = glob(["*.h"]),
+    include_prefix = "kj-rs-tokio",
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    strip_include_prefix = "/src/rust/cxx/kj-rs-tokio",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bridge",
+    ],
+)
+
+rust_library(
+    name = "kj-rs-tokio",
+    srcs = glob(["*.rs"]),
+    compile_data = glob(["*.h"]),
+    edition = "2024",
+    link_deps = [
+        ":bridge",
+        ":kj-rs-tokio-lib",
+    ],
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/rust/cxx",
+        "@crates_vendor//:tokio",
+    ],
+)
+
+wd_rust_test(
+    name = "kj-rs-tokio_test",
+    crate = "kj-rs-tokio",
+    edition = "2024",
+)
+
+rust_cxx_bridge(
+    name = "bridge",
+    src = "ffi.rs",
+    hdrs = glob(["*.h"]),
+    include_prefix = "kj-rs-tokio",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@capnp-cpp//src/kj:kj",
+        # kj-rs-tokio only needs the abstract async core (Promise / EventLoop / EventPort /
+        # Timer) to build the tokio-backed EventPort; it uses neither the abstract kj streams
+        # (:kj-async-io) nor the OS event loop (setupAsyncIo / UnixEventPort). Depending on
+        # :kj-async-core (not the :kj-async umbrella) keeps the tokio event loop off the
+        # concrete kj OS I/O layer (:kj-async-os), which the workerd rust-io hermeticity aspect
+        # forbids.
+        "@capnp-cpp//src/kj:kj-async-core",
+        "//src/rust/cxx:core",
+    ],
+)

--- a/src/rust/cxx/kj-rs-tokio/ffi.rs
+++ b/src/rust/cxx/kj-rs-tokio/ffi.rs
@@ -1,0 +1,123 @@
+//! The `#[cxx::bridge]` FFI island for kj-rs-tokio.
+//!
+//! This is the crate's single dedicated FFI-island file (file-top `#![allow(unsafe_code)]`). It
+//! holds the `#[cxx::bridge] mod bridge` -- the C++ <-> Rust wire the C++
+//! `kj_rs_tokio::TokioEventPort` drives (see `tokio-event-port.h`) -- and [`EnteredRuntime`], the
+//! one hand-written `unsafe` in the crate (a lifetime extension on tokio's `EnterGuard`).
+//! Everything else -- `lib.rs` and the entire event-port business logic in `port.rs` -- is
+//! wholly-safe, compiler-proven unsafe-free under the crate-root `#![deny(unsafe_code)]`.
+#![allow(unsafe_code)]
+
+use std::mem::ManuallyDrop;
+use std::ops::Deref;
+
+use tokio::runtime::EnterGuard;
+use tokio::runtime::Runtime;
+
+use crate::port::TokioPort;
+use crate::port::new_tokio_port;
+
+/// A tokio runtime whose context is entered on the owning thread for the runtime's whole life.
+///
+/// The KJ event loop turns its events *outside* `block_on` (only `wait()`/`poll()` are inside),
+/// yet code running in those turns -- bridged futures being polled, C++ calling into kj-rs-io --
+/// creates tokio resources (`TcpStream::from_std`, `AsyncFd`, `signal()`, timers) that must be
+/// registered with this runtime's drivers. tokio finds the runtime through the thread's current
+/// context, so without this the loop thread would have to re-enter the context around every
+/// single poll of every I/O future (a TLS swap plus an `Arc` clone each time) and around every
+/// synchronous resource creation. Entering once for the thread's lifetime removes all of that:
+/// `Handle::current()` on the loop thread is this runtime, always. `block_on` still works
+/// underneath (`Handle::enter` sets only the current handle, not the "inside a runtime" flag
+/// that `block_on` checks for nesting).
+///
+/// This is the one self-referential pair in the crate: `EnterGuard<'a>` borrows the `Runtime`
+/// it came from, but only nominally -- its `'a` is a `PhantomData<&'a Handle>`; the guard holds
+/// no pointer into the runtime and its `Drop` only restores the thread's previous context. We
+/// extend the lifetime to `'static` and guarantee by construction (a manual `Drop`) that the
+/// guard is dropped before the runtime. Like the guard it wraps, this type is `!Send` (the
+/// context must be left on the thread that entered it) and `Sync`.
+pub struct EnteredRuntime {
+    // Dropped first, explicitly, in `Drop::drop`; declared first as documentation of that order.
+    guard: ManuallyDrop<EnterGuard<'static>>,
+    runtime: Runtime,
+}
+
+impl EnteredRuntime {
+    pub fn new(runtime: Runtime) -> Self {
+        let guard: EnterGuard<'_> = runtime.enter();
+        // SAFETY: `EnterGuard<'a>`'s lifetime parameter exists only as `PhantomData<&'a Handle>`
+        // (tokio `runtime/handle.rs`); the guard stores no reference or pointer into the runtime,
+        // and its `Drop` touches only thread-local context state. Extending `'a` therefore cannot
+        // create a dangling access. We additionally uphold the *intent* of the borrow -- the
+        // guard does not outlive the runtime -- by dropping `guard` before `runtime` in `Drop`.
+        let guard: EnterGuard<'static> =
+            unsafe { std::mem::transmute::<EnterGuard<'_>, EnterGuard<'static>>(guard) };
+        Self {
+            guard: ManuallyDrop::new(guard),
+            runtime,
+        }
+    }
+}
+
+impl Deref for EnteredRuntime {
+    type Target = Runtime;
+    fn deref(&self) -> &Runtime {
+        &self.runtime
+    }
+}
+
+impl Drop for EnteredRuntime {
+    fn drop(&mut self) {
+        // SAFETY: `guard` is initialized (constructed in `new`, never taken out) and this is the
+        // only place it is dropped -- `Drop::drop` runs exactly once. It must go before `runtime`
+        // (which the compiler drops right after this body), restoring the thread's previous
+        // tokio context while the runtime it referred to is still alive.
+        unsafe { ManuallyDrop::drop(&mut self.guard) };
+    }
+}
+
+#[cxx::bridge(namespace = "kj_rs_tokio")]
+// FFI island: the cxx bridge macro generates the `unsafe` extern shims.
+// unnecessary_box_returns: returning the opaque `TokioPort` to C++ boxed is the cxx idiom. The
+// lint's firing is platform-dependent (it has a size threshold and `TokioPort`'s size differs by
+// target), so `#[expect]` would be unfulfilled on some targets.
+#[expect(clippy::allow_attributes)]
+#[allow(clippy::unnecessary_box_returns)]
+mod bridge {
+    // None of these are `Result`: they cannot fail in a way C++ could handle. The panics that CAN
+    // occur -- a second port on one thread (`TokioPort::new`), a nested `block_on` from a task
+    // that re-entered `promise.wait()` (`wait_*`/`poll`), the LocalSet slot being gone -- are
+    // caller-contract violations, and the in-tree cxx fork converts every panic escaping an
+    // `extern "Rust"` fn into a `kj::Exception` thrown at the C++ call site.
+    extern "Rust" {
+        type TokioPort;
+
+        fn new_tokio_port() -> Box<TokioPort>;
+
+        /// Cancel every task spawned onto this thread's `LocalSet` (dropping their state now, on
+        /// this thread). `TokioEventPort`'s destructor calls this before destroying the KJ event
+        /// loop and timer it owns, because spawned tasks may own KJ promises. Idempotent.
+        fn cancel_spawned_tasks(&self);
+
+        /// Block until `wake()` or `notify_kj_service()` is called, running tokio tasks in the
+        /// meantime. Returns the wake latch (see `TokioPort::take_wake_latch`).
+        fn wait_forever(&self) -> bool;
+
+        /// Like `wait_forever`, but additionally returns after `timeout_ns` nanoseconds. The
+        /// C++ side computes the timeout from `kj::TimerImpl::timeoutToNextEvent()`.
+        fn wait_timeout_ns(&self, timeout_ns: u64) -> bool;
+
+        /// Non-blocking: let the tokio scheduler run already-ready tasks for a bounded number of
+        /// turns. Never sleeps. Returns the wake latch.
+        fn poll(&self) -> bool;
+
+        /// Set the wake latch and unblock a concurrent `wait_*`. Callable from any thread.
+        fn wake(&self);
+
+        /// Loop thread only: KJ has told the port it needs the thread back -- through
+        /// `EventPort::setRunnable(true)` (an event was armed) or through the port's
+        /// `TimerImpl::SleepHooks` (a sooner timer was armed while sleeping). Unblocks a
+        /// concurrent `wait_*` without setting the wake latch; a no-op outside `wait_*`.
+        fn notify_kj_service(&self);
+    }
+}

--- a/src/rust/cxx/kj-rs-tokio/ffi.rs
+++ b/src/rust/cxx/kj-rs-tokio/ffi.rs
@@ -52,7 +52,7 @@ thread_local! {
 pub struct EnteredRuntime {
     // Dropped first, explicitly, in `Drop::drop`; declared first as documentation of that order.
     guard: ManuallyDrop<EnterGuard<'static>>,
-    runtime: Runtime,
+    runtime: ManuallyDrop<Runtime>,
 }
 
 impl EnteredRuntime {
@@ -68,7 +68,7 @@ impl EnteredRuntime {
             unsafe { std::mem::transmute::<EnterGuard<'_>, EnterGuard<'static>>(guard) };
         Self {
             guard: ManuallyDrop::new(guard),
-            runtime,
+            runtime: ManuallyDrop::new(runtime),
         }
     }
 }
@@ -90,6 +90,11 @@ impl Drop for EnteredRuntime {
             // SAFETY: The sentinel proves Tokio's thread-local context is still available.
             unsafe { ManuallyDrop::drop(&mut self.guard) };
         }
+        // SAFETY: `runtime` is initialized in `new`, never taken elsewhere, and this `Drop`
+        // implementation runs once. Background shutdown cancels async work without waiting
+        // indefinitely for user-submitted blocking tasks.
+        let runtime = unsafe { ManuallyDrop::take(&mut self.runtime) };
+        runtime.shutdown_background();
     }
 }
 

--- a/src/rust/cxx/kj-rs-tokio/ffi.rs
+++ b/src/rust/cxx/kj-rs-tokio/ffi.rs
@@ -17,6 +17,19 @@ use tokio::runtime::Runtime;
 use crate::port::TokioPort;
 use crate::port::new_tokio_port;
 
+struct TokioContextSentinel;
+
+impl Drop for TokioContextSentinel {
+    fn drop(&mut self) {}
+}
+
+thread_local! {
+    // Initialized after Tokio's context TLS. During thread teardown this sentinel is therefore
+    // destroyed first, making `try_with()` a reliable guard against touching Tokio's context
+    // after its destructor has run.
+    static TOKIO_CONTEXT_SENTINEL: TokioContextSentinel = const { TokioContextSentinel };
+}
+
 /// A tokio runtime whose context is entered on the owning thread for the runtime's whole life.
 ///
 /// The KJ event loop turns its events *outside* `block_on` (only `wait()`/`poll()` are inside),
@@ -45,6 +58,7 @@ pub struct EnteredRuntime {
 impl EnteredRuntime {
     pub fn new(runtime: Runtime) -> Self {
         let guard: EnterGuard<'_> = runtime.enter();
+        TOKIO_CONTEXT_SENTINEL.with(|_| {});
         // SAFETY: `EnterGuard<'a>`'s lifetime parameter exists only as `PhantomData<&'a Handle>`
         // (tokio `runtime/handle.rs`); the guard stores no reference or pointer into the runtime,
         // and its `Drop` touches only thread-local context state. Extending `'a` therefore cannot
@@ -72,7 +86,10 @@ impl Drop for EnteredRuntime {
         // only place it is dropped -- `Drop::drop` runs exactly once. It must go before `runtime`
         // (which the compiler drops right after this body), restoring the thread's previous
         // tokio context while the runtime it referred to is still alive.
-        unsafe { ManuallyDrop::drop(&mut self.guard) };
+        if TOKIO_CONTEXT_SENTINEL.try_with(|_| {}).is_ok() {
+            // SAFETY: The sentinel proves Tokio's thread-local context is still available.
+            unsafe { ManuallyDrop::drop(&mut self.guard) };
+        }
     }
 }
 

--- a/src/rust/cxx/kj-rs-tokio/ffi.rs
+++ b/src/rust/cxx/kj-rs-tokio/ffi.rs
@@ -118,7 +118,8 @@ mod bridge {
 
         /// Cancel every task spawned onto this thread's `LocalSet` (dropping their state now, on
         /// this thread). `TokioEventPort`'s destructor calls this before destroying the KJ event
-        /// loop and timer it owns, because spawned tasks may own KJ promises. Idempotent.
+        /// loop and timer it owns, because spawned tasks may own KJ promises. This terminal
+        /// operation is a no-op when repeated; the port must not be driven afterward.
         fn cancel_spawned_tasks(&self);
 
         /// Block until `wake()` or `notify_kj_service()` is called, running tokio tasks in the

--- a/src/rust/cxx/kj-rs-tokio/lib.rs
+++ b/src/rust/cxx/kj-rs-tokio/lib.rs
@@ -1,0 +1,46 @@
+//! Rust half of the tokio-backed KJ event loop foundation.
+//!
+//! This crate owns a per-thread tokio `current_thread` runtime and exposes the primitives the
+//! C++ `kj_rs_tokio::TokioEventPort` (see `tokio-event-port.h` for the full contract) needs to
+//! implement `kj::EventPort`: parking the thread in `Runtime::block_on` (which drives the
+//! whole tokio scheduler while C++ is "blocked"), a bounded non-blocking `poll`, and the
+//! cross-thread `wake()` latch that `kj::Executor` and
+//! `kj::newPromiseAndCrossThreadFulfiller` depend on, and the `notify_kj_service` entry point KJ
+//! reaches (via `setRunnable(true)` / the port's `TimerImpl::SleepHooks`) to hand the thread
+//! back whenever a tokio task has queued KJ work.
+
+// Safety & panic enforcement walls. Test code exempted.
+//
+// `unsafe` is quarantined into a single named FFI island: the crate root denies `unsafe_code`, so
+// the entire event-port business logic (`TokioPort`, the `wait`/`poll`/`wake` machinery) is
+// *compiler-proven* to contain no hand-written unsafe. The one island that opts back in
+// via `#![allow(unsafe_code)]` is `ffi.rs`: the `#[cxx::bridge]` wire.
+#![deny(unsafe_op_in_unsafe_fn)]
+#![deny(unsafe_code)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::todo,
+    clippy::unimplemented
+)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
+
+pub use port::TokioPort;
+pub use port::current_handle;
+pub use port::spawn;
+
+mod ffi;
+mod port;

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -330,6 +330,28 @@ impl Drop for TokioPort {
 mod tests {
     use super::*;
 
+    thread_local! {
+        static LATE_DROP_PORT: RefCell<Option<TokioPort>> = const { RefCell::new(None) };
+    }
+
+    #[test]
+    fn port_can_outlive_tokio_thread_locals() {
+        std::thread::spawn(|| {
+            // Initialize the holder before Tokio's context TLS. Thread-local values are dropped
+            // in reverse initialization order, so the stored port is destroyed after Tokio's
+            // context has already been torn down.
+            LATE_DROP_PORT.with(|holder| {
+                assert!(holder.borrow().is_none());
+            });
+            let port = TokioPort::new();
+            LATE_DROP_PORT.with(|holder| {
+                *holder.borrow_mut() = Some(port);
+            });
+        })
+        .join()
+        .expect("late TokioPort destruction must not panic");
+    }
+
     #[test]
     fn bare_port_drop_cancels_spawned_tasks() {
         // A TokioPort NOT owned by a TokioEventPort: dropping it must still cancel tasks

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -1,0 +1,326 @@
+//! Per-thread tokio `current_thread` runtime management and the Rust half of `TokioEventPort`.
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use tokio::runtime::Builder;
+use tokio::runtime::Handle;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tokio::task::LocalSet;
+
+use crate::ffi::EnteredRuntime;
+
+/// How many scheduler turns `poll()` grants the runtime. Each `yield_now` re-queues the main
+/// future at the back of the run queue, so every already-ready spawned task gets a chance to run
+/// (repeatedly, up to the budget) without ever parking the thread.
+///
+/// The value is a latency/throughput compromise, not derived from any tokio internal: large
+/// enough to drain a typical burst of already-ready tasks in one `poll()` call, small enough to
+/// bound how long `poll()` withholds control from the KJ loop when spawned tasks keep re-readying
+/// each other. Safe to retune if profiling shows either starvation or excessive poll latency.
+const POLL_YIELD_BUDGET: u32 = 16;
+
+thread_local! {
+    /// Handle to the `TokioPort` runtime driving the KJ event loop on this thread, if any.
+    /// Registered by `TokioPort::new` and cleared on drop. Used by code (e.g. kj-rs-io) that
+    /// needs to *enter* the runtime context so tokio resources can register with its I/O driver
+    /// and timers.
+    static LOOP_RUNTIME_HANDLE: RefCell<Option<Handle>> = const { RefCell::new(None) };
+
+    /// The `LocalSet` onto which [`spawn`] enqueues tasks, and which `wait_*`/`poll` drive. Held
+    /// behind an `Rc` so `spawn` (which has no `&TokioPort`) can reach it while the port keeps
+    /// driving it. The `LocalSet` is `!Send`/`!Sync` and lives entirely on the loop thread, which
+    /// is why `TokioPort` itself does NOT hold it (it must stay `Send + Sync` for cross-thread
+    /// `wake()`); ownership lives here. It is dropped -- cancelling every still-pending spawned
+    /// task -- by [`TokioPort::cancel_spawned_tasks`], which the C++ `TokioEventPort` destructor
+    /// calls while the KJ event loop and timer are still alive (spawned tasks may own KJ
+    /// promises), with `TokioPort::drop` as the fallback.
+    static LOOP_LOCAL_SET: RefCell<Option<Rc<LocalSet>>> = const { RefCell::new(None) };
+}
+/// Returns a handle to this thread's KJ-loop tokio runtime, if a `TokioEventPort` exists on this
+/// thread.
+#[must_use]
+pub fn current_handle() -> Option<Handle> {
+    LOOP_RUNTIME_HANDLE.with(|h| h.borrow().clone())
+}
+
+/// Returns this thread's KJ-loop `LocalSet`, if a `TokioEventPort` exists on this thread.
+fn current_local_set() -> Option<Rc<LocalSet>> {
+    LOOP_LOCAL_SET.with(|l| l.borrow().clone())
+}
+
+/// Spawns a future onto this thread's KJ-loop tokio runtime.
+///
+/// The task runs whenever the KJ event loop sleeps (i.e. whenever C++ is blocked in
+/// `promise.wait(waitScope)` or pumping via `poll()`), driven by the port's [`LocalSet`].
+///
+/// The future is spawned with [`LocalSet::spawn_local`], so it is pinned to this (the loop)
+/// thread and does **not** need to be `Send`: the per-thread `current_thread` runtime never
+/// migrates a task to another thread. This is what lets bridged futures that hold `!Send` KJ
+/// handles (`OwnPromiseNode`, `kj::Own`, ...) be spawned directly. `JoinHandle`/drop-cancels
+/// semantics are the same as `tokio::spawn`.
+///
+/// A spawned task may use KJ freely: complete bridged futures, fulfill `kj::PromiseFulfiller`s,
+/// arm KJ timers, create and await bridged promises. Every one of those either arms a KJ event,
+/// which KJ reports to the port through `EventPort::setRunnable(true)`, or moves the next KJ
+/// timer deadline, which KJ reports through the `TimerImpl::SleepHooks` the port installs while
+/// sleeping; either way the port ends the park. The one thing a task must not do is re-enter
+/// `promise.wait()` / `waitScope.poll()` on this thread: that nests `block_on` inside
+/// `block_on`, which tokio rejects (the panic surfaces as a `kj::Exception`).
+///
+/// # Panics
+///
+/// Panics if no `TokioEventPort` has been created on this thread.
+pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + 'static,
+    F::Output: 'static,
+{
+    #[expect(
+        clippy::expect_used,
+        reason = "documented `# Panics` on this public API: calling spawn() without first creating a TokioEventPort on this thread is a caller-contract violation, not a recoverable runtime path"
+    )]
+    let local = current_local_set()
+        .expect("no kj-rs-tokio runtime on this thread; create a TokioEventPort first");
+    local.spawn_local(future)
+}
+
+/// State shared with `wake()` callers on other threads.
+struct SharedState {
+    /// Unblocks the `block_on(...)` inside `wait_*` when `wake()` fires, or when KJ reports (via
+    /// `notify_kj_service`) that it has work.
+    notify: Notify,
+
+    /// The `kj::EventPort::wake()` latch: set by `wake()`, consumed (swapped to `false`) by the
+    /// return value of `wait_*`/`poll`. The KJ event loop uses a `true` return to know it must
+    /// drain cross-thread events (`kj::Executor`, `CrossThreadPromiseFulfiller`).
+    woken: AtomicBool,
+
+    /// True while the loop thread is inside `wait_*`'s `block_on`. `notify_kj_service` only acts
+    /// then: KJ also reports runnable transitions while it is turning events itself, and a permit
+    /// stored then would only make the next wait return spuriously once. Only mutated from the
+    /// loop thread; atomic so the struct stays `Sync`.
+    in_wait: AtomicBool,
+}
+
+/// The Rust backing of one `kj_rs_tokio::TokioEventPort` (C++): owns the per-thread
+/// `current_thread` tokio runtime.
+///
+/// The loop thread stays inside that runtime's context for the port's whole life (see
+/// [`EnteredRuntime`]): tokio resources created anywhere on the loop thread -- inside or outside
+/// `block_on` -- register with this runtime's drivers without any per-call `enter()`.
+///
+/// One instance per KJ event loop, created on (and driven by) that loop's thread. Only `wake()`
+/// may be called from other threads. `!Send` by type: the entered context must be left on the
+/// thread that entered it, which is also the only thread that may drive or drop the port.
+pub struct TokioPort {
+    runtime: EnteredRuntime,
+    state: Arc<SharedState>,
+}
+
+// `wake()` is called through a `&TokioPort` shared with arbitrary threads, so the type must be
+// `Sync` (`Runtime`, `Notify`, the atomics and the entered guard all are). It is deliberately
+// NOT `Send` (the guard is not), matching the one-thread contract above.
+const _: () = {
+    const fn assert_sync<T: Sync>() {}
+    assert_sync::<TokioPort>();
+};
+
+// Opaque cxx types must cross the bridge boxed. The lint's firing is platform-dependent (it has
+// a size threshold and `TokioPort`'s size differs by target), so `#[expect]` would be unfulfilled
+// on some targets.
+#[expect(clippy::allow_attributes)]
+#[allow(clippy::unnecessary_box_returns)]
+pub fn new_tokio_port() -> Box<TokioPort> {
+    Box::new(TokioPort::new())
+}
+
+impl TokioPort {
+    /// # Panics
+    ///
+    /// Panics if the tokio runtime cannot be built.
+    #[must_use]
+    pub fn new() -> Self {
+        let state = Arc::new(SharedState {
+            notify: Notify::new(),
+            woken: AtomicBool::new(false),
+            in_wait: AtomicBool::new(false),
+        });
+        #[expect(
+            clippy::expect_used,
+            reason = "startup-only: building the per-thread current_thread runtime fails only under resource exhaustion, at which point fail-fast at port construction is the correct behavior"
+        )]
+        let runtime = Builder::new_current_thread()
+            .enable_time()
+            // The I/O driver dispatches readiness for tokio sockets (used by kj-rs-io's
+            // tokio-backed KJ streams). It is only *driven* while this runtime is inside
+            // `block_on` (i.e. in `wait_*`/`poll`), which is exactly when the KJ loop sleeps.
+            .enable_io()
+            .build()
+            .expect("failed to build current_thread tokio runtime");
+        // Enter the runtime context for the life of the port (see EnteredRuntime): from here on,
+        // `Handle::current()` on this thread is this runtime.
+        let runtime = EnteredRuntime::new(runtime);
+        LOOP_RUNTIME_HANDLE.with(|h| {
+            let mut slot = h.borrow_mut();
+            assert!(
+                slot.is_none(),
+                "a kj-rs-tokio runtime already exists on this thread (one KJ event loop per \
+                 thread, hence one TokioEventPort per thread)"
+            );
+            *slot = Some(runtime.handle().clone());
+        });
+        // The `LocalSet` that `spawn()` enqueues onto and `wait_*`/`poll` drive. Owned by the
+        // thread-local (not by `TokioPort`, which must stay `Send + Sync`); dropped in `drop()`.
+        LOOP_LOCAL_SET.with(|l| {
+            *l.borrow_mut() = Some(Rc::new(LocalSet::new()));
+        });
+        Self { runtime, state }
+    }
+
+    /// Handle to this port's runtime, usable to spawn tasks from any thread. (On the loop thread
+    /// itself `tokio::runtime::Handle::current()` is the same runtime; see [`EnteredRuntime`].)
+    #[must_use]
+    pub fn handle(&self) -> Handle {
+        self.runtime.handle().clone()
+    }
+
+    /// Cancels every task spawned onto this thread's `LocalSet` via [`spawn`], by dropping the
+    /// `LocalSet` (their `Drop` impls run synchronously, here, on the loop thread).
+    ///
+    /// Spawned tasks routinely own KJ objects -- a bridged `PromiseFuture` holds an
+    /// `OwnPromiseNode` and an armed `RustPromiseAwaiter` event; a KJ timer promise holds a
+    /// registration in the port's `kj::TimerImpl` -- and dropping those requires the KJ event
+    /// loop and timer to still exist. The C++ `TokioEventPort` owns both and calls this FIRST in
+    /// its destructor, before any member is destroyed, which makes the teardown order a
+    /// structural guarantee rather than a rule spawned tasks have to follow. Idempotent; a later
+    /// call (including the one in `Drop`) finds nothing to do. Only ever affects the calling
+    /// thread's `LocalSet`: the slot is thread-local, so a call from any other thread is a no-op.
+    ///
+    /// Tasks spawned with plain `tokio::spawn` onto the runtime are unaffected (they are
+    /// cancelled when the runtime drops); being `Send`, they cannot hold KJ objects
+    /// (`OwnPromiseNode` and friends are `!Send`), so their order relative to the loop does
+    /// not matter.
+    pub fn cancel_spawned_tasks(&self) {
+        // Take the `Rc` out of the slot and drop it AFTER the borrow ends, so a cancelled
+        // task's `Drop` that itself borrows the slot does not hit a re-entrant-borrow panic.
+        // (A task `Drop` that tries to *spawn* during cancellation is unsupported: the slot is
+        // already `None`, so `spawn()` panics per its documented contract. Rescheduling from a
+        // destructor during teardown is not a sane pattern.)
+        let local_set = LOOP_LOCAL_SET
+            .try_with(|l| l.borrow_mut().take())
+            .ok()
+            .flatten();
+        drop(local_set);
+    }
+
+    pub(crate) fn wait_forever(&self) -> bool {
+        self.wait_impl(None)
+    }
+
+    pub(crate) fn wait_timeout_ns(&self, timeout_ns: u64) -> bool {
+        self.wait_impl(Some(Duration::from_nanos(timeout_ns)))
+    }
+
+    fn wait_impl(&self, timeout: Option<Duration>) -> bool {
+        let state = &self.state;
+
+        // This `block_on` is where tokio owns the thread: it drives *all* tasks — those spawned
+        // onto the port's `LocalSet` via `spawn()` (driven by `LocalSet::block_on`'s `run_until`)
+        // as well as any `tokio::spawn`ed tasks on the current_thread runtime — not just the
+        // future passed to it. Wake-up sources: `wake()` from another thread (with the `woken`
+        // latch set), KJ itself via `notify_kj_service` (a task in this very `block_on` armed a
+        // KJ event -- `EventPort::setRunnable(true)` -- or a sooner KJ timer -- the port's
+        // `TimerImpl::SleepHooks`), and the next KJ timer deadline via the tokio timer wheel.
+        // `Notify` stores a permit if `notify_one()` arrives before `notified()` is polled, so
+        // there is no lost-wakeup window; spurious early returns are explicitly allowed by the
+        // `kj::EventPort::wait()` contract.
+        #[expect(
+            clippy::expect_used,
+            reason = "TokioPort::new registers this thread's LocalSet; wait() only runs while this port drives its own thread, so the LocalSet is always present — absence is an unreachable internal invariant"
+        )]
+        let local =
+            current_local_set().expect("TokioPort is driving without a registered LocalSet");
+        state.in_wait.store(true, Ordering::Relaxed);
+        local.block_on(&self.runtime, async {
+            match timeout {
+                Some(t) => {
+                    let _ = tokio::time::timeout(t, state.notify.notified()).await;
+                }
+                None => state.notify.notified().await,
+            }
+        });
+        state.in_wait.store(false, Ordering::Relaxed);
+
+        self.take_wake_latch()
+    }
+
+    pub(crate) fn poll(&self) -> bool {
+        // Bounded, non-blocking pump: the main future is always immediately ready to run again
+        // after `yield_now`, so the scheduler never parks; it just interleaves any ready spawned
+        // tasks (LocalSet + runtime) with our yields until the budget is spent.
+        #[expect(
+            clippy::expect_used,
+            reason = "TokioPort::new registers this thread's LocalSet; poll() only runs while this port drives its own thread, so the LocalSet is always present — absence is an unreachable internal invariant"
+        )]
+        let local =
+            current_local_set().expect("TokioPort is driving without a registered LocalSet");
+        local.block_on(&self.runtime, async {
+            for _ in 0..POLL_YIELD_BUDGET {
+                tokio::task::yield_now().await;
+            }
+        });
+        self.take_wake_latch()
+    }
+
+    pub(crate) fn wake(&self) {
+        self.state.woken.store(true, Ordering::SeqCst);
+        self.state.notify.notify_one();
+    }
+
+    /// See the bridge doc (ffi.rs): KJ has told the C++ port it has work (`setRunnable(true)`,
+    /// or a sooner timer through the port's `TimerImpl::SleepHooks`). Wake the `notified()`
+    /// future if we are parked in `wait_*`; a no-op otherwise.
+    pub(crate) fn notify_kj_service(&self) {
+        if self.state.in_wait.load(Ordering::Relaxed) {
+            self.state.notify.notify_one();
+        }
+    }
+
+    /// Consumes the wake latch: returns `true` iff `wake()` was called since the last `true`
+    /// return from `wait_*`/`poll`.
+    fn take_wake_latch(&self) -> bool {
+        self.state.woken.swap(false, Ordering::SeqCst)
+    }
+}
+
+impl Default for TokioPort {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for TokioPort {
+    fn drop(&mut self) {
+        // `try_with`, not `with`: a port owned by an object destroyed during thread/process
+        // teardown (e.g. under KJ_CLEAN_SHUTDOWN) can be dropped after this thread's Rust TLS
+        // destructors have already run, where `with` panics with an AccessError. If the TLS is
+        // gone, its values (including the LocalSet) were already dropped with it, so there is
+        // nothing left to clear.
+        let _ = LOOP_RUNTIME_HANDLE.try_with(|h| {
+            *h.borrow_mut() = None;
+        });
+        // Fallback cancellation of spawned tasks (normally already done, while the KJ loop was
+        // still alive, by the C++ `TokioEventPort` destructor -- see `cancel_spawned_tasks`). A
+        // bare `TokioPort` (Rust unit tests) reaches here with its tasks still pending.
+        self.cancel_spawned_tasks();
+        // Dropping `self.runtime` cancels any tasks spawned via `tokio::spawn` (as opposed to the
+        // LocalSet); those are `Send` and so cannot hold KJ objects.
+    }
+}

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -16,9 +16,9 @@ use tokio::task::LocalSet;
 
 use crate::ffi::EnteredRuntime;
 
-/// How many scheduler turns `poll()` grants the runtime. Each `yield_now` re-queues the main
-/// future at the back of the run queue, so every already-ready spawned task gets a chance to run
-/// (repeatedly, up to the budget) without ever parking the thread.
+/// How many bounded yield points `poll()` grants the runtime. This gives ready work opportunities
+/// to run without promising an ordering or an exact number of task or driver polls, which are
+/// Tokio scheduler implementation details.
 ///
 /// The value is a latency/throughput compromise, not derived from any tokio internal: large
 /// enough to drain a typical burst of already-ready tasks in one `poll()` call, small enough to
@@ -35,9 +35,9 @@ thread_local! {
 
     /// The `LocalSet` onto which [`spawn`] enqueues tasks, and which `wait_*`/`poll` drive. Held
     /// behind an `Rc` so `spawn` (which has no `&TokioPort`) can reach it while the port keeps
-    /// driving it. The `LocalSet` is `!Send`/`!Sync` and lives entirely on the loop thread, which
-    /// is why `TokioPort` itself does NOT hold it (it must stay `Send + Sync` for cross-thread
-    /// `wake()`); ownership lives here. It is dropped -- cancelling every still-pending spawned
+    /// driving it. The `LocalSet` is `!Send`/`!Sync` and lives entirely on the loop thread, so it
+    /// cannot be stored in the `Sync` TokioPort shared with cross-thread `wake()` callers;
+    /// ownership lives here. It is dropped -- cancelling every still-pending spawned
     /// task -- by [`TokioPort::cancel_spawned_tasks`], which the C++ `TokioEventPort` destructor
     /// calls while the KJ event loop and timer are still alive (spawned tasks may own KJ
     /// promises), with `TokioPort::drop` as the fallback.
@@ -64,8 +64,8 @@ fn current_local_set() -> Option<Rc<LocalSet>> {
 /// The future is spawned with [`LocalSet::spawn_local`], so it is pinned to this (the loop)
 /// thread and does **not** need to be `Send`: the per-thread `current_thread` runtime never
 /// migrates a task to another thread. This is what lets bridged futures that hold `!Send` KJ
-/// handles (`OwnPromiseNode`, `kj::Own`, ...) be spawned directly. `JoinHandle`/drop-cancels
-/// semantics are the same as `tokio::spawn`.
+/// handles (`OwnPromiseNode`, `kj::Own`, ...) be spawned directly. Dropping the returned
+/// `JoinHandle` detaches the task, matching `tokio::spawn`; port teardown cancels detached tasks.
 ///
 /// A spawned task may use KJ freely: complete bridged futures, fulfill `kj::PromiseFulfiller`s,
 /// arm KJ timers, create and await bridged promises. Every one of those either arms a KJ event,
@@ -205,9 +205,9 @@ impl TokioPort {
     /// registration in the port's `kj::TimerImpl` -- and dropping those requires the KJ event
     /// loop and timer to still exist. The C++ `TokioEventPort` owns both and calls this FIRST in
     /// its destructor, before any member is destroyed, which makes the teardown order a
-    /// structural guarantee rather than a rule spawned tasks have to follow. Idempotent; a later
-    /// call (including the one in `Drop`) finds nothing to do. Only ever affects the calling
-    /// thread's `LocalSet`: the slot is thread-local, so a call from any other thread is a no-op.
+    /// structural guarantee rather than a rule spawned tasks have to follow. This is a terminal
+    /// operation: repeated calls find nothing to do, but later spawn, wait, or poll operations are
+    /// invalid. A call from another thread is a no-op and never touches that caller's `LocalSet`.
     ///
     /// Tasks spawned with plain `tokio::spawn` onto the runtime are unaffected (they are
     /// cancelled when the runtime drops); being `Send`, they cannot hold KJ objects
@@ -271,9 +271,9 @@ impl TokioPort {
     }
 
     pub(crate) fn poll(&self) -> bool {
-        // Bounded, non-blocking pump: the main future is always immediately ready to run again
-        // after `yield_now`, so the scheduler never parks; it just interleaves any ready spawned
-        // tasks (LocalSet + runtime) with our yields until the budget is spent.
+        // Bounded, non-blocking pump: each yield gives ready LocalSet and runtime work an
+        // opportunity to run. Tokio does not guarantee exact scheduling order or driver-poll
+        // counts here, so only the number of yield attempts is part of this implementation.
         #[expect(
             clippy::expect_used,
             reason = "TokioPort::new registers this thread's LocalSet; poll() only runs while this port drives its own thread, so the LocalSet is always present — absence is an unreachable internal invariant"

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -43,6 +43,7 @@ thread_local! {
     /// promises), with `TokioPort::drop` as the fallback.
     static LOOP_LOCAL_SET: RefCell<Option<Rc<LocalSet>>> = const { RefCell::new(None) };
 }
+
 /// Returns a handle to this thread's KJ-loop tokio runtime, if a `TokioEventPort` exists on this
 /// thread.
 #[must_use]

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -427,4 +427,72 @@ mod tests {
         }
         assert!(ran);
     }
+
+    #[test]
+    fn wake_latch_semantics() {
+        let port = TokioPort::new();
+        // No wake: a timed-out wait reports false.
+        assert!(!port.wait_timeout_ns(1_000_000));
+        // Wake before wait: latch is reported exactly once.
+        port.wake();
+        assert!(port.wait_timeout_ns(1_000_000));
+        assert!(!port.wait_timeout_ns(1_000_000));
+        // Wake is also consumed by poll().
+        port.wake();
+        assert!(port.poll());
+        assert!(!port.poll());
+    }
+
+    #[test]
+    fn wake_from_other_thread_unblocks_wait_forever() {
+        let port = TokioPort::new();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                std::thread::sleep(Duration::from_millis(10));
+                port.wake();
+            });
+            assert!(port.wait_forever());
+        });
+    }
+
+    /// The loop thread is inside the runtime's context for the port's whole life, so tokio
+    /// resources can be created outside `block_on` without any explicit `enter()`.
+    #[test]
+    fn loop_thread_is_permanently_in_the_runtime_context() {
+        assert!(tokio::runtime::Handle::try_current().is_err());
+        {
+            let port = TokioPort::new();
+            let current = tokio::runtime::Handle::try_current().expect("entered");
+            assert_eq!(current.id(), port.handle().id());
+            // A resource needing the I/O driver, created from plain sync code on this thread.
+            let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            std_listener.set_nonblocking(true).unwrap();
+            let _listener = tokio::net::TcpListener::from_std(std_listener).unwrap();
+        }
+        // Dropping the port leaves the context.
+        assert!(tokio::runtime::Handle::try_current().is_err());
+    }
+
+    #[test]
+    fn spawned_tasks_run_during_wait() {
+        let port = TokioPort::new();
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<u32>();
+        let mut jh = spawn(async move {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            tx.send(42).unwrap();
+        });
+        // The task only runs inside wait_impl's block_on.
+        let mut done = false;
+        for _ in 0..100 {
+            let _ = port.wait_timeout_ns(20_000_000);
+            if let Ok(v) = rx.try_recv() {
+                assert_eq!(v, 42);
+                done = true;
+                break;
+            }
+        }
+        assert!(done);
+        // The JoinHandle should complete promptly now.
+        port.runtime.block_on(&mut jh).unwrap();
+    }
 }

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -353,6 +353,40 @@ mod tests {
     }
 
     #[test]
+    fn port_drop_does_not_wait_for_blocking_tasks() {
+        let port = TokioPort::new();
+        let release = Arc::new(AtomicBool::new(false));
+        let task_release = Arc::clone(&release);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        port.handle().spawn_blocking(move || {
+            started_tx.send(()).unwrap();
+            while !task_release.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            done_tx.send(()).unwrap();
+        });
+        started_rx.recv().unwrap();
+
+        let watchdog_release = Arc::clone(&release);
+        let watchdog = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(250));
+            watchdog_release.store(true, Ordering::SeqCst);
+        });
+        let start = std::time::Instant::now();
+        drop(port);
+        let elapsed = start.elapsed();
+        release.store(true, Ordering::SeqCst);
+        done_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        watchdog.join().unwrap();
+
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "port teardown waited for a blocking task: {elapsed:?}"
+        );
+    }
+
+    #[test]
     fn bare_port_drop_cancels_spawned_tasks() {
         // A TokioPort NOT owned by a TokioEventPort: dropping it must still cancel tasks
         // spawned onto its LocalSet (the Drop fallback), and leave the thread clean so a fresh

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -495,4 +495,60 @@ mod tests {
         // The JoinHandle should complete promptly now.
         port.runtime.block_on(&mut jh).unwrap();
     }
+
+    #[test]
+    fn poll_never_sleeps() {
+        let port = TokioPort::new();
+        // A pending spawned task must not make poll() block.
+        let _jh = spawn(std::future::pending::<()>());
+        let start = std::time::Instant::now();
+        assert!(!port.poll());
+        assert!(start.elapsed() < Duration::from_millis(100));
+    }
+
+    /// `spawn` accepts `!Send` futures because it is backed by `LocalSet::spawn_local`. This
+    /// future holds an `Rc` — which is `!Send` — across an await point, exercising that path,
+    /// and proves such a task actually runs to completion on the loop thread.
+    #[test]
+    fn spawn_accepts_non_send_futures() {
+        use std::cell::Cell;
+        let port = TokioPort::new();
+        let counter = Rc::new(Cell::new(0u32));
+        let task_counter = Rc::clone(&counter);
+        // Detached on purpose; the `Rc` capture makes the future `!Send`.
+        let _jh = spawn(async move {
+            for _ in 0..3 {
+                tokio::task::yield_now().await;
+            }
+            task_counter.set(task_counter.get() + 1);
+        });
+        let mut done = false;
+        for _ in 0..100 {
+            let _ = port.wait_timeout_ns(1_000_000);
+            if counter.get() == 1 {
+                done = true;
+                break;
+            }
+        }
+        assert!(done, "non-Send spawned task did not run to completion");
+    }
+
+    /// Timed waits stay on tokio's timer wheel and remain accurate to its ~1 ms granularity --
+    /// the same granularity KJ's own epoll-based port has (`epoll_pwait` takes a millisecond
+    /// timeout).
+    #[test]
+    fn timeouts_are_accurate_to_the_wheel() {
+        let port = TokioPort::new();
+        let start = std::time::Instant::now();
+        let _ = port.wait_timeout_ns(20_000_000);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(19),
+            "woke early: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "woke far too late: {elapsed:?}"
+        );
+    }
 }

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -324,3 +324,107 @@ impl Drop for TokioPort {
         // LocalSet); those are `Send` and so cannot hold KJ objects.
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_port_drop_cancels_spawned_tasks() {
+        // A TokioPort NOT owned by a TokioEventPort: dropping it must still cancel tasks
+        // spawned onto its LocalSet (the Drop fallback), and leave the thread clean so a fresh
+        // port can be created afterward.
+        {
+            let port = TokioPort::new();
+            drop(spawn(std::future::pending::<()>()));
+            assert!(current_handle().is_some());
+            drop(port);
+        }
+        // TLS is cleared: a new port on this thread succeeds (would panic-on-double-register
+        // otherwise).
+        assert!(current_handle().is_none());
+        let port2 = TokioPort::new();
+        assert!(current_handle().is_some());
+        drop(port2);
+    }
+
+    #[test]
+    fn concurrent_wake_storm_from_many_threads_terminates() {
+        // TSAN stressor for SharedState (notify + woken latch): four threads hammer wake()
+        // concurrently while the loop thread services wait_timeout_ns. The assertion is
+        // deliberately interleaving-agnostic -- it only requires termination and that at least
+        // one wake was observed -- because exact latch counts are inherently racy. (Scoped
+        // threads borrowing `&TokioPort`: the port is `Sync` but, by design, not `Send`.)
+        use std::sync::atomic::AtomicUsize;
+        let port = TokioPort::new();
+        let done = AtomicUsize::new(0);
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                scope.spawn(|| {
+                    for _ in 0..250 {
+                        port.wake();
+                    }
+                    done.fetch_add(1, Ordering::SeqCst);
+                });
+            }
+            let mut latched = 0u64;
+            loop {
+                if port.wait_timeout_ns(1_000_000) {
+                    latched += 1;
+                }
+                // Once every waker has finished, one more wait must eventually drain to `false`.
+                if done.load(Ordering::SeqCst) == 4 && !port.wait_timeout_ns(1_000_000) {
+                    break;
+                }
+            }
+            assert!(latched >= 1);
+        });
+    }
+
+    #[test]
+    fn handle_spawns_a_runtime_task_from_another_thread() {
+        // `handle()` + `tokio::spawn` (the runtime-driven path, distinct from spawn()/LocalSet)
+        // from a foreign thread: the Send task runs when the loop next drives block_on.
+        let port = TokioPort::new();
+        let flag = Arc::new(AtomicBool::new(false));
+        let handle = port.handle();
+        let f2 = Arc::clone(&flag);
+        std::thread::spawn(move || {
+            handle.spawn(async move {
+                f2.store(true, Ordering::SeqCst);
+            });
+        })
+        .join()
+        .unwrap();
+        let mut ran = false;
+        for _ in 0..1000 {
+            let _ = port.wait_timeout_ns(1_000_000);
+            if flag.load(Ordering::SeqCst) {
+                ran = true;
+                break;
+            }
+        }
+        assert!(ran);
+    }
+
+    #[test]
+    fn poll_advances_a_ready_local_task() {
+        // Complements poll_never_sleeps (pending task): a ready LocalSet task (no await) is
+        // actually driven to completion by poll() within its budget, and poll() never latches.
+        let port = TokioPort::new();
+        let flag = Arc::new(AtomicBool::new(false));
+        let f2 = Arc::clone(&flag);
+        let _jh = spawn(async move {
+            f2.store(true, Ordering::SeqCst);
+        });
+        let mut ran = false;
+        for _ in 0..10 {
+            assert!(!port.poll(), "poll() must not report a wake latch here");
+            if flag.load(Ordering::SeqCst) {
+                ran = true;
+                break;
+            }
+        }
+        assert!(ran);
+    }
+}

--- a/src/rust/cxx/kj-rs-tokio/port.rs
+++ b/src/rust/cxx/kj-rs-tokio/port.rs
@@ -123,6 +123,7 @@ struct SharedState {
 pub struct TokioPort {
     runtime: EnteredRuntime,
     state: Arc<SharedState>,
+    owner_thread: std::thread::ThreadId,
 }
 
 // `wake()` is called through a `&TokioPort` shared with arbitrary threads, so the type must be
@@ -182,7 +183,11 @@ impl TokioPort {
         LOOP_LOCAL_SET.with(|l| {
             *l.borrow_mut() = Some(Rc::new(LocalSet::new()));
         });
-        Self { runtime, state }
+        Self {
+            runtime,
+            state,
+            owner_thread: std::thread::current().id(),
+        }
     }
 
     /// Handle to this port's runtime, usable to spawn tasks from any thread. (On the loop thread
@@ -209,6 +214,9 @@ impl TokioPort {
     /// (`OwnPromiseNode` and friends are `!Send`), so their order relative to the loop does
     /// not matter.
     pub fn cancel_spawned_tasks(&self) {
+        if self.owner_thread != std::thread::current().id() {
+            return;
+        }
         // Take the `Rc` out of the slot and drop it AFTER the borrow ends, so a cancelled
         // task's `Drop` that itself borrows the slot does not hit a re-entrant-borrow panic.
         // (A task `Drop` that tries to *spawn* during cancellation is unsupported: the slot is
@@ -384,6 +392,28 @@ mod tests {
             elapsed < Duration::from_millis(100),
             "port teardown waited for a blocking task: {elapsed:?}"
         );
+    }
+
+    #[test]
+    fn foreign_cancellation_does_not_cancel_the_callers_loop() {
+        let owner_port = TokioPort::new();
+        std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let caller_port = TokioPort::new();
+                    let ran = Arc::new(AtomicBool::new(false));
+                    let task_ran = Arc::clone(&ran);
+                    let _task = spawn(async move {
+                        task_ran.store(true, Ordering::SeqCst);
+                    });
+
+                    owner_port.cancel_spawned_tasks();
+                    assert!(!caller_port.poll());
+                    assert!(ran.load(Ordering::SeqCst));
+                })
+                .join()
+                .unwrap();
+        });
     }
 
     #[test]

--- a/src/rust/cxx/kj-rs-tokio/tests/BUILD.bazel
+++ b/src/rust/cxx/kj-rs-tokio/tests/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("//src/rust/cxx/tools/bazel:rust_cxx_bridge.bzl", "rust_cxx_bridge")
+
+rust_library(
+    name = "tests",
+    srcs = glob(["*.rs"]),
+    edition = "2024",
+    link_deps = [
+        ":bridge",
+    ],
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//src/rust/cxx",
+        "//src/rust/cxx/kj-rs",
+        "//src/rust/cxx/kj-rs-tokio",
+        "@crates_vendor//:tokio",
+    ],
+)
+
+rust_cxx_bridge(
+    name = "bridge",
+    src = "lib.rs",
+    hdrs = ["test-helpers.h"],
+    include_prefix = "kj-rs-tokio-test",
+    deps = [
+        "//src/rust/cxx/kj-rs",
+    ],
+)
+
+cc_test(
+    name = "tokio-event-port-test",
+    size = "medium",
+    srcs = [
+        "tokio-event-port-test.c++",
+    ],
+    linkstatic = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    target_compatible_with = select({
+        "@//build/config:no_build": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":bridge",
+        ":tests",
+        "//src/rust/cxx/kj-rs-tokio:kj-rs-tokio-lib",
+        "//src/rust/cxx/third-party:runtime",
+        "@capnp-cpp//src/kj:kj-test",
+    ],
+)

--- a/src/rust/cxx/kj-rs-tokio/tests/lib.rs
+++ b/src/rust/cxx/kj-rs-tokio/tests/lib.rs
@@ -1,0 +1,107 @@
+#![allow(clippy::unused_async)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::missing_panics_doc)]
+
+mod test_helpers;
+
+use test_helpers::completed_task_count;
+use test_helpers::has_loop_runtime_handle;
+use test_helpers::nested_wait_from_task;
+use test_helpers::spawn_detached_completing_task;
+use test_helpers::spawn_panicking_task;
+use test_helpers::spawn_pending_task;
+use test_helpers::spawn_task_awaiting_kj_never_promise;
+use test_helpers::spawn_task_holding_kj_timer;
+use test_helpers::spawn_task_on_runtime;
+use test_helpers::spawn_yield_loop_task;
+use test_helpers::std_thread_wake_future;
+use test_helpers::task_awaits_kj_timer;
+use test_helpers::task_fulfills_kj_fulfiller;
+use test_helpers::threaded_wake_future;
+use test_helpers::tokio_sleep_on_runtime;
+
+type Result<T> = std::io::Result<T>;
+type Error = std::io::Error;
+
+#[cxx::bridge(namespace = "kj_rs_tokio_test")]
+mod ffi {
+    extern "Rust" {
+        /// Spawns a task on this thread's KJ-loop tokio runtime which sleeps `delay_ms` (real
+        /// tokio time) and then produces `value`; awaits its `JoinHandle`. The returned future is
+        /// bridged to a `kj::Promise` by kj-rs and polled by the KJ event loop; the spawned task
+        /// itself only runs while the loop sleeps inside `TokioEventPort::wait()`/`poll()`.
+        async fn spawn_task_on_runtime(delay_ms: u64, value: u32) -> Result<u32>;
+
+        /// Spawns a `tokio::time::sleep` on the loop runtime and awaits it (via the task's
+        /// `JoinHandle`).
+        async fn tokio_sleep_on_runtime(delay_ms: u64) -> Result<()>;
+
+        /// A bridged Rust future that, on its first poll, spawns a task on the loop runtime which
+        /// sleeps ~10ms (real tokio time) and then wakes a clone of the future's waker. The wake
+        /// therefore arrives same-thread (the runtime is driven by the port on the loop thread),
+        /// exercising the future⇄promise bridge's asynchronous same-thread re-drive path.
+        async fn threaded_wake_future() -> Result<()>;
+
+        /// Detaches a never-completing task onto the loop runtime (for teardown testing: the
+        /// runtime must drop it cleanly when the port is destroyed).
+        fn spawn_pending_task();
+
+        /// Number of `spawn_task_on_runtime` tasks that ran to completion (process-wide).
+        fn completed_task_count() -> u64;
+
+        /// True if `kj_rs_tokio::current_handle()` finds a runtime on this thread.
+        fn has_loop_runtime_handle() -> bool;
+
+        /// Detaches a task onto the loop's LocalSet that awaits a 60s KJ timer promise (via
+        /// `kjTimerDelay`), so the task HOLDS live KJ objects -- a TimerPromiseAdapter in the
+        /// port's TimerImpl and an armed RustPromiseAwaiter Event -- when the context is torn
+        /// down. Teardown-ordering regression: the LocalSet must be dropped while those KJ
+        /// objects' owners (timer, event loop) are still alive.
+        fn spawn_task_holding_kj_timer();
+        /// Same shape, but the task awaits a never-resolving bridged KJ promise.
+        fn spawn_task_awaiting_kj_never_promise();
+        /// Woken from a plain std::thread while the loop is parked in the tokio port.
+        async fn std_thread_wake_future() -> Result<()>;
+        /// A task that yields forever; poll() must stay bounded.
+        fn spawn_yield_loop_task();
+        /// A task re-enters promise.wait(); must surface as an Err, not an abort.
+        async fn nested_wait_from_task() -> Result<()>;
+        /// A spawned task panics; the JoinHandle error surfaces as an Err (never an abort).
+        async fn spawn_panicking_task() -> Result<()>;
+        /// Detaches a task (drops its JoinHandle) that still runs to completion, bumping
+        /// completed_task_count().
+        fn spawn_detached_completing_task();
+
+        /// Spawns a task that sleeps `delay_ms` (tokio time, i.e. while the KJ loop is parked
+        /// inside the port) and then fulfills the test fulfiller installed by C++
+        /// (`setTestFulfiller`) with `value` -- a KJ event armed from a tokio task, by a means
+        /// other than a bridged waker, while the loop is parked. KJ's setRunnable(true) must
+        /// hand the thread back to KJ; nothing else will.
+        fn task_fulfills_kj_fulfiller(delay_ms: u64, value: i32);
+
+        /// Spawns a task that sleeps `delay_ms` (tokio time), then arms and awaits a KJ timer of
+        /// `timer_ms` (via `kjTimerDelay`) to completion, and awaits the task's JoinHandle. The
+        /// KJ timer is registered while the loop is parked with a longer (or no) planned
+        /// deadline; the port's TimerImpl::SleepHooks must notice the sooner deadline.
+        async fn task_awaits_kj_timer(delay_ms: u64, timer_ms: u64) -> Result<()>;
+    }
+
+    unsafe extern "C++" {
+        include!("kj-rs-tokio-test/test-helpers.h");
+
+        /// `timer.afterDelay(ms)` on the test's current context timer (see setTestTimer).
+        #[cxx_name = "kjTimerDelay"]
+        async fn kj_timer_delay(ms: u64);
+        /// `kj::NEVER_DONE` as a bridged promise.
+        #[cxx_name = "kjNeverPromise"]
+        async fn kj_never_promise();
+        /// Re-enters `promise.wait()` on the test's WaitScope from wherever it is called. Throws
+        /// (-> `Err`) when called from inside a spawned task.
+        #[cxx_name = "nestedWait"]
+        fn nested_wait() -> Result<()>;
+        /// Fulfills the kj::PromiseFulfiller the C++ test installed with `setTestFulfiller`.
+        #[cxx_name = "fulfillTestFulfiller"]
+        fn fulfill_test_fulfiller(value: i32) -> Result<()>;
+    }
+}

--- a/src/rust/cxx/kj-rs-tokio/tests/test-helpers.h
+++ b/src/rust/cxx/kj-rs-tokio/tests/test-helpers.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <kj/async.h>
+
+namespace kj_rs_tokio_test {
+
+// A KJ timer promise from the test's current TokioAsyncIoContext (the C++ test installs the
+// timer before spawning). Lets a Rust task spawned on the loop's LocalSet hold a live KJ promise
+// (a TimerPromiseAdapter registered with the port's kj::TimerImpl, plus an armed
+// RustPromiseAwaiter Event) across context teardown.
+kj::Promise<void> kjTimerDelay(uint64_t ms);
+
+// kj::NEVER_DONE, so a spawned Rust task can hold a live OwnPromiseNode + armed
+// RustPromiseAwaiter event across context teardown.
+kj::Promise<void> kjNeverPromise();
+
+// Re-enters promise.wait() on the test's current WaitScope (installed by the C++ test). From a
+// spawned task this nests block_on inside the port's block_on; the failure must surface as a
+// kj::Exception (which the bridge turns into a Rust Err), never an abort.
+void nestedWait();
+
+// Fulfills the kj::PromiseFulfiller<int> the current C++ test installed (setTestFulfiller).
+// Called from a spawned tokio task while the loop is parked: arms a KJ event by a means other than
+// a bridged waker.
+void fulfillTestFulfiller(int32_t value);
+
+}  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/test_helpers.rs
+++ b/src/rust/cxx/kj-rs-tokio/tests/test_helpers.rs
@@ -1,0 +1,215 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+
+use crate::Error;
+use crate::Result;
+
+/// Process-wide counter of completed `spawn_task_on_runtime` tasks, so C++ tests can verify the
+/// spawned task really ran (on the loop runtime) rather than the value being produced some other
+/// way.
+static COMPLETED_TASKS: AtomicU64 = AtomicU64::new(0);
+
+pub fn completed_task_count() -> u64 {
+    COMPLETED_TASKS.load(Ordering::SeqCst)
+}
+
+pub fn has_loop_runtime_handle() -> bool {
+    kj_rs_tokio::current_handle().is_some()
+}
+
+pub async fn spawn_task_on_runtime(delay_ms: u64, value: u32) -> Result<u32> {
+    let join_handle = kj_rs_tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        COMPLETED_TASKS.fetch_add(1, Ordering::SeqCst);
+        value
+    });
+    join_handle.await.map_err(Error::other)
+}
+
+pub async fn tokio_sleep_on_runtime(delay_ms: u64) -> Result<()> {
+    let join_handle = kj_rs_tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+    });
+    join_handle.await.map_err(Error::other)
+}
+
+pub fn spawn_pending_task() {
+    // Deliberately detached: dropping the JoinHandle does not cancel the task; it stays pending
+    // in the runtime until the runtime itself is dropped with the TokioEventPort.
+    drop(kj_rs_tokio::spawn(std::future::pending::<()>()));
+}
+
+/// A future that, on its first poll, spawns a task on the loop's own tokio runtime which sleeps
+/// briefly and then wakes a clone of the future's waker. Because that runtime is driven by the
+/// `TokioEventPort` on the event loop's own thread, the wake arrives *same-thread*. Exercises a
+/// bridged future being suspended and re-driven by an asynchronous same-thread wake (via a cloned
+/// waker) under the tokio-backed event port.
+struct DelayedWakeFuture {
+    spawned: bool,
+    done: Arc<AtomicBool>,
+}
+
+impl Future for DelayedWakeFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.done.load(Ordering::SeqCst) {
+            return Poll::Ready(());
+        }
+        if !self.spawned {
+            self.spawned = true;
+            let waker = cx.waker().clone();
+            let done = Arc::clone(&self.done);
+            // Detached task on the loop runtime; it runs on the loop thread when the port drives
+            // the runtime, so `waker.wake()` arms the FuturePollEvent same-thread.
+            drop(kj_rs_tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                done.store(true, Ordering::SeqCst);
+                waker.wake();
+            }));
+        }
+        Poll::Pending
+    }
+}
+
+pub async fn threaded_wake_future() -> Result<()> {
+    DelayedWakeFuture {
+        spawned: false,
+        done: Arc::new(AtomicBool::new(false)),
+    }
+    .await;
+    Ok(())
+}
+
+/// See the bridge doc on `spawn_task_holding_kj_timer` (lib.rs).
+pub fn spawn_task_holding_kj_timer() {
+    drop(kj_rs_tokio::spawn(async {
+        let _ = crate::ffi::kj_timer_delay(60_000).await;
+    }));
+}
+
+/// Like `spawn_task_holding_kj_timer`, but the detached task awaits a bridged KJ promise that
+/// never resolves (`kjNeverPromise`): at teardown it holds an `OwnPromiseNode` and an armed
+/// `RustPromiseAwaiter` event registered with the loop, which the `LocalSet` cancellation must
+/// drop while the loop still exists.
+pub fn spawn_task_awaiting_kj_never_promise() {
+    drop(kj_rs_tokio::spawn(async {
+        let _ = crate::ffi::kj_never_promise().await;
+    }));
+}
+
+/// A bridged future woken from a plain `std::thread` (no tokio, no KJ) ~20ms after its first
+/// poll, while the loop is parked in the port's `wait()`. Exercises the full cross-thread path
+/// into a PARKED tokio port: `FutureWakerCell` cross-thread fulfiller -> loop `Executor` -> port
+/// `wake()` -> `block_on` unpark. (Prep's cross-thread tests all run on a plain `kj::EventLoop`.)
+pub async fn std_thread_wake_future() -> Result<()> {
+    struct F {
+        woken: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        spawned: bool,
+    }
+    impl std::future::Future for F {
+        type Output = ();
+        fn poll(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<()> {
+            if self.woken.load(Ordering::SeqCst) {
+                return std::task::Poll::Ready(());
+            }
+            if !self.spawned {
+                self.spawned = true;
+                let waker = cx.waker().clone();
+                let woken = std::sync::Arc::clone(&self.woken);
+                std::thread::spawn(move || {
+                    std::thread::sleep(Duration::from_millis(20));
+                    woken.store(true, Ordering::SeqCst);
+                    waker.wake();
+                });
+            }
+            std::task::Poll::Pending
+        }
+    }
+    F {
+        woken: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spawned: false,
+    }
+    .await;
+    Ok(())
+}
+
+/// Detaches a task that re-readies itself forever (`yield_now` in a loop). `poll()` must stay
+/// bounded (`POLL_YIELD_BUDGET`) and the KJ loop must not be starved; the task is cancelled at
+/// teardown.
+pub fn spawn_yield_loop_task() {
+    drop(kj_rs_tokio::spawn(async {
+        loop {
+            tokio::task::yield_now().await;
+        }
+    }));
+}
+
+/// Spawns a task that re-enters `promise.wait()` on the loop thread (via the C++ helper
+/// `nestedWait`), which nests `block_on` inside the port's `block_on`. The resulting panic must
+/// surface to the task as a catchable `kj::Exception` (an `Err` here), never an abort, and the
+/// outer loop must keep working. Resolves `Ok` if the task observed the error.
+pub async fn nested_wait_from_task() -> Result<()> {
+    let observed_error = kj_rs_tokio::spawn(async { crate::ffi::nested_wait().is_err() })
+        .await
+        .map_err(Error::other)?;
+    if observed_error {
+        Ok(())
+    } else {
+        Err(Error::other(
+            "nested wait() inside a spawned task unexpectedly succeeded",
+        ))
+    }
+}
+
+/// Spawns a task that panics and awaits its `JoinHandle`. tokio isolates the panic into a
+/// `JoinError` (never an abort), which this maps to an `Err` -> a rejected bridged promise. The
+/// C++ test asserts it throws and that the loop stays healthy afterward. This is the only
+/// coverage of the `JoinHandle` error path (`join_handle.await.map_err(...)`).
+pub async fn spawn_panicking_task() -> Result<()> {
+    kj_rs_tokio::spawn(async {
+        panic!("deliberate panic in a spawned task");
+    })
+    .await
+    .map_err(Error::other)?;
+    Ok(())
+}
+
+/// Detaches (drops the `JoinHandle` of) a task that, after a short delay, bumps
+/// `COMPLETED_TASKS`. The positive counterpart of `spawn_pending_task`: a detached task still
+/// runs to completion (dropping the handle does not cancel it).
+pub fn spawn_detached_completing_task() {
+    drop(kj_rs_tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        COMPLETED_TASKS.fetch_add(1, Ordering::SeqCst);
+    }));
+}
+
+/// See the bridge doc on `task_fulfills_kj_fulfiller` (lib.rs).
+pub fn task_fulfills_kj_fulfiller(delay_ms: u64, value: i32) {
+    drop(kj_rs_tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        let _ = crate::ffi::fulfill_test_fulfiller(value);
+    }));
+}
+
+/// See the bridge doc on `task_awaits_kj_timer` (lib.rs).
+pub async fn task_awaits_kj_timer(delay_ms: u64, timer_ms: u64) -> Result<()> {
+    kj_rs_tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        // Infallible on the C++ side; the bridge still types it as a Result.
+        let _ = crate::ffi::kj_timer_delay(timer_ms).await;
+    })
+    .await
+    .map_err(Error::other)
+}

--- a/src/rust/cxx/kj-rs-tokio/tests/test_helpers.rs
+++ b/src/rust/cxx/kj-rs-tokio/tests/test_helpers.rs
@@ -105,10 +105,10 @@ pub fn spawn_task_awaiting_kj_never_promise() {
     }));
 }
 
-/// A bridged future woken from a plain `std::thread` (no tokio, no KJ) ~20ms after its first
-/// poll, while the loop is parked in the port's `wait()`. Exercises the full cross-thread path
-/// into a PARKED tokio port: `FutureWakerCell` cross-thread fulfiller -> loop `Executor` -> port
-/// `wake()` -> `block_on` unpark. (Prep's cross-thread tests all run on a plain `kj::EventLoop`.)
+/// A bridged future woken from a plain `std::thread` (no tokio, no KJ) about 20ms after its
+/// first poll, while the loop is parked in the port's `wait()`. The cloned `ArcWaker` fulfills
+/// its cross-thread promise through the loop's `Executor`, which calls the port's `wake()`
+/// and unparks `block_on`.
 pub async fn std_thread_wake_future() -> Result<()> {
     struct F {
         woken: std::sync::Arc<std::sync::atomic::AtomicBool>,

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -1,0 +1,94 @@
+// Tests for TokioEventPort / setupTokioAsyncIo: a kj::EventLoop driven by a per-thread tokio
+// current_thread runtime. Following kj-rs conventions, C++ KJ_TESTs drive; Rust helpers (see
+// tests/lib.rs, bridged by workerd-cxx) provide async behaviors.
+
+#include "kj-rs-tokio-test/lib.rs.h"
+#include "kj-rs-tokio/tokio-event-port.h"
+
+#include <kj/async.h>
+#include <kj/debug.h>
+#include <kj/test.h>
+#include <kj/thread.h>
+#include <kj/vector.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace kj_rs_tokio_test {
+namespace {
+
+using kj_rs_tokio::setupTokioAsyncIo;
+
+void delayMillis(uint64_t millis) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(millis));
+}
+
+// =======================================================================================
+// Basics: the KJ event loop works as usual on top of the tokio-backed port.
+
+KJ_TEST("promises resolve on a TokioEventPort loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  KJ_EXPECT(kj::evalLater([]() { return 123; }).wait(ws) == 123);
+  KJ_EXPECT(kj::Promise<int>(42).wait(ws) == 42);
+}
+
+KJ_TEST("evalLater ordering is preserved") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  kj::Vector<int> order;
+  // eagerlyEvaluate arms each promise immediately (KJ promises are otherwise lazy: continuations
+  // only get scheduled once awaited), so all three events sit in the queue in creation order.
+  auto p1 = kj::evalLater([&]() { order.add(1); }).eagerlyEvaluate(nullptr);
+  auto p2 = kj::evalLater([&]() { order.add(2); }).eagerlyEvaluate(nullptr);
+  auto p3 = kj::evalLater([&]() { order.add(3); }).eagerlyEvaluate(nullptr);
+
+  // Waiting on the last promise runs all three events in FIFO order.
+  p3.wait(ws);
+  p1.wait(ws);
+  p2.wait(ws);
+
+  KJ_ASSERT(order.size() == 3);
+  KJ_EXPECT(order[0] == 1);
+  KJ_EXPECT(order[1] == 2);
+  KJ_EXPECT(order[2] == 3);
+}
+
+KJ_TEST("promise chains resolve") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto promise =
+      kj::evalLater([]() { return 1; }).then([](int v) {
+    return kj::Promise<int>(v + 1);
+  }).then([](int v) { return v * 10; });
+  KJ_EXPECT(promise.wait(ws) == 20);
+}
+
+KJ_TEST("evalLast fires when the loop would sleep") {
+  // kj::evalLast events live on the would-sleep queue, which is only serviced through the
+  // EventLoop::poll() path (EventLoop::wait() switches to poll() when would-sleep waiters
+  // exist). This test hangs or misorders if the port's poll() is broken.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  kj::Vector<int> order;
+  auto last = kj::evalLast([&]() { order.add(2); });
+  auto later = kj::evalLater([&]() { order.add(1); });
+
+  later.wait(ws);
+  // evalLast must not have run yet: the loop never ran out of work while waiting on `later`.
+  KJ_ASSERT(order.size() == 1);
+  KJ_EXPECT(order[0] == 1);
+
+  last.wait(ws);
+  KJ_ASSERT(order.size() == 2);
+  KJ_EXPECT(order[1] == 2);
+}
+
+}  // namespace
+}  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -337,5 +337,125 @@ KJ_TEST("KJ coroutine can co_await spawned Rust tasks and KJ timers together") {
   KJ_EXPECT(result == 12);
 }
 
+// =======================================================================================
+// Teardown.
+
+kj::Timer *testTimer = nullptr;
+void setTestTimer(kj::Timer *timer) {
+  testTimer = timer;
+}
+kj::WaitScope *testWaitScope = nullptr;
+void setTestWaitScope(kj::WaitScope *ws) {
+  testWaitScope = ws;
+}
+kj::Maybe<kj::Own<kj::PromiseFulfiller<int>>> testFulfiller;
+}  // namespace
+
+// External linkage: called by the cxx bridge (kj_rs_tokio_test::kjTimerDelay etc.).
+kj::Promise<void> kjTimerDelay(uint64_t ms) {
+  KJ_REQUIRE(testTimer != nullptr, "setTestTimer() not called");
+  return testTimer->afterDelay(ms * kj::MILLISECONDS);
+}
+
+kj::Promise<void> kjNeverPromise() {
+  return kj::NEVER_DONE;
+}
+
+void nestedWait() {
+  KJ_REQUIRE(testWaitScope != nullptr, "setTestWaitScope() not called");
+  kj::evalLater([]() {}).wait(*testWaitScope);
+}
+
+void fulfillTestFulfiller(int32_t value) {
+  KJ_ASSERT_NONNULL(testFulfiller, "setTestFulfiller() not called")->fulfill(kj::cp(value));
+}
+
+namespace {
+
+KJ_TEST("context destruction with a spawned task HOLDING a KJ timer promise is clean") {
+  // Unlike the test below, the spawned task itself owns live KJ objects (TimerPromiseAdapter in
+  // the port's TimerImpl, armed RustPromiseAwaiter Event on the loop) at teardown. The LocalSet
+  // cancellation that drops them must run while the timer and loop still exist.
+  {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    setTestTimer(&io.getTimer());
+    KJ_DEFER(setTestTimer(nullptr));
+    spawn_task_holding_kj_timer();
+    // Let the task start: it registers the timer and arms its awaiter, then parks.
+    kj::evalLater([]() {}).wait(ws);
+    ws.poll();
+  }
+  {
+    auto io = setupTokioAsyncIo();
+    KJ_EXPECT(kj::evalLater([]() { return 7; }).wait(io.getWaitScope()) == 7);
+  }
+}
+
+KJ_TEST("context destruction with pending spawned tasks and armed timers is "
+        "clean") {
+  {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    auto &timer = io.getTimer();
+
+    // A detached, never-completing Rust task: must be dropped by the runtime at teardown.
+    spawn_pending_task();
+
+    // Armed timer and an in-flight spawned task; their promises are destroyed (canceling the
+    // KJ side) before the context itself, per declaration order.
+    auto timerPromise = timer.afterDelay(60 * kj::SECONDS);
+    auto spawnedPromise = spawn_task_on_runtime(60'000, 1);
+    KJ_EXPECT(!spawnedPromise.poll(ws));
+    KJ_EXPECT(!timerPromise.poll(ws));
+  }
+
+  // The thread is fully cleaned up: a fresh context on the same thread works.
+  {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    KJ_EXPECT(kj::evalLater([]() { return 5; }).wait(ws) == 5);
+    KJ_EXPECT(has_loop_runtime_handle());
+  }
+  KJ_EXPECT(!has_loop_runtime_handle());
+}
+
+KJ_TEST("context destruction with a spawned task awaiting a KJ promise is clean") {
+  // The task owns an OwnPromiseNode plus an armed RustPromiseAwaiter event registered with the
+  // loop. Cancellation must drop them while the loop still exists (else ~Event unlinks from a
+  // freed queue).
+  {
+    auto io = setupTokioAsyncIo();
+    auto &ws = io.getWaitScope();
+    spawn_task_awaiting_kj_never_promise();
+    kj::evalLater([]() {}).wait(ws);
+    ws.poll();
+  }
+  auto io = setupTokioAsyncIo();
+  KJ_EXPECT(kj::evalLater([]() { return 8; }).wait(io.getWaitScope()) == 8);
+}
+
+KJ_TEST("one TokioEventPort per thread") {
+  auto io = setupTokioAsyncIo();
+  // A second port on this thread is refused (KJ's one-loop-per-thread model): the C++ side
+  // KJ_REQUIREs it and the Rust side asserts it; either surfaces as a kj::Exception.
+  KJ_EXPECT_THROW(FAILED, kj::heap<kj_rs_tokio::TokioEventPort>());
+  // The failed construction must not have disturbed the live port.
+  KJ_EXPECT(kj::evalLater([]() { return 1; }).wait(io.getWaitScope()) == 1);
+  KJ_EXPECT(spawn_task_on_runtime(1, 4).wait(io.getWaitScope()) == 4);
+}
+
+KJ_TEST("bridged future woken from a plain std::thread while the loop is parked") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // The wake comes from a thread with neither a KJ loop nor a tokio context, ~20ms after the
+  // loop parks in the port's block_on: FutureWakerCell's cross-thread fulfiller -> this loop's
+  // Executor -> TokioEventPort::wake() -> unpark. A lost hop hangs this wait().
+  std_thread_wake_future().wait(ws);
+  // And again, back to back, so the second wake targets a freshly renewed fulfiller.
+  std_thread_wake_future().wait(ws);
+}
+
 }  // namespace
 }  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -40,6 +40,19 @@ KJ_TEST("Tokio setup rejects an already-current KJ event loop before installing 
   KJ_EXPECT(kj::Promise<int>(42).wait(io.getWaitScope()) == 42);
 }
 
+KJ_TEST("Tokio event-port operations reject a foreign physical thread") {
+  auto io = setupTokioAsyncIo();
+  auto &port = io.getPort();
+
+  kj::Thread thread([&port]() {
+    auto other = setupTokioAsyncIo();
+    KJ_EXPECT_THROW_MESSAGE("TokioEventPort used from a thread other than its owner", port.poll());
+    KJ_EXPECT(kj::Promise<int>(7).wait(other.getWaitScope()) == 7);
+  });
+
+  KJ_EXPECT(kj::Promise<int>(11).wait(io.getWaitScope()) == 11);
+}
+
 KJ_TEST("promises resolve on a TokioEventPort loop") {
   auto io = setupTokioAsyncIo();
   auto &ws = io.getWaitScope();

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -265,5 +265,77 @@ KJ_TEST("cross-thread fulfiller wakes a blocked wait()") {
   KJ_EXPECT(paf.promise.wait(ws) == 123);
 }
 
+// =======================================================================================
+// Rust integration: spawned tokio tasks run while C++ is blocked in promise.wait(), and the
+// existing kj-rs future<->promise bridge works unchanged under the new port.
+
+KJ_TEST("Rust task spawned on the loop's runtime completes while C++ is "
+        "blocked in wait()") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  KJ_EXPECT(has_loop_runtime_handle());
+
+  uint64_t completedBefore = completed_task_count();
+  auto promise = spawn_task_on_runtime(20, 42);
+  // This top-level wait() parks the thread inside the tokio runtime's block_on, which is what
+  // drives the spawned task (and its tokio sleep) to completion.
+  KJ_EXPECT(promise.wait(ws) == 42);
+  KJ_EXPECT(completed_task_count() == completedBefore + 1);
+}
+
+KJ_TEST("tokio timers inside spawned tasks work") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+  auto before = sysClock.now();
+  tokio_sleep_on_runtime(25).wait(ws);
+  KJ_EXPECT(sysClock.now() - before >= 25 * kj::MILLISECONDS);
+}
+
+KJ_TEST("promise.poll() pumps the tokio scheduler without blocking") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto promise = spawn_task_on_runtime(500, 7);
+  // Not done yet; poll() must not sleep the task's 500 ms away. The bound is generous on
+  // purpose: it distinguishes "returned without parking" from "slept until the task finished",
+  // not scheduler latency.
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+  auto before = sysClock.now();
+  KJ_EXPECT(!promise.poll(ws));
+  KJ_EXPECT(sysClock.now() - before < 250 * kj::MILLISECONDS);
+
+  KJ_EXPECT(promise.wait(ws) == 7);
+}
+
+KJ_TEST("kj-rs bridged Rust future with same-thread delayed waker works under the new "
+        "port") {
+  // A bridged Rust future that suspends, then is re-driven by a wake delivered from a task on the
+  // loop's own tokio runtime (same thread, via the TokioEventPort). Exercises the future⇄promise
+  // bridge's asynchronous same-thread re-drive path under the new port.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  threaded_wake_future().wait(ws);
+
+  []() -> kj::Promise<void> { co_await threaded_wake_future(); }().wait(ws);
+}
+
+KJ_TEST("KJ coroutine can co_await spawned Rust tasks and KJ timers together") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  int result = [&timer]() -> kj::Promise<int> {
+    co_await timer.afterDelay(5 * kj::MILLISECONDS);
+    uint32_t value = co_await spawn_task_on_runtime(5, 11);
+    co_await timer.afterDelay(5 * kj::MILLISECONDS);
+    co_return static_cast<int>(value) + 1;
+  }().wait(ws);
+  KJ_EXPECT(result == 12);
+}
+
 }  // namespace
 }  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -158,5 +158,112 @@ KJ_TEST("timer fires while blocked waiting on a cross-thread event") {
   timerPromise.wait(ws);
 }
 
+// =======================================================================================
+// Timer precision: tokio's timer wheel (~1 ms granularity, the same as KJ's own epoll-based
+// port, whose epoll_pwait takes a millisecond timeout). No high-resolution side channel.
+
+KJ_TEST("wake() from another thread interrupts a loop cycling through short timers promptly") {
+  // While the loop keeps re-arming a short timer (so wait() is always a short timed sleep), a
+  // cross-thread fulfill must still get through promptly: the timer wakeup and wake() share the
+  // same Notify, and the wake latch must survive interleaved timer wakeups.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+
+  struct Chain {
+    static kj::Promise<void> run(kj::Timer &timer) {
+      return timer.afterDelay(1 * kj::MILLISECONDS).then([&timer]() { return run(timer); });
+    }
+  };
+  auto keepBusy = Chain::run(timer).eagerlyEvaluate(nullptr);
+
+  auto paf = kj::newPromiseAndCrossThreadFulfiller<int>();
+  auto before = sysClock.now();
+  kj::Thread thread([fulfiller = kj::mv(paf.fulfiller)]() mutable {
+    delayMillis(5);
+    fulfiller->fulfill(7);
+  });
+
+  KJ_EXPECT(paf.promise.wait(ws) == 7);
+  auto elapsed = sysClock.now() - before;
+  KJ_EXPECT(elapsed >= 5 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+  KJ_EXPECT(elapsed < 1000 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+}
+
+KJ_TEST("long sleeps are accurate") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+
+  auto before = sysClock.now();
+  timer.afterDelay(20 * kj::MILLISECONDS).wait(ws);
+  auto elapsed = sysClock.now() - before;
+  KJ_EXPECT(elapsed >= 20 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+  KJ_EXPECT(elapsed < 1000 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+}
+
+KJ_TEST("a cancelled timer does not fire and a later one still does") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  bool earlyFired = false;
+  auto early = timer.afterDelay(5 * kj::MILLISECONDS).then([&]() {
+    earlyFired = true;
+  }).eagerlyEvaluate(nullptr);
+  auto late = timer.afterDelay(30 * kj::MILLISECONDS);
+  early = nullptr;  // cancel: deregisters from TimerImpl before the loop ever sleeps
+
+  auto before = timer.now();
+  late.wait(ws);
+  KJ_EXPECT(!earlyFired);
+  KJ_EXPECT(timer.now() - before >= 30 * kj::MILLISECONDS);
+}
+
+// =======================================================================================
+// Cross-thread: the wake() -> wait()-returns-true latch is what drains kj::Executor events and
+// cross-thread fulfillers.
+
+KJ_TEST("executeAsync from another thread runs on the tokio-ported loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  const kj::Executor &executor = kj::getCurrentThreadExecutor();
+  auto paf = kj::newPromiseAndFulfiller<int>();
+  auto fulfiller = kj::mv(paf.fulfiller);
+
+  kj::Thread thread([&executor, &fulfiller]() {
+    // A plain portless loop so this thread can wait on the cross-thread promise.
+    kj::EventLoop loop;
+    kj::WaitScope threadWs(loop);
+    kj::uint result = executor
+                          .executeAsync([&fulfiller]() {
+      // Runs on the main (tokio-ported) loop.
+      fulfiller->fulfill(42);
+      return 99u;
+    }).wait(threadWs);
+    KJ_ASSERT(result == 99);
+  });
+
+  // While we are blocked here, the other thread's executeAsync must wake the port (wake() ->
+  // wait() returns true -> executor drained).
+  KJ_EXPECT(paf.promise.wait(ws) == 42);
+}
+
+KJ_TEST("cross-thread fulfiller wakes a blocked wait()") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto paf = kj::newPromiseAndCrossThreadFulfiller<int>();
+  kj::Thread thread([fulfiller = kj::mv(paf.fulfiller)]() mutable {
+    delayMillis(10);  // Give the main thread time to actually block in wait().
+    fulfiller->fulfill(123);
+  });
+
+  KJ_EXPECT(paf.promise.wait(ws) == 123);
+}
+
 }  // namespace
 }  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -457,5 +457,99 @@ KJ_TEST("bridged future woken from a plain std::thread while the loop is parked"
   std_thread_wake_future().wait(ws);
 }
 
+// =======================================================================================
+// A tokio task hands KJ work by means other than a bridged waker while the loop is parked in
+// wait(): KJ reports it to the port (setRunnable(true) for events, the TimerImpl SleepHooks for
+// timers) and the park must end. Each test is bounded by a long timer that turns "hangs forever"
+// into a failed assertion.
+
+KJ_TEST("a spawned task fulfilling a kj::PromiseFulfiller while the loop is parked wakes it") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+
+  auto paf = kj::newPromiseAndFulfiller<int>();
+  testFulfiller = kj::mv(paf.fulfiller);
+  KJ_DEFER(testFulfiller = kj::none);
+
+  // The task fulfills ~20 ms into the park; the 10 s timer is the "we hung" bound. Without KJ
+  // reporting the arm (setRunnable(true)) it sits unserviced until that timer.
+  task_fulfills_kj_fulfiller(20, 42);
+  auto before = sysClock.now();
+  int value = paf.promise
+                  .exclusiveJoin(timer.afterDelay(10 * kj::SECONDS).then([]() -> int {
+    KJ_FAIL_ASSERT("KJ event armed by a tokio task was not serviced while the loop was parked");
+  })).wait(ws);
+  KJ_EXPECT(value == 42);
+  KJ_EXPECT(sysClock.now() - before < 2 * kj::SECONDS);
+}
+
+KJ_TEST("a spawned task fulfilling a kj::PromiseFulfiller during a wait-forever park wakes it") {
+  // No timer at all: wait() plans to sleep forever. A hang here is a real hang, so this test
+  // guards itself with a cross-thread kill switch instead of a KJ timer.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  auto paf = kj::newPromiseAndFulfiller<int>();
+  testFulfiller = kj::mv(paf.fulfiller);
+  KJ_DEFER(testFulfiller = kj::none);
+
+  auto bound = kj::newPromiseAndCrossThreadFulfiller<int>();
+  std::atomic<bool> done{false};
+  kj::Thread watchdog([&done, fulfiller = kj::mv(bound.fulfiller)]() mutable {
+    for (int i = 0; i < 1000 && !done.load(); i++) delayMillis(10);
+    if (!done.load()) fulfiller->fulfill(-1);
+  });
+
+  task_fulfills_kj_fulfiller(20, 7);
+  int value = paf.promise.exclusiveJoin(kj::mv(bound.promise)).wait(ws);
+  done.store(true);
+  KJ_EXPECT(
+      value == 7, "KJ event armed by a tokio task was not serviced during a wait-forever park");
+}
+
+KJ_TEST("a KJ timer armed by a spawned task during the park is honored at its own deadline") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+  setTestTimer(&timer);
+  KJ_DEFER(setTestTimer(nullptr));
+
+  // wait() plans against the 10 s bound; 10 ms (wall clock) into the park the task arms a 20 ms
+  // KJ timer and awaits it to completion. The park must end at that timer, not at 10 s.
+  //
+  // The port is the TimerImpl's SleepHooks while parked, so kj::Timer::now() reads the live
+  // clock: the task's afterDelay(20ms) is measured from the moment it is armed (~10 ms in), and
+  // the timer is due at ~30 ms of wall time -- KJ's intended semantics for code using the timer
+  // while the loop sleeps (see kj::TimerImpl::setSleeping).
+  auto before = sysClock.now();
+  task_awaits_kj_timer(10, 20)
+      .exclusiveJoin(timer.afterDelay(10 * kj::SECONDS).then([]() {
+    KJ_FAIL_ASSERT("KJ timer armed by a tokio task during the park was not honored");
+  })).wait(ws);
+  auto elapsed = sysClock.now() - before;
+  KJ_EXPECT(elapsed >= 30 * kj::MILLISECONDS, elapsed / kj::MILLISECONDS);
+  KJ_EXPECT(elapsed < 2 * kj::SECONDS, elapsed / kj::MILLISECONDS);
+}
+
+KJ_TEST("a KJ timer armed by a spawned task during a wait-forever park is honored") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  setTestTimer(&io.getTimer());
+  KJ_DEFER(setTestTimer(nullptr));
+
+  auto bound = kj::newPromiseAndCrossThreadFulfiller<void>();
+  std::atomic<bool> done{false};
+  kj::Thread watchdog([&done, fulfiller = kj::mv(bound.fulfiller)]() mutable {
+    for (int i = 0; i < 1000 && !done.load(); i++) delayMillis(10);
+    if (!done.load()) fulfiller->reject(KJ_EXCEPTION(FAILED, "park never ended"));
+  });
+
+  task_awaits_kj_timer(10, 20).exclusiveJoin(kj::mv(bound.promise)).wait(ws);
+  done.store(true);
+}
+
 }  // namespace
 }  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -689,5 +689,37 @@ KJ_TEST("two tokio-ported loops on two threads executeAsync into each other conc
   mainFinished.promise.wait(ws);
 }
 
+KJ_TEST("a spawned task that panics surfaces as a kj::Exception, not an abort") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  // tokio isolates a spawned task's panic into a JoinError; the bridged future maps it to an
+  // Err, so co_await throws rather than aborting the process.
+  kj::Maybe<kj::Exception> maybeException;
+  try {
+    spawn_panicking_task().wait(ws);
+  } catch (...) {
+    maybeException = kj::getCaughtExceptionAsKj();
+  }
+  KJ_EXPECT(maybeException != kj::none, "a panicking spawned task must throw");
+
+  // The loop is still healthy afterward.
+  KJ_EXPECT(kj::evalLater([]() { return 11; }).wait(ws) == 11);
+}
+
+KJ_TEST("a detached spawned task (JoinHandle dropped) still runs to completion") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  uint64_t before = completed_task_count();
+  spawn_detached_completing_task();  // drops the JoinHandle immediately
+  // Drive the loop until the detached task has run (bounded; each afterDelay lets the runtime
+  // turn). Dropping the handle must NOT have cancelled it.
+  for (int i = 0; i < 200 && completed_task_count() == before; i++) {
+    io.getTimer().afterDelay(2 * kj::MILLISECONDS).wait(ws);
+  }
+  KJ_EXPECT(completed_task_count() == before + 1);
+}
+
 }  // namespace
 }  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -15,11 +15,14 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
+#include <type_traits>
 
 namespace kj_rs_tokio_test {
 namespace {
 
 using kj_rs_tokio::setupTokioAsyncIo;
+
+static_assert(!std::is_move_constructible_v<kj_rs_tokio::TokioAsyncIoContext>);
 
 void delayMillis(uint64_t millis) {
   std::this_thread::sleep_for(std::chrono::milliseconds(millis));

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -551,5 +551,89 @@ KJ_TEST("a KJ timer armed by a spawned task during a wait-forever park is honore
   done.store(true);
 }
 
+KJ_TEST("cross-thread bridged wake arriving while the loop is busy (not parked) is delivered") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+
+  // The wake lands ~20 ms in; keep the loop turning events (never parking) for ~60 ms. The wake
+  // then travels cell -> cross-thread fulfiller -> Executor -> port.wake(); the loop only sees
+  // the latch through busy-poll's port.poll() (enabled here; KJ's default never busy-polls),
+  // never through wait().
+  ws.setBusyPollInterval(8);
+  auto woken = std_thread_wake_future();
+  auto busyUntil = sysClock.now() + 60 * kj::MILLISECONDS;
+  [&]() -> kj::Promise<void> {
+    while (sysClock.now() < busyUntil) {
+      co_await kj::evalLater([]() {});
+    }
+  }().wait(ws);
+
+  woken
+      .exclusiveJoin(timer.afterDelay(10 * kj::SECONDS).then([]() {
+    KJ_FAIL_ASSERT("cross-thread wake during a busy loop was lost");
+  })).wait(ws);
+}
+
+KJ_TEST("a bare TokioEventPort (no context) tears down cleanly with tasks holding KJ objects") {
+  // The port owns its loop and cancels spawned tasks before destroying anything, so even without
+  // a TokioAsyncIoContext a task holding a KJ timer promise and an armed awaiter event is dropped
+  // while the loop and timer are alive. ASAN target.
+  {
+    auto port = kj::heap<kj_rs_tokio::TokioEventPort>();
+    kj::WaitScope ws(port->getLoop());
+    setTestTimer(&port->getTimer());
+    KJ_DEFER(setTestTimer(nullptr));
+    spawn_task_holding_kj_timer();
+    spawn_task_awaiting_kj_never_promise();
+    kj::evalLater([]() {}).wait(ws);
+    ws.poll();
+    // `ws` is destroyed first (declared after `port`), then the port: tasks, loop, runtime, timer.
+  }
+  auto io = setupTokioAsyncIo();
+  KJ_EXPECT(kj::evalLater([]() { return 9; }).wait(io.getWaitScope()) == 9);
+}
+
+KJ_TEST("a task that yields forever keeps poll() bounded and does not starve the KJ loop") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+
+  spawn_yield_loop_task();
+  // poll() lets ready tasks run for a bounded number of turns (POLL_YIELD_BUDGET) and returns.
+  ws.poll();
+  ws.poll();
+  // The KJ side still makes progress alongside the spinning task.
+  KJ_EXPECT(kj::evalLater([]() { return 21; }).wait(ws) == 21);
+  KJ_EXPECT(spawn_task_on_runtime(1, 9).wait(ws) == 9);
+  // The spinning task is cancelled at teardown (LocalSet cancellation, above).
+}
+
+KJ_TEST("a spawned task re-entering promise.wait() gets a kj::Exception, not an abort") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  setTestWaitScope(&ws);
+  KJ_DEFER(setTestWaitScope(nullptr));
+
+  // Documented in tokio-event-port.h: nesting block_on inside block_on is rejected by tokio;
+  // the panic must reach the task as a catchable exception (an Err across the bridge), and the
+  // outer loop must stay healthy.
+  nested_wait_from_task().wait(ws);
+  KJ_EXPECT(kj::evalLater([]() { return 3; }).wait(ws) == 3);
+}
+
+KJ_TEST("already-due timer returns promptly from wait()") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  // timeoutToNextEvent() is zero: wait() must not sleep; it returns and advanceTo() fires the
+  // timer.
+  auto start = kj::systemPreciseMonotonicClock().now();
+  timer.afterDelay(0 * kj::MILLISECONDS).wait(ws);
+  timer.atTime(timer.now()).wait(ws);
+  KJ_EXPECT(kj::systemPreciseMonotonicClock().now() - start < 200 * kj::MILLISECONDS);
+}
+
 }  // namespace
 }  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -90,5 +90,73 @@ KJ_TEST("evalLast fires when the loop would sleep") {
   KJ_EXPECT(order[1] == 2);
 }
 
+// =======================================================================================
+// Timers: kj::TimerImpl fed by the port; advanceTo() after every wait()/poll().
+
+KJ_TEST("timer.afterDelay fires with real elapsed time") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  auto &sysClock = kj::systemPreciseMonotonicClock();
+  auto before = sysClock.now();
+  auto timerBefore = timer.now();
+
+  // If the port forgot timerImpl.advanceTo() after waits, this would never resolve (caught by
+  // the test timeout).
+  timer.afterDelay(30 * kj::MILLISECONDS).wait(ws);
+
+  KJ_EXPECT(sysClock.now() - before >= 30 * kj::MILLISECONDS);
+  // Timer time is synced to the monotonic clock at each wait return.
+  KJ_EXPECT(timer.now() - timerBefore >= 30 * kj::MILLISECONDS);
+}
+
+KJ_TEST("multiple timers fire in deadline order") {
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  kj::Vector<int> order;
+  auto p3 = timer.afterDelay(30 * kj::MILLISECONDS).then([&]() {
+    order.add(3);
+  }).eagerlyEvaluate(nullptr);
+  auto p1 =
+      timer.afterDelay(5 * kj::MILLISECONDS).then([&]() { order.add(1); }).eagerlyEvaluate(nullptr);
+  auto p2 = timer.afterDelay(15 * kj::MILLISECONDS).then([&]() {
+    order.add(2);
+  }).eagerlyEvaluate(nullptr);
+
+  p3.wait(ws);
+  KJ_ASSERT(order.size() == 3);
+  KJ_EXPECT(order[0] == 1);
+  KJ_EXPECT(order[1] == 2);
+  KJ_EXPECT(order[2] == 3);
+  p1.wait(ws);
+  p2.wait(ws);
+}
+
+KJ_TEST("timer fires while blocked waiting on a cross-thread event") {
+  // The port must bound each sleep by timeoutToNextEvent(): the loop first wakes at the timer
+  // deadline (long before the cross-thread fulfill), fires the timer, then goes back to sleep.
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto &timer = io.getTimer();
+
+  auto paf = kj::newPromiseAndCrossThreadFulfiller<void>();
+  bool timerFired = false;
+  auto timerPromise = timer.afterDelay(10 * kj::MILLISECONDS).then([&]() {
+    timerFired = true;
+  }).eagerlyEvaluate(nullptr);
+
+  kj::Thread thread([fulfiller = kj::mv(paf.fulfiller)]() mutable {
+    delayMillis(100);
+    fulfiller->fulfill();
+  });
+
+  paf.promise.wait(ws);
+  KJ_EXPECT(timerFired);
+  timerPromise.wait(ws);
+}
+
 }  // namespace
 }  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -28,6 +28,18 @@ void delayMillis(uint64_t millis) {
 // =======================================================================================
 // Basics: the KJ event loop works as usual on top of the tokio-backed port.
 
+KJ_TEST("Tokio setup rejects an already-current KJ event loop before installing runtime TLS") {
+  {
+    kj::EventLoop loop;
+    kj::WaitScope waitScope(loop);
+    KJ_EXPECT_THROW_MESSAGE("cannot create a TokioEventPort while another KJ event loop is current",
+        setupTokioAsyncIo());
+  }
+
+  auto io = setupTokioAsyncIo();
+  KJ_EXPECT(kj::Promise<int>(42).wait(io.getWaitScope()) == 42);
+}
+
 KJ_TEST("promises resolve on a TokioEventPort loop") {
   auto io = setupTokioAsyncIo();
   auto &ws = io.getWaitScope();

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -477,11 +477,11 @@ KJ_TEST("bridged future woken from a plain std::thread while the loop is parked"
   auto io = setupTokioAsyncIo();
   auto &ws = io.getWaitScope();
 
-  // The wake comes from a thread with neither a KJ loop nor a tokio context, ~20ms after the
-  // loop parks in the port's block_on: FutureWakerCell's cross-thread fulfiller -> this loop's
-  // Executor -> TokioEventPort::wake() -> unpark. A lost hop hangs this wait().
+  // The wake comes from a thread with neither a KJ loop nor a tokio context, about 20ms after
+  // this loop parks in block_on. ArcWaker fulfills its cross-thread promise through the loop's
+  // Executor, which calls TokioEventPort::wake() and unparks the loop.
   std_thread_wake_future().wait(ws);
-  // And again, back to back, so the second wake targets a freshly renewed fulfiller.
+  // Repeat with a new future and its own ArcWaker promise.
   std_thread_wake_future().wait(ws);
 }
 

--- a/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
+++ b/src/rust/cxx/kj-rs-tokio/tests/tokio-event-port-test.c++
@@ -635,5 +635,59 @@ KJ_TEST("already-due timer returns promptly from wait()") {
   KJ_EXPECT(kj::systemPreciseMonotonicClock().now() - start < 200 * kj::MILLISECONDS);
 }
 
+KJ_TEST("two tokio-ported loops on two threads executeAsync into each other concurrently") {
+  // Both directions at once, N round trips each way, so both ports' wake paths (Executor ->
+  // wake() -> block_on unpark) race under load. TSAN target. A lost wake hangs the test.
+  //
+  // Protocol: each side publishes its Executor, runs N round trips into the peer while its own
+  // loop services the peer's round trips, then fulfills the peer's "I'm finished" cross-thread
+  // fulfiller and waits (on its own loop, still servicing) for the peer's. Only when both have
+  // finished does either loop go away, so no call is ever left without a live target.
+  constexpr kj::uint N = 200;
+  using ExecSlot = kj::MutexGuarded<kj::Maybe<kj::Own<const kj::Executor>>>;
+  using FulfillerSlot =
+      kj::MutexGuarded<kj::Maybe<kj::Own<const kj::CrossThreadPromiseFulfiller<void>>>>;
+  ExecSlot mainExecSlot;
+  ExecSlot otherExecSlot;
+  // Each side creates its own PAF (the promise stays on its loop) and hands the fulfiller over.
+  FulfillerSlot mainFinishedSlot;   // fulfilled by `other` when it is done
+  FulfillerSlot otherFinishedSlot;  // fulfilled by main when it is done
+
+  auto takeFromSlot = [](auto &slot) {
+    auto lock = slot.lockExclusive();
+    lock.wait([](auto &v) { return v != kj::none; });
+    return kj::mv(KJ_ASSERT_NONNULL(*lock));
+  };
+
+  auto io = setupTokioAsyncIo();
+  auto &ws = io.getWaitScope();
+  auto mainFinished = kj::newPromiseAndCrossThreadFulfiller<void>();
+  *mainFinishedSlot.lockExclusive() = kj::mv(mainFinished.fulfiller);
+  *mainExecSlot.lockExclusive() = kj::getCurrentThreadExecutor().addRef();
+
+  kj::Thread other([&]() noexcept {
+    auto io2 = setupTokioAsyncIo();
+    auto &ws2 = io2.getWaitScope();
+    auto otherFinished = kj::newPromiseAndCrossThreadFulfiller<void>();
+    *otherFinishedSlot.lockExclusive() = kj::mv(otherFinished.fulfiller);
+    *otherExecSlot.lockExclusive() = kj::getCurrentThreadExecutor().addRef();
+
+    auto mainExec = takeFromSlot(mainExecSlot);
+    for (kj::uint i = 0; i < N; i++) {
+      KJ_ASSERT(mainExec->executeAsync([i]() { return i; }).wait(ws2) == i);
+    }
+    takeFromSlot(mainFinishedSlot)->fulfill();
+    // Keep servicing main's round trips until it reports finished.
+    otherFinished.promise.wait(ws2);
+  });
+
+  auto otherExec = takeFromSlot(otherExecSlot);
+  for (kj::uint i = 0; i < N; i++) {
+    KJ_EXPECT(otherExec->executeAsync([i]() { return i * 2; }).wait(ws) == i * 2);
+  }
+  takeFromSlot(otherFinishedSlot)->fulfill();
+  mainFinished.promise.wait(ws);
+}
+
 }  // namespace
 }  // namespace kj_rs_tokio_test

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.c++
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.c++
@@ -1,0 +1,116 @@
+#include "kj-rs-tokio/tokio-event-port.h"
+
+#include <kj/debug.h>
+
+namespace kj_rs_tokio {
+
+namespace {
+// The port active on this loop thread, to enforce one port per thread (KJ's one-loop-per-thread
+// model); set by the constructor, cleared by the destructor.
+thread_local TokioEventPort* activePort = nullptr;
+
+// Enforce one port per thread on the C++ side too (the Rust half asserts the same when it
+// registers its runtime handle), so the `activePort` invariant is guaranteed where the pointer
+// lives rather than relied upon from across the bridge.
+const kj::MonotonicClock& requireNoActivePort() {
+  KJ_REQUIRE(activePort == nullptr,
+      "only one TokioEventPort may exist per thread (KJ's one-loop-per-thread model)");
+  return kj::systemPreciseMonotonicClock();
+}
+}  // namespace
+
+TokioEventPort::TokioEventPort()
+    : clock(requireNoActivePort()),
+      timerImpl(clock.now()),
+      rustPort(new_tokio_port()),
+      loop(kj::heap<kj::EventLoop>(*this)) {
+  activePort = this;
+}
+
+TokioEventPort::~TokioEventPort() noexcept(false) {
+  // Cancel spawned tasks while the loop and timer -- our members, destroyed after this body --
+  // are still alive: a cancelled task's destructors may unlink an armed kj::_::Event from the
+  // loop or deregister a kj::TimerImpl timer.
+  cancelSpawnedTasks();
+  if (activePort == this) {
+    activePort = nullptr;
+  }
+}
+
+void TokioEventPort::cancelSpawnedTasks() {
+  // Guarded so a task-drop panic (surfaced as a kj::Exception by the cxx fork) does not
+  // std::terminate if the caller is already unwinding (this runs from destructors).
+  unwindDetector.catchExceptionsIfUnwinding([this]() { rustPort->cancel_spawned_tasks(); });
+}
+
+void TokioEventPort::setRunnable(bool runnable) {
+  // Called by the EventLoop on the loop thread on empty <-> runnable transitions. The loop
+  // reports `false` right before it calls wait(), so a `true` that arrives while we are parked
+  // means a tokio task armed a KJ event: hand the thread back to KJ.
+  if (runnable) {
+    rustPort->notify_kj_service();
+  }
+}
+
+void TokioEventPort::updateNextTimerEvent(kj::Maybe<kj::TimePoint> time) {
+  // A timer was armed or cancelled while we sleep. Only a deadline sooner than the one this
+  // wait() was planned against needs the thread back: KJ must re-plan the sleep.
+  KJ_IF_SOME(next, time) {
+    bool sooner =
+        plannedNextEvent.map([&](kj::TimePoint planned) { return next < planned; }).orDefault(true);
+    if (sooner) {
+      rustPort->notify_kj_service();
+    }
+  }
+}
+
+bool TokioEventPort::wait() {
+  bool woken;
+  // Bound the sleep by the next KJ timer deadline, if any, and remember which deadline that was
+  // so updateNextTimerEvent() can spot a sooner one armed during the park. `timeoutToNextEvent()`
+  // rounds up, so we always sleep until just *after* the timer is due.
+  plannedNextEvent = timerImpl.nextEvent();
+  KJ_DEFER(plannedNextEvent = kj::none);
+  // While parked, be the timer's sleep hooks: tokio tasks arming KJ timers mid-park get live
+  // time from now() and re-plan the sleep if their deadline is sooner. advanceTo() below clears
+  // the hooks (KJ's contract for setSleeping()).
+  timerImpl.setSleeping(*this);
+  KJ_IF_SOME(timeoutNs, timerImpl.timeoutToNextEvent(clock.now(), kj::NANOSECONDS, kj::maxValue)) {
+    woken = rustPort->wait_timeout_ns(timeoutNs);
+  } else {
+    woken = rustPort->wait_forever();
+  }
+
+  // Load-bearing: TimerImpl only fires timer events from advanceTo(). Forgetting this after a
+  // wait means every kj::Timer promise silently never resolves. (This also clears the sleep
+  // hooks installed above.)
+  timerImpl.advanceTo(clock.now());
+  return woken;
+}
+
+bool TokioEventPort::poll() {
+  bool woken = rustPort->poll();
+  timerImpl.advanceTo(clock.now());
+  return woken;
+}
+
+void TokioEventPort::wake() const {
+  // Callable from any thread; the Rust side latches the flag and unblocks a concurrent wait().
+  rustPort->wake();
+}
+
+TokioAsyncIoContext::~TokioAsyncIoContext() noexcept(false) {
+  // Cancel spawned tasks while the WaitScope is still alive as well (the port's destructor
+  // repeats this harmlessly). A moved-from context (null port) owns nothing.
+  if (port.get() != nullptr) {
+    port->cancelSpawnedTasks();
+  }
+}
+
+TokioAsyncIoContext setupTokioAsyncIo() {
+  auto port = kj::heap<TokioEventPort>();
+  auto waitScope = kj::heap<kj::WaitScope>(port->getLoop());
+  return TokioAsyncIoContext(kj::mv(port), kj::mv(waitScope));
+}
+
+}  // namespace kj_rs_tokio

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.c++
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.c++
@@ -15,6 +15,8 @@ thread_local TokioEventPort* activePort = nullptr;
 const kj::MonotonicClock& requireNoActivePort() {
   KJ_REQUIRE(activePort == nullptr,
       "only one TokioEventPort may exist per thread (KJ's one-loop-per-thread model)");
+  KJ_REQUIRE(kj::tryGetCurrentThreadExecutor() == kj::none,
+      "cannot create a TokioEventPort while another KJ event loop is current");
   return kj::systemPreciseMonotonicClock();
 }
 }  // namespace

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.c++
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.c++
@@ -2,6 +2,8 @@
 
 #include <kj/debug.h>
 
+#include <cstdlib>
+
 namespace kj_rs_tokio {
 
 namespace {
@@ -22,7 +24,8 @@ const kj::MonotonicClock& requireNoActivePort() {
 }  // namespace
 
 TokioEventPort::TokioEventPort()
-    : clock(requireNoActivePort()),
+    : ownerThread(kj::ThreadId::current()),
+      clock(requireNoActivePort()),
       timerImpl(clock.now()),
       rustPort(new_tokio_port()),
       loop(kj::heap<kj::EventLoop>(*this)) {
@@ -30,6 +33,10 @@ TokioEventPort::TokioEventPort()
 }
 
 TokioEventPort::~TokioEventPort() noexcept(false) {
+  KJ_ASSERT(ownerThread == kj::ThreadId::current(),
+      "TokioEventPort destroyed on a thread other than its owner") {
+    std::abort();
+  }
   // Cancel spawned tasks while the loop and timer -- our members, destroyed after this body --
   // are still alive: a cancelled task's destructors may unlink an armed kj::_::Event from the
   // loop or deregister a kj::TimerImpl timer.
@@ -39,13 +46,20 @@ TokioEventPort::~TokioEventPort() noexcept(false) {
   }
 }
 
+void TokioEventPort::assertOwnerThread() const {
+  KJ_REQUIRE(ownerThread == kj::ThreadId::current(),
+      "TokioEventPort used from a thread other than its owner");
+}
+
 void TokioEventPort::cancelSpawnedTasks() {
+  assertOwnerThread();
   // Guarded so a task-drop panic (surfaced as a kj::Exception by the cxx fork) does not
   // std::terminate if the caller is already unwinding (this runs from destructors).
   unwindDetector.catchExceptionsIfUnwinding([this]() { rustPort->cancel_spawned_tasks(); });
 }
 
 void TokioEventPort::setRunnable(bool runnable) {
+  assertOwnerThread();
   // Called by the EventLoop on the loop thread on empty <-> runnable transitions. The loop
   // reports `false` right before it calls wait(), so a `true` that arrives while we are parked
   // means a tokio task armed a KJ event: hand the thread back to KJ.
@@ -55,6 +69,7 @@ void TokioEventPort::setRunnable(bool runnable) {
 }
 
 void TokioEventPort::updateNextTimerEvent(kj::Maybe<kj::TimePoint> time) {
+  assertOwnerThread();
   // A timer was armed or cancelled while we sleep. Only a deadline sooner than the one this
   // wait() was planned against needs the thread back: KJ must re-plan the sleep.
   KJ_IF_SOME(next, time) {
@@ -67,6 +82,7 @@ void TokioEventPort::updateNextTimerEvent(kj::Maybe<kj::TimePoint> time) {
 }
 
 bool TokioEventPort::wait() {
+  assertOwnerThread();
   bool woken;
   // Bound the sleep by the next KJ timer deadline, if any, and remember which deadline that was
   // so updateNextTimerEvent() can spot a sooner one armed during the park. `timeoutToNextEvent()`
@@ -91,6 +107,7 @@ bool TokioEventPort::wait() {
 }
 
 bool TokioEventPort::poll() {
+  assertOwnerThread();
   bool woken = rustPort->poll();
   timerImpl.advanceTo(clock.now());
   return woken;

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
@@ -1,0 +1,174 @@
+#pragma once
+// TokioEventPort: a kj::EventPort backed by a per-thread tokio current_thread runtime.
+// Ownership inversion, not replacement: C++ keeps creating and awaiting kj::Promises exactly
+// as today; what changes is *who sleeps*. When the KJ loop would block in the OS, wait()
+// parks the thread inside `tokio::Runtime::block_on`, driving the whole tokio scheduler, so
+// every Rust task on the loop's runtime makes progress while C++ is "blocked".
+//
+// Notes on the kj::EventPort contract (see kj/async.h):
+//  - wait()/poll() return true iff wake() latched. This is load-bearing: kj::Executor's
+//    executeAsync and kj::newPromiseAndCrossThreadFulfiller only get drained on `true`.
+//  - The kj::TimerImpl is advanced after every wait()/poll(). Timer precision is tokio's timer
+//    wheel (~1 ms), the same granularity KJ's own epoll-based port has.
+//  - One TokioEventPort (and hence one runtime, one kj::EventLoop) per thread, matching KJ's
+//    one-loop-per-thread model. The port owns its EventLoop: the loop is constructed on the port
+//    and destroyed before any of the port's other members, so the port can always ask the loop
+//    whether it needs service (below) and can always cancel spawned tasks while the loop and
+//    timer are alive.
+//  - Tokio tasks on this runtime may use KJ freely -- fulfill a PromiseFulfiller, arm a timer,
+//    add to a TaskSet, create or await bridged promises, wake bridged futures. Every one of those
+//    either arms a KJ event or moves the next KJ timer deadline, and KJ reports both to the port
+//    while it sleeps: kj::EventLoop reports setRunnable(false) before calling wait() and so
+//    setRunnable(true) on the first arm during it, and the port is the kj::TimerImpl's SleepHooks
+//    for the duration of the park (updateNextTimerEvent() on a changed earliest deadline;
+//    kj::Timer::now() reads the live clock). Either report ends the park. The one thing a task
+//    must never do is re-enter `promise.wait()` / `waitScope.poll()` on this thread: that nests
+//    block_on inside block_on, which tokio rejects (the panic surfaces as a kj::Exception).
+//
+// Object relationships (one loop thread):
+//
+//   TokioAsyncIoContext                       -- kj::setupAsyncIo() analogue
+//       ├── Own<TokioEventPort>               -- the kj::EventPort; one per thread
+//       │       ├── kj::TimerImpl             -- fed from wait()/poll(); declared BEFORE the
+//       │       │                                 Rust half so it outlives cancelled tasks
+//       │       ├── rust::Box<TokioPort>      -- Send + Sync (wake() is called cross-thread)
+//       │       │       ├── tokio::Runtime (current_thread, I/O + time drivers)
+//       │       │       └── Arc<SharedState>  -- Notify + `woken` latch + `in_wait` flag; the
+//       │       │                                ONE thing every wake source touches
+//       │       └── Own<kj::EventLoop>        -- constructed on the port; declared LAST so it
+//       │                                        is destroyed first
+//       │   (the port is also the TimerImpl's SleepHooks while parked)
+//       └── Own<kj::WaitScope>
+//
+//   Thread-locals (loop thread only), all installed by construction / cleared by destruction:
+//       LOOP_RUNTIME_HANDLE                   -- for kj_rs_tokio::current_handle()
+//       LOOP_LOCAL_SET: Rc<LocalSet>          -- what kj_rs_tokio::spawn() enqueues onto and
+//                                                wait()/poll() drive. Not a TokioPort member
+//                                                because LocalSet is !Send; dropped by
+//                                                TokioEventPort's destructor
+//       activePort                            -- enforces one port per thread
+//
+//   Wake sources -> SharedState.notify: wake() from any thread (kj::Executor,
+//   CrossThreadPromiseFulfiller); on the loop thread setRunnable(true) and the SleepHooks timer
+//   callback; and the planned timer deadline via tokio's timer wheel.
+//
+// Teardown order is structural, not a convention: ~TokioEventPort cancels the LocalSet's spawned
+// tasks FIRST (they may own KJ promises whose destructors need the loop and timer), then destroys
+// the loop (asserting its queue is empty), the runtime, and finally the timer.
+
+#include "kj-rs-tokio/ffi.rs.h"
+
+#include <kj/async.h>
+#include <kj/exception.h>
+#include <kj/time.h>
+#include <kj/timer.h>
+
+namespace kj_rs_tokio {
+
+class TokioEventPort final: public kj::EventPort, private kj::TimerImpl::SleepHooks {
+ public:
+  TokioEventPort();
+  ~TokioEventPort() noexcept(false);
+  KJ_DISALLOW_COPY_AND_MOVE(TokioEventPort);
+
+  // kj::EventPort implementation. setRunnable(true) during wait() -- an event armed by a tokio
+  // task running inside the park -- ends the park; kj::EventLoop guarantees setRunnable(false)
+  // right before wait(), so that edge is always delivered.
+  bool wait() override;
+  bool poll() override;
+  void wake() const override;
+  void setRunnable(bool runnable) override;
+
+  // The kj::EventLoop this port drives. Owned by the port (see the file comment).
+  kj::EventLoop &getLoop() {
+    return *loop;
+  }
+
+  // Timer fed by this port. now() is frozen while KJ events run and advances only when the loop
+  // waits/polls, preserving stock KJ timer semantics (the port calls timerImpl.advanceTo() after
+  // every wait()/poll() return; timers would silently never fire otherwise).
+  kj::Timer &getTimer() {
+    return timerImpl;
+  }
+
+  // The Rust half (runtime + wake state). Rust code on this thread can also reach the runtime
+  // via kj_rs_tokio::current_handle() / kj_rs_tokio::spawn().
+  const TokioPort &getRustPort() const {
+    return *rustPort;
+  }
+
+  // Cancel every task spawned onto this thread's LocalSet (kj_rs_tokio::spawn()), running their
+  // destructors now. The destructor does this itself, first; TokioAsyncIoContext also does it
+  // while its WaitScope is still alive. Idempotent.
+  void cancelSpawnedTasks();
+
+ private:
+  // kj::TimerImpl::SleepHooks, installed by wait() for the duration of the park (KJ clears them
+  // in advanceTo()). KJ calls updateNextTimerEvent() whenever the earliest deadline changes; a
+  // deadline sooner than the one this wait() was planned against ends the park. While installed,
+  // kj::Timer::now() reads the live clock through getTimeWhileSleeping().
+  void updateNextTimerEvent(kj::Maybe<kj::TimePoint> time) override;
+  kj::TimePoint getTimeWhileSleeping() override {
+    return clock.now();
+  }
+
+  const kj::MonotonicClock &clock;
+  // Declaration order is destruction order in reverse, and it matters: `loop` is destroyed
+  // first, then `rustPort` (the runtime), then `timerImpl`. The destructor body cancels spawned
+  // tasks before any of them go.
+  kj::TimerImpl timerImpl;
+  ::rust::Box<TokioPort> rustPort;
+  kj::Own<kj::EventLoop> loop;
+
+  // The earliest timer deadline wait() computed its sleep from (none = no timer; sleep forever).
+  // updateNextTimerEvent() compares against it so only a *sooner* deadline ends the park. Loop
+  // thread only; meaningful only inside wait().
+  kj::Maybe<kj::TimePoint> plannedNextEvent;
+
+  // Guards the Rust call in cancelSpawnedTasks(): a cancelled task's drop can throw (a panic
+  // surfaced as a kj::Exception by the cxx fork); if the caller is already unwinding, swallow
+  // rather than std::terminate (same pattern as ~RustPromiseAwaiter in kj-rs/awaiter.c++).
+  kj::UnwindDetector unwindDetector;
+};
+
+// Mirrors the shape of kj::setupAsyncIo() (see kj/async-io.h) for the tokio-backed loop. Owns
+// the event port (and thus the per-thread tokio runtime and the kj::EventLoop) and the
+// kj::WaitScope.
+//
+// Teardown: spawned tasks are cancelled first, while the WaitScope is still alive (the port's
+// own destructor would do it too, but by then the WaitScope is gone), then the WaitScope, then
+// the port (loop, runtime, timer -- see TokioEventPort). Bridged Rust futures that C++ co_awaits
+// are separate: they are cancelled through KJ promise destruction and never outlive the loop.
+struct TokioAsyncIoContext {
+  TokioAsyncIoContext(kj::Own<TokioEventPort> port, kj::Own<kj::WaitScope> waitScope)
+      : port(kj::mv(port)),
+        waitScope(kj::mv(waitScope)) {}
+  ~TokioAsyncIoContext() noexcept(false);
+  // Move-CONSTRUCTIBLE only (setupTokioAsyncIo() returns by value; a moved-from context owns
+  // nothing and its destructor is a no-op). Move-ASSIGNMENT is deleted on purpose: it would
+  // destroy the existing members via their kj::Owns without running ~TokioAsyncIoContext first.
+  // Return-by-value needs only the move constructor, so nothing is lost.
+  TokioAsyncIoContext(TokioAsyncIoContext &&) = default;
+  TokioAsyncIoContext &operator=(TokioAsyncIoContext &&) = delete;
+  KJ_DISALLOW_COPY(TokioAsyncIoContext);
+
+  kj::Own<TokioEventPort> port;
+  kj::Own<kj::WaitScope> waitScope;
+
+  TokioEventPort &getPort() {
+    return *port;
+  }
+  kj::EventLoop &getLoop() {
+    return port->getLoop();
+  }
+  kj::WaitScope &getWaitScope() {
+    return *waitScope;
+  }
+  kj::Timer &getTimer() {
+    return port->getTimer();
+  }
+};
+
+TokioAsyncIoContext setupTokioAsyncIo();
+
+}  // namespace kj_rs_tokio

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
@@ -81,6 +81,7 @@ class TokioEventPort final: public kj::EventPort, private kj::TimerImpl::SleepHo
 
   // The kj::EventLoop this port drives. Owned by the port (see the file comment).
   kj::EventLoop &getLoop() {
+    assertOwnerThread();
     return *loop;
   }
 
@@ -88,12 +89,14 @@ class TokioEventPort final: public kj::EventPort, private kj::TimerImpl::SleepHo
   // waits/polls, preserving stock KJ timer semantics (the port calls timerImpl.advanceTo() after
   // every wait()/poll() return; timers would silently never fire otherwise).
   kj::Timer &getTimer() {
+    assertOwnerThread();
     return timerImpl;
   }
 
   // The Rust half (runtime + wake state). Rust code on this thread can also reach the runtime
   // via kj_rs_tokio::current_handle() / kj_rs_tokio::spawn().
   const TokioPort &getRustPort() const {
+    assertOwnerThread();
     return *rustPort;
   }
 
@@ -109,9 +112,13 @@ class TokioEventPort final: public kj::EventPort, private kj::TimerImpl::SleepHo
   // kj::Timer::now() reads the live clock through getTimeWhileSleeping().
   void updateNextTimerEvent(kj::Maybe<kj::TimePoint> time) override;
   kj::TimePoint getTimeWhileSleeping() override {
+    assertOwnerThread();
     return clock.now();
   }
 
+  void assertOwnerThread() const;
+
+  const kj::ThreadId ownerThread;
   const kj::MonotonicClock &clock;
   // Declaration order is destruction order in reverse, and it matters: `loop` is destroyed
   // first, then `rustPort` (the runtime), then `timerImpl`. The destructor body cancels spawned

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
@@ -151,13 +151,7 @@ struct TokioAsyncIoContext {
       : port(kj::mv(port)),
         waitScope(kj::mv(waitScope)) {}
   ~TokioAsyncIoContext() noexcept(false);
-  // Move-CONSTRUCTIBLE only (setupTokioAsyncIo() returns by value; a moved-from context owns
-  // nothing and its destructor is a no-op). Move-ASSIGNMENT is deleted on purpose: it would
-  // destroy the existing members via their kj::Owns without running ~TokioAsyncIoContext first.
-  // Return-by-value needs only the move constructor, so nothing is lost.
-  TokioAsyncIoContext(TokioAsyncIoContext &&) = default;
-  TokioAsyncIoContext &operator=(TokioAsyncIoContext &&) = delete;
-  KJ_DISALLOW_COPY(TokioAsyncIoContext);
+  KJ_DISALLOW_COPY_AND_MOVE(TokioAsyncIoContext);
 
   kj::Own<TokioEventPort> port;
   kj::Own<kj::WaitScope> waitScope;

--- a/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
+++ b/src/rust/cxx/kj-rs-tokio/tokio-event-port.h
@@ -31,7 +31,7 @@
 //       ├── Own<TokioEventPort>               -- the kj::EventPort; one per thread
 //       │       ├── kj::TimerImpl             -- fed from wait()/poll(); declared BEFORE the
 //       │       │                                 Rust half so it outlives cancelled tasks
-//       │       ├── rust::Box<TokioPort>      -- Send + Sync (wake() is called cross-thread)
+//       │       ├── rust::Box<TokioPort>      -- Sync but not Send; wake() is cross-thread
 //       │       │       ├── tokio::Runtime (current_thread, I/O + time drivers)
 //       │       │       └── Arc<SharedState>  -- Notify + `woken` latch + `in_wait` flag; the
 //       │       │                                ONE thing every wake source touches
@@ -102,7 +102,7 @@ class TokioEventPort final: public kj::EventPort, private kj::TimerImpl::SleepHo
 
   // Cancel every task spawned onto this thread's LocalSet (kj_rs_tokio::spawn()), running their
   // destructors now. The destructor does this itself, first; TokioAsyncIoContext also does it
-  // while its WaitScope is still alive. Idempotent.
+  // while its WaitScope is still alive. This terminal operation is a no-op when repeated.
   void cancelSpawnedTasks();
 
  private:

--- a/src/rust/cxx/kj-rs/BUILD.bazel
+++ b/src/rust/cxx/kj-rs/BUILD.bazel
@@ -51,6 +51,10 @@ rust_cxx_bridge(
     deps = [
         "//src/rust/cxx:core",
         "@capnp-cpp//src/kj:kj",
-        "@capnp-cpp//src/kj:kj-async",
+        # kj-rs is the base cxx<->rust Promise/Future bridge: it uses only the abstract async
+        # core (kj::Promise / kj::EventLoop via async.h), no kj OS I/O. Depending on
+        # :kj-async-core (not the :kj-async umbrella) keeps the whole kj-rs stack -- and thus
+        # kj-rs-io / kj-rs-tokio built on it -- off the concrete kj OS event loop (:kj-async-os).
+        "@capnp-cpp//src/kj:kj-async-core",
     ],
 )

--- a/src/rust/cxx/kj-rs/future.h
+++ b/src/rust/cxx/kj-rs/future.h
@@ -85,6 +85,11 @@ struct RustFuture {
 
   template <typename T>
   operator kj::Promise<T>() {
+    return lazily<T>().eagerlyEvaluate(nullptr);
+  }
+
+  template <typename T>
+  kj::Promise<T> lazily() {
     struct Impl {
       using ExceptionOrValue = ::kj::_::ExceptionOr<::kj::_::FixVoid<T>>;
       using Output = ::kj::_::FixVoid<T>;

--- a/src/rust/cxx/kj-rs/future.h
+++ b/src/rust/cxx/kj-rs/future.h
@@ -83,13 +83,15 @@ using DropCallback = void (*)(void /* RustFuture::fut */* fut);
 // which drops the Rust Future and transitively cancels any KJ sub-promises it was .await'ing.
 struct RustFuture {
 
+  // Start polling without waiting for a consumer. The caller retains cancellation ownership.
   template <typename T>
-  operator kj::Promise<T>() {
-    return lazily<T>().eagerlyEvaluate(nullptr);
+  kj::Promise<T> eagerly() {
+    return static_cast<kj::Promise<T>>(*this).eagerlyEvaluate(nullptr);
   }
 
+  // Keep the Rust future cold until the returned promise is polled or explicitly started.
   template <typename T>
-  kj::Promise<T> lazily() {
+  operator kj::Promise<T>() {
     struct Impl {
       using ExceptionOrValue = ::kj::_::ExceptionOr<::kj::_::FixVoid<T>>;
       using Output = ::kj::_::FixVoid<T>;

--- a/src/rust/cxx/kj-rs/tests/awaitables-cc-test.c++
+++ b/src/rust/cxx/kj-rs/tests/awaitables-cc-test.c++
@@ -8,6 +8,11 @@
 
 #include <kj/test.h>
 
+extern "C" {
+void kj_rs_demo_work_before_poll(uint64_t* target, ::kj_rs::repr::RustFuture* out);
+void kj_rs_demo_lazy_future_awaiting_cancellable_promise(::kj_rs::repr::RustFuture* out);
+}
+
 namespace kj_rs_demo {
 namespace {
 
@@ -218,8 +223,19 @@ KJ_TEST("Work before poll") {
   uint64_t val = 0;
   // It should be possible for rust function to do work before returning the future
   // even if we don't poll or cancel it.
-  auto promise = work_before_poll(val);
+  ::kj_rs::repr::RustFuture fut;
+  kj_rs_demo_work_before_poll(&val, &fut);
+  auto promise = fut.lazily<void>();
   KJ_EXPECT(val == 42);
+}
+
+KJ_TEST("bridged async functions run eagerly at promise creation") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  reset_side_effect_counter();
+  { auto promise = new_side_effect_future_void(); }
+  KJ_EXPECT(get_side_effect_counter() == 1);
 }
 
 // TODO(someday): More test cases.
@@ -240,7 +256,11 @@ KJ_TEST("Cancellation: drop never-polled Rust future") {
   kj::EventLoop loop;
   kj::WaitScope waitScope(loop);
 
-  { auto promise = new_future_awaiting_cancellable_promise(); }
+  {
+    ::kj_rs::repr::RustFuture fut;
+    kj_rs_demo_lazy_future_awaiting_cancellable_promise(&fut);
+    auto promise = fut.lazily<void>();
+  }
 }
 
 KJ_TEST("Cancellation: C++ dropping promise cancels Rust future's awaited KJ promise") {

--- a/src/rust/cxx/kj-rs/tests/awaitables-cc-test.c++
+++ b/src/rust/cxx/kj-rs/tests/awaitables-cc-test.c++
@@ -11,6 +11,7 @@
 extern "C" {
 void kj_rs_demo_work_before_poll(uint64_t* target, ::kj_rs::repr::RustFuture* out);
 void kj_rs_demo_lazy_future_awaiting_cancellable_promise(::kj_rs::repr::RustFuture* out);
+void kj_rs_demo_side_effect_future(::kj_rs::repr::RustFuture* out);
 }
 
 namespace kj_rs_demo {
@@ -225,17 +226,56 @@ KJ_TEST("Work before poll") {
   // even if we don't poll or cancel it.
   ::kj_rs::repr::RustFuture fut;
   kj_rs_demo_work_before_poll(&val, &fut);
-  auto promise = fut.lazily<void>();
+  kj::Promise<void> promise = fut;
   KJ_EXPECT(val == 42);
 }
 
-KJ_TEST("bridged async functions run eagerly at promise creation") {
+KJ_TEST("bridged async functions stay cold until awaited") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  reset_side_effect_counter();
+  auto promise = new_side_effect_future_void();
+  KJ_EXPECT(get_side_effect_counter() == 0);
+  kj::evalLater([]() {}).wait(waitScope);
+  KJ_EXPECT(get_side_effect_counter() == 0);
+  promise.wait(waitScope);
+  KJ_EXPECT(get_side_effect_counter() == 1);
+}
+
+KJ_TEST("dropping a cold bridged future does not enter its body") {
   kj::EventLoop loop;
   kj::WaitScope waitScope(loop);
 
   reset_side_effect_counter();
   { auto promise = new_side_effect_future_void(); }
+  KJ_EXPECT(get_side_effect_counter() == 0);
+}
+
+KJ_TEST("explicit eager conversion starts a bridged future") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  reset_side_effect_counter();
+  ::kj_rs::repr::RustFuture fut;
+  kj_rs_demo_side_effect_future(&fut);
+  auto promise = fut.eagerly<void>();
   KJ_EXPECT(get_side_effect_counter() == 1);
+  promise.wait(waitScope);
+}
+
+KJ_TEST("canceling an explicitly started future cancels its KJ dependency") {
+  kj::EventLoop loop;
+  kj::WaitScope waitScope(loop);
+
+  reset_cancellation_counter();
+  {
+    ::kj_rs::repr::RustFuture fut;
+    kj_rs_demo_lazy_future_awaiting_cancellable_promise(&fut);
+    auto promise = fut.eagerly<void>();
+    KJ_EXPECT(!promise.poll(waitScope));
+  }
+  KJ_EXPECT(get_cancellation_counter() == 1);
 }
 
 // TODO(someday): More test cases.
@@ -259,7 +299,7 @@ KJ_TEST("Cancellation: drop never-polled Rust future") {
   {
     ::kj_rs::repr::RustFuture fut;
     kj_rs_demo_lazy_future_awaiting_cancellable_promise(&fut);
-    auto promise = fut.lazily<void>();
+    kj::Promise<void> promise = fut;
   }
 }
 

--- a/src/rust/cxx/kj-rs/tests/lib.rs
+++ b/src/rust/cxx/kj-rs/tests/lib.rs
@@ -14,6 +14,7 @@ mod test_refcount;
 
 use kj_rs::KjOwn;
 use test_futures::clear_retained_waker;
+use test_futures::get_side_effect_counter;
 use test_futures::new_drop_cancellable_promise_without_polling;
 use test_futures::new_error_handling_future_void_infallible;
 use test_futures::new_errored_future_void;
@@ -27,11 +28,13 @@ use test_futures::new_ready_future_i32;
 use test_futures::new_ready_future_void;
 use test_futures::new_retained_waker_future_void;
 use test_futures::new_select_with_cancellation;
+use test_futures::new_side_effect_future_void;
 use test_futures::new_threaded_delay_future_void;
 use test_futures::new_two_step_cancellable_future;
 use test_futures::new_waking_future_void;
 use test_futures::new_wrapped_waker_future_void;
 use test_futures::poll_and_stash_promise_future;
+use test_futures::reset_side_effect_counter;
 use test_futures::unstash_and_await_promise_future;
 use test_futures::wake_retained_waker_from_background_thread;
 use test_maybe::take_maybe_own;
@@ -283,6 +286,10 @@ pub mod ffi {
 
         async unsafe fn work_before_poll<'a>(target: &'a mut u64) -> Result<()>;
 
+        fn reset_side_effect_counter();
+        fn get_side_effect_counter() -> u64;
+        async fn new_side_effect_future_void();
+
         // Cancellation test helpers.
         async fn new_future_awaiting_cancellable_promise() -> Result<()>;
         async fn new_two_step_cancellable_future() -> Result<()>;
@@ -361,6 +368,25 @@ fn work_before_poll(target: &mut u64) -> impl Future<Output = Result<()>> {
     async move {
         unimplemented!("not expected to be polled");
     }
+}
+
+/// # Safety
+///
+/// `out` must point to aligned, writable, uninitialized storage for one `RustFuture`,
+/// disjoint from `target`. The caller takes ownership and must consume or drop the
+/// returned future exactly once.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kj_rs_demo_work_before_poll<'a>(
+    target: &'a mut u64,
+    out: *mut kj_rs::repr::RustFuture<'a, ()>,
+) {
+    let fut = kj_rs::repr::future(Box::pin(kj_rs::map_err(
+        work_before_poll(target),
+        file!(),
+        line!(),
+    )));
+    // Safety: the C++ caller passes uninitialized storage for one RustFuture and takes ownership.
+    unsafe { out.write(fut) };
 }
 
 #[cfg(test)]

--- a/src/rust/cxx/kj-rs/tests/test_futures.rs
+++ b/src/rust/cxx/kj-rs/tests/test_futures.rs
@@ -12,6 +12,20 @@ use std::task::Poll;
 use std::task::Wake;
 use std::task::Waker;
 
+static SIDE_EFFECT_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+pub fn reset_side_effect_counter() {
+    SIDE_EFFECT_COUNTER.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
+pub fn get_side_effect_counter() -> u64 {
+    SIDE_EFFECT_COUNTER.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+pub async fn new_side_effect_future_void() {
+    SIDE_EFFECT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+}
+
 use crate::Error;
 use crate::Result;
 use crate::ffi::CloningAction;
@@ -290,6 +304,26 @@ pub async fn new_future_awaiting_cancellable_promise() -> Result<()> {
         .await
         .map_err(Error::other)?;
     Ok(())
+}
+
+pub async fn new_lazy_future_awaiting_cancellable_promise() -> Result<()> {
+    crate::ffi::new_cancellation_detecting_promise_void()
+        .await
+        .map_err(Error::other)?;
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kj_rs_demo_lazy_future_awaiting_cancellable_promise(
+    out: *mut kj_rs::repr::RustFuture<'static, ()>,
+) {
+    let fut = kj_rs::repr::future(Box::pin(kj_rs::map_err(
+        new_lazy_future_awaiting_cancellable_promise(),
+        file!(),
+        line!(),
+    )));
+    // Safety: the C++ caller passes uninitialized storage for one RustFuture and takes ownership.
+    unsafe { out.write(fut) };
 }
 
 /// Two-step future: the first step completes normally, and the second step awaits a

--- a/src/rust/cxx/kj-rs/tests/test_futures.rs
+++ b/src/rust/cxx/kj-rs/tests/test_futures.rs
@@ -26,6 +26,19 @@ pub async fn new_side_effect_future_void() {
     SIDE_EFFECT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 }
 
+/// # Safety
+///
+/// `out` must point to aligned, writable, uninitialized storage for one `RustInfallibleFuture`.
+/// The caller takes ownership and must consume or drop the returned future exactly once.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kj_rs_demo_side_effect_future(
+    out: *mut kj_rs::repr::RustInfallibleFuture<'static, ()>,
+) {
+    let fut = kj_rs::repr::infallible_future(Box::pin(new_side_effect_future_void()));
+    // Safety: the C++ caller supplies storage for the ABI-compatible RustFuture and takes ownership.
+    unsafe { out.write(fut) };
+}
+
 use crate::Error;
 use crate::Result;
 use crate::ffi::CloningAction;
@@ -313,6 +326,10 @@ pub async fn new_lazy_future_awaiting_cancellable_promise() -> Result<()> {
     Ok(())
 }
 
+/// # Safety
+///
+/// `out` must point to aligned, writable, uninitialized storage for one `RustFuture`.
+/// The caller takes ownership and must consume or drop the returned future exactly once.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kj_rs_demo_lazy_future_awaiting_cancellable_promise(
     out: *mut kj_rs::repr::RustFuture<'static, ()>,


### PR DESCRIPTION
This draft runs CI for the Tokio-backed KJ event port and I/O provider using the existing ArcWaker bridge. It includes the abstract-async-core prerequisite and the review fixes, without the persistent-waker-cell/shared-sink redesign. RustFuture conversion is cold by default at the tip; the socket-write adapter explicitly starts writes so HTTP headers can make progress.

Read the 71-commit series commit by commit: runtime setup, the event port, I/O operations, tests, and corrective commits marked `[fix]` are separated. Fixes needed to keep intermediate commits buildable are folded into their introducing commits.

The earlier eager-conversion step remains in this history to preserve buildable intermediate commits. The [final commit](https://github.com/cloudflare/workerd/commit/ba27630e0f45eda119f02e4236f611dc9acd6a07) restores cold conversion, replaces `lazily()` with explicit `eagerly()`, and adapts the independent writer/pump test callers and signal documentation. Read those two commits together when evaluating the final promise behavior. [The prerequisite draft](https://github.com/cloudflare/workerd/pull/7317) now contains only the async-core dependency change.

Linux validation: the final full Rust run passed all 52 executed targets (`tsan:race` skipped); recursive bridge lint and changed-file formatting passed. An initial run failed the existing `long sleeps are accurate` test's precise-clock lower bound. A temporary 5 ms pause before measurement reproduced that assertion on the eager baseline: `afterDelay()` uses cached loop time, not the precise clock. That diagnostic edit is not included, and the test assumption remains unresolved.

Assisted-by: Codex:gpt-6-astra
