### PR TITLE
Refresh the regenerated Shapely test archive checksum

### DIFF
--- a/build/python_metadata.bzl
+++ b/build/python_metadata.bzl
@@ -169,7 +169,7 @@ BUNDLE_VERSION_INFO = _make_bundle_version_info([
             {
                 "name": "shapely",
                 "abi": "3.13",
-                "sha256": "2e5c462cb32ee8697b3647dfc9d5c88dcdfd0702da34a2d7dc6b07b8090dd321",
+                "sha256": "67300050ba000bc08f10029ecd300a529132b99acaeba85cc1331205cb6d803b",
             },
         ],
     },


### PR DESCRIPTION
CI cannot fetch the Python 3.13 vendored Shapely fixture because the ZIP served at its existing R2 URL was regenerated. This updates the expected SHA-256 to the currently served archive.

Compared against a cached original whose checksum matches the old pin, the Shapely 2.0.7 and NumPy 2.2.5 implementation files are byte-identical. Differences are ZIP timestamps, generated virtualenv/support files, and NumPy script installation metadata. The changed `_virtualenv.py` exactly matches [uv's published helper](https://github.com/astral-sh/uv/blob/e91ebe8f66feaca28f03cadd476d54793d281b1b/crates/uv-virtualenv/src/_virtualenv.py). Archive paths were checked for traversal, duplicates, and symlinks. This payload comparison does not establish who reuploaded the object.

Validation: downloaded archive SHA-256 and per-file content comparison verified. Both the normal and explicitly enabled GC-stress vendored Shapely targets passed uncached on Linux, including their snapshot/import checks. This remains a draft for CI and review.

Assisted-by: Codex:gpt-6-astra
