### PR TITLE
Document KJ exception handling in C++ reviews

### DIFF
--- a/docs/reference/api-review-checklist.md
+++ b/docs/reference/api-review-checklist.md
@@ -43,7 +43,7 @@ End-to-end, real-world performance is the priority over micro-optimizations.
 - **Never** recommend or approve changing/inverting the meaning of an existing compatibility flag.
 - **Never** suggest the compatibility flag checks are "dead code" that can be removed. Compatibility flags are permanent and must be maintained indefinitely, even if there is nothing apparently depending on them.
 - **Always** review consistency with existing API patterns
-- **Always** prefer KJ_TRY/KJ_CATCH over raw try/catch and JSG_TRY/JSG_CATCH over jsg::Lock::tryCatch (e.g. `js.tryCatch(fn)`)
+- **Always** prefer `JSG_TRY` / `JSG_CATCH` over `jsg::Lock::tryCatch` (e.g. `js.tryCatch(fn)`)
 
 ### Security Vulnerabilities
 

--- a/docs/reference/detail/review-checklist.md
+++ b/docs/reference/detail/review-checklist.md
@@ -5,6 +5,8 @@ When reviewing workerd C++ code, check for each of these items.
 - **Always** check for STL leaking in: `std::string`, `std::vector`, `std::optional`, `std::unique_ptr`, etc.
 - **Never** allow raw `new`/`delete`**. Should be `kj::heap<T>()` or similar
 - **Never** use `throw` statements. Should use `KJ_ASSERT`/`KJ_REQUIRE`/`KJ_FAIL_ASSERT`/etc
+- **Always** prefer `KJ_TRY` / `KJ_CATCH` over raw `try` / `catch`, including in tests, when catchable exceptions should be normalized to `kj::Exception`.
+- **Always** rethrow from `KJ_CATCH` with `kj::throwFatalException(kj::mv(exception))`, not `throw;`. The body is not a real C++ catch handler, and `kj::throwFatalException()` extends the stack trace after `kj::getCaughtExceptionAsKj()` truncated its common portion.
 - **Never** use `noexcept`
 - **Always** use `noexcept(false)` on explicit destructors
 - **Never** use `[=]` lambda captures


### PR DESCRIPTION
General KJ exception-handling guidance was only reachable through the API
review checklist, so ordinary C++ reviews could miss it. This puts the
`KJ_TRY` / `KJ_CATCH` rule in the mandatory C++ checklist, including the
stack-trace handling needed when rethrowing, while leaving the JSG-specific
advice with API review.

Assisted-by: Codex:gpt-5.6-sol
