### PR TITLE
Prevent internal exception details from reaching JavaScript

### DIFF
--- a/src/workerd/api/crypto/ec.c++
+++ b/src/workerd/api/crypto/ec.c++
@@ -577,7 +577,7 @@ kj::Own<EVP_PKEY> ellipticJwkReader(
     }
 
     auto x = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.x), DOMDataError, "Invalid ", crv,
-        " key in JSON WebKey; missing or invalid public key component (\"x\").");
+        " key in JSON WebKey: missing or invalid public key component (\"x\").");
     JSG_REQUIRE(x.size() == 32, DOMDataError, "Invalid length ", x.size(), " for public key");
 
     if (keyDataJwk.d == kj::none) {
@@ -596,7 +596,7 @@ kj::Own<EVP_PKEY> ellipticJwkReader(
     // seems to throw it away when a private key is provided.
 
     auto d = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.d), DOMDataError, "Invalid ", curveName,
-        " key in JSON Web Key; missing or invalid private key component (\"d\").");
+        " key in JSON Web Key: missing or invalid private key component (\"d\").");
     JSG_REQUIRE(d.size() == 32, DOMDataError, "Invalid length ", d.size(), " for private key");
 
     return OSSLCALL_OWN(EVP_PKEY, EVP_PKEY_new_raw_private_key(evpId, nullptr, d.begin(), d.size()),
@@ -634,9 +634,9 @@ kj::Own<EVP_PKEY> ellipticJwkReader(
       "Error importing EC key", tryDescribeOpensslErrors());
 
   auto x = UNWRAP_JWK_BIGNUM(
-      kj::mv(keyDataJwk.x), DOMDataError, "Invalid EC key in JSON Web Key; missing \"x\".");
+      kj::mv(keyDataJwk.x), DOMDataError, "Invalid EC key in JSON Web Key: missing \"x\".");
   auto y = UNWRAP_JWK_BIGNUM(
-      kj::mv(keyDataJwk.y), DOMDataError, "Invalid EC key in JSON Web Key; missing \"y\".");
+      kj::mv(keyDataJwk.y), DOMDataError, "Invalid EC key in JSON Web Key: missing \"y\".");
 
   auto group = EC_KEY_get0_group(ecKey);
 
@@ -647,23 +647,23 @@ kj::Own<EVP_PKEY> ellipticJwkReader(
 
   auto point = OSSL_NEW(EC_POINT, group);
   JSG_REQUIRE(1 == EC_POINT_set_affine_coordinates_GFp(group, point, bigX, bigY, nullptr),
-      DOMOperationError, "Invalid EC key; public key coordinates \"x\" and \"y\" are invalid",
+      DOMOperationError, "Invalid EC key: public key coordinates \"x\" and \"y\" are invalid",
       tryDescribeOpensslErrors());
   JSG_REQUIRE(1 == EC_KEY_set_public_key(ecKey, point), DOMOperationError,
-      "Invalid EC key; public key coordinates \"x\" and \"y\" are invalid",
+      "Invalid EC key: public key coordinates \"x\" and \"y\" are invalid",
       tryDescribeOpensslErrors());
 
   if (keyDataJwk.d != kj::none) {
     // This is a private key.
 
     auto d = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.d), DOMDataError,
-        "Invalid EC key in JSON Web Key; missing or invalid private key component (\"d\").");
+        "Invalid EC key in JSON Web Key: missing or invalid private key component (\"d\").");
 
     auto bigD = JSG_REQUIRE_NONNULL(toBignum(d), InternalDOMOperationError,
         "Error importing EC key", internalDescribeOpensslErrors());
 
     JSG_REQUIRE(1 == EC_KEY_set_private_key(ecKey, bigD), DOMOperationError,
-        "Invalid EC key; "
+        "Invalid EC key: "
         "private key component \"d\" is invalid",
         tryDescribeOpensslErrors());
   }

--- a/src/workerd/api/crypto/keys.c++
+++ b/src/workerd/api/crypto/keys.c++
@@ -406,7 +406,7 @@ AsymmetricKeyData importAsymmetricForWebCrypto(jsg::Lock& js,
         for (const auto& op: ops) {
           JSG_REQUIRE(normalizedName != "ECDH" && normalizedName != "X25519", DOMDataError,
               "A JSON Web Key should have either a Public Key Use parameter (\"use\") or a Key "
-              "Operations parameter (\"key_ops\"); otherwise, the parameters must be consistent "
+              "Operations parameter (\"key_ops\"). Otherwise, the parameters must be consistent "
               "with each other. For public ",
               normalizedName,
               " keys, there are no valid usages,"
@@ -416,7 +416,7 @@ AsymmetricKeyData importAsymmetricForWebCrypto(jsg::Lock& js,
           //   using the Web Crypto API...
           JSG_REQUIRE(op == op0 || op == op1, DOMDataError,
               "A JSON Web Key should have either a Public Key Use parameter (\"use\") or a Key "
-              "Operations parameter (\"key_ops\"); otherwise, the parameters must be consistent "
+              "Operations parameter (\"key_ops\"). Otherwise, the parameters must be consistent "
               "with each other. A Public Key Use for ",
               normalizedName,
               " would allow a Key "

--- a/src/workerd/api/crypto/rsa.c++
+++ b/src/workerd/api/crypto/rsa.c++
@@ -242,15 +242,15 @@ kj::Maybe<AsymmetricKeyData> Rsa::fromJwk(
 
   if (jwk.kty != "RSA"_kj) return kj::none;
   auto n = JSG_REQUIRE_NONNULL(jwk.n.map([](auto& str) { return str.asPtr(); }), Error,
-      "Invalid RSA key in JSON Web Key; missing or invalid "
+      "Invalid RSA key in JSON Web Key: missing or invalid "
       "Modulus parameter (\"n\").");
   auto e = JSG_REQUIRE_NONNULL(jwk.e.map([](auto& str) { return str.asPtr(); }), Error,
-      "Invalid RSA key in JSON Web Key; missing or invalid "
+      "Invalid RSA key in JSON Web Key: missing or invalid "
       "Exponent parameter (\"e\").");
 
   auto rsa = OSSL_NEW(RSA);
 
-  static constexpr auto kInvalidBase64Error = "Invalid RSA key in JSON Web Key; invalid base64."_kj;
+  static constexpr auto kInvalidBase64Error = "Invalid RSA key in JSON Web Key: invalid base64."_kj;
 
   auto nBuf = simdutfBase64UrlDecodeChecked(js, n, kInvalidBase64Error);
   auto nDecoded = toBignumOwned(nBuf.asArrayPtr());
@@ -263,22 +263,22 @@ kj::Maybe<AsymmetricKeyData> Rsa::fromJwk(
 
   if (keyType == KeyType::PRIVATE) {
     auto d = JSG_REQUIRE_NONNULL(jwk.d.map([](auto& str) { return str.asPtr(); }), Error,
-        "Invalid RSA key in JSON Web Key; missing or invalid "
+        "Invalid RSA key in JSON Web Key: missing or invalid "
         "Private Exponent parameter (\"d\").");
     auto p = JSG_REQUIRE_NONNULL(jwk.p.map([](auto& str) { return str.asPtr(); }), Error,
-        "Invalid RSA key in JSON Web Key; missing or invalid "
+        "Invalid RSA key in JSON Web Key: missing or invalid "
         "First Prime Factor parameter (\"p\").");
     auto q = JSG_REQUIRE_NONNULL(jwk.q.map([](auto& str) { return str.asPtr(); }), Error,
-        "Invalid RSA key in JSON Web Key; missing or invalid "
+        "Invalid RSA key in JSON Web Key: missing or invalid "
         "Second Prime Factor parameter (\"q\").");
     auto dp = JSG_REQUIRE_NONNULL(jwk.dp.map([](auto& str) { return str.asPtr(); }), Error,
-        "Invalid RSA key in JSON Web Key; missing or invalid "
+        "Invalid RSA key in JSON Web Key: missing or invalid "
         "First Factor CRT Exponent parameter (\"dp\").");
     auto dq = JSG_REQUIRE_NONNULL(jwk.dq.map([](auto& str) { return str.asPtr(); }), Error,
-        "Invalid RSA key in JSON Web Key; missing or invalid "
+        "Invalid RSA key in JSON Web Key: missing or invalid "
         "Second Factor CRT Exponent parameter (\"dq\").");
     auto qi = JSG_REQUIRE_NONNULL(jwk.qi.map([](auto& str) { return str.asPtr(); }), Error,
-        "Invalid RSA key in JSON Web Key; missing or invalid "
+        "Invalid RSA key in JSON Web Key: missing or invalid "
         "First CRT Coefficient parameter (\"qi\").");
     auto dBuf = simdutfBase64UrlDecodeChecked(js, d, "Invalid RSA key in JSON Web Key"_kj);
     auto dDecoded = toBignumOwned(dBuf.asArrayPtr());
@@ -752,10 +752,10 @@ kj::Own<EVP_PKEY> rsaJwkReader(SubtleCrypto::JsonWebKey&& keyDataJwk) {
   auto rsaKey = OSSL_NEW(RSA);
 
   auto modulus = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.n), DOMDataError,
-      "Invalid RSA key in JSON Web Key; missing or invalid Modulus "
+      "Invalid RSA key in JSON Web Key: missing or invalid Modulus "
       "parameter (\"n\").");
   auto publicExponent = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.e), DOMDataError,
-      "Invalid RSA key in JSON Web Key; missing or invalid "
+      "Invalid RSA key in JSON Web Key: missing or invalid "
       "Exponent parameter (\"e\").");
 
   auto nBignum = toBignumOwned(modulus);
@@ -768,7 +768,7 @@ kj::Own<EVP_PKEY> rsaJwkReader(SubtleCrypto::JsonWebKey&& keyDataJwk) {
     // This is a private key.
 
     auto privateExponent = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.d), DOMDataError,
-        "Invalid RSA key in JSON Web Key; missing or invalid "
+        "Invalid RSA key in JSON Web Key: missing or invalid "
         "Private Exponent parameter (\"d\").");
 
     auto dBignum = toBignumOwned(privateExponent);
@@ -780,19 +780,19 @@ kj::Own<EVP_PKEY> rsaJwkReader(SubtleCrypto::JsonWebKey&& keyDataJwk) {
 
     if (presence == 5) {
       auto firstPrimeFactor = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.p), DOMDataError,
-          "Invalid RSA key in JSON Web Key; invalid First Prime "
+          "Invalid RSA key in JSON Web Key: invalid First Prime "
           "Factor parameter (\"p\").");
       auto secondPrimeFactor = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.q), DOMDataError,
-          "Invalid RSA key in JSON Web Key; invalid Second Prime "
+          "Invalid RSA key in JSON Web Key: invalid Second Prime "
           "Factor parameter (\"q\").");
       auto firstFactorCrtExponent = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.dp), DOMDataError,
-          "Invalid RSA key in JSON Web Key; invalid First Factor "
+          "Invalid RSA key in JSON Web Key: invalid First Factor "
           "CRT Exponent parameter (\"dp\").");
       auto secondFactorCrtExponent = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.dq), DOMDataError,
-          "Invalid RSA key in JSON Web Key; invalid Second Factor "
+          "Invalid RSA key in JSON Web Key: invalid Second Factor "
           "CRT Exponent parameter (\"dq\").");
       auto firstCrtCoefficient = UNWRAP_JWK_BIGNUM(kj::mv(keyDataJwk.qi), DOMDataError,
-          "Invalid RSA key in JSON Web Key; invalid First CRT "
+          "Invalid RSA key in JSON Web Key: invalid First CRT "
           "Coefficient parameter (\"qi\").");
 
       auto pBn = toBignumOwned(firstPrimeFactor);
@@ -810,7 +810,7 @@ kj::Own<EVP_PKEY> rsaJwkReader(SubtleCrypto::JsonWebKey&& keyDataJwk) {
       qiBn.release();
     } else {
       JSG_REQUIRE(presence == 0, DOMDataError,
-          "Invalid RSA private key in JSON Web Key; if one Prime "
+          "Invalid RSA private key in JSON Web Key: if one Prime "
           "Factor or CRT Exponent/Coefficient parameter is present, then they must all be "
           "present (\"p\", \"q\", \"dp\", \"dq\", \"qi\").");
     }

--- a/src/workerd/api/tests/crypto-impl-asymmetric-test.js
+++ b/src/workerd/api/tests/crypto-impl-asymmetric-test.js
@@ -92,6 +92,24 @@ export const ecdhJwkTest = {
       true,
       []
     );
+
+    for (const coordinate of ['x', 'y']) {
+      const invalidJwk = { ...publicJwk };
+      delete invalidJwk[coordinate];
+      await assert.rejects(
+        crypto.subtle.importKey(
+          'jwk',
+          invalidJwk,
+          { name: 'ECDH', namedCurve: 'P-256' },
+          true,
+          []
+        ),
+        {
+          name: 'DataError',
+          message: `Invalid EC key in JSON Web Key: missing "${coordinate}".`,
+        }
+      );
+    }
   },
 };
 

--- a/src/workerd/jsg/README.md
+++ b/src/workerd/jsg/README.md
@@ -195,6 +195,12 @@ brand, not a secret. Not represented in RTTI/generated types.
 
 ### Error Handling
 
+Tunneled native exceptions whose message contains `; ` are treated as internal errors, including
+when a serialized JavaScript error is attached. One `internal error; reference = ` fragment is
+allowed anywhere in the message, but any `; ` before or after it is rejected. Transport and assertion
+prefixes are removed before this check. Internal diagnostics remain in native logs, not in the
+JavaScript error message.
+
 | Macro                                      | Description                                   |
 | ------------------------------------------ | --------------------------------------------- |
 | `JSG_REQUIRE(cond, type, msg...)`          | Throw JS error if condition false             |

--- a/src/workerd/jsg/exception.c++
+++ b/src/workerd/jsg/exception.c++
@@ -23,6 +23,15 @@ constexpr auto ERROR_TUNNELED_PREFIX_JSG = "jsg."_kj;
 constexpr auto ERROR_INTERNAL_SOURCE_PREFIX_JSG = "jsg-internal."_kj;
 }  // namespace
 
+bool hasInternalExceptionDetails(kj::StringPtr message) {
+  constexpr auto referenceMarker = "internal error; reference = "_kj;
+  KJ_IF_SOME(i, message.find(referenceMarker)) {
+    return message.first(i).contains(ERROR_PREFIX_DELIM) ||
+        message.slice(i + referenceMarker.size()).contains(ERROR_PREFIX_DELIM);
+  }
+  return message.contains(ERROR_PREFIX_DELIM);
+}
+
 TunneledErrorType tunneledErrorType(kj::StringPtr internalMessage) {
   // A tunneled error in an internal message is prefixed by one of the following patterns,
   // anchored at the beginning of the message:
@@ -66,24 +75,33 @@ TunneledErrorType tunneledErrorType(kj::StringPtr internalMessage) {
 
   auto tryExtractError = [](kj::StringPtr msg,
                              Properties properties) -> kj::Maybe<TunneledErrorType> {
+    // A remaining delimiter may introduce internal diagnostic fields. Fail closed, including
+    // disabling serialized-error restoration, rather than exposing any of this message to JS.
+    bool containsContext = msg.contains(ERROR_PREFIX_DELIM);
+    KJ_IF_SOME(i, msg.find(": "_kj)) {
+      containsContext = msg.first(i).contains(ERROR_PREFIX_DELIM) ||
+          hasInternalExceptionDetails(msg.slice(i + 2));
+    }
     if (msg.startsWith(ERROR_TUNNELED_PREFIX_JSG)) {
       return TunneledErrorType{
         .message = msg.slice(ERROR_TUNNELED_PREFIX_JSG.size()),
-        .isJsgError = true,
-        .isInternal = false,
+        .isJsgError = !containsContext,
+        .isInternal = containsContext,
         .isFromRemote = properties.isFromRemote,
         .isDurableObjectReset = properties.isDurableObjectReset,
         .isDoNotLogException = properties.isDoNotLogException,
+        .hasInternalDetails = containsContext,
       };
     }
     if (msg.startsWith(ERROR_INTERNAL_SOURCE_PREFIX_JSG)) {
       return TunneledErrorType{
         .message = msg.slice(ERROR_INTERNAL_SOURCE_PREFIX_JSG.size()),
-        .isJsgError = true,
+        .isJsgError = !containsContext,
         .isInternal = true,
         .isFromRemote = properties.isFromRemote,
         .isDurableObjectReset = properties.isDurableObjectReset,
         .isDoNotLogException = properties.isDoNotLogException,
+        .hasInternalDetails = containsContext,
       };
     }
 

--- a/src/workerd/jsg/exception.h
+++ b/src/workerd/jsg/exception.h
@@ -114,6 +114,9 @@ namespace workerd::jsg {
 // Given a KJ exception's description, strips any leading "remote exception: " prefixes.
 kj::StringPtr stripRemoteExceptionPrefix(kj::StringPtr internalMessage);
 
+// Checks a public message for diagnostic delimiters, allowing only the internal-error reference.
+bool hasInternalExceptionDetails(kj::StringPtr message);
+
 // Given a KJ exception's description, returns whether it contains a tunneled exception that could
 // be converted back to JavaScript via exceptionToJs().
 bool isTunneledException(kj::StringPtr internalMessage);
@@ -148,6 +151,9 @@ struct TunneledErrorType {
 
   // Does the error contain the "worker_do_not_log" magic constant?
   bool isDoNotLogException;
+
+  // Was a tunneled error blocked because its message may contain internal diagnostic fields?
+  bool hasInternalDetails = false;
 };
 
 TunneledErrorType tunneledErrorType(kj::StringPtr internalMessage);

--- a/src/workerd/jsg/function-test.c++
+++ b/src/workerd/jsg/function-test.c++
@@ -62,7 +62,7 @@ KJ_TEST("callbacks") {
   e.expectEval("callCallbackReturningBox(() => {\n"
                "  return 'foo';\n"
                "})",
-      "throws", "TypeError: Callback returned incorrect type; expected 'NumberBox'");
+      "throws", "TypeError: Callback returned incorrect type: expected 'NumberBox'");
 
   e.expectEval("class Frobber {\n"
                "  constructor(s, n) {\n"

--- a/src/workerd/jsg/jsg.c++
+++ b/src/workerd/jsg/jsg.c++
@@ -27,7 +27,7 @@ kj::String stringifyHandle(v8::Local<v8::Value> value) {
     if (*utf8 == nullptr) {
       return kj::str("(couldn't stringify)");
     } else {
-      return kj::str(*utf8);
+      return kj::str(kj::arrayPtr(*utf8, utf8.length()));
     }
   });
 }

--- a/src/workerd/jsg/util-test.c++
+++ b/src/workerd/jsg/util-test.c++
@@ -150,6 +150,14 @@ KJ_TEST("throw internal error") {
 // ========================================================================================
 
 struct TunneledContext: public ContextGlobalObject {
+  void throwDescription(kj::String description) {
+    kj::throwFatalException(
+        kj::Exception(kj::Exception::Type::FAILED, __FILE__, __LINE__, kj::mv(description)));
+  }
+  void throwSerializedException(jsg::Lock& js, v8::Local<v8::Value> value) {
+    auto exception = createTunneledException(js.v8Isolate, value);
+    js.throwException(kj::mv(exception), {.trusted = true});
+  }
   void throwTunneledTypeError() {
     JSG_FAIL_REQUIRE(TypeError, "thrown from throwTunneledTypeError");
   }
@@ -250,6 +258,8 @@ struct TunneledContext: public ContextGlobalObject {
 
   JSG_RESOURCE_TYPE(TunneledContext) {
     JSG_NESTED_TYPE(DOMException);
+    JSG_METHOD(throwDescription);
+    JSG_METHOD(throwSerializedException);
     JSG_METHOD(throwTunneledTypeError);
     JSG_METHOD(throwTunneledTypeErrorWithoutMessage);
     JSG_METHOD(throwTunneledTypeErrorLateColon);
@@ -340,6 +350,67 @@ KJ_TEST("throw tunneled exception") {
     e.expectEval("throwTunneledGarbledDOMException()", "throws",
         "Error: internal error; reference = 0123456789abcdefghijklmn");
   }
+}
+
+KJ_TEST("tunneled exceptions containing diagnostic delimiters are not exposed to JS") {
+  setPredictableModeForTest();
+  Evaluator<TunneledContext, TunneledIsolate> e(v8System);
+  for (auto prefix: {"jsg.Error: ", "jsg.TypeError: ", "jsg.DOMException(OperationError): ",
+         "jsg-internal.Error: ", "expected condition; jsg.Error: ",
+         "remote exception: remote.broken.outputGateBroken; jsg.Error: "}) {
+    auto description = kj::str(prefix, "Replica disconnected from primary.; ownerId = secret; ");
+    KJ_EXPECT(!isTunneledException(description));
+    KJ_EXPECT(extractTunneledExceptionDescription(description) == "Error: internal error");
+    KJ_EXPECT_LOG(ERROR, "ownerId = secret");
+    KJ_EXPECT_LOG(WARNING, "Almost returned an exception with internal details to user");
+    e.expectEval(kj::str("throwDescription('", description, "')"), "throws",
+        "Error: internal error; reference = 0123456789abcdefghijklmn");
+  }
+
+  e.expectEval("throwDescription('expected condition; jsg.Error: safe')", "throws", "Error: safe");
+  e.expectEval("throwDescription('remote.broken.outputGateBroken; jsg.Error: safe')", "throws",
+      "Error: safe");
+  e.expectEval(
+      "throwDescription('jsg.Error: safe;without-space')", "throws", "Error: safe;without-space");
+}
+
+KJ_TEST("serialized exceptions cannot bypass diagnostic delimiter protection") {
+  setPredictableModeForTest();
+  Evaluator<TunneledContext, TunneledIsolate> e(v8System);
+  for (auto message: {"public message; ownerId = secret", "public\\0; ownerId = secret",
+         "internal error; reference = abc; ownerId = secret"}) {
+    KJ_EXPECT_LOG(ERROR, "ownerId = secret");
+    KJ_EXPECT_LOG(WARNING, "Almost returned an exception with internal details to user");
+    e.expectEval(kj::str("try { throwSerializedException(new Error('", message,
+                     "')); } catch (e) { e.message; }"),
+        "string", "internal error; reference = 0123456789abcdefghijklmn");
+  }
+  e.expectEval("throwSerializedException(new TypeError('safe'))", "throws", "TypeError: safe");
+}
+
+KJ_TEST("internal-error references are the only allowed diagnostic delimiter") {
+  Evaluator<TunneledContext, TunneledIsolate> e(v8System);
+  for (auto prefix: {"jsg.Error: ", "jsg.TypeError: ", "jsg.DOMException(OperationError): ",
+         "remote exception: remote.broken.outputGateBroken; jsg.Error: "}) {
+    auto description = kj::str(prefix, "internal error; reference = abc");
+    KJ_EXPECT(isTunneledException(description));
+    e.expectEval(kj::str("try { throwDescription('", description, "'); } catch (e) { e.message; }"),
+        "string", "internal error; reference = abc");
+    KJ_EXPECT(!isTunneledException(kj::str(description, "; ownerId = secret")));
+  }
+  KJ_EXPECT(!isTunneledException("jsg.Error: public; internal error; reference = abc"));
+  KJ_EXPECT(!isTunneledException("jsg.Error: internal error; referenceOther = secret"));
+  KJ_EXPECT(
+      !isTunneledException("jsg.DOMException(internal; details): internal error; reference = abc"));
+  KJ_EXPECT(!hasInternalExceptionDetails("wrapper: internal error; reference = abc"));
+  KJ_EXPECT(
+      hasInternalExceptionDetails("ownerId = secret; wrapper: internal error; reference = abc"));
+  KJ_EXPECT(
+      hasInternalExceptionDetails("wrapper: internal error; reference = abc; ownerId = secret"));
+  e.expectEval("throwDescription('jsg.Error: wrapper: internal error; reference = abc')", "throws",
+      "Error: wrapper: internal error; reference = abc");
+  e.expectEval("throwSerializedException(new Error('internal error; reference = abc'))", "throws",
+      "Error: internal error; reference = abc");
 }
 
 KJ_TEST("runTunnelingExceptions") {

--- a/src/workerd/jsg/util.c++
+++ b/src/workerd/jsg/util.c++
@@ -195,6 +195,9 @@ DecodedException decodeTunneledException(
   //
   // TODO(someday): Support arbitrary user-defined error types, not just Error?
   auto tunneledInfo = tunneledErrorType(exception.getDescription());
+  if (tunneledInfo.hasInternalDetails) {
+    KJ_LOG(WARNING, "Almost returned an exception with internal details to user", exception);
+  }
   DecodedException result;
   result.isDisconnection = false;
   result.isDoNotLogException = tunneledInfo.isDoNotLogException;
@@ -534,7 +537,7 @@ static kj::String typeErrorMessage(TypeErrorContext c, const char* expectedType)
       return kj::str("Failed to execute function: parameter ", c.argumentIndex + 1,
           " is not of type '", expectedType, "'.");
     case TypeErrorContext::CALLBACK_RETURN:
-      return kj::str("Callback returned incorrect type; expected '", expectedType, "'");
+      return kj::str("Callback returned incorrect type: expected '", expectedType, "'");
     case TypeErrorContext::DICT_KEY:
       return kj::str("Incorrect type for map entry '", c.memberName,
           "': the provided key is not of type '", expectedType, "'.");
@@ -591,7 +594,11 @@ static kj::String unimplementedErrorMessage(TypeErrorContext c) {
 }
 
 void throwTypeError(v8::Isolate* isolate, kj::StringPtr message) {
-  isolate->ThrowException(v8::Exception::TypeError(v8Str(isolate, message)));
+  if (hasInternalExceptionDetails(message)) {
+    isolate->ThrowException(makeInternalError(isolate, message));
+  } else {
+    isolate->ThrowException(v8::Exception::TypeError(v8Str(isolate, message)));
+  }
   throw JsExceptionThrown();
 }
 


### PR DESCRIPTION
Reject diagnostic delimiters in tunneled exception messages, except for the internal-error reference marker. Log blocked exceptions and preserve embedded NULs so serialized errors cannot bypass the check.

Reword affected public validation messages and add regression tests. Apply the protection without a compatibility flag to avoid preserving disclosure of internal diagnostics.